### PR TITLE
Fix: GitHub status emoji not being set (Opus single-line output) (closes #36)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -16,6 +16,7 @@ from kennel.github import GitHub
 from kennel.prompts import Prompts
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
+_SHORTCODE_RE = re.compile(r"^(:[a-z0-9_+\-]+:)\s*(.*)", re.DOTALL)
 
 log = logging.getLogger(__name__)
 
@@ -329,12 +330,23 @@ class Worker:
             return
 
         lines = raw.splitlines()
-        if len(lines) < 2:
-            log.warning("set_status: expected 2 lines, got %d — skipping", len(lines))
-            return
+        if len(lines) >= 2:
+            emoji = lines[0].strip()
+            text = lines[1].strip()[:80]
+        else:
+            # Single-line output — extract :shortcode: prefix if present,
+            # otherwise fall back to :dog: and use the whole line as text.
+            m = _SHORTCODE_RE.match(raw.strip())
+            if m:
+                emoji = m.group(1)
+                text = m.group(2).strip()[:80]
+            else:
+                emoji = ":dog:"
+                text = raw.strip()[:80]
+            if not text:
+                log.warning("set_status: no status text extracted — skipping")
+                return
 
-        emoji = lines[0].strip()
-        text = lines[1].strip()[:80]
         self.gh.set_user_status(text, emoji, busy=busy)
         log.info("set_status: %s %s", emoji, text)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -256,10 +256,54 @@ class TestWorker:
             Worker(tmp_path, gh).set_status("idle")
         gh.set_user_status.assert_not_called()
 
-    def test_set_status_skips_when_only_one_line(self, tmp_path: Path) -> None:
+    def test_set_status_falls_back_on_single_line_emoji(self, tmp_path: Path) -> None:
+        # Single unicode emoji with no text → :dog: fallback emoji, emoji char as text
         gh = self._make_gh()
         with (
             patch("kennel.worker.claude.generate_status", return_value="🐕"),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("idle")
+        gh.set_user_status.assert_called_once_with("🐕", ":dog:", busy=True)
+
+    def test_set_status_parses_shortcode_from_single_line(self, tmp_path: Path) -> None:
+        # Opus squishes two-line output into one :shortcode: text line
+        gh = self._make_gh()
+        with (
+            patch(
+                "kennel.worker.claude.generate_status",
+                return_value=":dog: Fetching bugs",
+            ),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("idle")
+        gh.set_user_status.assert_called_once_with("Fetching bugs", ":dog:", busy=True)
+
+    def test_set_status_falls_back_to_dog_emoji_on_plain_single_line(
+        self, tmp_path: Path
+    ) -> None:
+        # No shortcode found → :dog: fallback, whole line as text
+        gh = self._make_gh()
+        with (
+            patch(
+                "kennel.worker.claude.generate_status",
+                return_value="Sniffing out endpoints",
+            ),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("idle")
+        gh.set_user_status.assert_called_once_with(
+            "Sniffing out endpoints", ":dog:", busy=True
+        )
+
+    def test_set_status_skips_when_shortcode_only_no_text(self, tmp_path: Path) -> None:
+        # :shortcode: with no text → nothing meaningful to display
+        gh = self._make_gh()
+        with (
+            patch("kennel.worker.claude.generate_status", return_value=":dog:"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -296,20 +340,20 @@ class TestWorker:
                 Worker(tmp_path, gh).set_status("idle")
         assert "empty" in caplog.text
 
-    def test_set_status_logs_warning_on_single_line(
+    def test_set_status_logs_warning_when_no_text_extracted(
         self, tmp_path: Path, caplog
     ) -> None:
         import logging
 
         gh = self._make_gh()
         with (
-            patch("kennel.worker.claude.generate_status", return_value="🐕"),
+            patch("kennel.worker.claude.generate_status", return_value=":dog:"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
             with caplog.at_level(logging.WARNING, logger="kennel"):
                 Worker(tmp_path, gh).set_status("idle")
-        assert "expected 2 lines" in caplog.text
+        assert "no status text" in caplog.text
 
     def test_set_status_logs_info_on_success(self, tmp_path: Path, caplog) -> None:
         import logging


### PR DESCRIPTION
Fixes the GitHub status emoji not being set because Opus sometimes squishes its two-line response (emoji + text) into a single line — the `set_status` parser then skips it entirely since it expects exactly two lines. This change makes the parsing more robust so it can extract the emoji shortcode even from single-line output, falling back to `:dog:` when Opus gets creative with formatting.

Fixes #36.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Fix set_status() to extract emoji shortcode robustly from Opus single-line output
</details>
<!-- WORK_QUEUE_END -->