### PR TITLE
Re-request review after addressing review comments (closes #27)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -424,6 +424,28 @@ def _pick_next_task(task_list: list[dict[str, Any]]) -> dict[str, Any] | None:
     return pending[0]
 
 
+def should_rerequest_review(
+    owner_reviews: list[dict[str, Any]],
+    commits: list[dict[str, Any]],
+) -> bool:
+    """Return True if fido should re-request review from the owner.
+
+    True when the latest owner review is CHANGES_REQUESTED and either no
+    timestamps are available or the review pre-dates the latest commit
+    (meaning new work has been pushed that addresses the feedback).
+    """
+    if not owner_reviews:
+        return False
+    latest_review = owner_reviews[-1]
+    if latest_review.get("state") != "CHANGES_REQUESTED":
+        return False
+    review_at = latest_review.get("submittedAt", "")
+    latest_commit_date = max((c.get("committedDate", "") for c in commits), default="")
+    if review_at and latest_commit_date and review_at > latest_commit_date:
+        return False
+    return True
+
+
 class Worker:
     """Fido worker for a single repository.
 
@@ -1265,12 +1287,7 @@ class Worker:
         )
 
         if latest_state == "CHANGES_REQUESTED":
-            latest_review = owner_reviews[-1]
-            review_at = latest_review.get("submittedAt", "")
-            latest_commit_date = max(
-                (c.get("committedDate", "") for c in commits), default=""
-            )
-            if review_at and latest_commit_date and review_at > latest_commit_date:
+            if not should_rerequest_review(owner_reviews, commits):
                 log.info(
                     "PR #%s: CHANGES_REQUESTED review newer than latest commit — skipping re-request",
                     pr_number,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -29,6 +29,7 @@ from kennel.worker import (
     load_state,
     run,
     save_state,
+    should_rerequest_review,
     sync_tasks,
     sync_tasks_background,
 )
@@ -4615,6 +4616,79 @@ class TestRunExecuteTaskIntegration:
         ):
             worker.run()
         mock_execute.assert_not_called()
+
+
+class TestShouldRerequestReview:
+    """Tests for the should_rerequest_review module-level helper."""
+
+    def _review(
+        self,
+        state: str = "CHANGES_REQUESTED",
+        submitted_at: str = "",
+    ) -> dict:
+        r: dict = {"state": state}
+        if submitted_at:
+            r["submittedAt"] = submitted_at
+        return r
+
+    def _commit(self, committed_date: str) -> dict:
+        return {"committedDate": committed_date}
+
+    def test_empty_reviews_returns_false(self) -> None:
+        assert should_rerequest_review([], []) is False
+
+    def test_approved_returns_false(self) -> None:
+        assert should_rerequest_review([self._review("APPROVED")], []) is False
+
+    def test_commented_returns_false(self) -> None:
+        assert should_rerequest_review([self._review("COMMENTED")], []) is False
+
+    def test_changes_requested_no_dates_returns_true(self) -> None:
+        assert should_rerequest_review([self._review()], []) is True
+
+    def test_changes_requested_no_submitted_at_returns_true(self) -> None:
+        commits = [self._commit("2024-01-02T12:00:00Z")]
+        assert should_rerequest_review([self._review()], commits) is True
+
+    def test_changes_requested_no_commits_returns_true(self) -> None:
+        review = self._review(submitted_at="2024-01-02T12:00:00Z")
+        assert should_rerequest_review([review], []) is True
+
+    def test_review_older_than_commit_returns_true(self) -> None:
+        """Review pre-dates latest commit — we addressed it."""
+        review = self._review(submitted_at="2024-01-01T10:00:00Z")
+        commits = [self._commit("2024-01-02T12:00:00Z")]
+        assert should_rerequest_review([review], commits) is True
+
+    def test_review_newer_than_commit_returns_false(self) -> None:
+        """Review post-dates latest commit — new feedback, not yet addressed."""
+        review = self._review(submitted_at="2024-01-02T12:00:00Z")
+        commits = [self._commit("2024-01-01T10:00:00Z")]
+        assert should_rerequest_review([review], commits) is False
+
+    def test_uses_latest_commit_date(self) -> None:
+        """Max commit date is used, not the first one."""
+        review = self._review(submitted_at="2024-01-02T10:00:00Z")
+        commits = [
+            self._commit("2024-01-01T08:00:00Z"),
+            self._commit("2024-01-03T08:00:00Z"),
+        ]
+        assert should_rerequest_review([review], commits) is True
+
+    def test_uses_latest_owner_review(self) -> None:
+        """Only the last review matters."""
+        reviews = [
+            self._review("APPROVED"),
+            self._review("CHANGES_REQUESTED"),
+        ]
+        assert should_rerequest_review(reviews, []) is True
+
+    def test_last_review_approved_overrides_earlier_changes_requested(self) -> None:
+        reviews = [
+            self._review("CHANGES_REQUESTED"),
+            self._review("APPROVED"),
+        ]
+        assert should_rerequest_review(reviews, []) is False
 
 
 class TestHandlePromoteMerge:


### PR DESCRIPTION
Teach fido to re-request review after addressing review comments, so the owner actually gets a notification that feedback was handled. After all pending comment tasks are resolved and commits are pushed, fido calls `gh pr edit --add-reviewer` to nudge the reviewer back — no more changes silently pushed without a ping.

Fixes #27.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add should_rerequest_review helper and wire into handle_promote_merge
- [x] replace gh CLI usage with Python GitHub REST API class
</details>
<!-- WORK_QUEUE_END -->