### PR TITLE
pr_ready uses REST PATCH which can't change draft status — needs GraphQL (closes #91)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -278,7 +278,14 @@ class GH:
 
     def pr_ready(self, repo: str, pr: int | str) -> None:
         """Mark a PR ready for review."""
-        self._patch(f"/repos/{repo}/pulls/{pr}", draft=False)
+        pr_data = self._get(f"/repos/{repo}/pulls/{pr}")
+        node_id = pr_data["node_id"]
+        query = (
+            "mutation($prId:ID!){"
+            "markPullRequestReadyForReview(input:{pullRequestId:$prId})"
+            "{pullRequest{isDraft}}}"
+        )
+        self._graphql(query, prId=node_id)
 
     def pr_merge(
         self, repo: str, pr: int | str, squash: bool = True, auto: bool = False

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -279,11 +279,18 @@ class TestGitHubClass:
 
     def test_pr_ready_delegates(self) -> None:
         gh = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        with patch.object(gh._gh._s, "patch", return_value=mock_resp) as mock_patch:
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"node_id": "PR_xyz"}
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {"data": {}}
+        with (
+            patch.object(gh._gh._s, "get", return_value=pr_resp),
+            patch.object(gh._gh._s, "post", return_value=graphql_resp) as mock_post,
+        ):
             gh.pr_ready("o/r", 10)
-        assert mock_patch.call_args.kwargs["json"]["draft"] is False
+        body = mock_post.call_args.kwargs["json"]
+        assert "markPullRequestReadyForReview" in body["query"]
+        assert body["variables"]["prId"] == "PR_xyz"
 
     def test_pr_merge_delegates(self) -> None:
         gh = self._github()
@@ -877,13 +884,18 @@ class TestGHClass:
 
     def test_pr_ready(self) -> None:
         gh = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        with patch.object(gh._s, "patch", return_value=mock_resp) as mock_patch:
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"node_id": "PR_xyz"}
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {"data": {}}
+        with (
+            patch.object(gh._s, "get", return_value=pr_resp),
+            patch.object(gh._s, "post", return_value=graphql_resp) as mock_post,
+        ):
             gh.pr_ready("o/r", 10)
-        url = mock_patch.call_args.args[0]
-        assert "repos/o/r/pulls/10" in url
-        assert mock_patch.call_args.kwargs["json"]["draft"] is False
+        body = mock_post.call_args.kwargs["json"]
+        assert "markPullRequestReadyForReview" in body["query"]
+        assert body["variables"]["prId"] == "PR_xyz"
 
     def test_pr_merge_squash(self) -> None:
         gh = self._gh()


### PR DESCRIPTION
Working on: pr_ready uses REST PATCH which can't change draft status — needs GraphQL (closes #91). Implementation in progress.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Replace GH.pr_ready REST PATCH with GraphQL markPullRequestReadyForReview mutation
</details>
<!-- WORK_QUEUE_END -->