### PR TITLE
Self-restart does git pull on current branch instead of checking out main (closes #101)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -36,9 +36,10 @@ _RESTART_CMDS: list[list[str]] = [
 
 
 def _run_git_cmd(work_dir: Path, cmd: list[str]) -> bool:
-    result = subprocess.run(cmd, cwd=str(work_dir), capture_output=True)
-    if result.returncode != 0:
-        log.error("self-restart: git command failed (%d): %s", result.returncode, cmd)
+    try:
+        subprocess.run(cmd, cwd=str(work_dir), capture_output=True, check=True)
+    except subprocess.CalledProcessError as e:
+        log.error("self-restart: git command failed (%d): %s", e.returncode, cmd)
         return False
     return True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import subprocess
 import threading
 import time
 import urllib.error
@@ -581,7 +582,7 @@ class TestSelfRestart:
                 patch("kennel.server.os.execv") as mock_exec,
             ):
                 # First command fails; subsequent commands and exec should be skipped.
-                mock_run.return_value = MagicMock(returncode=1)
+                mock_run.side_effect = subprocess.CalledProcessError(1, [])
                 status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
                 assert status == 200
                 time.sleep(0.2)


### PR DESCRIPTION
Working on: Self-restart does git pull on current branch instead of checking out main (closes #101). Implementation in progress.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Fix self-restart to checkout main before pulling
- [x] [add git reset --hard and safe git clean before pull on self-restart](https://github.com/rhencke/kennel/pull/104#discussion_r3051136405)
- [x] [move git reset --hard and git clean -fd before git checkout main](https://github.com/rhencke/kennel/pull/104#discussion_r3051160572)
- [x] PR comment: DRY up with helper function + data-driven loop, check error handling
- [x] [use check=True in _run_git_cmd subprocess call](https://github.com/rhencke/kennel/pull/104#discussion_r3051210717)
</details>
<!-- WORK_QUEUE_END -->