### PR TITLE
Status too long: retry with same Opus session asking for shorter, max 3 tries (closes #59)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -264,6 +264,24 @@ def generate_status(
     )
 
 
+def generate_status_emoji(
+    prompt: str,
+    system_prompt: str,
+    model: str = "claude-opus-4-6",
+    timeout: int = 15,
+) -> str:
+    """Ask claude to choose a single emoji for a GitHub status.
+
+    Returns the stripped response, or an empty string on failure.
+    """
+    return print_prompt(
+        prompt=prompt,
+        model=model,
+        system_prompt=system_prompt,
+        timeout=timeout,
+    )
+
+
 def generate_status_with_session(
     prompt: str,
     system_prompt: str,

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -210,7 +210,8 @@ class Prompts:
         prompt = p.persona_wrap(instruction)
         prompt = p.react_prompt(comment_body)
         prompt = p.pickup_comment_prompt(issue_title)
-        prompt = p.status_prompt(what)
+        prompt = p.status_text_prompt(what)
+        prompt = p.status_emoji_prompt(text)
     """
 
     def __init__(self, persona: str) -> None:
@@ -241,17 +242,27 @@ class Prompts:
             f"{plain}"
         )
 
-    def status_prompt(self, what: str) -> str:
-        """Build the user prompt for GitHub status generation."""
+    def status_text_prompt(self, what: str) -> str:
+        """Build the user prompt for GitHub status text generation."""
         return f"{self.persona}\n\nWhat you're doing right now: {what}"
 
-    def status_system_prompt(self) -> str:
-        """Return the system prompt for GitHub status generation."""
+    def status_text_system_prompt(self) -> str:
+        """Return the system prompt for GitHub status text generation."""
         return (
             "You are writing your GitHub profile status as Fido the dog. "
-            "Output exactly two lines. "
-            "Line 1: a single emoji for the status icon. "
-            "Line 2: the status text (under 80 chars, no quotes, no preamble)."
+            "Output ONLY the status text — no emoji, no quotes, no preamble. "
+            "Keep it under 80 characters."
+        )
+
+    def status_emoji_prompt(self, text: str) -> str:
+        """Build the user prompt for GitHub status emoji selection."""
+        return f"{self.persona}\n\nYour current GitHub status text is: {text}\n\nChoose one emoji."
+
+    def status_emoji_system_prompt(self) -> str:
+        """Return the system prompt for GitHub status emoji generation."""
+        return (
+            "You are choosing an emoji for your GitHub profile status as Fido the dog. "
+            "Output ONLY a single emoji or :shortcode:. No other text."
         )
 
     def react_prompt(self, comment_body: str) -> str:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -17,7 +17,6 @@ from kennel.github import GitHub
 from kennel.prompts import Prompts
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
-_SHORTCODE_RE = re.compile(r"^(:[a-z0-9_+\-]+:)\s*(.*)", re.DOTALL)
 
 log = logging.getLogger(__name__)
 
@@ -535,9 +534,11 @@ class Worker:
     def set_status(self, what: str, busy: bool = True) -> None:
         """Set the authenticated user's GitHub status using Claude-generated text.
 
-        Reads the persona from sub/persona.md, asks Claude to generate a two-line
-        status (emoji + text), then updates the GitHub user status via GraphQL.
-        Silently skips if Claude returns an empty or malformed response.
+        Makes two separate Opus calls: the first generates short status text
+        (≤80 chars), the second picks an emoji.  If the text exceeds 80
+        characters, retries up to 3 times in the same session to shorten it,
+        then truncates as a last resort.  Silently skips if Claude returns an
+        empty response for the text call.
         """
         persona_path = _sub_dir() / "persona.md"
         try:
@@ -546,31 +547,37 @@ class Worker:
             persona = ""
 
         prompts = Prompts(persona)
-        raw = claude.generate_status(
-            prompt=prompts.status_prompt(what),
-            system_prompt=prompts.status_system_prompt(),
+
+        # Call 1: generate status text
+        text, session_id = claude.generate_status_with_session(
+            prompt=prompts.status_text_prompt(what),
+            system_prompt=prompts.status_text_system_prompt(),
         )
-        if not raw:
+        if not text:
             log.warning("set_status: claude returned empty — skipping")
             return
 
-        lines = raw.splitlines()
-        if len(lines) >= 2:
-            emoji = lines[0].strip()
-            text = lines[1].strip()[:80]
-        else:
-            # Single-line output — extract :shortcode: prefix if present,
-            # otherwise fall back to :dog: and use the whole line as text.
-            m = _SHORTCODE_RE.match(raw.strip())
-            if m:
-                emoji = m.group(1)
-                text = m.group(2).strip()[:80]
-            else:
-                emoji = ":dog:"
-                text = raw.strip()[:80]
-            if not text:
-                log.warning("set_status: no status text extracted — skipping")
-                return
+        for _ in range(3):
+            if len(text) <= 80 or not session_id:
+                break
+            retry_raw = claude.resume_status(
+                session_id,
+                f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
+            )
+            if not retry_raw:
+                break
+            text = retry_raw.strip()
+
+        if len(text) > 80:
+            text = text[:80]
+
+        # Call 2: generate emoji
+        emoji = claude.generate_status_emoji(
+            prompt=prompts.status_emoji_prompt(text),
+            system_prompt=prompts.status_emoji_system_prompt(),
+        )
+        if not emoji:
+            emoji = ":dog:"
 
         self.gh.set_user_status(text, emoji, busy=busy)
         log.info("set_status: %s %s", emoji, text)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -11,6 +11,7 @@ from kennel.claude import (
     generate_branch_name,
     generate_reply,
     generate_status,
+    generate_status_emoji,
     generate_status_with_session,
     print_prompt,
     print_prompt_from_file,
@@ -642,6 +643,28 @@ class TestGenerateStatusWithSession:
             text, sid = generate_status_with_session("working", "sys")
         assert text == "🐶\nwoof"
         assert sid == ""
+
+
+class TestGenerateStatusEmoji:
+    def test_returns_emoji(self) -> None:
+        with patch("subprocess.run", return_value=_completed("🐕")):
+            result = generate_status_emoji("pick emoji", "be fido")
+        assert result == "🐕"
+
+    def test_returns_empty_on_failure(self) -> None:
+        with patch("subprocess.run", return_value=_completed("", returncode=1)):
+            result = generate_status_emoji("pick emoji", "sys")
+        assert result == ""
+
+    def test_passes_correct_flags(self) -> None:
+        with patch("subprocess.run", return_value=_completed("🐕")) as mock:
+            generate_status_emoji(
+                "pick emoji", "be fido", model="claude-sonnet-4-6", timeout=10
+            )
+        cmd = mock.call_args.args[0]
+        assert "claude-sonnet-4-6" in cmd
+        assert "be fido" in cmd
+        assert mock.call_args.kwargs["timeout"] == 10
 
 
 class TestResumeStatus:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -347,22 +347,46 @@ class TestIssueReplyInstruction:
 # ── Prompts.status_system_prompt ─────────────────────────────────────────────
 
 
-class TestStatusSystemPrompt:
+class TestStatusTextSystemPrompt:
     def test_returns_string(self) -> None:
-        result = Prompts("persona").status_system_prompt()
+        result = Prompts("persona").status_text_system_prompt()
         assert isinstance(result, str)
 
-    def test_mentions_two_lines(self) -> None:
-        result = Prompts("persona").status_system_prompt()
-        assert "two lines" in result
+    def test_no_emoji_instruction(self) -> None:
+        result = Prompts("persona").status_text_system_prompt()
+        assert "no emoji" in result.lower() or "ONLY the status text" in result
+
+    def test_mentions_80_chars(self) -> None:
+        result = Prompts("persona").status_text_system_prompt()
+        assert "80" in result
+
+    def test_mentions_fido(self) -> None:
+        result = Prompts("persona").status_text_system_prompt()
+        assert "Fido" in result
+
+
+class TestStatusEmojiSystemPrompt:
+    def test_returns_string(self) -> None:
+        result = Prompts("persona").status_emoji_system_prompt()
+        assert isinstance(result, str)
 
     def test_mentions_emoji(self) -> None:
-        result = Prompts("persona").status_system_prompt()
+        result = Prompts("persona").status_emoji_system_prompt()
         assert "emoji" in result
 
     def test_mentions_fido(self) -> None:
-        result = Prompts("persona").status_system_prompt()
+        result = Prompts("persona").status_emoji_system_prompt()
         assert "Fido" in result
+
+
+class TestStatusEmojiPrompt:
+    def test_includes_persona(self) -> None:
+        result = Prompts("I am Fido.").status_emoji_prompt("working hard")
+        assert "I am Fido." in result
+
+    def test_includes_text(self) -> None:
+        result = Prompts("persona").status_emoji_prompt("chasing bugs")
+        assert "chasing bugs" in result
 
 
 # ── Prompts class ─────────────────────────────────────────────────────────────
@@ -412,17 +436,17 @@ class TestPromptsReactPrompt:
         assert "emoji" in result
 
 
-class TestPromptsStatusPrompt:
+class TestPromptsStatusTextPrompt:
     def test_includes_persona(self) -> None:
-        result = Prompts("I am Fido.").status_prompt("writing tests")
+        result = Prompts("I am Fido.").status_text_prompt("writing tests")
         assert "I am Fido." in result
 
     def test_includes_what(self) -> None:
-        result = Prompts("persona").status_prompt("reviewing PRs")
+        result = Prompts("persona").status_text_prompt("reviewing PRs")
         assert "reviewing PRs" in result
 
     def test_what_is_framed_as_doing(self) -> None:
-        result = Prompts("persona").status_prompt("fixing a bug")
+        result = Prompts("persona").status_text_prompt("fixing a bug")
         assert "What you're doing right now" in result
         assert "fixing a bug" in result
 
@@ -468,6 +492,6 @@ class TestPromptsStoresPersona:
     def test_different_personas_independent(self) -> None:
         p1 = Prompts("persona A")
         p2 = Prompts("persona B")
-        assert "persona A" in p1.status_prompt("working")
-        assert "persona B" in p2.status_prompt("working")
-        assert "persona A" not in p2.status_prompt("working")
+        assert "persona A" in p1.status_text_prompt("working")
+        assert "persona B" in p2.status_text_prompt("working")
+        assert "persona A" not in p2.status_text_prompt("working")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -236,8 +236,10 @@ class TestWorker:
         gh = self._make_gh()
         with (
             patch(
-                "kennel.worker.claude.generate_status", return_value="🐕\nwriting tests"
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("writing tests", "sess-1"),
             ),
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -247,7 +249,11 @@ class TestWorker:
     def test_set_status_busy_false_forwarded(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         with (
-            patch("kennel.worker.claude.generate_status", return_value="😴\nnapping"),
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("napping", "sess-1"),
+            ),
+            patch("kennel.worker.claude.generate_status_emoji", return_value="😴"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -257,48 +263,25 @@ class TestWorker:
     def test_set_status_skips_when_claude_returns_empty(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         with (
-            patch("kennel.worker.claude.generate_status", return_value=""),
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("", ""),
+            ),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
             Worker(tmp_path, gh).set_status("idle")
         gh.set_user_status.assert_not_called()
 
-    def test_set_status_falls_back_on_single_line_emoji(self, tmp_path: Path) -> None:
-        # Single unicode emoji with no text → :dog: fallback emoji, emoji char as text
-        gh = self._make_gh()
-        with (
-            patch("kennel.worker.claude.generate_status", return_value="🐕"),
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            Worker(tmp_path, gh).set_status("idle")
-        gh.set_user_status.assert_called_once_with("🐕", ":dog:", busy=True)
-
-    def test_set_status_parses_shortcode_from_single_line(self, tmp_path: Path) -> None:
-        # Opus squishes two-line output into one :shortcode: text line
+    def test_set_status_emoji_fallback_when_empty(self, tmp_path: Path) -> None:
+        # generate_status_emoji returns empty → :dog: fallback
         gh = self._make_gh()
         with (
             patch(
-                "kennel.worker.claude.generate_status",
-                return_value=":dog: Fetching bugs",
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("Sniffing out endpoints", "sess-1"),
             ),
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            Worker(tmp_path, gh).set_status("idle")
-        gh.set_user_status.assert_called_once_with("Fetching bugs", ":dog:", busy=True)
-
-    def test_set_status_falls_back_to_dog_emoji_on_plain_single_line(
-        self, tmp_path: Path
-    ) -> None:
-        # No shortcode found → :dog: fallback, whole line as text
-        gh = self._make_gh()
-        with (
-            patch(
-                "kennel.worker.claude.generate_status",
-                return_value="Sniffing out endpoints",
-            ),
+            patch("kennel.worker.claude.generate_status_emoji", return_value=""),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -307,29 +290,102 @@ class TestWorker:
             "Sniffing out endpoints", ":dog:", busy=True
         )
 
-    def test_set_status_skips_when_shortcode_only_no_text(self, tmp_path: Path) -> None:
-        # :shortcode: with no text → nothing meaningful to display
-        gh = self._make_gh()
-        with (
-            patch("kennel.worker.claude.generate_status", return_value=":dog:"),
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            Worker(tmp_path, gh).set_status("idle")
-        gh.set_user_status.assert_not_called()
-
     def test_set_status_text_truncated_to_80_chars(self, tmp_path: Path) -> None:
+        # All retries fail (return empty) → fall back to truncation
         gh = self._make_gh()
         long_text = "x" * 100
         with (
             patch(
-                "kennel.worker.claude.generate_status",
-                return_value=f"🐕\n{long_text}",
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=(long_text, "sess-1"),
             ),
+            patch("kennel.worker.claude.resume_status", return_value=""),
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
             Worker(tmp_path, gh).set_status("something")
+        called_text = gh.set_user_status.call_args[0][0]
+        assert len(called_text) == 80
+
+    def test_set_status_retries_when_text_exceeds_80_chars(
+        self, tmp_path: Path
+    ) -> None:
+        gh = self._make_gh()
+        long_text = "y" * 90
+        with (
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=(long_text, "sess-99"),
+            ),
+            patch(
+                "kennel.worker.claude.resume_status",
+                return_value="shorter text",
+            ) as mock_resume,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("something")
+        mock_resume.assert_called_once_with("sess-99", ANY)
+        gh.set_user_status.assert_called_once_with("shorter text", "🐕", busy=True)
+
+    def test_set_status_stops_retrying_when_text_fits(self, tmp_path: Path) -> None:
+        # Second retry produces short text → no third retry
+        gh = self._make_gh()
+        long_text = "z" * 90
+        with (
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=(long_text, "sess-7"),
+            ),
+            patch(
+                "kennel.worker.claude.resume_status",
+                side_effect=["z" * 85, "good"],
+            ) as mock_resume,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("something")
+        assert mock_resume.call_count == 2
+        gh.set_user_status.assert_called_once_with("good", "🐕", busy=True)
+
+    def test_set_status_retries_up_to_3_times_max(self, tmp_path: Path) -> None:
+        gh = self._make_gh()
+        long_text = "w" * 90
+        with (
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=(long_text, "sess-3"),
+            ),
+            patch(
+                "kennel.worker.claude.resume_status",
+                return_value=long_text,
+            ) as mock_resume,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("something")
+        assert mock_resume.call_count == 3
+
+    def test_set_status_skips_retry_when_no_session_id(self, tmp_path: Path) -> None:
+        # No session_id → retry loop is skipped, truncation applied directly
+        gh = self._make_gh()
+        long_text = "v" * 100
+        with (
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=(long_text, ""),
+            ),
+            patch("kennel.worker.claude.resume_status") as mock_resume,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            Worker(tmp_path, gh).set_status("something")
+        mock_resume.assert_not_called()
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
 
@@ -340,7 +396,10 @@ class TestWorker:
 
         gh = self._make_gh()
         with (
-            patch("kennel.worker.claude.generate_status", return_value=""),
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("", ""),
+            ),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -348,27 +407,16 @@ class TestWorker:
                 Worker(tmp_path, gh).set_status("idle")
         assert "empty" in caplog.text
 
-    def test_set_status_logs_warning_when_no_text_extracted(
-        self, tmp_path: Path, caplog
-    ) -> None:
-        import logging
-
-        gh = self._make_gh()
-        with (
-            patch("kennel.worker.claude.generate_status", return_value=":dog:"),
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            with caplog.at_level(logging.WARNING, logger="kennel"):
-                Worker(tmp_path, gh).set_status("idle")
-        assert "no status text" in caplog.text
-
     def test_set_status_logs_info_on_success(self, tmp_path: Path, caplog) -> None:
         import logging
 
         gh = self._make_gh()
         with (
-            patch("kennel.worker.claude.generate_status", return_value="🐕\nfetching"),
+            patch(
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("fetching", "sess-1"),
+            ),
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
@@ -383,23 +431,27 @@ class TestWorker:
         missing_dir = tmp_path / "no_such_dir"
         with (
             patch(
-                "kennel.worker.claude.generate_status", return_value="🐕\nworking"
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("working", "sess-1"),
             ) as mock_gen,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
             patch("kennel.worker._sub_dir", return_value=missing_dir),
         ):
             Worker(tmp_path, gh).set_status("working")
-        # persona file missing — generate_status still called with empty persona
+        # persona file missing — generate_status_with_session still called with empty persona
         prompt_arg = mock_gen.call_args[1]["prompt"]
         assert "What you're doing right now: working" in prompt_arg
 
-    def test_set_status_passes_system_prompt_to_generate_status(
+    def test_set_status_passes_system_prompt_to_generate_status_with_session(
         self, tmp_path: Path
     ) -> None:
         gh = self._make_gh()
         with (
             patch(
-                "kennel.worker.claude.generate_status", return_value="🐕\nworking"
+                "kennel.worker.claude.generate_status_with_session",
+                return_value=("working", "sess-1"),
             ) as mock_gen,
+            patch("kennel.worker.claude.generate_status_emoji", return_value="🐕"),
             patch("kennel.worker._sub_dir", return_value=tmp_path),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")


### PR DESCRIPTION
When Opus generates a GitHub status that's too long, we now retry up to 3 times in the same session asking it to shorten up — instead of just brutally chopping the string. Only truncates as a last resort if Opus can't get it under 80 chars after 3 tries, and the emoji is always preserved.

Fixes #59.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add generate_status_with_session and resume_status to claude.py with tests
- [x] Retry set_status up to 3 times in same Opus session when text exceeds 80 chars
- [x] split status generation into two Opus calls — first for short text, then separate call for emoji
</details>
<!-- WORK_QUEUE_END -->