### PR TITLE
Include thread metadata in task context for review-comment tasks (closes #129)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1158,13 +1158,23 @@ class Worker:
         task_title = task["title"]
         log.info("task: %s", task_title)
         self.set_status(f"Working on: {task_title}")
-        context = (
-            f"PR: {pr_number}\n"
-            f"Repo: {repo_ctx.repo}\n"
-            f"Branch: {slug}\n"
-            f"Upstream: origin/{repo_ctx.default_branch}\n"
-            f"\nTask title: {task_title}"
-        )
+        thread = task.get("thread") or {}
+        context_parts = [
+            f"PR: {pr_number}",
+            f"Repo: {repo_ctx.repo}",
+            f"Branch: {slug}",
+            f"Upstream: origin/{repo_ctx.default_branch}",
+            f"\nTask title: {task_title}",
+        ]
+        if thread.get("comment_id"):
+            context_parts.append(
+                f"\nThis task originated from a PR review comment."
+                f"\nThread comment_id: {thread['comment_id']}"
+                f"\nPR: {thread.get('pr', pr_number)}"
+            )
+            if thread.get("url"):
+                context_parts.append(f"Thread URL: {thread['url']}")
+        context = "\n".join(context_parts)
         build_prompt(fido_dir, "task", context)
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
         session_id, output = claude_run(fido_dir)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4489,6 +4489,55 @@ class TestExecuteTask:
         _, _, context = mock_bp.call_args[0]
         assert "Task title: The special task" in context
 
+    def test_context_includes_thread_metadata(self, tmp_path: Path) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = {
+            "id": "t1",
+            "title": "Fix the thing",
+            "status": "pending",
+            "thread": {
+                "repo": "owner/repo",
+                "pr": 42,
+                "comment_id": 12345,
+                "url": "https://github.com/owner/repo/pull/42#discussion_r12345",
+            },
+        }
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt") as mock_bp,
+            patch("kennel.worker.claude_run", return_value=("", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.worker.tasks.complete_by_title"),
+            patch("kennel.worker.sync_tasks_background"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
+        _, _, context = mock_bp.call_args[0]
+        assert "comment_id: 12345" in context
+        assert "review comment" in context
+        assert "Thread URL:" in context
+
+    def test_context_omits_thread_when_no_thread(self, tmp_path: Path) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Plain task")
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt") as mock_bp,
+            patch("kennel.worker.claude_run", return_value=("", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.worker.tasks.complete_by_title"),
+            patch("kennel.worker.sync_tasks_background"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
+        _, _, context = mock_bp.call_args[0]
+        assert "comment_id" not in context
+        assert "review comment" not in context
+
     def test_calls_claude_run(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)


### PR DESCRIPTION
When sub-Claude executes a task that came from a PR review comment, the task context now includes the comment_id, PR number, and thread URL. This lets sub-Claude fetch the full review thread and understand what the reviewer actually requested — previously it only saw the task title and had no way to find the original feedback.

Fixes #129.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Include thread metadata in task context for review-comment tasks
</details>
<!-- WORK_QUEUE_END -->