### PR TITLE
Stream sub-Claude output to log in real time (closes #128)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -8,6 +8,7 @@ import re
 import select
 import subprocess
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -26,6 +27,14 @@ def _claude(
         text=True,
         timeout=timeout,
     )
+
+
+class ClaudeStreamError(Exception):
+    """Raised by _run_streaming when the subprocess exits with a non-zero code or times out."""
+
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+        super().__init__(f"claude exited with code {returncode}")
 
 
 # ── Stream-JSON helpers ───────────────────────────────────────────────────────
@@ -140,27 +149,23 @@ def _run_streaming(
     cmd: list[str],
     stdin_file: Path,
     idle_timeout: float = 1800.0,
-) -> tuple[str, int]:
+) -> Iterator[str]:
     """Run a command, streaming stdout with idle-timeout detection.
 
-    Reads stdout line by line.  If no new output arrives for
-    *idle_timeout* seconds, the process is killed.
-
-    Returns ``(stdout_text, returncode)``.  On idle timeout the process
-    is killed and returncode is ``-1``.
+    Yields each line of stdout as it arrives.  If no new output arrives for
+    *idle_timeout* seconds, the process is killed and ``ClaudeStreamError(-1)``
+    is raised.  If the process exits with a non-zero code,
+    ``ClaudeStreamError(returncode)`` is raised.  ``FileNotFoundError``
+    propagates naturally if the command is not found.
     """
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdin=stdin_file.open(),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-    except FileNotFoundError:
-        return "", -1
+    proc = subprocess.Popen(
+        cmd,
+        stdin=stdin_file.open(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
-    lines: list[str] = []
     last_activity = time.monotonic()
 
     while True:
@@ -169,7 +174,7 @@ def _run_streaming(
             line = proc.stdout.readline()
             if not line:
                 break  # EOF
-            lines.append(line)
+            yield line
             log.info(line.rstrip())
             last_activity = time.monotonic()
         elif proc.poll() is not None:
@@ -178,14 +183,15 @@ def _run_streaming(
             log.warning("claude idle for %.0fs — killing", idle_timeout)
             proc.kill()
             proc.wait()
-            return "".join(lines).strip(), -1
+            raise ClaudeStreamError(-1)
 
     proc.wait()
     # Drain any remaining output
     remaining = proc.stdout.read()
     if remaining:
-        lines.append(remaining)
-    return "".join(lines).strip(), proc.returncode
+        yield remaining
+    if proc.returncode != 0:
+        raise ClaudeStreamError(proc.returncode)
 
 
 def print_prompt_from_file(
@@ -212,8 +218,10 @@ def print_prompt_from_file(
         str(system_file),
         "--print",
     ]
-    output, rc = _run_streaming(cmd, prompt_file, idle_timeout)
-    return output if rc == 0 else ""
+    try:
+        return "".join(_run_streaming(cmd, prompt_file, idle_timeout)).strip()
+    except ClaudeStreamError, FileNotFoundError:
+        return ""
 
 
 def resume_session(
@@ -240,8 +248,10 @@ def resume_session(
         session_id,
         "--print",
     ]
-    output, rc = _run_streaming(cmd, prompt_file, idle_timeout)
-    return output if rc == 0 else ""
+    try:
+        return "".join(_run_streaming(cmd, prompt_file, idle_timeout)).strip()
+    except ClaudeStreamError, FileNotFoundError:
+        return ""
 
 
 # ── Specialised wrappers used by events.py ───────────────────────────────────

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from kennel.claude import (
+    ClaudeStreamError,
     _claude,
     extract_result_text,
     extract_session_id,
@@ -189,32 +190,45 @@ class TestPrintPromptJson:
 
 
 class TestRunStreaming:
-    def test_returns_output_and_returncode(self, tmp_path: Path) -> None:
+    def test_yields_output_lines(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming
 
         stdin_file = tmp_path / "input.txt"
         stdin_file.write_text("hello")
-        output, rc = _run_streaming(["echo", "hi"], stdin_file)
-        assert output == "hi"
-        assert rc == 0
+        lines = list(_run_streaming(["echo", "hi"], stdin_file))
+        assert "".join(lines).strip() == "hi"
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming
 
         stdin_file = tmp_path / "input.txt"
         stdin_file.write_text("")
-        output, rc = _run_streaming(["/nonexistent/binary"], stdin_file)
-        assert output == ""
-        assert rc == -1
+        import pytest
 
-    def test_kills_on_idle_timeout(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            list(_run_streaming(["/nonexistent/binary"], stdin_file))
+
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming
 
         stdin_file = tmp_path / "input.txt"
         stdin_file.write_text("")
-        # sleep 60 will be killed after 0.1s idle timeout
-        output, rc = _run_streaming(["sleep", "60"], stdin_file, idle_timeout=0.1)
-        assert rc == -1
+        import pytest
+
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            list(_run_streaming(["sleep", "60"], stdin_file, idle_timeout=0.1))
+        assert exc_info.value.returncode == -1
+
+    def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
+        from kennel.claude import _run_streaming
+
+        stdin_file = tmp_path / "input.txt"
+        stdin_file.write_text("")
+        import pytest
+
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            list(_run_streaming(["false"], stdin_file))
+        assert exc_info.value.returncode != 0
 
     def test_handles_process_exit_without_eof(self, tmp_path: Path) -> None:
         """Cover the proc.poll() is not None branch."""
@@ -240,9 +254,8 @@ class TestRunStreaming:
             # select returns NOT ready — forces poll() check
             patch("select.select", return_value=([], [], [])),
         ):
-            output, rc = _run_streaming(["fake"], stdin_file)
-        assert "leftover" in output
-        assert rc == 0
+            result = "".join(_run_streaming(["fake"], stdin_file))
+        assert "leftover" in result
 
     def test_drains_remaining_output(self, tmp_path: Path) -> None:
         """Cover the remaining = proc.stdout.read() branch."""
@@ -270,9 +283,9 @@ class TestRunStreaming:
             patch("subprocess.Popen", return_value=mock_proc),
             patch("select.select", return_value=([mock_stdout], [], [])),
         ):
-            output, rc = _run_streaming(["fake"], stdin_file)
-        assert "line1" in output
-        assert "extra" in output
+            result = "".join(_run_streaming(["fake"], stdin_file))
+        assert "line1" in result
+        assert "extra" in result
 
 
 class TestPrintPromptFromFile:
@@ -285,25 +298,33 @@ class TestPrintPromptFromFile:
 
     def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        with patch("kennel.claude._run_streaming", return_value=("session output", 0)):
+        with patch(
+            "kennel.claude._run_streaming", return_value=iter(["session output"])
+        ):
             result = print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
         assert result == "session output"
 
     def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        with patch("kennel.claude._run_streaming", return_value=("err", 1)):
+        with patch("kennel.claude._run_streaming", side_effect=ClaudeStreamError(1)):
             result = print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
         assert result == ""
 
     def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        with patch("kennel.claude._run_streaming", return_value=("partial", -1)):
+        with patch("kennel.claude._run_streaming", side_effect=ClaudeStreamError(-1)):
+            result = print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+        assert result == ""
+
+    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        with patch("kennel.claude._run_streaming", side_effect=FileNotFoundError):
             result = print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
         assert result == ""
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        with patch("kennel.claude._run_streaming", return_value=("out", 0)) as mock:
+        with patch("kennel.claude._run_streaming", return_value=iter(["out"])) as mock:
             print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
         cmd = mock.call_args[0][0]
         assert "--model" in cmd
@@ -314,7 +335,7 @@ class TestPrintPromptFromFile:
 
     def test_passes_idle_timeout(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        with patch("kennel.claude._run_streaming", return_value=("out", 0)) as mock:
+        with patch("kennel.claude._run_streaming", return_value=iter(["out"])) as mock:
             print_prompt_from_file(sys, prompt, "claude-sonnet-4-6", idle_timeout=600.0)
         assert mock.call_args[0][2] == 600.0
 
@@ -323,28 +344,35 @@ class TestResumeSession:
     def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("continue")
-        with patch("kennel.claude._run_streaming", return_value=("continued", 0)):
+        with patch("kennel.claude._run_streaming", return_value=iter(["continued"])):
             result = resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
         assert result == "continued"
 
     def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
-        with patch("kennel.claude._run_streaming", return_value=("", 1)):
+        with patch("kennel.claude._run_streaming", side_effect=ClaudeStreamError(1)):
             result = resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
         assert result == ""
 
     def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
-        with patch("kennel.claude._run_streaming", return_value=("partial", -1)):
+        with patch("kennel.claude._run_streaming", side_effect=ClaudeStreamError(-1)):
+            result = resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
+        assert result == ""
+
+    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("p")
+        with patch("kennel.claude._run_streaming", side_effect=FileNotFoundError):
             result = resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
         assert result == ""
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
-        with patch("kennel.claude._run_streaming", return_value=("out", 0)) as mock:
+        with patch("kennel.claude._run_streaming", return_value=iter(["out"])) as mock:
             resume_session("my-session-id", prompt_file, "claude-sonnet-4-6")
         cmd = mock.call_args[0][0]
         assert "--resume" in cmd
@@ -354,7 +382,7 @@ class TestResumeSession:
     def test_passes_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
-        with patch("kennel.claude._run_streaming", return_value=("out", 0)) as mock:
+        with patch("kennel.claude._run_streaming", return_value=iter(["out"])) as mock:
             resume_session(
                 "sess-1", prompt_file, "claude-sonnet-4-6", idle_timeout=900.0
             )


### PR DESCRIPTION
Pipes sub-Claude stdout to the kennel log line-by-line as it arrives, so `tail -f` actually shows what's happening instead of going silent for minutes. The full output is still collected and returned — this just adds real-time visibility during execution.

Fixes #128.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Log each output line as it arrives in _run_streaming
- [x] ensure logging level is set to capture streamed sub-Claude output
- [x] [Instead of a lines collection and having to add to it, why don't we just yield e](https://github.com/rhencke/kennel/pull/133#discussion_r3053077954)
</details>
<!-- WORK_QUEUE_END -->