### PR TITLE
kennel status subcommand doesn't know repo paths  (closes #148)

### DIFF
--- a/kennel/main.py
+++ b/kennel/main.py
@@ -14,19 +14,9 @@ def main(argv: list[str] | None = None) -> None:
 
         task_main(args[1:])
     elif args and args[0] == "status":
-        from pathlib import Path
-        from types import SimpleNamespace
-
-        from kennel.config import RepoConfig
         from kennel.status import collect, format_status
 
-        repos: dict[str, RepoConfig] = {}
-        for spec in args[1:]:
-            name, path_str = spec.split(":", 1)
-            repos[name] = RepoConfig(
-                name=name, work_dir=Path(path_str).expanduser().resolve()
-            )
-        print(format_status(collect(SimpleNamespace(repos=repos))))
+        print(format_status(collect()))
     elif args and args[0] == "sync-tasks":
         from pathlib import Path
 

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from kennel.config import Config, RepoConfig
+from kennel.config import RepoConfig
 
 
 @dataclass
@@ -230,11 +230,12 @@ def repo_status(repo_config: RepoConfig) -> RepoStatus:
     )
 
 
-def collect(config: Config) -> KennelStatus:
+def collect() -> KennelStatus:
     """Collect the full kennel + per-repo status."""
     pid = _kennel_pid()
     uptime = _process_uptime_seconds(pid) if pid is not None else None
-    repos = [repo_status(rc) for rc in config.repos.values()]
+    repo_configs = _repos_from_pid(pid) if pid is not None else []
+    repos = [repo_status(rc) for rc in repo_configs]
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,8 +75,8 @@ class TestMain:
 
         assert mock_sync.call_args[0][0] == Path.cwd()
 
-    def test_status_subcommand_no_repos_prints_output(self) -> None:
-        """'kennel status' with no repos calls collect/format_status and prints."""
+    def test_status_subcommand_prints_output(self) -> None:
+        """'kennel status' calls collect/format_status and prints the result."""
         with (
             patch("kennel.status.collect") as mock_collect,
             patch(
@@ -85,23 +85,6 @@ class TestMain:
             patch("builtins.print") as mock_print,
         ):
             main(["status"])
-        mock_collect.assert_called_once()
-        mock_fmt.assert_called_once()
+        mock_collect.assert_called_once_with()
+        mock_fmt.assert_called_once_with(mock_collect.return_value)
         mock_print.assert_called_once_with("kennel: DOWN")
-
-    def test_status_subcommand_parses_repo_specs(self, tmp_path) -> None:
-        """'kennel status owner/repo:/path' passes repos to collect."""
-        from kennel.config import RepoConfig
-
-        with (
-            patch("kennel.status.collect") as mock_collect,
-            patch("kennel.status.format_status", return_value="ok"),
-            patch("builtins.print"),
-        ):
-            main(["status", f"owner/repo:{tmp_path}"])
-
-        cfg = mock_collect.call_args[0][0]
-        assert "owner/repo" in cfg.repos
-        assert cfg.repos["owner/repo"] == RepoConfig(
-            name="owner/repo", work_dir=tmp_path
-        )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -444,17 +444,8 @@ class TestRepoStatus:
 
 
 class TestCollect:
-    def _make_config(self, tmp_path: Path) -> object:
-        from kennel.config import RepoConfig
-
-        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
-
-        cfg = MagicMock()
-        cfg.repos = {"owner/repo": rc}
-        return cfg
-
     def test_kennel_up_with_uptime(self, tmp_path: Path) -> None:
-        cfg = self._make_config(tmp_path)
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
         fake_repo_status = RepoStatus(
             name="owner/repo",
             fido_running=False,
@@ -467,35 +458,28 @@ class TestCollect:
         )
         with (
             patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
             patch("kennel.status._process_uptime_seconds", return_value=600),
             patch("kennel.status.repo_status", return_value=fake_repo_status),
         ):
-            result = collect(cfg)
+            result = collect()
 
         assert result.kennel_pid == 42
         assert result.kennel_uptime == 600
         assert len(result.repos) == 1
 
-    def test_kennel_down(self, tmp_path: Path) -> None:
-        cfg = self._make_config(tmp_path)
-        fake_repo_status = RepoStatus(
-            name="owner/repo",
-            fido_running=False,
-            issue=None,
-            pending=0,
-            completed=0,
-            current_task=None,
-            claude_pid=None,
-            claude_uptime=None,
-        )
+    def test_kennel_down(self) -> None:
         with (
             patch("kennel.status._kennel_pid", return_value=None),
+            patch("kennel.status._repos_from_pid") as mock_repos,
             patch("kennel.status._process_uptime_seconds") as mock_uptime,
-            patch("kennel.status.repo_status", return_value=fake_repo_status),
+            patch("kennel.status.repo_status") as mock_repo_status,
         ):
-            result = collect(cfg)
+            result = collect()
 
         mock_uptime.assert_not_called()
+        mock_repos.assert_not_called()
+        mock_repo_status.assert_not_called()
         assert result.kennel_pid is None
         assert result.kennel_uptime is None
 


### PR DESCRIPTION
Teach `kennel status` to sniff out repo paths on its own by reading the running kennel process's `/proc/<pid>/cmdline` instead of requiring them as arguments. The running kennel already knows its repos — no reason to make the human repeat themselves!

Fixes #148.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Fix Python 2-style except syntax in status.py
- [x] Add _repos_from_pid() to read repo specs from kennel process cmdline
- [x] Wire repo autodiscovery into collect() and simplify kennel status in main.py
</details>
<!-- WORK_QUEUE_END -->