### PR TITLE
Use Opus for setup/planning, Sonnet for task execution (closes #153)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -369,7 +369,7 @@ def sync_tasks_background(work_dir: Path, gh: GitHub) -> None:
 
 def claude_start(
     fido_dir: Path,
-    model: str = "claude-sonnet-4-6",
+    model: str = "claude-opus-4-6",
     timeout: int = 300,
 ) -> str:
     """Start a new sub-Claude session from fido_dir/system and fido_dir/prompt.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1549,7 +1549,7 @@ class TestClaudeStart:
         mock_ppf.assert_called_once_with(
             fido_dir / "system",
             fido_dir / "prompt",
-            "claude-sonnet-4-6",
+            "claude-opus-4-6",
             300,
         )
 
@@ -1561,8 +1561,8 @@ class TestClaudeStart:
             ) as mock_ppf,
             patch("kennel.claude.extract_session_id", return_value=""),
         ):
-            claude_start(fido_dir, model="claude-opus-4-6")
-        assert mock_ppf.call_args[0][2] == "claude-opus-4-6"
+            claude_start(fido_dir, model="claude-sonnet-4-6")
+        assert mock_ppf.call_args[0][2] == "claude-sonnet-4-6"
 
     def test_passes_custom_timeout(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -1575,7 +1575,7 @@ class TestClaudeStart:
             claude_start(fido_dir, timeout=600)
         assert mock_ppf.call_args[0][3] == 600
 
-    def test_default_model_is_sonnet(self, tmp_path: Path) -> None:
+    def test_default_model_is_opus(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         with (
             patch(
@@ -1584,7 +1584,7 @@ class TestClaudeStart:
             patch("kennel.claude.extract_session_id", return_value=""),
         ):
             claude_start(fido_dir)
-        assert mock_ppf.call_args[0][2] == "claude-sonnet-4-6"
+        assert mock_ppf.call_args[0][2] == "claude-opus-4-6"
 
     def test_default_timeout_is_300(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)


### PR DESCRIPTION
Switches fido's brain to use Opus (claude-opus-4-6) for setup and planning where good architectural thinking matters, then Sonnet (claude-sonnet-4-6) for task execution where speed is king. Cross-model session resume means the context carries over seamlessly — Opus plans it, Sonnet builds it, no sniffing around for lost context.

Fixes #153.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Change claude_start default model to claude-opus-4-6 and update tests
</details>
<!-- WORK_QUEUE_END -->