### PR TITLE
Render thread metadata as clickable hyperlinks in task list (closes #154)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -145,7 +145,12 @@ def dispatch(
                 "pr_body": (issue.get("body", "") or "")[:500],
                 "comment_id": comment_id,
             },
-            thread={"repo": repo, "pr": number, "comment_id": comment_id}
+            thread={
+                "repo": repo,
+                "pr": number,
+                "comment_id": comment_id,
+                "url": comment.get("html_url", ""),
+            }
             if number and comment_id
             else None,
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -256,7 +256,12 @@ class TestDispatchIssueComment:
         payload = {
             **_payload(),
             "action": "created",
-            "comment": {"id": 456, "body": "looks good", "user": {"login": "owner"}},
+            "comment": {
+                "id": 456,
+                "body": "looks good",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/10#issuecomment-456",
+            },
             "issue": {
                 "number": 10,
                 "title": "test pr",
@@ -267,6 +272,11 @@ class TestDispatchIssueComment:
         result = dispatch("issue_comment", payload, cfg, _repo_cfg(tmp_path))
         assert result is not None
         assert result.comment_body == "looks good"
+        assert result.thread is not None
+        assert (
+            result.thread["url"]
+            == "https://github.com/owner/repo/pull/10#issuecomment-456"
+        )
 
     def test_non_pr_ignored(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -376,7 +376,12 @@ class TestProcessAction:
         payload = {
             **self._payload(),
             "action": "created",
-            "comment": {"id": 300, "body": "looks good", "user": {"login": "owner"}},
+            "comment": {
+                "id": 300,
+                "body": "looks good",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/11#issuecomment-300",
+            },
             "issue": {
                 "number": 11,
                 "title": "my pr",
@@ -399,7 +404,12 @@ class TestProcessAction:
                 "do it",
                 cfg,
                 cfg.repos["owner/repo"],
-                thread={"repo": "owner/repo", "pr": 11, "comment_id": 300},
+                thread={
+                    "repo": "owner/repo",
+                    "pr": 11,
+                    "comment_id": 300,
+                    "url": "https://github.com/owner/repo/pull/11#issuecomment-300",
+                },
             )
 
     def test_issue_comment_no_task_for_answer(self, server: tuple) -> None:


### PR DESCRIPTION
Working on: Render thread metadata as clickable hyperlinks in task list (closes #154). Implementation in progress.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add url field to issue_comment thread dict and update tests
</details>
<!-- WORK_QUEUE_END -->