### PR TITLE
Streamed sub-Claude output logged at INFO — should be DEBUG (closes #142)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -175,7 +175,7 @@ def _run_streaming(
             if not line:
                 break  # EOF
             yield line
-            log.info(line.rstrip())
+            log.debug(line.rstrip())
             last_activity = time.monotonic()
         elif proc.poll() is not None:
             break  # process exited


### PR DESCRIPTION
Working on: Streamed sub-Claude output logged at INFO — should be DEBUG (closes #142). Implementation in progress.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Change streamed sub-Claude output log level from INFO to DEBUG in claude.py _run_streaming()
</details>
<!-- WORK_QUEUE_END -->