### PR TITLE
Multi-repo status clobbering: idle worker overwrites busy worker status (closes #100)

### DIFF
--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 from kennel.config import RepoConfig
@@ -42,6 +43,7 @@ class WorkerRegistry:
         self._factory = thread_factory
         self._activities: dict[str, WorkerActivity] = {}
         self._activity_lock = threading.Lock()
+        self._status_lock = threading.Lock()
 
     def start(self, repo_cfg: RepoConfig) -> None:
         """Create and start a WorkerThread for *repo_cfg*."""
@@ -79,6 +81,18 @@ class WorkerRegistry:
         """Return a snapshot of all registered workers' current activities."""
         with self._activity_lock:
             return list(self._activities.values())
+
+    @contextmanager
+    def status_update(self) -> Generator[None, None, None]:
+        """Context manager that serializes GitHub status updates across workers.
+
+        Only one worker may generate and publish a status at a time.  Callers
+        should hold this for the entire report-activity → generate-status →
+        set-user-status flow so that an idle worker cannot overwrite a busy
+        worker's status.
+        """
+        with self._status_lock:
+            yield
 
     def stop_all(self) -> None:
         """Request every managed thread to stop after its current iteration."""

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -8,6 +8,7 @@ import logging
 import re
 import subprocess
 import threading
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, Any, Protocol
@@ -64,6 +65,8 @@ class ActivityReporter(Protocol):
     def report_activity(self, repo_name: str, what: str, busy: bool) -> None: ...
 
     def get_all_activities(self) -> list[Any]: ...
+
+    def status_update(self) -> AbstractContextManager[None]: ...
 
 
 class LockHeld(Exception):

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -8,7 +8,7 @@ import logging
 import re
 import subprocess
 import threading
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, Any, Protocol
@@ -662,48 +662,54 @@ class Worker:
 
         prompts = Prompts(persona)
 
-        if self._registry is not None:
-            self._registry.report_activity(self._repo_name, what, busy)
-            activities = [
-                (a.repo_name, a.what, a.busy)
-                for a in self._registry.get_all_activities()
-            ]
-        else:
-            activities = [(self.work_dir.name, what, busy)]
-
-        # Call 1: generate status text
-        text, session_id = _generate_status_with_session(
-            prompt=prompts.status_text_prompt(activities),
-            system_prompt=prompts.status_text_system_prompt(),
+        ctx = (
+            self._registry.status_update()
+            if self._registry is not None
+            else nullcontext()
         )
-        if not text:
-            log.warning("set_status: claude returned empty — skipping")
-            return
+        with ctx:
+            if self._registry is not None:
+                self._registry.report_activity(self._repo_name, what, busy)
+                activities = [
+                    (a.repo_name, a.what, a.busy)
+                    for a in self._registry.get_all_activities()
+                ]
+            else:
+                activities = [(self.work_dir.name, what, busy)]
 
-        for _ in range(3):
-            if len(text) <= 80 or not session_id:
-                break
-            retry_raw = _resume_status(
-                session_id,
-                f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
+            # Call 1: generate status text
+            text, session_id = _generate_status_with_session(
+                prompt=prompts.status_text_prompt(activities),
+                system_prompt=prompts.status_text_system_prompt(),
             )
-            if not retry_raw:
-                break
-            text = retry_raw.strip()
+            if not text:
+                log.warning("set_status: claude returned empty — skipping")
+                return
 
-        if len(text) > 80:
-            text = text[:80]
+            for _ in range(3):
+                if len(text) <= 80 or not session_id:
+                    break
+                retry_raw = _resume_status(
+                    session_id,
+                    f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
+                )
+                if not retry_raw:
+                    break
+                text = retry_raw.strip()
 
-        # Call 2: generate emoji
-        emoji = _generate_status_emoji(
-            prompt=prompts.status_emoji_prompt(text),
-            system_prompt=prompts.status_emoji_system_prompt(),
-        )
-        if not emoji:
-            emoji = ":dog:"
+            if len(text) > 80:
+                text = text[:80]
 
-        self.gh.set_user_status(text, emoji, busy=busy)
-        log.info("set_status: %s %s", emoji, text)
+            # Call 2: generate emoji
+            emoji = _generate_status_emoji(
+                prompt=prompts.status_emoji_prompt(text),
+                system_prompt=prompts.status_emoji_system_prompt(),
+            )
+            if not emoji:
+                emoji = ":dog:"
+
+            self.gh.set_user_status(text, emoji, busy=busy)
+            log.info("set_status: %s %s", emoji, text)
 
     def find_next_issue(self, fido_dir: Path, repo_ctx: RepoContext) -> int | None:
         """Find the next eligible open issue assigned to gh_user.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -209,6 +210,36 @@ class TestWorkerRegistry:
         assert set(final) == set(repos)
         for repo in repos:
             assert final[repo].what == f"step {n_writes - 1}"
+
+    def test_status_update_is_context_manager(self) -> None:
+        reg, _ = self._make_registry()
+        with reg.status_update():
+            pass  # must not raise
+
+    def test_status_update_serializes_concurrent_callers(self) -> None:
+        """Only one caller may be inside status_update() at a time."""
+        reg, _ = self._make_registry()
+        inside_count = 0
+        max_concurrent = 0
+        counter_lock = threading.Lock()
+
+        def task() -> None:
+            nonlocal inside_count, max_concurrent
+            with reg.status_update():
+                with counter_lock:
+                    inside_count += 1
+                    max_concurrent = max(max_concurrent, inside_count)
+                time.sleep(0.001)
+                with counter_lock:
+                    inside_count -= 1
+
+        threads = [threading.Thread(target=task) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert max_concurrent == 1
 
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
+import time
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
@@ -508,6 +510,65 @@ class TestWorker:
         prompt_arg = mock_gen.call_args[1]["prompt"]
         assert "owner/repo-a" in prompt_arg
         assert "owner/repo-b" in prompt_arg
+
+    def test_set_status_acquires_status_lock_when_registry_present(
+        self, tmp_path: Path
+    ) -> None:
+        gh = self._make_gh()
+        registry = MagicMock()
+        registry.get_all_activities.return_value = []
+        (tmp_path / "persona.md").write_text("I am Fido.")
+        Worker(tmp_path, gh, repo_name="owner/repo", registry=registry).set_status(
+            "working", **self._ss(tmp_path, text="working")
+        )
+        registry.status_update.assert_called_once()
+
+    def test_set_status_serializes_concurrent_calls_via_registry_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """Concurrent set_status calls on different workers sharing a registry serialize."""
+        from kennel.registry import WorkerRegistry
+
+        registry = WorkerRegistry(MagicMock())
+        inside_count = 0
+        max_concurrent = 0
+        counter_lock = threading.Lock()
+
+        def slow_generate(*args, **kwargs) -> tuple[str, str]:
+            nonlocal inside_count, max_concurrent
+            with counter_lock:
+                inside_count += 1
+                max_concurrent = max(max_concurrent, inside_count)
+            time.sleep(0.005)
+            with counter_lock:
+                inside_count -= 1
+            return ("status text", "sess-1")
+
+        workers = [
+            Worker(
+                tmp_path, self._make_gh(), repo_name=f"owner/repo{i}", registry=registry
+            )
+            for i in range(3)
+        ]
+        threads = [
+            threading.Thread(
+                target=w.set_status,
+                args=("working",),
+                kwargs={
+                    "_generate_status_with_session": slow_generate,
+                    "_generate_status_emoji": MagicMock(return_value="🐕"),
+                    "_resume_status": MagicMock(return_value=""),
+                    "_sub_dir_fn": lambda: tmp_path / "nosub",
+                },
+            )
+            for w in workers
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert max_concurrent == 1
 
     # --- get_current_issue ---
 


### PR DESCRIPTION


Adds a `status_update()` context manager to `WorkerRegistry` (exposed via the `ActivityReporter` protocol) that serializes the entire status-generation flow behind a single lock. `Worker.set_status` acquires this lock before reporting activity, reading the registry snapshot, calling Claude, and setting the GitHub status — so an idle worker can no longer clobber a busy worker's status by winning the last-writer race on `set_user_status`.

Fixes #100.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add status serialization lock to WorkerRegistry and ActivityReporter protocol <!-- type:spec -->
- [x] Serialize Worker.set_status under the registry status lock <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->