### PR TITLE
Sanitize status text: strip whitespace and collapse multi-line to single line (closes #116)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -184,6 +184,11 @@ def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Pat
     return system_file, prompt_file
 
 
+def _sanitize_status_text(text: str) -> str:
+    """Strip leading/trailing whitespace and collapse newlines to a single space."""
+    return re.sub(r"\s*\n\s*", " ", text).strip()
+
+
 def _sanitize_slug(raw: str, fallback: str) -> str:
     """Sanitize a branch name slug: lowercase, hyphens only, max 40 chars.
 
@@ -685,6 +690,8 @@ class Worker:
             if not text:
                 log.warning("set_status: claude returned empty — skipping")
                 return
+
+            text = _sanitize_status_text(text)
 
             for _ in range(3):
                 if len(text) <= 80 or not session_id:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -25,6 +25,7 @@ from kennel.worker import (
     _pick_next_task,
     _resolve_git_dir,
     _sanitize_slug,
+    _sanitize_status_text,
     _thread_repo,
     acquire_lock,
     build_prompt,
@@ -1941,6 +1942,31 @@ class TestSanitizeSlug:
         result = _sanitize_slug("x", "Add New Feature!")
         assert result == result.lower()
         assert "!" not in result
+
+
+class TestSanitizeStatusText:
+    """Tests for _sanitize_status_text."""
+
+    def test_plain_text_unchanged(self) -> None:
+        assert _sanitize_status_text("working on tests") == "working on tests"
+
+    def test_strips_leading_whitespace(self) -> None:
+        assert _sanitize_status_text("  hello") == "hello"
+
+    def test_strips_trailing_whitespace(self) -> None:
+        assert _sanitize_status_text("hello  ") == "hello"
+
+    def test_collapses_newline_to_space(self) -> None:
+        assert _sanitize_status_text("line one\nline two") == "line one line two"
+
+    def test_collapses_newline_with_surrounding_whitespace(self) -> None:
+        assert _sanitize_status_text("line one  \n  line two") == "line one line two"
+
+    def test_collapses_multiple_newlines(self) -> None:
+        assert _sanitize_status_text("a\nb\nc") == "a b c"
+
+    def test_strips_and_collapses_combined(self) -> None:
+        assert _sanitize_status_text("  foo\nbar  ") == "foo bar"
 
 
 class TestGit:


### PR DESCRIPTION


Adds a `_sanitize_status_text()` helper in `worker.py` that strips leading/trailing whitespace and collapses multi-line Claude responses into a single line. The helper is applied in `set_status()` immediately after receiving text from Claude and before the length-check/truncation loop, ensuring clean single-line status text reaches the GitHub API.

Fixes #116.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Sanitize status text: strip whitespace and collapse multi-line to single line <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->