### PR TITLE
Fix find_pr GraphQL query syntax error

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -195,7 +195,7 @@ class GH:
             " ...on PullRequest{number headRefName state author{login}}}}"
             "...on DisconnectedEvent{subject{__typename"
             " ...on PullRequest{number}}}"
-            "}}}}}}"
+            "}}}}}"
         )
         keyword_prs: set[int] = set()
         sidebar_prs: set[int] = set()


### PR DESCRIPTION
The GraphQL timeline query had 18 closing braces but only 17 opening — the extra `}` caused a syntax error at position 562. Verified query works against the real GitHub API after fix.

1226 tests, 100% coverage.