### PR TITLE
use GitHub timeline API instead of search to find linked PRs (closes #122)

### DIFF
--- a/sync-tasks.sh
+++ b/sync-tasks.sh
@@ -39,10 +39,18 @@ if [[ -z "$CURRENT_ISSUE" ]]; then
 fi
 
 GH_USER=$(gh api user --jq .login)
-_PR_JSON=$(gh pr list --repo "$REPO" --state open --json number,headRefName,author \
-  --search "#$CURRENT_ISSUE in:body" 2>/dev/null \
-  | jq -r --arg user "$GH_USER" '[.[] | select(.author.login == $user)] | .[0] // empty')
-PR=$(printf '%s' "$_PR_JSON" | jq -r '.number // empty')
+PR=$(gh api --paginate "repos/$REPO/issues/$CURRENT_ISSUE/timeline" \
+  --jq '.[]' 2>/dev/null \
+  | jq -rs --arg user "$GH_USER" --arg issue "$CURRENT_ISSUE" \
+      '[.[] | select(
+        .event == "cross-referenced" and
+        (.source.issue.pull_request // null) != null and
+        .source.issue.user.login == $user and
+        .source.issue.state == "open" and
+        (.source.issue.body // "" | test(
+          "(?i)\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#" + $issue + "\\b"
+        ))
+      ) | .source.issue.number] | .[0] // empty' 2>/dev/null || true)
 
 if [[ -z "$PR" ]]; then
   log "no open PR for issue #$CURRENT_ISSUE — nothing to sync"

--- a/work.sh
+++ b/work.sh
@@ -267,11 +267,22 @@ ISSUE_TITLE=$(gh issue view "$CURRENT_ISSUE" --repo "$REPO" --json title --jq .t
 REQUEST="$ISSUE_TITLE (closes #$CURRENT_ISSUE)"
 
 # ── Find or create branch + PR ─────────────────────────────────────────────
-_PR_JSON=$(gh pr list --repo "$REPO" --state open --json number,headRefName,author \
-  --search "#$CURRENT_ISSUE in:body" 2>/dev/null \
-  | jq -r --arg user "$GH_USER" '[.[] | select(.author.login == $user)] | .[0] // empty')
-EXISTING_PR=$(printf '%s' "$_PR_JSON" | jq -r '.number // empty')
-EXISTING_SLUG=$(printf '%s' "$_PR_JSON" | jq -r '.headRefName // empty')
+EXISTING_PR=$(gh api --paginate "repos/$REPO/issues/$CURRENT_ISSUE/timeline" \
+  --jq '.[]' 2>/dev/null \
+  | jq -rs --arg user "$GH_USER" --arg issue "$CURRENT_ISSUE" \
+      '[.[] | select(
+        .event == "cross-referenced" and
+        (.source.issue.pull_request // null) != null and
+        .source.issue.user.login == $user and
+        .source.issue.state == "open" and
+        (.source.issue.body // "" | test(
+          "(?i)\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#" + $issue + "\\b"
+        ))
+      ) | .source.issue.number] | .[0] // empty' 2>/dev/null || true)
+EXISTING_SLUG=""
+if [[ -n "$EXISTING_PR" ]]; then
+  EXISTING_SLUG=$(gh api "repos/$REPO/pulls/$EXISTING_PR" --jq .head.ref 2>/dev/null || true)
+fi
 
 if [[ -n "$EXISTING_SLUG" ]]; then
   SLUG="$EXISTING_SLUG"


### PR DESCRIPTION


The shell scripts `work.sh` and `sync-tasks.sh` still use `gh pr list --search` to find linked PRs, which is unreliable compared to the timeline API that tracks actual issue-PR linkage. This PR rewrites `find_pr` in `github.py` from GraphQL to the REST timeline API, then replaces the `gh pr list --search` calls in both `work.sh` and `sync-tasks.sh` with equivalent `gh api` calls against the issue timeline endpoint, filtering for cross-referenced and connected/disconnected events by user.

Fixes #122.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Rewrite find_pr from GraphQL to REST timeline API <!-- type:spec -->
- [x] Replace gh pr list --search in work.sh with timeline API call <!-- type:spec -->
- [x] Replace gh pr list --search in sync-tasks.sh with timeline API call <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->