### PR TITLE
Fido doesn't re-request review after addressing changes-requested feedback (closes #124)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1591,12 +1591,22 @@ class Worker:
                     pr_number,
                 )
                 return 0
-            log.info(
-                "PR #%s: changes requested — all addressed, re-requesting review",
-                pr_number,
-            )
             if repo_ctx.owner not in requested_reviewers:
-                self.gh.add_pr_reviewer(repo_ctx.repo, pr_number, repo_ctx.owner)
+                checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
+                required = self.gh.get_required_checks(
+                    repo_ctx.repo, repo_ctx.default_branch
+                )
+                if ci_ready_for_review(checks, required):
+                    log.info(
+                        "PR #%s: changes requested — all addressed, CI passing — re-requesting review",
+                        pr_number,
+                    )
+                    self.gh.add_pr_reviewer(repo_ctx.repo, pr_number, repo_ctx.owner)
+                else:
+                    log.info(
+                        "PR #%s: changes requested — all addressed, but CI not yet passing — deferring re-request",
+                        pr_number,
+                    )
             return 0
 
         if is_draft:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -508,20 +508,33 @@ def _has_pending_asks(task_list: list[dict[str, Any]]) -> bool:
     )
 
 
+_DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
+
+
+def latest_decisive_review(
+    owner_reviews: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the most recent APPROVED or CHANGES_REQUESTED review, or None.
+
+    COMMENTED reviews are non-decisive and do not affect the merge/re-request
+    decision, so they are excluded.
+    """
+    decisive = [r for r in owner_reviews if r.get("state") in _DECISIVE_REVIEW_STATES]
+    return decisive[-1] if decisive else None
+
+
 def should_rerequest_review(
     owner_reviews: list[dict[str, Any]],
     commits: list[dict[str, Any]],
 ) -> bool:
     """Return True if fido should re-request review from the owner.
 
-    True when the latest owner review is CHANGES_REQUESTED and either no
-    timestamps are available or the review pre-dates the latest commit
+    True when the latest decisive owner review is CHANGES_REQUESTED and either
+    no timestamps are available or the review pre-dates the latest commit
     (meaning new work has been pushed that addresses the feedback).
     """
-    if not owner_reviews:
-        return False
-    latest_review = owner_reviews[-1]
-    if latest_review.get("state") != "CHANGES_REQUESTED":
+    latest_review = latest_decisive_review(owner_reviews)
+    if latest_review is None or latest_review.get("state") != "CHANGES_REQUESTED":
         return False
     review_at = latest_review.get("submittedAt", "")
     latest_commit_date = max((c.get("committedDate", "") for c in commits), default="")
@@ -1533,8 +1546,9 @@ class Worker:
         owner_reviews = [
             r for r in reviews if r.get("author", {}).get("login") == repo_ctx.owner
         ]
+        _latest_decisive = latest_decisive_review(owner_reviews)
         latest_state = (
-            owner_reviews[-1].get("state", "NONE") if owner_reviews else "NONE"
+            _latest_decisive.get("state", "NONE") if _latest_decisive else "NONE"
         )
         is_approved = latest_state == "APPROVED"
         task_list = tasks.list_tasks(self.work_dir)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6055,15 +6055,45 @@ class TestHandlePromoteMerge:
 
     # --- changes requested ---
 
-    def test_changes_requested_adds_reviewer(self, tmp_path: Path) -> None:
+    def test_changes_requested_ci_passing_adds_reviewer(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._reviews(
             state="CHANGES_REQUESTED", is_draft=False
         )
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+
+    def test_changes_requested_ci_failing_skips_reviewer(self, tmp_path: Path) -> None:
+        """CI not passing — re-request deferred until CI is green."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(
+            state="CHANGES_REQUESTED", is_draft=False
+        )
+        gh.pr_checks.return_value = [{"name": "ci", "state": "FAILURE"}]
+        gh.get_required_checks.return_value = ["ci"]
+        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.add_pr_reviewer.assert_not_called()
+
+    def test_changes_requested_ci_failing_returns_0(self, tmp_path: Path) -> None:
+        """CI not passing — returns 0 (waiting for CI)."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(
+            state="CHANGES_REQUESTED", is_draft=False
+        )
+        gh.pr_checks.return_value = [{"name": "ci", "state": "FAILURE"}]
+        gh.get_required_checks.return_value = ["ci"]
+        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        assert result == 0
 
     def test_changes_requested_returns_0(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -6071,6 +6101,8 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(
             state="CHANGES_REQUESTED", is_draft=False
         )
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
@@ -6083,6 +6115,8 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(
             state="CHANGES_REQUESTED", is_draft=False
         )
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_merge.assert_not_called()
@@ -6383,6 +6417,8 @@ class TestHandlePromoteMerge:
             "commits": [{"committedDate": "2024-01-02T12:00:00Z"}],
             "isDraft": False,
         }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
@@ -6405,6 +6441,8 @@ class TestHandlePromoteMerge:
             "commits": [{"committedDate": "2024-01-02T12:00:00Z"}],
             "isDraft": False,
         }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
@@ -6420,6 +6458,8 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(
             state="CHANGES_REQUESTED", is_draft=False
         )
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_called_once()
@@ -6439,6 +6479,8 @@ class TestHandlePromoteMerge:
             "commits": [],
             "isDraft": False,
         }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_called_once()
@@ -6547,6 +6589,8 @@ class TestHandlePromoteMerge:
             "commits": [],
             "isDraft": False,
         }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -34,6 +34,7 @@ from kennel.worker import (
     claude_start,
     clear_state,
     create_compact_script,
+    latest_decisive_review,
     load_state,
     run,
     save_state,
@@ -5610,6 +5611,45 @@ class TestRunExecuteTaskIntegration:
         mock_execute.assert_not_called()
 
 
+class TestLatestDecisiveReview:
+    """Tests for the latest_decisive_review module-level helper."""
+
+    def test_empty_returns_none(self) -> None:
+        assert latest_decisive_review([]) is None
+
+    def test_approved_returned(self) -> None:
+        r = {"state": "APPROVED"}
+        assert latest_decisive_review([r]) is r
+
+    def test_changes_requested_returned(self) -> None:
+        r = {"state": "CHANGES_REQUESTED"}
+        assert latest_decisive_review([r]) is r
+
+    def test_commented_returns_none(self) -> None:
+        assert latest_decisive_review([{"state": "COMMENTED"}]) is None
+
+    def test_returns_last_decisive_not_last_overall(self) -> None:
+        """APPROVED followed by COMMENTED → APPROVED is the decisive one."""
+        approved = {"state": "APPROVED"}
+        commented = {"state": "COMMENTED"}
+        assert latest_decisive_review([approved, commented]) is approved
+
+    def test_changes_requested_then_commented_returns_changes_requested(self) -> None:
+        cr = {"state": "CHANGES_REQUESTED"}
+        commented = {"state": "COMMENTED"}
+        assert latest_decisive_review([cr, commented]) is cr
+
+    def test_changes_requested_then_approved(self) -> None:
+        cr = {"state": "CHANGES_REQUESTED"}
+        approved = {"state": "APPROVED"}
+        assert latest_decisive_review([cr, approved]) is approved
+
+    def test_approved_then_changes_requested(self) -> None:
+        approved = {"state": "APPROVED"}
+        cr = {"state": "CHANGES_REQUESTED"}
+        assert latest_decisive_review([approved, cr]) is cr
+
+
 class TestShouldRerequestReview:
     """Tests for the should_rerequest_review module-level helper."""
 
@@ -5679,6 +5719,22 @@ class TestShouldRerequestReview:
         reviews = [
             self._review("CHANGES_REQUESTED"),
             self._review("APPROVED"),
+        ]
+        assert should_rerequest_review(reviews, []) is False
+
+    def test_changes_requested_then_commented_still_rerequests(self) -> None:
+        """COMMENTED after CHANGES_REQUESTED does not override the decisive state."""
+        reviews = [
+            self._review("CHANGES_REQUESTED"),
+            self._review("COMMENTED"),
+        ]
+        assert should_rerequest_review(reviews, []) is True
+
+    def test_approved_then_commented_returns_false(self) -> None:
+        """COMMENTED after APPROVED does not override the decisive APPROVED."""
+        reviews = [
+            self._review("APPROVED"),
+            self._review("COMMENTED"),
         ]
         assert should_rerequest_review(reviews, []) is False
 
@@ -6434,6 +6490,85 @@ class TestHandlePromoteMerge:
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewer.assert_not_called()
 
+    # --- decisive review state (APPROVED/CHANGES_REQUESTED vs COMMENTED) ---
+
+    def test_approved_then_commented_merges(self, tmp_path: Path) -> None:
+        """APPROVED followed by COMMENTED: decisive state is APPROVED — must merge."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {"author": {"login": "rhencke"}, "state": "APPROVED"},
+                {"author": {"login": "rhencke"}, "state": "COMMENTED"},
+            ],
+            "commits": [],
+            "isDraft": False,
+        }
+        gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch.object(worker, "_git"),
+            patch.object(worker, "set_status"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.pr_merge.assert_called_once()
+
+    def test_approved_then_commented_does_not_rerequest(self, tmp_path: Path) -> None:
+        """APPROVED followed by COMMENTED: should not re-request review."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {"author": {"login": "rhencke"}, "state": "APPROVED"},
+                {"author": {"login": "rhencke"}, "state": "COMMENTED"},
+            ],
+            "commits": [],
+            "isDraft": False,
+        }
+        gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch.object(worker, "_git"),
+            patch.object(worker, "set_status"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.add_pr_reviewer.assert_not_called()
+
+    def test_changes_requested_then_commented_rerequests(self, tmp_path: Path) -> None:
+        """CHANGES_REQUESTED followed by COMMENTED: decisive state is
+        CHANGES_REQUESTED — should re-request review, not treat as COMMENTED."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {"author": {"login": "rhencke"}, "state": "CHANGES_REQUESTED"},
+                {"author": {"login": "rhencke"}, "state": "COMMENTED"},
+            ],
+            "commits": [],
+            "isDraft": False,
+        }
+        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+
+    def test_changes_requested_then_commented_does_not_merge(
+        self, tmp_path: Path
+    ) -> None:
+        """CHANGES_REQUESTED followed by COMMENTED: must not merge."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {"author": {"login": "rhencke"}, "state": "CHANGES_REQUESTED"},
+                {"author": {"login": "rhencke"}, "state": "COMMENTED"},
+            ],
+            "commits": [],
+            "isDraft": False,
+        }
+        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.pr_merge.assert_not_called()
+
     # --- draft promote ---
 
     def test_draft_no_completed_tasks_returns_0(self, tmp_path: Path) -> None:
@@ -6668,18 +6803,19 @@ class TestHandlePromoteMerge:
         gh.pr_checks.assert_not_called()
         gh.add_pr_reviewer.assert_not_called()
 
-    def test_non_draft_commented_review_skips_ci_check(self, tmp_path: Path) -> None:
-        """COMMENTED review state (not NONE) — falls through to idle, no CI poll."""
+    def test_non_draft_commented_review_polls_ci(self, tmp_path: Path) -> None:
+        """COMMENTED review has no decisive state — treated as NONE, CI polled."""
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._reviews(state="COMMENTED", is_draft=False)
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
         with (
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.pr_checks.assert_not_called()
-        gh.add_pr_reviewer.assert_not_called()
+        gh.pr_checks.assert_called_once()
 
     # --- idle / no work ---
 


### PR DESCRIPTION


After addressing changes-requested review feedback, fido never re-requests review because `handle_promote_merge` uses the last review of any state — a subsequent `COMMENTED` review masks the `CHANGES_REQUESTED` decision, causing fido to fall through to "no work." Task 1 ("Use latest decisive review state in handle_promote_merge") fixes the root cause by determining `latest_state` from the most recent `APPROVED` or `CHANGES_REQUESTED` review, ignoring `COMMENTED`/`DISMISSED`. Task 2 ("Gate CHANGES_REQUESTED re-request on CI passing") aligns the re-request path with the other review-request paths by waiting for CI to pass before nudging the reviewer.

Fixes #124.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Use latest decisive review state (APPROVED/CHANGES_REQUESTED) in handle_promote_merge <!-- type:spec -->
- [x] Gate CHANGES_REQUESTED re-request on CI passing <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->