### PR TITLE
Fix find_pr missing PRs with closing keyword in title

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -190,7 +190,7 @@ class GH:
             "pageInfo{hasNextPage endCursor}"
             "nodes{__typename"
             "...on CrossReferencedEvent{source{__typename"
-            " ...on PullRequest{number headRefName state body author{login}}}}"
+            " ...on PullRequest{number headRefName state title body author{login}}}}"
             "...on ConnectedEvent{subject{__typename"
             " ...on PullRequest{number headRefName state author{login}}}}"
             "...on DisconnectedEvent{subject{__typename"
@@ -228,7 +228,9 @@ class GH:
                         continue
                     if pr.get("author", {}).get("login") != user:
                         continue
-                    if not pattern.search(pr.get("body", "") or ""):
+                    body = pr.get("body", "") or ""
+                    title = pr.get("title", "") or ""
+                    if not (pattern.search(body) or pattern.search(title)):
                         continue
                     pr_cache.setdefault(pr["number"], pr)
                     keyword_prs.add(pr["number"])

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -849,12 +849,23 @@ class TestGHClass:
         )
         assert gh.find_pr("o/r", 5, "fido") is None
 
-    def test_find_pr_body_only_not_title(self) -> None:
-        """Issue reference in PR title alone does not count — body only."""
+    def test_find_pr_title_keyword_matches(self) -> None:
+        """Issue reference in PR title (not body) still matches."""
         gh, mock_s = self._gh()
         pr = self._gql_pr(7, "feat", "OPEN", "fido", "")
         node = self._cross_ref_node(pr)
-        node["source"]["title"] = "closes #5"  # reference only in title
+        node["source"]["title"] = "closes #5"
+        mock_s.post.return_value.json.return_value = self._gql_timeline([node])
+        result = gh.find_pr("o/r", 5, "fido")
+        assert result is not None
+        assert result["number"] == 7
+
+    def test_find_pr_no_keyword_in_body_or_title(self) -> None:
+        """No closing keyword in body or title — not matched."""
+        gh, mock_s = self._gh()
+        pr = self._gql_pr(7, "feat", "OPEN", "fido", "some other text")
+        node = self._cross_ref_node(pr)
+        node["source"]["title"] = "unrelated title"
         mock_s.post.return_value.json.return_value = self._gql_timeline([node])
         assert gh.find_pr("o/r", 5, "fido") is None
 


### PR DESCRIPTION
## Summary
- `find_pr` only checked PR body for closing keywords (`closes #N`), but GitHub generates `CrossReferencedEvent` for keywords in the title too
- This caused fido to create duplicate PRs for the same issue (#218 + #219 for issue #122)
- Now checks both body and title; added `title` to the GraphQL PullRequest fragment

Closes #222

## Test plan
- [x] 1241 tests pass, 100% coverage
- [x] New test: title-only keyword matches
- [x] New test: no keyword in body or title → no match
- [x] Existing test updated: title-only no longer returns None