### PR TITLE
Task titles from review comments are literal quotes — should be action items (closes #134)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -110,7 +110,7 @@ def dispatch(
             is_bot=is_bot,
             context={
                 "pr_title": pr.get("title", ""),
-                "pr_body": (pr.get("body", "") or "")[:500],
+                "pr_body": pr.get("body", "") or "",
                 "file": comment.get("path", ""),
                 "line": comment.get("line"),
                 "diff_hunk": comment.get("diff_hunk", ""),
@@ -143,7 +143,7 @@ def dispatch(
             is_bot=is_bot,
             context={
                 "pr_title": issue.get("title", ""),
-                "pr_body": (issue.get("body", "") or "")[:500],
+                "pr_body": issue.get("body", "") or "",
                 "comment_id": comment_id,
             },
             thread={

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -450,6 +450,19 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
     return answer.startswith("YES")
 
 
+def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
+    """Ask Opus to convert a comment into a short imperative action-item title."""
+    if _print_prompt is None:
+        _print_prompt = claude.print_prompt
+    prompt = (
+        "Convert this PR review comment into a short, imperative task title starting with a verb. "
+        "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
+        f"Comment: {comment_body}"
+    )
+    result = _print_prompt(prompt, "claude-opus-4-6", timeout=15).strip()
+    return result or comment_body[:80]
+
+
 def _triage(
     comment_body: str,
     is_bot: bool,
@@ -457,7 +470,7 @@ def _triage(
     *,
     _print_prompt=None,
 ) -> tuple[str, str]:
-    """Ask Haiku to triage a comment. Returns (prefix, title)."""
+    """Ask Opus to triage a comment. Returns (prefix, title)."""
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = triage_prompt(comment_body, is_bot, context)
@@ -469,8 +482,10 @@ def _triage(
         title = title.strip()
         if prefix in ("ACT", "ASK", "ANSWER", "DO", "DEFER", "DUMP"):
             return prefix, title
-    # Fallback: ACT for humans, DO for bots
-    return ("DO" if is_bot else "ACT"), comment_body[:80]
+    # Fallback: ACT for humans, DO for bots; summarize comment into action item
+    category = "DO" if is_bot else "ACT"
+    title = _summarize_as_action_item(comment_body, _print_prompt=_print_prompt)
+    return category, title
 
 
 def reply_to_issue_comment(

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -458,8 +458,15 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
     return answer.startswith("YES")
 
 
+_MAX_TITLE_LEN = 80
+
+
 def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
-    """Ask Opus to convert a comment into a short imperative action-item title."""
+    """Ask Opus to convert a comment into a short imperative action-item title.
+
+    If the result is too long, asks Claude to shorten it up to 3 times before
+    falling back to hard truncation.
+    """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = (
@@ -468,7 +475,16 @@ def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
         f"Comment: {comment_body}"
     )
     result = _print_prompt(prompt, "claude-opus-4-6", timeout=15).strip()
-    return result or comment_body[:80]
+    for _ in range(3):
+        if not result or len(result) <= _MAX_TITLE_LEN:
+            break
+        result = _print_prompt(
+            f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
+            f"Reply with ONLY the shortened title.\n\nTitle: {result}",
+            "claude-opus-4-6",
+            timeout=15,
+        ).strip()
+    return result[:_MAX_TITLE_LEN] if result else comment_body[:_MAX_TITLE_LEN]
 
 
 def _triage(

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -279,8 +279,16 @@ def reply_to_comment(
     prompts = Prompts(persona)
     comment = action.comment_body
 
-    # Enrich context with sibling threads when the comment needs more context
     context: dict[str, Any] = dict(action.context) if action.context else {}
+
+    # Always fetch the full thread for this comment
+    if info.get("repo") and info.get("pr") and info.get("comment_id"):
+        thread = gh.fetch_comment_thread(info["repo"], info["pr"], info["comment_id"])
+        if thread:
+            context["comment_thread"] = thread
+            log.info("fetched %d comment(s) in thread for context", len(thread))
+
+    # Enrich context with sibling threads when the comment needs more context
     if (
         needs_more_context(comment, _print_prompt=_print_prompt)
         and info.get("repo")

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -140,6 +140,31 @@ class GH:
 
         return list(threads.values())
 
+    def fetch_comment_thread(
+        self, repo: str, pr: int | str, comment_id: int
+    ) -> list[dict[str, Any]]:
+        """Return all comments in the review thread containing comment_id.
+
+        Returns [{author, body}, ...] in posting order, empty on error.
+        """
+        try:
+            raw = self.get_pull_comments(repo, pr)
+        except Exception:
+            log.exception("failed to fetch comment thread for %s#%s", repo, pr)
+            return []
+
+        by_id = {c["id"]: c for c in raw}
+        comment = by_id.get(comment_id)
+        if comment is None:
+            return []
+        root_id = comment.get("in_reply_to_id") or comment_id
+
+        return [
+            {"author": c.get("user", {}).get("login", ""), "body": c.get("body", "")}
+            for c in raw
+            if c["id"] == root_id or c.get("in_reply_to_id") == root_id
+        ]
+
     def get_review_comments(
         self, repo: str, pr: int | str, review_id: int | str
     ) -> list[tuple[int, str]]:
@@ -610,6 +635,12 @@ class GitHub:
     def fetch_sibling_threads(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return all review-comment threads for a PR as a structured list."""
         return self._gh.fetch_sibling_threads(repo, pr)
+
+    def fetch_comment_thread(
+        self, repo: str, pr: int | str, comment_id: int
+    ) -> list[dict[str, Any]]:
+        """Return all comments in the review thread containing comment_id."""
+        return self._gh.fetch_comment_thread(repo, pr, comment_id)
 
     def find_pr(
         self, repo: str, issue_number: int | str, user: str

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -30,6 +30,8 @@ def triage_context_block(context: dict[str, Any] | None) -> str:
     parts: list[str] = []
     if ctx.get("pr_title"):
         parts.append(f"PR: {ctx['pr_title']}")
+    if ctx.get("pr_body"):
+        parts.append(f"PR description:\n{ctx['pr_body']}")
     if ctx.get("file"):
         parts.append(f"File: {ctx['file']}")
     if ctx.get("diff_hunk"):

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -64,7 +64,8 @@ def triage_prompt(
     return (
         f"Triage this PR comment into exactly one category: {categories}\n\n"
         f"{ctx_str}\n\nComment: {comment_body}\n\n"
-        "Reply with ONLY the category word (e.g. ACT or DEFER), then a colon, then a short task title. "
+        "Reply with ONLY the category word (e.g. ACT or DEFER), then a colon, then a short imperative task title. "
+        "The title must be an action item starting with a verb — never quote or paraphrase the comment text. "
         "Example: ACT: add unit tests for parser"
     )
 

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -36,6 +36,12 @@ def triage_context_block(context: dict[str, Any] | None) -> str:
         parts.append(f"File: {ctx['file']}")
     if ctx.get("diff_hunk"):
         parts.append(f"Diff:\n{ctx['diff_hunk']}")
+    if ctx.get("comment_thread"):
+        lines = [
+            f"  {c.get('author', '')}: {c.get('body', '')}"
+            for c in ctx["comment_thread"]
+        ]
+        parts.append("Comment thread:\n" + "\n".join(lines))
     if ctx.get("sibling_threads"):
         thread_parts: list[str] = []
         for thread in ctx["sibling_threads"]:
@@ -48,6 +54,8 @@ def triage_context_block(context: dict[str, Any] | None) -> str:
             ]
             thread_parts.append(header + "\n" + "\n".join(comment_lines))
         parts.append("Sibling threads:\n" + "\n\n".join(thread_parts))
+    if ctx.get("conversation"):
+        parts.append(ctx["conversation"])
     return "\n".join(parts)
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,6 +8,7 @@ from kennel.events import (
     Action,
     _comment_lock,
     _is_allowed,
+    _summarize_as_action_item,
     _triage,
     create_task,
     dispatch,
@@ -304,6 +305,37 @@ class TestCommentLock:
         assert path.parent.is_dir()
 
 
+class TestSummarizeAsActionItem:
+    def test_returns_model_result(self) -> None:
+        pp = MagicMock(return_value="add logging to streamed sub-Claude output")
+        result = _summarize_as_action_item(
+            "Ensure we log at that level too.", _print_prompt=pp
+        )
+        assert result == "add logging to streamed sub-Claude output"
+
+    def test_falls_back_to_comment_body_when_empty(self) -> None:
+        pp = MagicMock(return_value="")
+        result = _summarize_as_action_item("short comment", _print_prompt=pp)
+        assert result == "short comment"
+
+    def test_truncates_long_comment_in_fallback(self) -> None:
+        long_comment = "x" * 200
+        pp = MagicMock(return_value="")
+        result = _summarize_as_action_item(long_comment, _print_prompt=pp)
+        assert result == long_comment[:80]
+
+    def test_strips_whitespace_from_result(self) -> None:
+        pp = MagicMock(return_value="  add tests  ")
+        result = _summarize_as_action_item("add tests please", _print_prompt=pp)
+        assert result == "add tests"
+
+    def test_defaults_to_claude_print_prompt(self) -> None:
+        with patch("kennel.claude.print_prompt", return_value="add tests") as mock_pp:
+            result = _summarize_as_action_item("add some tests")
+        mock_pp.assert_called_once()
+        assert result == "add tests"
+
+
 class TestTriage:
     def test_returns_parsed_category(self, tmp_path: Path) -> None:
         cat, title = _triage(
@@ -315,16 +347,16 @@ class TestTriage:
         assert title == "add tests"
 
     def test_fallback_on_bad_response(self, tmp_path: Path) -> None:
-        cat, title = _triage(
-            "do stuff", is_bot=False, _print_prompt=MagicMock(return_value="")
-        )
+        pp = MagicMock(side_effect=["", "implement the thing"])
+        cat, title = _triage("do stuff", is_bot=False, _print_prompt=pp)
         assert cat == "ACT"
+        assert title == "implement the thing"
 
     def test_fallback_for_bot(self, tmp_path: Path) -> None:
-        cat, title = _triage(
-            "do stuff", is_bot=True, _print_prompt=MagicMock(return_value="")
-        )
+        pp = MagicMock(side_effect=["", "implement the thing"])
+        cat, title = _triage("do stuff", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
+        assert title == "implement the thing"
 
     def test_with_context(self, tmp_path: Path) -> None:
         ctx = {"pr_title": "My PR", "file": "foo.py", "diff_hunk": "@@ -1 +1 @@"}
@@ -337,25 +369,22 @@ class TestTriage:
         assert cat == "DEFER"
 
     def test_unrecognized_category_falls_back(self, tmp_path: Path) -> None:
-        cat, title = _triage(
-            "hi", is_bot=False, _print_prompt=MagicMock(return_value="WEIRD: something")
-        )
+        pp = MagicMock(side_effect=["WEIRD: something", "do the thing"])
+        cat, title = _triage("hi", is_bot=False, _print_prompt=pp)
         assert cat == "ACT"
+        assert title == "do the thing"
 
     def test_timeout_falls_back(self, tmp_path: Path) -> None:
-        cat, title = _triage(
-            "hi", is_bot=True, _print_prompt=MagicMock(return_value="")
-        )
+        pp = MagicMock(side_effect=["", "do the thing"])
+        cat, title = _triage("hi", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
 
     def test_task_category_falls_back(self, tmp_path: Path) -> None:
         """TASK is no longer a valid bot category — falls back to DO."""
-        cat, title = _triage(
-            "cache results",
-            is_bot=True,
-            _print_prompt=MagicMock(return_value="TASK: add caching"),
-        )
+        pp = MagicMock(side_effect=["TASK: add caching", "add result caching"])
+        cat, title = _triage("cache results", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
+        assert title == "add result caching"
 
     def test_bot_categories_in_prompt(self, tmp_path: Path) -> None:
         """Ensure bot-specific categories (DO/DEFER/DUMP) are used when is_bot=True."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -335,6 +335,35 @@ class TestSummarizeAsActionItem:
         mock_pp.assert_called_once()
         assert result == "add tests"
 
+    def test_short_result_returned_without_retry(self) -> None:
+        short_title = "add unit tests"
+        pp = MagicMock(return_value=short_title)
+        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        assert result == short_title
+        pp.assert_called_once()  # no retry needed
+
+    def test_retries_when_result_too_long(self) -> None:
+        long_title = "a" * 81
+        short_title = "add tests"
+        pp = MagicMock(side_effect=[long_title, short_title])
+        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        assert result == short_title
+        assert pp.call_count == 2
+
+    def test_retries_up_to_three_times_then_truncates(self) -> None:
+        long_title = "a" * 81
+        pp = MagicMock(return_value=long_title)
+        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        assert result == long_title[:80]
+        assert pp.call_count == 4  # 1 initial + 3 retries
+
+    def test_stops_retrying_once_short_enough(self) -> None:
+        titles = ["a" * 81, "b" * 81, "short title"]
+        pp = MagicMock(side_effect=titles)
+        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        assert result == "short title"
+        assert pp.call_count == 3  # 1 initial + 2 retries
+
 
 class TestTriage:
     def test_returns_parsed_category(self, tmp_path: Path) -> None:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -193,6 +193,22 @@ class TestGitHubClass:
         result = gh.fetch_sibling_threads("o/r", 7)
         assert result == []
 
+    def test_fetch_comment_thread_delegates(self) -> None:
+        gh, mock_s = self._github()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {
+                "id": 10,
+                "in_reply_to_id": None,
+                "user": {"login": "alice"},
+                "body": "root",
+            }
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.fetch_comment_thread("o/r", 7, 10)
+        assert result == [{"author": "alice", "body": "root"}]
+
     def test_find_pr_delegates(self) -> None:
         gh, mock_s = self._github()
         pr = {
@@ -666,6 +682,89 @@ class TestGHClass:
         mock_resp.raise_for_status.side_effect = Exception("403")
         mock_s.get.return_value = mock_resp
         result = gh.fetch_sibling_threads("o/r", 7)
+        assert result == []
+
+    def test_fetch_comment_thread_returns_thread(self) -> None:
+        gh, mock_s = self._gh()
+        comments = [
+            {
+                "id": 10,
+                "in_reply_to_id": None,
+                "user": {"login": "alice"},
+                "body": "root comment",
+            },
+            {
+                "id": 11,
+                "in_reply_to_id": 10,
+                "user": {"login": "fido"},
+                "body": "reply one",
+            },
+            {
+                "id": 12,
+                "in_reply_to_id": 10,
+                "user": {"login": "alice"},
+                "body": "reply two",
+            },
+            {
+                "id": 20,
+                "in_reply_to_id": None,
+                "user": {"login": "bob"},
+                "body": "other thread",
+            },
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = comments
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.fetch_comment_thread("o/r", 7, 10)
+        assert result == [
+            {"author": "alice", "body": "root comment"},
+            {"author": "fido", "body": "reply one"},
+            {"author": "alice", "body": "reply two"},
+        ]
+
+    def test_fetch_comment_thread_finds_thread_by_reply_id(self) -> None:
+        """When comment_id is a reply, finds the root and returns the full thread."""
+        gh, mock_s = self._gh()
+        comments = [
+            {
+                "id": 10,
+                "in_reply_to_id": None,
+                "user": {"login": "alice"},
+                "body": "root",
+            },
+            {
+                "id": 11,
+                "in_reply_to_id": 10,
+                "user": {"login": "fido"},
+                "body": "reply",
+            },
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = comments
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.fetch_comment_thread("o/r", 7, 11)
+        assert result == [
+            {"author": "alice", "body": "root"},
+            {"author": "fido", "body": "reply"},
+        ]
+
+    def test_fetch_comment_thread_returns_empty_when_not_found(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.fetch_comment_thread("o/r", 7, 999)
+        assert result == []
+
+    def test_fetch_comment_thread_returns_empty_on_error(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("403")
+        mock_s.get.return_value = mock_resp
+        result = gh.fetch_comment_thread("o/r", 7, 10)
         assert result == []
 
     def test_get_run_log_skips_non_failing_jobs(self) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -56,15 +56,27 @@ class TestTriageContextBlock:
         assert "Diff:" in result
         assert "@@ -1,2 +1,3 @@" in result
 
+    def test_pr_body(self) -> None:
+        result = triage_context_block({"pr_body": "Adds caching to the parser."})
+        assert "PR description:" in result
+        assert "Adds caching to the parser." in result
+
+    def test_empty_pr_body_omitted(self) -> None:
+        result = triage_context_block({"pr_body": ""})
+        assert "PR description:" not in result
+
     def test_all_fields(self) -> None:
         result = triage_context_block(
             {
                 "pr_title": "Refactor",
+                "pr_body": "Refactors the parser.",
                 "file": "app.py",
                 "diff_hunk": "- old\n+ new",
             }
         )
         assert "PR: Refactor" in result
+        assert "PR description:" in result
+        assert "Refactors the parser." in result
         assert "File: app.py" in result
         assert "Diff:" in result
         assert "- old\n+ new" in result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -147,6 +147,30 @@ class TestTriageContextBlock:
         result = triage_context_block({"sibling_threads": []})
         assert "Sibling threads:" not in result
 
+    def test_comment_thread_rendered(self) -> None:
+        result = triage_context_block(
+            {
+                "comment_thread": [
+                    {"author": "alice", "body": "fix this please"},
+                    {"author": "fido", "body": "done in latest commit"},
+                ]
+            }
+        )
+        assert "Comment thread:" in result
+        assert "alice: fix this please" in result
+        assert "fido: done in latest commit" in result
+
+    def test_empty_comment_thread_omitted(self) -> None:
+        result = triage_context_block({"comment_thread": []})
+        assert "Comment thread:" not in result
+
+    def test_conversation_rendered(self) -> None:
+        result = triage_context_block(
+            {"conversation": "\n\nFull conversation:\nalice: hi"}
+        )
+        assert "Full conversation:" in result
+        assert "alice: hi" in result
+
 
 # ── triage_prompt ─────────────────────────────────────────────────────────────
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -162,6 +162,12 @@ class TestTriagePrompt:
         result = triage_prompt("x", is_bot=False)
         assert "Example:" in result
 
+    def test_requires_imperative_action_item_title(self) -> None:
+        result = triage_prompt("x", is_bot=False)
+        assert "imperative" in result
+        assert "verb" in result
+        assert "never quote" in result.lower()
+
     def test_no_context(self) -> None:
         # Prompt with empty context still works — just has an empty ctx_str
         result = triage_prompt("hello", is_bot=False, context=None)


### PR DESCRIPTION
Task titles created from review comments were literal copies of the comment text (e.g. "Ensure we are running at that logging level too.") instead of actionable items. This PR updates the triage prompt to explicitly request imperative, verb-first action-item titles and fixes the `_triage` fallback path to summarize the comment into an action item via a second LLM call instead of using the raw `comment_body[:80]`.

Fixes #134.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Enrich triage prompt with planning session context and full plan text <!-- type:thread -->
- [x] [Include full comment chain context (file-level, line-level, and PR-level) in triage prompt](https://github.com/rhencke/kennel/pull/227#issuecomment-4219582215) <!-- type:thread -->
- [x] [Loop up to 3 times asking Claude to shorten the action-item title before truncating](https://github.com/rhencke/kennel/pull/227#discussion_r3061709240) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->