### PR TITLE
move sync_tasks call into tasks module (closes #136)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -629,8 +629,8 @@ def _maybe_abort_for_new_task(
     pending for later (ABORT_KEEP).  Equal or lower priority does not
     preempt.
     """
+    from kennel.state import load_state
     from kennel.tasks import list_tasks
-    from kennel.worker import load_state
 
     fido_dir = repo_cfg.work_dir / ".git" / "fido"
     if not (fido_dir / "state.json").exists():

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -690,7 +690,7 @@ def create_task(
 
 def launch_sync(config: Config, repo_cfg: RepoConfig, *, _gh=None) -> None:
     """Sync tasks.json → PR body in a background thread."""
-    from kennel.worker import sync_tasks_background
+    from kennel.tasks import sync_tasks_background
 
     gh = _gh if _gh is not None else get_github()
     sync_tasks_background(repo_cfg.work_dir, gh)

--- a/kennel/main.py
+++ b/kennel/main.py
@@ -25,7 +25,7 @@ def main(argv: list[str] | None = None) -> None:
         from pathlib import Path
 
         from kennel.github import GitHub
-        from kennel.worker import sync_tasks
+        from kennel.tasks import sync_tasks
 
         work_dir = Path(args[1]) if len(args) > 1 else Path.cwd()
         sync_tasks(work_dir, GitHub())

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -1,0 +1,51 @@
+"""State file and git-dir utilities shared between worker and tasks."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import subprocess
+from pathlib import Path
+from typing import IO, Any
+
+
+def _state_lock(fido_dir: Path, exclusive: bool = False) -> IO[str]:
+    """Open and flock state.lock in fido_dir. Caller must close the returned fd."""
+    lock_path = fido_dir / "state.lock"
+    lock_path.touch(exist_ok=True)
+    lock_fd = open(lock_path)  # noqa: SIM115
+    fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    return lock_fd
+
+
+def load_state(fido_dir: Path) -> dict[str, Any]:
+    """Load state.json from fido_dir, returning an empty dict if absent."""
+    with _state_lock(fido_dir):
+        state_path = fido_dir / "state.json"
+        if not state_path.exists():
+            return {}
+        return json.loads(state_path.read_text())
+
+
+def save_state(fido_dir: Path, state: dict[str, Any]) -> None:
+    """Write state to state.json in fido_dir."""
+    with _state_lock(fido_dir, exclusive=True):
+        (fido_dir / "state.json").write_text(json.dumps(state))
+
+
+def clear_state(fido_dir: Path) -> None:
+    """Remove state.json from fido_dir (no-op if absent)."""
+    with _state_lock(fido_dir, exclusive=True):
+        (fido_dir / "state.json").unlink(missing_ok=True)
+
+
+def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
+    """Return the absolute .git directory for *work_dir*."""
+    result = _run(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -6,10 +6,14 @@ import fcntl
 import json
 import logging
 import random
+import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any
 
+from kennel.github import GitHub
+from kennel.state import _resolve_git_dir, load_state
 from kennel.types import TaskStatus, TaskType
 
 log = logging.getLogger(__name__)
@@ -173,3 +177,214 @@ def remove_task(work_dir: Path, task_id: str) -> bool:
             lock.write(new_tasks)
             return True
     return False
+
+
+def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
+    """Format a task list into work-queue markdown.
+
+    Priority order: CI failures → comment-originated → others.
+    Completed tasks appear in a collapsible ``<details>`` section.
+    Each line includes a ``<!-- type:X -->`` HTML comment for round-tripping.
+    """
+    ci_pending: list[tuple[str, str]] = []
+    comment_pending: list[tuple[str, str]] = []
+    other_pending: list[tuple[str, str]] = []
+    completed: list[tuple[str, str]] = []
+
+    def _fmt(t: dict[str, Any]) -> str:
+        title = t.get("title", "")
+        url = (t.get("thread") or {}).get("url", "")
+        return f"[{title}]({url})" if url else title
+
+    for t in task_list:
+        status = t.get("status", TaskStatus.PENDING)
+        task_type = t.get("type", TaskType.SPEC)
+        display = _fmt(t)
+        if status == TaskStatus.COMPLETED:
+            completed.append((display, task_type))
+        elif status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS):
+            title = t.get("title", "")
+            if title.startswith("CI failure:"):
+                ci_pending.append((display, task_type))
+            elif t.get("thread"):
+                comment_pending.append((display, task_type))
+            else:
+                other_pending.append((display, task_type))
+
+    pending = ci_pending + comment_pending + other_pending
+    lines: list[str] = []
+    for i, (display, task_type) in enumerate(pending):
+        suffix = " **→ next**" if i == 0 else ""
+        lines.append(f"- [ ] {display}{suffix} <!-- type:{task_type} -->")
+
+    if completed:
+        lines.append("")
+        lines.append(f"<details><summary>Completed ({len(completed)})</summary>")
+        lines.append("")
+        for display, task_type in completed:
+            lines.append(f"- [x] {display} <!-- type:{task_type} -->")
+        lines.append("</details>")
+
+    return "\n".join(lines)
+
+
+def _apply_queue_to_body(body: str, queue: str) -> str:
+    """Replace the WORK_QUEUE_START/END section in a PR body with *queue*.
+
+    Returns *body* unchanged if the markers are absent.
+    """
+    start_marker = "<!-- WORK_QUEUE_START -->"
+    end_marker = "<!-- WORK_QUEUE_END -->"
+    start = body.find(start_marker)
+    end = body.find(end_marker)
+    if start == -1 or end == -1:
+        return body
+    start += len(start_marker)
+    return body[:start] + "\n" + queue + "\n" + body[end:]
+
+
+def _auto_complete_ask_tasks(
+    work_dir: Path,
+    gh: GitHub,
+    repo: str,
+    pr_number: int | str,
+    *,
+    _list_tasks=list_tasks,
+    _complete_by_id=complete_by_id,
+) -> None:
+    """Mark pending ASK tasks complete when their review thread is resolved."""
+    task_list = _list_tasks(work_dir)
+    ask_tasks = [
+        t
+        for t in task_list
+        if t.get("status") == TaskStatus.PENDING
+        and t.get("title", "").upper().startswith("ASK:")
+        and t.get("thread")
+    ]
+    if not ask_tasks:
+        return
+
+    try:
+        owner, repo_name = repo.split("/", 1)
+        threads_data = gh.get_review_threads(owner, repo_name, pr_number)
+    except Exception:
+        log.exception("sync_tasks: failed to fetch review threads for ASK resolution")
+        return
+
+    resolved_ids: set[int] = set()
+    for node in (
+        threads_data.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    ):
+        if node.get("isResolved"):
+            comments = node.get("comments", {}).get("nodes", [])
+            if comments and comments[0].get("databaseId"):
+                resolved_ids.add(int(comments[0]["databaseId"]))
+
+    for task in ask_tasks:
+        comment_id = (task.get("thread") or {}).get("comment_id")
+        if comment_id and int(comment_id) in resolved_ids:
+            log.info(
+                "sync_tasks: ASK task thread resolved — completing: %s", task["title"]
+            )
+            _complete_by_id(work_dir, task["id"])
+
+
+def sync_tasks(
+    work_dir: Path,
+    gh: GitHub,
+    *,
+    _resolve_git_dir_fn=_resolve_git_dir,
+    _list_tasks=list_tasks,
+    _auto_complete_ask_tasks_fn=_auto_complete_ask_tasks,
+) -> None:
+    """Sync tasks.json → PR body work queue.
+
+    Python replacement for sync-tasks.sh.  Protected by a flock so concurrent
+    calls silently skip rather than race.  Re-runs if tasks.json changes while
+    the body is being updated.
+    """
+    try:
+        git_dir = _resolve_git_dir_fn(work_dir)
+    except subprocess.CalledProcessError:
+        log.warning("sync_tasks: could not resolve git dir for %s", work_dir)
+        return
+
+    fido_dir = git_dir / "fido"
+    fido_dir.mkdir(parents=True, exist_ok=True)
+    sync_lock_path = fido_dir / "sync.lock"
+    sync_lock_fd = open(sync_lock_path, "w")  # noqa: SIM115
+    try:
+        fcntl.flock(sync_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        log.info("sync_tasks: another sync running — skipping")
+        sync_lock_fd.close()
+        return
+
+    try:
+        state = load_state(fido_dir)
+        issue = state.get("issue")
+        if issue is None:
+            log.info("sync_tasks: no current issue — nothing to sync")
+            return
+
+        try:
+            repo = gh.get_repo_info(cwd=work_dir)
+            user = gh.get_user()
+        except Exception:
+            log.exception("sync_tasks: failed to get repo info or user")
+            return
+
+        pr_data = gh.find_pr(repo, issue, user)
+        if pr_data is None or pr_data.get("state") != "OPEN":
+            log.info("sync_tasks: no open PR for issue #%s — nothing to sync", issue)
+            return
+
+        pr_number = pr_data["number"]
+        _auto_complete_ask_tasks_fn(work_dir, gh, repo, pr_number)
+
+        task_list = _list_tasks(work_dir)
+        if not task_list:
+            log.info("sync_tasks: no tasks — nothing to sync")
+            return
+
+        queue = _format_work_queue(task_list)
+        log.info("sync_tasks: syncing task list → PR #%s", pr_number)
+
+        try:
+            body = gh.get_pr_body(repo, pr_number)
+        except Exception:
+            log.exception("sync_tasks: failed to get PR body")
+            return
+
+        if "WORK_QUEUE_START" not in body:
+            log.info(
+                "sync_tasks: PR #%s has no work queue markers — skipping",
+                pr_number,
+            )
+            return
+
+        new_body = _apply_queue_to_body(body, queue)
+        try:
+            gh.edit_pr_body(repo, pr_number, new_body)
+            log.info("sync_tasks: PR #%s work queue synced", pr_number)
+        except Exception:
+            log.exception("sync_tasks: failed to update PR body")
+    finally:
+        sync_lock_fd.close()
+
+
+def sync_tasks_background(
+    work_dir: Path, gh: GitHub, *, _start=threading.Thread.start
+) -> None:
+    """Launch :func:`sync_tasks` in a daemon background thread."""
+    t = threading.Thread(
+        target=sync_tasks,
+        args=(work_dir, gh),
+        name=f"sync-{work_dir.name}",
+        daemon=True,
+    )
+    _start(t)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -16,6 +16,12 @@ from typing import IO, Any, Protocol
 from kennel import claude, hooks, tasks
 from kennel.github import GitHub
 from kennel.prompts import Prompts
+from kennel.state import (
+    _resolve_git_dir,
+    clear_state,
+    load_state,
+    save_state,
+)
 from kennel.types import TaskStatus, TaskType
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
@@ -135,36 +141,6 @@ def create_compact_script(fido_dir: Path) -> Path:
     return script_path
 
 
-def _state_lock(fido_dir: Path, exclusive: bool = False) -> IO[str]:
-    """Open and flock state.lock in fido_dir. Caller must close the returned fd."""
-    lock_path = fido_dir / "state.lock"
-    lock_path.touch(exist_ok=True)
-    lock_fd = open(lock_path)  # noqa: SIM115
-    fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
-    return lock_fd
-
-
-def load_state(fido_dir: Path) -> dict[str, Any]:
-    """Load state.json from fido_dir, returning an empty dict if absent."""
-    with _state_lock(fido_dir):
-        state_path = fido_dir / "state.json"
-        if not state_path.exists():
-            return {}
-        return json.loads(state_path.read_text())
-
-
-def save_state(fido_dir: Path, state: dict[str, Any]) -> None:
-    """Write state to state.json in fido_dir."""
-    with _state_lock(fido_dir, exclusive=True):
-        (fido_dir / "state.json").write_text(json.dumps(state))
-
-
-def clear_state(fido_dir: Path) -> None:
-    """Remove state.json from fido_dir (no-op if absent)."""
-    with _state_lock(fido_dir, exclusive=True):
-        (fido_dir / "state.json").unlink(missing_ok=True)
-
-
 def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Path]:
     """Write system and prompt files for a sub-Claude session.
 
@@ -200,18 +176,6 @@ def _sanitize_slug(raw: str, fallback: str) -> str:
         clean = re.sub(r"\(closes\s*#\d+\)", "", fallback, flags=re.IGNORECASE)
         slug = re.sub(r"[^a-z0-9]+", "-", clean.lower()).strip("-")[:40]
     return slug
-
-
-def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
-    """Return the absolute .git directory for *work_dir*."""
-    result = _run(
-        ["git", "rev-parse", "--absolute-git-dir"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return Path(result.stdout.strip())
 
 
 def _format_work_queue(task_list: list[dict[str, Any]]) -> str:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -178,217 +178,6 @@ def _sanitize_slug(raw: str, fallback: str) -> str:
     return slug
 
 
-def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
-    """Format a task list into work-queue markdown.
-
-    Priority order: CI failures → comment-originated → others.
-    Completed tasks appear in a collapsible ``<details>`` section.
-    Each line includes a ``<!-- type:X -->`` HTML comment for round-tripping.
-    """
-    ci_pending: list[tuple[str, str]] = []
-    comment_pending: list[tuple[str, str]] = []
-    other_pending: list[tuple[str, str]] = []
-    completed: list[tuple[str, str]] = []
-
-    def _fmt(t: dict[str, Any]) -> str:
-        title = t.get("title", "")
-        url = (t.get("thread") or {}).get("url", "")
-        return f"[{title}]({url})" if url else title
-
-    for t in task_list:
-        status = t.get("status", TaskStatus.PENDING)
-        task_type = t.get("type", TaskType.SPEC)
-        display = _fmt(t)
-        if status == TaskStatus.COMPLETED:
-            completed.append((display, task_type))
-        elif status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS):
-            title = t.get("title", "")
-            if title.startswith("CI failure:"):
-                ci_pending.append((display, task_type))
-            elif t.get("thread"):
-                comment_pending.append((display, task_type))
-            else:
-                other_pending.append((display, task_type))
-
-    pending = ci_pending + comment_pending + other_pending
-    lines: list[str] = []
-    for i, (display, task_type) in enumerate(pending):
-        suffix = " **→ next**" if i == 0 else ""
-        lines.append(f"- [ ] {display}{suffix} <!-- type:{task_type} -->")
-
-    if completed:
-        lines.append("")
-        lines.append(f"<details><summary>Completed ({len(completed)})</summary>")
-        lines.append("")
-        for display, task_type in completed:
-            lines.append(f"- [x] {display} <!-- type:{task_type} -->")
-        lines.append("</details>")
-
-    return "\n".join(lines)
-
-
-def _apply_queue_to_body(body: str, queue: str) -> str:
-    """Replace the WORK_QUEUE_START/END section in a PR body with *queue*.
-
-    Returns *body* unchanged if the markers are absent.
-    """
-    start_marker = "<!-- WORK_QUEUE_START -->"
-    end_marker = "<!-- WORK_QUEUE_END -->"
-    start = body.find(start_marker)
-    end = body.find(end_marker)
-    if start == -1 or end == -1:
-        return body
-    start += len(start_marker)
-    return body[:start] + "\n" + queue + "\n" + body[end:]
-
-
-def _auto_complete_ask_tasks(
-    work_dir: Path,
-    gh: GitHub,
-    repo: str,
-    pr_number: int | str,
-    *,
-    _list_tasks=tasks.list_tasks,
-    _complete_by_id=tasks.complete_by_id,
-) -> None:
-    """Mark pending ASK tasks complete when their review thread is resolved."""
-    task_list = _list_tasks(work_dir)
-    ask_tasks = [
-        t
-        for t in task_list
-        if t.get("status") == TaskStatus.PENDING
-        and t.get("title", "").upper().startswith("ASK:")
-        and t.get("thread")
-    ]
-    if not ask_tasks:
-        return
-
-    try:
-        owner, repo_name = repo.split("/", 1)
-        threads_data = gh.get_review_threads(owner, repo_name, pr_number)
-    except Exception:
-        log.exception("sync_tasks: failed to fetch review threads for ASK resolution")
-        return
-
-    resolved_ids: set[int] = set()
-    for node in (
-        threads_data.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    ):
-        if node.get("isResolved"):
-            comments = node.get("comments", {}).get("nodes", [])
-            if comments and comments[0].get("databaseId"):
-                resolved_ids.add(int(comments[0]["databaseId"]))
-
-    for task in ask_tasks:
-        comment_id = (task.get("thread") or {}).get("comment_id")
-        if comment_id and int(comment_id) in resolved_ids:
-            log.info(
-                "sync_tasks: ASK task thread resolved — completing: %s", task["title"]
-            )
-            _complete_by_id(work_dir, task["id"])
-
-
-def sync_tasks(
-    work_dir: Path,
-    gh: GitHub,
-    *,
-    _resolve_git_dir_fn=_resolve_git_dir,
-    _list_tasks=tasks.list_tasks,
-    _auto_complete_ask_tasks_fn=_auto_complete_ask_tasks,
-) -> None:
-    """Sync tasks.json → PR body work queue.
-
-    Python replacement for sync-tasks.sh.  Protected by a flock so concurrent
-    calls silently skip rather than race.  Re-runs if tasks.json changes while
-    the body is being updated.
-    """
-    try:
-        git_dir = _resolve_git_dir_fn(work_dir)
-    except subprocess.CalledProcessError:
-        log.warning("sync_tasks: could not resolve git dir for %s", work_dir)
-        return
-
-    fido_dir = git_dir / "fido"
-    fido_dir.mkdir(parents=True, exist_ok=True)
-    sync_lock_path = fido_dir / "sync.lock"
-    sync_lock_fd = open(sync_lock_path, "w")  # noqa: SIM115
-    try:
-        fcntl.flock(sync_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
-        log.info("sync_tasks: another sync running — skipping")
-        sync_lock_fd.close()
-        return
-
-    try:
-        state = load_state(fido_dir)
-        issue = state.get("issue")
-        if issue is None:
-            log.info("sync_tasks: no current issue — nothing to sync")
-            return
-
-        try:
-            repo = gh.get_repo_info(cwd=work_dir)
-            user = gh.get_user()
-        except Exception:
-            log.exception("sync_tasks: failed to get repo info or user")
-            return
-
-        pr_data = gh.find_pr(repo, issue, user)
-        if pr_data is None or pr_data.get("state") != "OPEN":
-            log.info("sync_tasks: no open PR for issue #%s — nothing to sync", issue)
-            return
-
-        pr_number = pr_data["number"]
-        _auto_complete_ask_tasks_fn(work_dir, gh, repo, pr_number)
-
-        task_list = _list_tasks(work_dir)
-        if not task_list:
-            log.info("sync_tasks: no tasks — nothing to sync")
-            return
-
-        queue = _format_work_queue(task_list)
-        log.info("sync_tasks: syncing task list → PR #%s", pr_number)
-
-        try:
-            body = gh.get_pr_body(repo, pr_number)
-        except Exception:
-            log.exception("sync_tasks: failed to get PR body")
-            return
-
-        if "WORK_QUEUE_START" not in body:
-            log.info(
-                "sync_tasks: PR #%s has no work queue markers — skipping",
-                pr_number,
-            )
-            return
-
-        new_body = _apply_queue_to_body(body, queue)
-        try:
-            gh.edit_pr_body(repo, pr_number, new_body)
-            log.info("sync_tasks: PR #%s work queue synced", pr_number)
-        except Exception:
-            log.exception("sync_tasks: failed to update PR body")
-    finally:
-        sync_lock_fd.close()
-
-
-def sync_tasks_background(
-    work_dir: Path, gh: GitHub, *, _start=threading.Thread.start
-) -> None:
-    """Launch :func:`sync_tasks` in a daemon background thread."""
-    t = threading.Thread(
-        target=sync_tasks,
-        args=(work_dir, gh),
-        name=f"sync-{work_dir.name}",
-        daemon=True,
-    )
-    _start(t)
-
-
 def claude_start(
     fido_dir: Path,
     model: str = "claude-opus-4-6",
@@ -1055,7 +844,7 @@ class Worker:
         log.info("CI fix done (session=%s)", session_id)
 
         # CI failures have no task entry — no complete call needed
-        sync_tasks(self.work_dir, self.gh)
+        tasks.sync_tasks(self.work_dir, self.gh)
         return True
 
     def _filter_threads(
@@ -1194,7 +983,7 @@ class Worker:
         build_prompt(fido_dir, "comments", context)
         session_id, _ = claude_run(fido_dir, cwd=self.work_dir)
         log.info("threads done (session=%s)", session_id)
-        sync_tasks_background(self.work_dir, self.gh)
+        tasks.sync_tasks_background(self.work_dir, self.gh)
         return True
 
     def ensure_pushed(self, remote: str, slug: str) -> bool | None:
@@ -1288,7 +1077,7 @@ class Worker:
         state.pop("current_task_id", None)
         save_state(fido_dir, state)
         self._abort_task.clear()
-        sync_tasks(self.work_dir, self.gh)
+        tasks.sync_tasks(self.work_dir, self.gh)
 
     def execute_task(
         self,
@@ -1385,7 +1174,7 @@ class Worker:
             state = load_state(fido_dir)
             state.pop("current_task_id", None)
             save_state(fido_dir, state)
-            sync_tasks(self.work_dir, self.gh)
+            tasks.sync_tasks(self.work_dir, self.gh)
         return True
 
     def seed_tasks_from_pr_body(self, repo: str, pr_number: int) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1744,13 +1744,13 @@ class TestLaunchSync:
     def test_calls_sync_tasks_background(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        with patch("kennel.worker.sync_tasks_background") as mock_sync:
+        with patch("kennel.tasks.sync_tasks_background") as mock_sync:
             launch_sync(cfg, self._repo_cfg(tmp_path), _gh=mock_gh)
         mock_sync.assert_called_once_with(tmp_path, mock_gh)
 
     def test_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
-        with patch("kennel.worker.sync_tasks_background"):
+        with patch("kennel.tasks.sync_tasks_background"):
             launch_sync(
                 cfg, self._repo_cfg(tmp_path), _gh=MagicMock()
             )  # should not raise

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,7 +62,7 @@ class TestMain:
     def test_sync_tasks_subcommand_dispatches(self, tmp_path) -> None:
         """'kennel sync-tasks <path>' should invoke sync_tasks."""
         with (
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
             patch("kennel.github.GitHub"),
         ):
             main(["sync-tasks", str(tmp_path)])
@@ -72,7 +72,7 @@ class TestMain:
     def test_sync_tasks_subcommand_defaults_to_cwd(self) -> None:
         """'kennel sync-tasks' without path uses cwd."""
         with (
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
             patch("kennel.github.GitHub"),
         ):
             main(["sync-tasks"])

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,6 +11,12 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from kennel.state import (
+    _resolve_git_dir,
+    clear_state,
+    load_state,
+    save_state,
+)
 from kennel.worker import (
     LockHeld,
     RepoContext,
@@ -23,7 +29,6 @@ from kennel.worker import (
     _auto_complete_ask_tasks,
     _format_work_queue,
     _pick_next_task,
-    _resolve_git_dir,
     _sanitize_slug,
     _sanitize_status_text,
     _thread_repo,
@@ -32,12 +37,9 @@ from kennel.worker import (
     ci_ready_for_review,
     claude_run,
     claude_start,
-    clear_state,
     create_compact_script,
     latest_decisive_review,
-    load_state,
     run,
-    save_state,
     should_rerequest_review,
     sync_tasks,
     sync_tasks_background,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17,6 +17,13 @@ from kennel.state import (
     load_state,
     save_state,
 )
+from kennel.tasks import (
+    _apply_queue_to_body,
+    _auto_complete_ask_tasks,
+    _format_work_queue,
+    sync_tasks,
+    sync_tasks_background,
+)
 from kennel.worker import (
     LockHeld,
     RepoContext,
@@ -25,9 +32,6 @@ from kennel.worker import (
     Worker,
     WorkerContext,
     WorkerThread,
-    _apply_queue_to_body,
-    _auto_complete_ask_tasks,
-    _format_work_queue,
     _pick_next_task,
     _sanitize_slug,
     _sanitize_status_text,
@@ -41,8 +45,6 @@ from kennel.worker import (
     latest_decisive_review,
     run,
     should_rerequest_review,
-    sync_tasks,
-    sync_tasks_background,
 )
 
 
@@ -3282,7 +3284,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is True
@@ -3300,7 +3302,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is True
@@ -3318,7 +3320,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 7, "branch")
         mock_status.assert_called_once_with("Fixing CI: unit-tests on PR #7")
@@ -3340,7 +3342,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         gh.get_run_log.assert_called_once_with("owner/repo", "55555")
@@ -3357,7 +3359,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         gh.get_run_log.assert_not_called()
@@ -3380,7 +3382,7 @@ class TestHandleCi:
             ),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         log_section = captured_context["ctx"].split("Failure log")[1]
@@ -3400,7 +3402,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 42, "branch")
         gh.get_review_threads.assert_called_once_with("owner", "repo", 42)
@@ -3418,7 +3420,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 5, "fix-branch")
         mock_bp.assert_called_once()
@@ -3441,7 +3443,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess-1", "")) as mock_cr,
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path)
@@ -3460,7 +3462,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         mock_complete.assert_not_called()
@@ -3478,7 +3480,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         mock_sync.assert_called_once_with(tmp_path, gh)
@@ -3498,7 +3500,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         # First failing check is "fail-check"
@@ -3519,7 +3521,7 @@ class TestHandleCi:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4072,7 +4074,7 @@ class TestHandleThreads:
         with (
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
-            patch("kennel.worker.sync_tasks_background"),
+            patch("kennel.tasks.sync_tasks_background"),
         ):
             result = worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is True
@@ -4092,7 +4094,7 @@ class TestHandleThreads:
         with (
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("sid", "")),
-            patch("kennel.worker.sync_tasks_background"),
+            patch("kennel.tasks.sync_tasks_background"),
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 5, "my-branch")
         mock_bp.assert_called_once()
@@ -4109,7 +4111,7 @@ class TestHandleThreads:
         with (
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess-1", "")) as mock_cr,
-            patch("kennel.worker.sync_tasks_background"),
+            patch("kennel.tasks.sync_tasks_background"),
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
         mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path)
@@ -4122,7 +4124,7 @@ class TestHandleThreads:
         with (
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.sync_tasks_background") as mock_sync,
+            patch("kennel.tasks.sync_tasks_background") as mock_sync,
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
         mock_sync.assert_called_once_with(tmp_path, gh)
@@ -4137,7 +4139,7 @@ class TestHandleThreads:
         with (
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.sync_tasks_background"),
+            patch("kennel.tasks.sync_tasks_background"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4728,7 +4730,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is True
@@ -4745,7 +4747,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "my-branch")
         mock_status.assert_called_once_with("Working on: Write the tests")
@@ -4762,7 +4764,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "fix-branch")
         _, skill, _ = mock_bp.call_args[0]
@@ -4780,7 +4782,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "my-slug")
         _, _, context = mock_bp.call_args[0]
@@ -4801,7 +4803,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         _, _, context = mock_bp.call_args[0]
@@ -4829,7 +4831,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
         _, _, context = mock_bp.call_args[0]
@@ -4849,7 +4851,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         _, _, context = mock_bp.call_args[0]
@@ -4868,7 +4870,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_run.assert_called_once_with(fido_dir, session_id="", cwd=tmp_path)
@@ -4885,7 +4887,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True) as mock_push,
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "my-slug")
         mock_push.assert_called_once_with("origin", "my-slug")
@@ -4902,7 +4904,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_complete.assert_called_once_with(tmp_path, task["id"])
@@ -4919,7 +4921,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_complete.assert_not_called()
@@ -4936,7 +4938,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
@@ -4953,7 +4955,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_sync.assert_not_called()
@@ -4970,7 +4972,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_complete.assert_called_once_with(tmp_path, task["id"])
@@ -4987,7 +4989,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
@@ -5004,7 +5006,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_sync.assert_called_once_with(tmp_path, gh)
@@ -5021,7 +5023,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_sync.assert_called_once_with(tmp_path, gh)
@@ -5040,7 +5042,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5060,7 +5062,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5090,7 +5092,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         # First call: fresh start. Second call: resume with session_id.
@@ -5121,7 +5123,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         # build_prompt called twice: initial + fresh restart
@@ -5157,7 +5159,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert mock_run.call_count == 4
@@ -5178,7 +5180,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_run.assert_called_once_with(
@@ -5200,7 +5202,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_run.assert_called_once_with(fido_dir, session_id="", cwd=tmp_path)
@@ -5218,7 +5220,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert load_state(fido_dir).get("setup_session_id") == "returned-sess"
@@ -5236,7 +5238,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert "setup_session_id" not in load_state(fido_dir)
@@ -5256,7 +5258,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         state = load_state(fido_dir)
@@ -5284,7 +5286,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert captured.get("current_task_id") == "task-99"
@@ -5302,7 +5304,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert "current_task_id" not in load_state(fido_dir)
@@ -5328,7 +5330,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "br")
         assert captured.get("issue") == 5
@@ -5348,7 +5350,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert load_state(fido_dir).get("current_task_id") == "task-push-fail"
@@ -5384,7 +5386,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
             patch("kennel.worker.tasks.remove_task") as mock_remove,
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
@@ -5418,7 +5420,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
             patch("kennel.worker.tasks.remove_task") as mock_remove,
-            patch("kennel.worker.sync_tasks") as mock_sync,
+            patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
@@ -5443,7 +5445,7 @@ class TestExecuteTask:
             patch.object(worker, "git_clean"),
             patch("kennel.worker.tasks.remove_task"),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_complete.assert_not_called()
@@ -5463,7 +5465,7 @@ class TestExecuteTask:
             ) as mock_squash,
             patch.object(worker, "ensure_pushed", return_value=True),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "feat-branch")
         mock_squash.assert_called_once_with("origin", "feat-branch", "main")
@@ -5492,7 +5494,7 @@ class TestExecuteTask:
                 side_effect=lambda *a: call_order.append("push") or True,
             ),
             patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert call_order == ["squash", "push"]
@@ -5510,7 +5512,7 @@ class TestExecuteTask:
             patch.object(worker, "_squash_wip_commit", return_value=True),
             patch.object(worker, "ensure_pushed", return_value=None),
             patch("kennel.worker.tasks.complete_by_id") as mock_complete,
-            patch("kennel.worker.sync_tasks"),
+            patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True


### PR DESCRIPTION
Move `_state_lock`, `load_state`, `save_state`, `clear_state`, and `_resolve_git_dir` out of `worker.py` into a new `kennel/state.py` module to break the circular import between `worker` and `tasks`. Then move `sync_tasks`, `sync_tasks_background`, and their helpers (`_format_work_queue`, `_apply_queue_to_body`, `_auto_complete_ask_tasks`) from `worker.py` into `tasks.py` where they naturally belong alongside the task CRUD operations. Update all call sites in `events.py` and `main.py`, and retarget ~60 test patches from `kennel.worker` to `kennel.tasks`/`kennel.state`.

Fixes #136.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Extract state utilities to kennel/state.py <!-- type:spec -->
- [x] Move sync_tasks and helpers from worker.py to tasks.py <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->