### PR TITLE
Dynamically reorder and rewrite tasks based on dependency analysis (closes #165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,8 @@ When a `thread`-type task is created (PR comment feedback), `create_task()` trig
 
 - Only fires for `thread` tasks — `spec` tasks created during initial setup are already ordered by the planner
 - Double-read pattern: task list is read before the Opus call (for the prompt), then re-read inside the write lock (to pick up concurrent additions). Tasks added while Opus is thinking are preserved as `newly_added` rather than dropped
-- In-progress tasks that Opus omits are reinstated at the front of the result list
-- Thread tasks that are dropped or modified trigger a `comment_issue` notification to the original commenter via `_notify_thread_change()`
+- Pending tasks Opus omits are marked completed (not removed); in-progress tasks that are omitted also trigger `_on_inprogress_affected` so the worker aborts and picks the new next task
+- Thread tasks that are completed by rescoping or modified trigger a `comment_issue` notification to the original commenter via `_notify_thread_change()`
 - Prompt builder: `rescope_prompt()` in `prompts.py`; response parser: `_parse_reorder_response()` in `tasks.py`
 
 ### Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ kennel task <work_dir> list                                # list all tasks as J
 
 ### Priority order
 
-`_pick_next_task` selects by type: `ci` first, `thread` second, `spec` last.
+`_pick_next_task` selects by type: `ci` first, then first in list wins (thread and spec tasks share equal priority).
 
 ### Dynamic task reordering (rescoping)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,16 @@ kennel task <work_dir> list                                # list all tasks as J
 
 `_pick_next_task` selects by type: `ci` first, `thread` second, `spec` last.
 
+### Dynamic task reordering (rescoping)
+
+When a `thread`-type task is created (PR comment feedback), `create_task()` triggers a background Opus call via `reorder_tasks()` to reorder and rewrite the pending task list based on dependency analysis.
+
+- Only fires for `thread` tasks — `spec` tasks created during initial setup are already ordered by the planner
+- Double-read pattern: task list is read before the Opus call (for the prompt), then re-read inside the write lock (to pick up concurrent additions). Tasks added while Opus is thinking are preserved as `newly_added` rather than dropped
+- In-progress tasks that Opus omits are reinstated at the front of the result list
+- Thread tasks that are dropped or modified trigger a `comment_issue` notification to the original commenter via `_notify_thread_change()`
+- Prompt builder: `rescope_prompt()` in `prompts.py`; response parser: `_parse_reorder_response()` in `tasks.py`
+
 ### Notes
 
 - `handle_review_feedback` has been removed from `Worker`; review feedback is now handled through the normal task system via events creating thread tasks

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -681,18 +681,112 @@ def _get_commit_summary(work_dir: Path) -> str:
         return ""
 
 
+def _notify_thread_change(
+    change: dict[str, Any],
+    config: Config,
+    *,
+    _print_prompt=None,
+    _gh=None,
+) -> None:
+    """Post a brief comment notifying a commenter that their task was rescoped.
+
+    Called for each thread task that was dropped or modified during dependency
+    analysis.  Uses Opus (in Fido's voice) to generate the message; falls back
+    to a plain factual note if Opus returns nothing.
+
+    Posts via the issue comments API so the notification appears regardless of
+    whether the original comment was an inline review comment or a top-level
+    PR comment.
+    """
+    if _print_prompt is None:
+        _print_prompt = claude.print_prompt
+    gh = _gh if _gh is not None else get_github()
+
+    task = change["task"]
+    thread = task.get("thread") or {}
+    comment_id = thread.get("comment_id")
+    repo = thread.get("repo", "")
+    pr = thread.get("pr")
+    url = thread.get("url", "")
+    if not (comment_id and repo and pr):
+        return
+
+    kind = change["kind"]
+    original_title = task.get("title", "")
+    prompts = Prompts(_load_persona(config))
+
+    if kind == "dropped":
+        instruction = (
+            f"The task you were planning from a PR comment has been removed from "
+            f"your work queue — a subsequent comment changed the requirements and "
+            f"this work is no longer needed.\n\n"
+            f"Original task: {original_title}\n"
+            f"Comment: {url}\n\n"
+            "Write a very brief PR comment letting the reviewer know their original "
+            "task has been dropped and is no longer needed. Reference the comment URL."
+        )
+        fallback = (
+            f"FYI — the task from your comment ('{original_title}') has been "
+            f"removed from my queue: a subsequent change made it unnecessary."
+        )
+    else:
+        new_title = change.get("new_title", "")
+        instruction = (
+            f"The task you were planning from a PR comment has been updated to "
+            f"reflect new requirements.\n\n"
+            f"Original task: {original_title}\n"
+            f"Updated task: {new_title}\n"
+            f"Comment: {url}\n\n"
+            "Write a very brief PR comment letting the reviewer know their original "
+            "task has been updated. Reference the comment URL."
+        )
+        fallback = (
+            f"FYI — the task from your comment has been updated to: '{new_title}' "
+            f"based on new requirements."
+        )
+
+    body = _print_prompt(
+        prompts.persona_wrap(instruction),
+        "claude-opus-4-6",
+        system_prompt=prompts.reply_system_prompt(),
+        timeout=15,
+    )
+    if not body:
+        body = fallback
+
+    try:
+        gh.comment_issue(repo, pr, body)
+        log.info("notified thread %s (%s)", comment_id, kind)
+    except Exception:
+        log.exception("failed to notify thread %s", comment_id)
+
+
 def _reorder_tasks_background(
     work_dir: Path,
     commit_summary: str,
+    config: Config,
     *,
     _start=threading.Thread.start,
+    _gh=None,
 ) -> None:
-    """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread."""
+    """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread.
+
+    Passes an ``_on_changes`` callback so that any thread tasks dropped or
+    modified during rescoping trigger a notification reply to the original
+    comment.
+    """
     from kennel.tasks import reorder_tasks
+
+    gh = _gh if _gh is not None else get_github()
+
+    def on_changes(changes: list[dict[str, Any]]) -> None:
+        for change in changes:
+            _notify_thread_change(change, config, _gh=gh)
 
     t = threading.Thread(
         target=reorder_tasks,
         args=(work_dir, commit_summary),
+        kwargs={"_on_changes": on_changes},
         name=f"reorder-{work_dir.name}",
         daemon=True,
     )
@@ -734,7 +828,7 @@ def create_task(
     launch_sync(config, repo_cfg)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
-        _reorder_background_fn(repo_cfg.work_dir, commit_summary)
+        _reorder_background_fn(repo_cfg.work_dir, commit_summary, config)
     if registry is not None:
         _maybe_abort_for_new_task(repo_cfg, new_task, registry)
     return new_task

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -740,21 +740,20 @@ def _notify_thread_change(
     prompts = Prompts(_load_persona(config))
     mention = f"@{author} " if author else ""
 
-    if kind == "dropped":
+    if kind == "completed":
         instruction = (
-            f"The task you were planning from a PR comment has been removed from "
-            f"your work queue — a subsequent comment changed the requirements and "
-            f"this work is no longer needed.\n\n"
+            f"A task originating from a PR comment has been marked done — it was "
+            f"covered by work already committed and is no longer in the active queue.\n\n"
             f"Original task: {original_title}\n"
             f"Comment author: {author or '(unknown)'}\n"
             f"Comment: {url}\n\n"
             "Write a very brief PR comment notifying the comment author (mention them "
-            "with @username if known) that their original task has been dropped and is "
-            "no longer needed. Reference the comment URL."
+            "with @username if known) that their task has been marked done because it "
+            "was covered by recent commits. Reference the comment URL."
         )
         fallback = (
             f"{mention}FYI — the task from your comment ('{original_title}') has been "
-            f"removed from my queue: a subsequent change made it unnecessary."
+            f"marked done: it was covered by recent commits."
         )
     else:
         new_title = change.get("new_title", "")

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -791,6 +791,8 @@ def _reorder_tasks_background(
     work_dir: Path,
     commit_summary: str,
     config: Config,
+    repo_cfg: RepoConfig | None = None,
+    registry: WorkerRegistry | None = None,
     *,
     _start=threading.Thread.start,
     _gh=None,
@@ -800,6 +802,11 @@ def _reorder_tasks_background(
     Passes an ``_on_changes`` callback so that any thread tasks dropped or
     modified during rescoping trigger a notification reply to the original
     comment.
+
+    If *repo_cfg* and *registry* are provided, also passes an
+    ``_on_inprogress_affected`` callback that aborts the running worker whenever
+    the in-progress task is dropped or modified by the rescope, so the worker
+    loop restarts on the new next task.
     """
     from kennel.tasks import reorder_tasks
 
@@ -809,10 +816,22 @@ def _reorder_tasks_background(
         for change in changes:
             _notify_thread_change(change, config, _gh=gh)
 
+    kwargs: dict[str, Any] = {"_on_changes": on_changes}
+    if registry is not None and repo_cfg is not None:
+
+        def on_inprogress_affected() -> None:
+            log.info(
+                "reorder_tasks_background: in-progress task affected — aborting %s",
+                repo_cfg.name,
+            )
+            registry.abort_task(repo_cfg.name)
+
+        kwargs["_on_inprogress_affected"] = on_inprogress_affected
+
     t = threading.Thread(
         target=reorder_tasks,
         args=(work_dir, commit_summary),
-        kwargs={"_on_changes": on_changes},
+        kwargs=kwargs,
         name=f"reorder-{work_dir.name}",
         daemon=True,
     )
@@ -854,7 +873,9 @@ def create_task(
     launch_sync(config, repo_cfg)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
-        _reorder_background_fn(repo_cfg.work_dir, commit_summary, config)
+        _reorder_background_fn(
+            repo_cfg.work_dir, commit_summary, config, repo_cfg, registry
+        )
     if registry is not None:
         _maybe_abort_for_new_task(repo_cfg, new_task, registry)
     return new_task

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -109,6 +109,7 @@ def dispatch(
                 "pr": number,
                 "comment_id": comment_id,
                 "url": comment.get("html_url", ""),
+                "author": user,
             },
             comment_body=comment_body,
             is_bot=is_bot,
@@ -155,6 +156,7 @@ def dispatch(
                 "pr": number,
                 "comment_id": comment_id,
                 "url": comment.get("html_url", ""),
+                "author": user,
             }
             if number and comment_id
             else None,
@@ -726,12 +728,14 @@ def _notify_thread_change(
     repo = thread.get("repo", "")
     pr = thread.get("pr")
     url = thread.get("url", "")
+    author = thread.get("author", "")
     if not (comment_id and repo and pr):
         return
 
     kind = change["kind"]
     original_title = task.get("title", "")
     prompts = Prompts(_load_persona(config))
+    mention = f"@{author} " if author else ""
 
     if kind == "dropped":
         instruction = (
@@ -739,12 +743,14 @@ def _notify_thread_change(
             f"your work queue — a subsequent comment changed the requirements and "
             f"this work is no longer needed.\n\n"
             f"Original task: {original_title}\n"
+            f"Comment author: {author or '(unknown)'}\n"
             f"Comment: {url}\n\n"
-            "Write a very brief PR comment letting the reviewer know their original "
-            "task has been dropped and is no longer needed. Reference the comment URL."
+            "Write a very brief PR comment notifying the comment author (mention them "
+            "with @username if known) that their original task has been dropped and is "
+            "no longer needed. Reference the comment URL."
         )
         fallback = (
-            f"FYI — the task from your comment ('{original_title}') has been "
+            f"{mention}FYI — the task from your comment ('{original_title}') has been "
             f"removed from my queue: a subsequent change made it unnecessary."
         )
     else:
@@ -754,13 +760,15 @@ def _notify_thread_change(
             f"reflect new requirements.\n\n"
             f"Original task: {original_title}\n"
             f"Updated task: {new_title}\n"
+            f"Comment author: {author or '(unknown)'}\n"
             f"Comment: {url}\n\n"
-            "Write a very brief PR comment letting the reviewer know their original "
-            "task has been updated. Reference the comment URL."
+            "Write a very brief PR comment notifying the comment author (mention them "
+            "with @username if known) that their original task has been updated. "
+            "Reference the comment URL."
         )
         fallback = (
-            f"FYI — the task from your comment has been updated to: '{new_title}' "
-            f"based on new requirements."
+            f"{mention}FYI — the task from your comment has been updated to: "
+            f"'{new_title}' based on new requirements."
         )
 
     body = _print_prompt(

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -850,9 +850,9 @@ def create_task(
 ) -> dict[str, Any]:
     """Write a task to the shared task file, then trigger sync.
 
-    PR comment tasks (those with a thread) carry a thread payload that causes
-    ``_pick_next_task`` to prioritise them as NEXT (second only to CI failures),
-    without inserting them out-of-order in the list.
+    PR comment tasks (those with a thread) are added to the task list at the
+    position determined by the rescoping reorder — they receive spec-level
+    priority (first in list wins among non-CI tasks).
 
     When *thread* is set (a PR comment task), also triggers a background
     dependency-analysis reorder via Opus so that remaining spec tasks are

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -262,18 +262,20 @@ def reply_to_comment(
     *,
     _print_prompt=None,
     _gh=None,
-) -> tuple[bool, str, str]:
+) -> tuple[bool, str, list[str]]:
     """Triage a comment via Opus, generate a reply via Opus, post it.
 
-    Returns (posted, triage_category, task_title).
+    Returns (posted, triage_category, task_titles).
     posted is True only when the reply was successfully sent to GitHub.
+    task_titles is a list: one entry for non-task categories (used as reply
+    context), or one or more entries for ACT/DO (each becomes a task).
     Uses a per-comment lockfile to prevent races with work.sh.
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     info = action.reply_to
     if not info or not action.comment_body:
-        return (False, "ACT", action.comment_body or action.prompt)
+        return (False, "ACT", [action.comment_body or action.prompt])
 
     # Per-comment lock — prevents kennel and work.sh from both replying
     cid = info.get("comment_id")
@@ -285,7 +287,7 @@ def reply_to_comment(
         except OSError:
             log.info("comment %s locked by another process — skipping", cid)
             lock_fd.close()
-            return (False, "ACT", action.comment_body[:80])
+            return (False, "ACT", [action.comment_body[:80]])
     else:
         lock_fd = None
 
@@ -317,19 +319,21 @@ def reply_to_comment(
             )
 
     # Step 1: Haiku triage
-    category, title = _triage(
+    category, titles = _triage(
         comment, action.is_bot, context, _print_prompt=_print_prompt
     )
-    log.info("triage: %s — %s", category, title)
+    log.info("triage: %s — %s", category, titles)
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply
     issue_url: str | None = None
     if category == "DEFER" and info.get("repo"):
         pr_url = f"https://github.com/{info['repo']}/pull/{info['pr']}"
-        issue_url = _open_defer_issue(gh, info["repo"], pr_url, title, comment)
+        issue_url = _open_defer_issue(gh, info["repo"], pr_url, titles[0], comment)
 
     # Step 3: Opus reply based on triage
-    instr = reply_instruction(category, comment, title, context, issue_url=issue_url)
+    instr = reply_instruction(
+        category, comment, ", ".join(titles), context, issue_url=issue_url
+    )
 
     log.info(
         "generating %s reply for PR #%s comment %s",
@@ -379,7 +383,7 @@ def reply_to_comment(
     if lock_fd:
         lock_fd.close()
 
-    return (posted, category, title)
+    return (posted, category, titles)
 
 
 def _try_resolve_thread(info: dict[str, Any], config: Config) -> None:
@@ -507,23 +511,37 @@ def _triage(
     context: dict[str, Any] | None = None,
     *,
     _print_prompt=None,
-) -> tuple[str, str]:
-    """Ask Opus to triage a comment. Returns (prefix, title)."""
+) -> tuple[str, list[str]]:
+    """Ask Opus to triage a comment. Returns (category, titles).
+
+    A comment may produce zero or many tasks: titles is a list with one entry
+    for ANSWER/ASK/DEFER/DUMP (used as reply context), or one or more entries
+    for ACT/DO (each becomes a separate work-queue task).
+    """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = triage_prompt(comment_body, is_bot, context)
     text = _print_prompt(prompt, "claude-opus-4-6", timeout=15)
-    line = text.splitlines()[0] if text else ""
-    if ":" in line:
+    category: str | None = None
+    titles: list[str] = []
+    for line in text.splitlines() if text else []:
+        if ":" not in line:
+            continue
         prefix, title = line.split(":", 1)
         prefix = prefix.strip().upper()
         title = title.strip()
-        if prefix in ("ACT", "ASK", "ANSWER", "DO", "DEFER", "DUMP"):
-            return prefix, title
+        if prefix not in ("ACT", "ASK", "ANSWER", "DO", "DEFER", "DUMP"):
+            continue
+        if category is None:
+            category = prefix
+        if prefix == category and title:
+            titles.append(title)
+    if category is not None and titles:
+        return category, titles
     # Fallback: ACT for humans, DO for bots; summarize comment into action item
     category = "DO" if is_bot else "ACT"
     title = _summarize_as_action_item(comment_body, _print_prompt=_print_prompt)
-    return category, title
+    return category, [title]
 
 
 def reply_to_issue_comment(
@@ -533,7 +551,7 @@ def reply_to_issue_comment(
     *,
     _print_prompt=None,
     _gh=None,
-) -> tuple[str, str]:
+) -> tuple[str, list[str]]:
     """Triage and reply to a top-level PR comment (issue_comment event)."""
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
@@ -569,19 +587,19 @@ def reply_to_issue_comment(
         context["conversation"] = conversation_context
 
     prompts = Prompts(_load_persona(config))
-    category, title = _triage(
+    category, titles = _triage(
         comment, action.is_bot, context or None, _print_prompt=_print_prompt
     )
-    log.info("issue comment triage: %s — %s", category, title)
+    log.info("issue comment triage: %s — %s", category, titles)
 
     # For DEFER, open a tracking issue before crafting the reply
     issue_url: str | None = None
     if category == "DEFER":
         pr_url = f"https://github.com/{repo_full}/pull/{number}" if number else ""
-        issue_url = _open_defer_issue(gh, repo_full, pr_url, title, comment)
+        issue_url = _open_defer_issue(gh, repo_full, pr_url, titles[0], comment)
 
     instr = issue_reply_instruction(
-        category, comment, title, action.context, issue_url=issue_url
+        category, comment, ", ".join(titles), action.context, issue_url=issue_url
     )
 
     log.info("generating %s reply for issue comment on PR #%s", category, number)
@@ -614,7 +632,7 @@ def reply_to_issue_comment(
             _gh=gh,
         )
 
-    return (category, title)
+    return (category, titles)
 
 
 _TYPE_PRIORITY = {TaskType.CI: 0, TaskType.THREAD: 1, TaskType.SPEC: 2}

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import fcntl
 import logging
 import re
+import subprocess
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -659,18 +661,64 @@ def _maybe_abort_for_new_task(
         registry.abort_task(repo_cfg.name)
 
 
+def _get_commit_summary(work_dir: Path) -> str:
+    """Return a short ``git log --oneline`` summary of recent commits.
+
+    Used to give Opus context about what has already been implemented when
+    it reorders the pending task list.  Returns an empty string on any error
+    (e.g. not a git repository, git not found, timeout).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "--oneline", "-20"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _reorder_tasks_background(
+    work_dir: Path,
+    commit_summary: str,
+    *,
+    _start=threading.Thread.start,
+) -> None:
+    """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread."""
+    from kennel.tasks import reorder_tasks
+
+    t = threading.Thread(
+        target=reorder_tasks,
+        args=(work_dir, commit_summary),
+        name=f"reorder-{work_dir.name}",
+        daemon=True,
+    )
+    _start(t)
+
+
 def create_task(
     prompt: str,
     config: Config,
     repo_cfg: RepoConfig,
     thread: dict[str, Any] | None = None,
     registry: WorkerRegistry | None = None,
+    *,
+    _get_commit_summary_fn=_get_commit_summary,
+    _reorder_background_fn=_reorder_tasks_background,
 ) -> dict[str, Any]:
     """Write a task to the shared task file, then trigger sync.
 
     PR comment tasks (those with a thread) carry a thread payload that causes
     ``_pick_next_task`` to prioritise them as NEXT (second only to CI failures),
     without inserting them out-of-order in the list.
+
+    When *thread* is set (a PR comment task), also triggers a background
+    dependency-analysis reorder via Opus so that remaining spec tasks are
+    resequenced to account for the new requirement.  Spec tasks created during
+    initial setup are not rescoped — the planner already ordered them.
 
     If *registry* is given, checks whether the new task has higher priority
     than the current in-progress task; if so, signals abort so the worker
@@ -684,6 +732,9 @@ def create_task(
         repo_cfg.work_dir, title=prompt, task_type=task_type, thread=thread
     )
     launch_sync(config, repo_cfg)
+    if thread:
+        commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
+        _reorder_background_fn(repo_cfg.work_dir, commit_summary)
     if registry is not None:
         _maybe_abort_for_new_task(repo_cfg, new_task, registry)
     return new_task

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 # ── Triage ────────────────────────────────────────────────────────────────────
@@ -199,6 +200,72 @@ def issue_reply_instruction(
             return f"Write a short polite decline.\n\n{context_str}"
         case _:
             return f"Write a short GitHub PR reply.\n\n{context_str}"
+
+
+# ── Rescoping ────────────────────────────────────────────────────────────────
+
+
+def rescope_prompt(
+    task_list: list[dict[str, Any]],
+    commit_summary: str,
+) -> str:
+    """Build an Opus prompt for dependency-aware task reordering.
+
+    Presents the full task list and a summary of commits already made, then
+    asks Opus to return a JSON array of the reordered pending tasks.
+
+    Rules enforced in the prompt:
+    - CI tasks (type "ci") must remain first.
+    - Completed tasks are excluded from the output.
+    - Task IDs must be preserved exactly.
+    - Tasks already covered by a commit should be removed.
+    - Thread-task requirements that conflict with a spec task should cause
+      the spec task title/description to be updated.
+
+    The caller is responsible for parsing the returned JSON and applying it.
+    """
+    pending = [t for t in task_list if t.get("status") != "completed"]
+    completed = [t for t in task_list if t.get("status") == "completed"]
+
+    def _fmt(t: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": t.get("id", ""),
+            "type": t.get("type", "spec"),
+            "status": t.get("status", "pending"),
+            "title": t.get("title", ""),
+            "description": t.get("description", ""),
+        }
+
+    pending_json = json.dumps([_fmt(t) for t in pending], indent=2)
+    completed_titles = [t.get("title", "") for t in completed]
+    completed_block = (
+        "\n".join(f"- {title}" for title in completed_titles)
+        if completed_titles
+        else "(none)"
+    )
+
+    return (
+        "You are reviewing the pending work queue for a pull request in progress.\n\n"
+        "Already completed tasks:\n"
+        f"{completed_block}\n\n"
+        "Recent commits (already implemented):\n"
+        f"{commit_summary or '(none)'}\n\n"
+        "Pending tasks (current order):\n"
+        f"{pending_json}\n\n"
+        "Reorder these tasks for the optimal implementation sequence based on "
+        "dependency analysis. Apply these rules:\n"
+        '1. Tasks with type "ci" must come first — do not move them.\n'
+        "2. Reorder remaining tasks so each task builds on what comes before it.\n"
+        "3. If a task is already covered by a recent commit, remove it.\n"
+        "4. If a thread task changes the requirements of an existing spec task, "
+        "rewrite that spec task's title and/or description to reflect the updated "
+        "requirements.\n"
+        "5. Preserve every task ID exactly — never change or drop IDs.\n"
+        "6. Include only pending and in_progress tasks in the output — omit completed.\n\n"
+        'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
+        'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
+        "No other text before or after the JSON."
+    )
 
 
 # ── Prompts DI class ──────────────────────────────────────────────────────────

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -221,7 +221,8 @@ def rescope_prompt(
     - CI tasks (type "ci") must remain first.
     - Completed tasks are excluded from the output.
     - Task IDs must be preserved exactly.
-    - Tasks already covered by a commit should be removed.
+    - Tasks already covered by a commit should be omitted — they will be marked
+      completed automatically by the caller.
     - Thread-task requirements that conflict with a spec task should cause
       the spec task title/description to be updated.
 
@@ -259,7 +260,7 @@ def rescope_prompt(
         "dependency analysis. Apply these rules:\n"
         '1. Tasks with type "ci" must come first — do not move them.\n'
         "2. Reorder remaining tasks so each task builds on what comes before it.\n"
-        "3. If a task is already covered by a recent commit, remove it.\n"
+        "3. If a task is already covered by a recent commit, omit it from the output — it will be marked done.\n"
         "4. If a thread task changes the requirements of an existing spec task, "
         "rewrite that spec task's title and/or description to reflect the updated "
         "requirements.\n"

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -67,17 +67,20 @@ def triage_prompt(
 ) -> str:
     """Build a triage prompt for Haiku/Opus.
 
-    Returns a prompt that asks the model to classify the comment and return a
-    category + short task title in the form ``CATEGORY: title``.
+    Returns a prompt that asks the model to classify the comment and return one
+    or more ``CATEGORY: title`` lines.  A single comment may produce zero tasks
+    (ANSWER/ASK/DEFER/DUMP) or multiple tasks (multiple ACT/DO lines).
     """
     categories = triage_categories(is_bot)
     ctx_str = triage_context_block(context)
     return (
-        f"Triage this PR comment into exactly one category: {categories}\n\n"
+        f"Triage this PR comment into one or more categories: {categories}\n\n"
         f"{ctx_str}\n\nComment: {comment_body}\n\n"
-        "Reply with ONLY the category word (e.g. ACT or DEFER), then a colon, then a short imperative task title. "
-        "The title must be an action item starting with a verb — never quote or paraphrase the comment text. "
-        "Example: ACT: add unit tests for parser"
+        "Reply with one line per task: category word, colon, short imperative task title. "
+        "For ACT/DO, list each distinct required change on its own line. "
+        "Task titles must start with a verb — never quote or paraphrase the comment text. "
+        "Example (one task): ACT: add unit tests for parser\n"
+        "Example (two tasks): ACT: add unit tests for parser\nACT: update documentation"
     )
 
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -132,9 +132,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 if cid and cid in _replied_comments:
                     log.info("already replied to comment %s — skipping", cid)
                     handled = True
-                    category, title = None, None
+                    category, titles = None, []
                 else:
-                    posted, category, title = type(self)._fn_reply_to_comment(
+                    posted, category, titles = type(self)._fn_reply_to_comment(
                         action, self.config, repo_cfg
                     )
                     if cid and posted:
@@ -142,17 +142,16 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     handled = True
                 # Create task based on triage result.
                 # DEFER files a GitHub issue (handled in reply_to_comment) — no tasks.json entry.
-                # ACT, DO → add to work queue.
-                if category in ("DUMP", "ANSWER", "ASK", "DEFER"):
-                    pass  # No task needed
-                elif title:
-                    type(self)._fn_create_task(
-                        title,
-                        self.config,
-                        repo_cfg,
-                        thread=action.reply_to,
-                        registry=self.registry,
-                    )
+                # ACT, DO → add each task title to work queue.
+                if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):
+                    for title in titles or []:
+                        type(self)._fn_create_task(
+                            title,
+                            self.config,
+                            repo_cfg,
+                            thread=action.reply_to,
+                            registry=self.registry,
+                        )
 
             if action.review_comments:
                 type(self)._fn_reply_to_review(
@@ -162,19 +161,20 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
             # Top-level PR comments (issue_comment) — no reply_to, but has comment_body
             if not handled and action.comment_body:
-                category, title = type(self)._fn_reply_to_issue_comment(
+                category, titles = type(self)._fn_reply_to_issue_comment(
                     action, self.config, repo_cfg
                 )
                 handled = True
                 # DEFER files a GitHub issue — no tasks.json entry.
-                if category not in ("DUMP", "ANSWER", "ASK", "DEFER") and title:
-                    type(self)._fn_create_task(
-                        title,
-                        self.config,
-                        repo_cfg,
-                        thread=action.thread,
-                        registry=self.registry,
-                    )
+                if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):
+                    for title in titles:
+                        type(self)._fn_create_task(
+                            title,
+                            self.config,
+                            repo_cfg,
+                            thread=action.thread,
+                            registry=self.registry,
+                        )
 
             # Non-comment events just trigger kennel worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -413,7 +413,8 @@ def _apply_reorder(
     Rules (in priority order):
     - CI tasks always come first.
     - Non-CI pending tasks follow in Opus dependency order.
-    - In-progress tasks that Opus dropped are reinstated at the front (safety net).
+    - In-progress tasks dropped by Opus are removed; the caller detects this
+      and signals an abort so the worker picks the new next task.
     - Tasks added after the original snapshot (IDs not in *original_ids*) are
       appended at the end so they are never silently dropped.
     - Completed tasks are always preserved at the end in their original order.
@@ -438,11 +439,9 @@ def _apply_reorder(
             orig["description"] = item["description"]
         merged.append(orig)
 
-    # Safety net: never silently drop an in-progress task.
-    for t in current:
-        if t.get("status") == TaskStatus.IN_PROGRESS and t["id"] not in seen_ids:
-            merged.insert(0, t)
-            seen_ids.add(t["id"])
+    # In-progress tasks are intentionally NOT reinstated here.
+    # If Opus drops an in-progress task, the caller (reorder_tasks) will detect
+    # it was affected and signal an abort so the worker picks the new next task.
 
     ci = [t for t in merged if t.get("type") == TaskType.CI]
     non_ci = [t for t in merged if t.get("type") != TaskType.CI]
@@ -509,6 +508,7 @@ def reorder_tasks(
     _print_prompt=_claude_print_prompt,
     _rescope_prompt_fn=_rescope_prompt_default,
     _on_changes=None,
+    _on_inprogress_affected=None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
 
@@ -525,6 +525,12 @@ def reorder_tasks(
 
     If *_on_changes* is provided and any thread tasks were dropped or modified,
     it is called with a list of change records (see :func:`_compute_thread_changes`).
+
+    If *_on_inprogress_affected* is provided and the currently in-progress task
+    is dropped or modified by Opus, it is called with no arguments so the caller
+    can abort the running worker and restart on the new next task.  When the
+    in-progress task is modified its status is reset to ``pending`` so the worker
+    loop picks it up again with the updated title/description.
     """
     task_list = list_tasks(work_dir)
     if not task_list:
@@ -544,15 +550,45 @@ def reorder_tasks(
         return
 
     path = _task_file(work_dir)
+    inprogress_affected = False
     with _locked(path, write=True) as lock:
         current = lock.read()
+        inprogress = next(
+            (t for t in current if t.get("status") == TaskStatus.IN_PROGRESS), None
+        )
         result = _apply_reorder(current, ordered_items, original_ids)
+        if inprogress is not None:
+            inprogress_in_result = next(
+                (t for t in result if t["id"] == inprogress["id"]), None
+            )
+            if inprogress_in_result is None:
+                # Opus dropped the in-progress task — it's gone.
+                inprogress_affected = True
+                log.info(
+                    "reorder_tasks: in-progress task dropped by Opus: %s",
+                    inprogress.get("title", "")[:60],
+                )
+            elif inprogress_in_result.get("title") != inprogress.get(
+                "title"
+            ) or inprogress_in_result.get("description") != inprogress.get(
+                "description"
+            ):
+                # Opus modified the in-progress task — reset to pending.
+                inprogress_affected = True
+                inprogress_in_result["status"] = str(TaskStatus.PENDING)
+                log.info(
+                    "reorder_tasks: in-progress task modified by Opus — reset to pending: %s",
+                    inprogress_in_result.get("title", "")[:60],
+                )
         lock.write(result)
 
     if _on_changes is not None:
         changes = _compute_thread_changes(current, result, original_ids)
         if changes:
             _on_changes(changes)
+
+    if inprogress_affected and _on_inprogress_affected is not None:
+        _on_inprogress_affected()
 
     log.info("reorder_tasks: applied reorder — %d tasks", len(result))
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -460,12 +460,55 @@ def _apply_reorder(
     return ci + non_ci + completed + newly_added
 
 
+def _compute_thread_changes(
+    original: list[dict[str, Any]],
+    result: list[dict[str, Any]],
+    original_ids: frozenset[str],
+) -> list[dict[str, Any]]:
+    """Return change records for thread tasks that were dropped or modified.
+
+    Only tasks in *original_ids* (those Opus knew about) with a ``thread``
+    attachment are reported.  Completed tasks are excluded.
+
+    Each record is one of:
+    - ``{"task": ..., "kind": "dropped"}``
+    - ``{"task": ..., "kind": "modified", "new_title": ..., "new_description": ...}``
+    """
+    result_by_id = {t["id"]: t for t in result}
+    changes: list[dict[str, Any]] = []
+    for t in original:
+        if t["id"] not in original_ids:
+            continue
+        if not t.get("thread"):
+            continue
+        if t.get("status") == TaskStatus.COMPLETED:
+            continue
+        tid = t["id"]
+        if tid not in result_by_id:
+            changes.append({"task": t, "kind": "dropped"})
+        else:
+            r = result_by_id[tid]
+            if r.get("title") != t.get("title") or r.get("description") != t.get(
+                "description"
+            ):
+                changes.append(
+                    {
+                        "task": t,
+                        "kind": "modified",
+                        "new_title": r.get("title", ""),
+                        "new_description": r.get("description", ""),
+                    }
+                )
+    return changes
+
+
 def reorder_tasks(
     work_dir: Path,
     commit_summary: str,
     *,
     _print_prompt=_claude_print_prompt,
     _rescope_prompt_fn=_rescope_prompt_default,
+    _on_changes=None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
 
@@ -479,6 +522,9 @@ def reorder_tasks(
 
     CI tasks always stay first; completed tasks are always preserved.
     An empty or unparseable Opus response leaves the task list unchanged.
+
+    If *_on_changes* is provided and any thread tasks were dropped or modified,
+    it is called with a list of change records (see :func:`_compute_thread_changes`).
     """
     task_list = list_tasks(work_dir)
     if not task_list:
@@ -502,6 +548,12 @@ def reorder_tasks(
         current = lock.read()
         result = _apply_reorder(current, ordered_items, original_ids)
         lock.write(result)
+
+    if _on_changes is not None:
+        changes = _compute_thread_changes(current, result, original_ids)
+        if changes:
+            _on_changes(changes)
+
     log.info("reorder_tasks: applied reorder — %d tasks", len(result))
 
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -411,8 +411,9 @@ def _apply_reorder(
     Rules (in priority order):
     - CI tasks always come first.
     - Non-CI pending tasks follow in Opus dependency order.
-    - In-progress tasks dropped by Opus are removed; the caller detects this
-      and signals an abort so the worker picks the new next task.
+    - Pending/in_progress tasks that Opus omits are marked completed; the caller
+      detects affected in-progress tasks and signals an abort so the worker picks
+      the new next task.
     - Tasks added after the original snapshot (IDs not in *original_ids*) are
       appended at the end so they are never silently dropped.
     - Completed tasks are always preserved at the end in their original order.
@@ -437,13 +438,20 @@ def _apply_reorder(
             orig["description"] = item["description"]
         merged.append(orig)
 
-    # In-progress tasks are intentionally NOT reinstated here.
-    # If Opus drops an in-progress task, the caller (reorder_tasks) will detect
-    # it was affected and signal an abort so the worker picks the new next task.
-
     ci = [t for t in merged if t.get("type") == TaskType.CI]
     non_ci = [t for t in merged if t.get("type") != TaskType.CI]
     completed = [t for t in current if t.get("status") == TaskStatus.COMPLETED]
+
+    # Tasks Opus omitted that were pending/in_progress — mark them completed
+    # rather than silently removing them.  The caller detects in-progress ones
+    # and triggers a worker abort so the next task is picked up cleanly.
+    newly_completed = [
+        {**t, "status": str(TaskStatus.COMPLETED)}
+        for t in current
+        if t["id"] in original_ids
+        and t["id"] not in seen_ids
+        and t.get("status") != TaskStatus.COMPLETED
+    ]
 
     # Tasks added while Opus was thinking — preserve them rather than drop.
     newly_added = [
@@ -454,7 +462,7 @@ def _apply_reorder(
         and t.get("status") != TaskStatus.COMPLETED
     ]
 
-    return ci + non_ci + completed + newly_added
+    return ci + non_ci + completed + newly_completed + newly_added
 
 
 def _compute_thread_changes(
@@ -462,13 +470,13 @@ def _compute_thread_changes(
     result: list[dict[str, Any]],
     original_ids: frozenset[str],
 ) -> list[dict[str, Any]]:
-    """Return change records for thread tasks that were dropped or modified.
+    """Return change records for thread tasks that were completed or modified.
 
     Only tasks in *original_ids* (those Opus knew about) with a ``thread``
-    attachment are reported.  Completed tasks are excluded.
+    attachment are reported.  Already-completed tasks are excluded.
 
     Each record is one of:
-    - ``{"task": ..., "kind": "dropped"}``
+    - ``{"task": ..., "kind": "completed"}`` — Opus omitted it; now marked done
     - ``{"task": ..., "kind": "modified", "new_title": ..., "new_description": ...}``
     """
     result_by_id = {t["id"]: t for t in result}
@@ -481,21 +489,20 @@ def _compute_thread_changes(
         if t.get("status") == TaskStatus.COMPLETED:
             continue
         tid = t["id"]
-        if tid not in result_by_id:
-            changes.append({"task": t, "kind": "dropped"})
-        else:
-            r = result_by_id[tid]
-            if r.get("title") != t.get("title") or r.get("description") != t.get(
-                "description"
-            ):
-                changes.append(
-                    {
-                        "task": t,
-                        "kind": "modified",
-                        "new_title": r.get("title", ""),
-                        "new_description": r.get("description", ""),
-                    }
-                )
+        r = result_by_id.get(tid)
+        if r is None or r.get("status") == TaskStatus.COMPLETED:
+            changes.append({"task": t, "kind": "completed"})
+        elif r.get("title") != t.get("title") or r.get("description") != t.get(
+            "description"
+        ):
+            changes.append(
+                {
+                    "task": t,
+                    "kind": "modified",
+                    "new_title": r.get("title", ""),
+                    "new_description": r.get("description", ""),
+                }
+            )
     return changes
 
 
@@ -521,14 +528,14 @@ def reorder_tasks(
     CI tasks always stay first; completed tasks are always preserved.
     An empty or unparseable Opus response leaves the task list unchanged.
 
-    If *_on_changes* is provided and any thread tasks were dropped or modified,
+    If *_on_changes* is provided and any thread tasks were completed or modified,
     it is called with a list of change records (see :func:`_compute_thread_changes`).
 
     If *_on_inprogress_affected* is provided and the currently in-progress task
-    is dropped or modified by Opus, it is called with no arguments so the caller
-    can abort the running worker and restart on the new next task.  When the
-    in-progress task is modified its status is reset to ``pending`` so the worker
-    loop picks it up again with the updated title/description.
+    is marked completed or modified by Opus, it is called with no arguments so
+    the caller can abort the running worker and restart on the new next task.
+    When the in-progress task is modified its status is reset to ``pending`` so
+    the worker loop picks it up again with the updated title/description.
     """
     task_list = list_tasks(work_dir)
     if not task_list:
@@ -559,11 +566,14 @@ def reorder_tasks(
             inprogress_in_result = next(
                 (t for t in result if t["id"] == inprogress["id"]), None
             )
-            if inprogress_in_result is None:
-                # Opus dropped the in-progress task — it's gone.
+            if (
+                inprogress_in_result is None
+                or inprogress_in_result.get("status") == TaskStatus.COMPLETED
+            ):
+                # Opus omitted the in-progress task — marked completed.
                 inprogress_affected = True
                 log.info(
-                    "reorder_tasks: in-progress task dropped by Opus: %s",
+                    "reorder_tasks: in-progress task marked completed by Opus: %s",
                     inprogress.get("title", "")[:60],
                 )
             elif inprogress_in_result.get("title") != inprogress.get(

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -6,13 +6,16 @@ import fcntl
 import json
 import logging
 import random
+import re
 import subprocess
 import threading
 import time
 from pathlib import Path
 from typing import Any
 
+from kennel.claude import print_prompt as _claude_print_prompt
 from kennel.github import GitHub
+from kennel.prompts import rescope_prompt as _rescope_prompt_default
 from kennel.state import _resolve_git_dir, load_state
 from kennel.types import TaskStatus, TaskType
 
@@ -375,6 +378,131 @@ def sync_tasks(
             log.exception("sync_tasks: failed to update PR body")
     finally:
         sync_lock_fd.close()
+
+
+def _parse_reorder_response(raw: str) -> list[dict[str, Any]] | None:
+    """Parse the Opus rescope response into a list of task items.
+
+    Scans *raw* for a JSON object containing a ``"tasks"`` list.  Tries the
+    full string first (happy path), then falls back to a greedy regex scan so
+    that minor Opus preamble does not break parsing.
+
+    Returns the ``tasks`` list, or ``None`` if no valid response is found.
+    """
+    candidates = [raw.strip()]
+    for m in re.finditer(r"\{.*\}", raw, re.DOTALL):
+        candidates.append(m.group())
+    for candidate in candidates:
+        try:
+            obj = json.loads(candidate)
+            tasks = obj.get("tasks")
+            if isinstance(tasks, list):
+                return tasks
+        except json.JSONDecodeError, AttributeError:
+            continue
+    return None
+
+
+def _apply_reorder(
+    current: list[dict[str, Any]],
+    ordered_items: list[dict[str, Any]],
+    original_ids: frozenset[str] = frozenset(),
+) -> list[dict[str, Any]]:
+    """Apply Opus-ordered items to the current task list.
+
+    Rules (in priority order):
+    - CI tasks always come first.
+    - Non-CI pending tasks follow in Opus dependency order.
+    - In-progress tasks that Opus dropped are reinstated at the front (safety net).
+    - Tasks added after the original snapshot (IDs not in *original_ids*) are
+      appended at the end so they are never silently dropped.
+    - Completed tasks are always preserved at the end in their original order.
+    - Title/description are updated from Opus's output; all other fields kept.
+    - Opus-returned IDs absent from *current* or duplicated are ignored.
+    """
+    by_id = {t["id"]: t for t in current}
+    merged: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for item in ordered_items:
+        tid = item.get("id", "")
+        if not tid or tid not in by_id:
+            continue
+        if tid in seen_ids:
+            continue
+        seen_ids.add(tid)
+        orig = dict(by_id[tid])
+        if item.get("title"):
+            orig["title"] = item["title"]
+        if "description" in item:
+            orig["description"] = item["description"]
+        merged.append(orig)
+
+    # Safety net: never silently drop an in-progress task.
+    for t in current:
+        if t.get("status") == TaskStatus.IN_PROGRESS and t["id"] not in seen_ids:
+            merged.insert(0, t)
+            seen_ids.add(t["id"])
+
+    ci = [t for t in merged if t.get("type") == TaskType.CI]
+    non_ci = [t for t in merged if t.get("type") != TaskType.CI]
+    completed = [t for t in current if t.get("status") == TaskStatus.COMPLETED]
+
+    # Tasks added while Opus was thinking — preserve them rather than drop.
+    newly_added = [
+        t
+        for t in current
+        if t["id"] not in original_ids
+        and t["id"] not in seen_ids
+        and t.get("status") != TaskStatus.COMPLETED
+    ]
+
+    return ci + non_ci + completed + newly_added
+
+
+def reorder_tasks(
+    work_dir: Path,
+    commit_summary: str,
+    *,
+    _print_prompt=_claude_print_prompt,
+    _rescope_prompt_fn=_rescope_prompt_default,
+) -> None:
+    """Reorder pending tasks by Opus dependency analysis.
+
+    Reads the task list, asks Opus to reorder/rewrite/drop tasks based on
+    dependency analysis and recent commits, then atomically writes the result.
+
+    The task list is read twice: once before the Opus call (to build the
+    prompt) and once inside the write-lock (to pick up any tasks added while
+    Opus was thinking).  Tasks added in that window are preserved at the end
+    of the list rather than silently dropped.
+
+    CI tasks always stay first; completed tasks are always preserved.
+    An empty or unparseable Opus response leaves the task list unchanged.
+    """
+    task_list = list_tasks(work_dir)
+    if not task_list:
+        log.info("reorder_tasks: no tasks — skipping")
+        return
+
+    original_ids = frozenset(t["id"] for t in task_list)
+    prompt = _rescope_prompt_fn(task_list, commit_summary)
+    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    if not raw:
+        log.warning("reorder_tasks: Opus returned empty response — skipping")
+        return
+
+    ordered_items = _parse_reorder_response(raw)
+    if ordered_items is None:
+        log.warning("reorder_tasks: could not parse Opus response — skipping")
+        return
+
+    path = _task_file(work_dir)
+    with _locked(path, write=True) as lock:
+        current = lock.read()
+        result = _apply_reorder(current, ordered_items, original_ids)
+        lock.write(result)
+    log.info("reorder_tasks: applied reorder — %d tasks", len(result))
 
 
 def sync_tasks_background(

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -185,12 +185,11 @@ def remove_task(work_dir: Path, task_id: str) -> bool:
 def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
     """Format a task list into work-queue markdown.
 
-    Priority order: CI failures → comment-originated → others.
+    Priority order: CI failures → everything else (preserving list order).
     Completed tasks appear in a collapsible ``<details>`` section.
     Each line includes a ``<!-- type:X -->`` HTML comment for round-tripping.
     """
     ci_pending: list[tuple[str, str]] = []
-    comment_pending: list[tuple[str, str]] = []
     other_pending: list[tuple[str, str]] = []
     completed: list[tuple[str, str]] = []
 
@@ -209,12 +208,10 @@ def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
             title = t.get("title", "")
             if title.startswith("CI failure:"):
                 ci_pending.append((display, task_type))
-            elif t.get("thread"):
-                comment_pending.append((display, task_type))
             else:
                 other_pending.append((display, task_type))
 
-    pending = ci_pending + comment_pending + other_pending
+    pending = ci_pending + other_pending
     lines: list[str] = []
     for i, (display, task_type) in enumerate(pending):
         suffix = " **→ next**" if i == 0 else ""

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -237,8 +237,7 @@ def _pick_next_task(task_list: list[dict[str, Any]]) -> dict[str, Any] | None:
     (case-insensitive).  Among the remaining candidates the priority order is:
 
     1. Tasks with ``type`` == ``TaskType.CI``
-    2. Tasks with ``type`` == ``TaskType.THREAD``
-    3. Everything else (first in list wins)
+    2. Everything else (first in list wins, including thread tasks)
     """
     pending = [
         t
@@ -251,9 +250,6 @@ def _pick_next_task(task_list: list[dict[str, Any]]) -> dict[str, Any] | None:
         return None
     for t in pending:
         if t.get("type") == TaskType.CI:
-            return t
-    for t in pending:
-        if t.get("type") == TaskType.THREAD:
             return t
     return pending[0]
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -9,6 +9,7 @@ from kennel.events import (
     _comment_lock,
     _get_commit_summary,
     _is_allowed,
+    _notify_thread_change,
     _reorder_tasks_background,
     _summarize_as_action_item,
     _triage,
@@ -1749,11 +1750,14 @@ class TestCreateTask:
                 repo_cfg,
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "abc1234 add thing",
-                _reorder_background_fn=lambda wd, cs: reorder_called.append((wd, cs)),
+                _reorder_background_fn=lambda wd, cs, cfg: reorder_called.append(
+                    (wd, cs, cfg)
+                ),
             )
         assert len(reorder_called) == 1
         assert reorder_called[0][0] == tmp_path
         assert reorder_called[0][1] == "abc1234 add thing"
+        assert reorder_called[0][2] is cfg
 
     def test_spec_task_does_not_trigger_reorder(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1801,7 +1805,7 @@ class TestCreateTask:
                 repo_cfg,
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "custom summary",
-                _reorder_background_fn=lambda wd, cs: summaries.append(cs),
+                _reorder_background_fn=lambda wd, cs, cfg: summaries.append(cs),
             )
         assert summaries == ["custom summary"]
 
@@ -1853,10 +1857,24 @@ class TestGetCommitSummary:
 
 
 class TestReorderTasksBackground:
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            self_repo=None,
+            sub_dir=tmp_path / "sub",
+        )
+
     def test_starts_daemon_thread(self, tmp_path: Path) -> None:
         started: list = []
         _reorder_tasks_background(
-            tmp_path, "some commits", _start=lambda t: started.append(t)
+            tmp_path,
+            "some commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
         )
         assert len(started) == 1
         t = started[0]
@@ -1865,7 +1883,7 @@ class TestReorderTasksBackground:
     def test_thread_name_includes_dir_name(self, tmp_path: Path) -> None:
         started: list = []
         _reorder_tasks_background(
-            tmp_path, "commits", _start=lambda t: started.append(t)
+            tmp_path, "commits", self._cfg(tmp_path), _start=lambda t: started.append(t)
         )
         assert tmp_path.name in started[0].name
 
@@ -1874,16 +1892,125 @@ class TestReorderTasksBackground:
 
         started: list = []
         _reorder_tasks_background(
-            tmp_path, "commits", _start=lambda t: started.append(t)
+            tmp_path, "commits", self._cfg(tmp_path), _start=lambda t: started.append(t)
         )
         assert started[0]._target is reorder_tasks
 
     def test_thread_args_are_work_dir_and_commit_summary(self, tmp_path: Path) -> None:
         started: list = []
         _reorder_tasks_background(
-            tmp_path, "feat: add parser", _start=lambda t: started.append(t)
+            tmp_path,
+            "feat: add parser",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
         )
         assert started[0]._args == (tmp_path, "feat: add parser")
+
+
+class TestNotifyThreadChange:
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            self_repo=None,
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _task(self, **overrides) -> dict:
+        t = {
+            "id": "t1",
+            "title": "Fix the thing",
+            "status": "pending",
+            "type": "thread",
+            "thread": {
+                "repo": "owner/repo",
+                "pr": 42,
+                "comment_id": 999,
+                "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
+            },
+        }
+        t.update(overrides)
+        return t
+
+    def test_dropped_posts_comment(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {"task": self._task(), "kind": "dropped"}
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value="Noted!"), _gh=mock_gh
+        )
+        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Noted!")
+
+    def test_modified_posts_comment(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {
+            "task": self._task(),
+            "kind": "modified",
+            "new_title": "Updated title",
+            "new_description": "",
+        }
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value="Updated!"), _gh=mock_gh
+        )
+        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Updated!")
+
+    def test_missing_thread_skips_comment(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        task = self._task()
+        task["thread"] = {}
+        change = {"task": task, "kind": "dropped"}
+        _notify_thread_change(change, cfg, _print_prompt=MagicMock(), _gh=mock_gh)
+        mock_gh.comment_issue.assert_not_called()
+
+    def test_empty_opus_uses_fallback_for_dropped(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {"task": self._task(), "kind": "dropped"}
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+        )
+        body = mock_gh.comment_issue.call_args[0][2]
+        assert "Fix the thing" in body
+
+    def test_empty_opus_uses_fallback_for_modified(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {
+            "task": self._task(),
+            "kind": "modified",
+            "new_title": "New title",
+            "new_description": "",
+        }
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+        )
+        body = mock_gh.comment_issue.call_args[0][2]
+        assert "New title" in body
+
+    def test_gh_none_uses_get_github(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {"task": self._task(), "kind": "dropped"}
+        with patch("kennel.events.get_github", return_value=mock_gh):
+            _notify_thread_change(
+                change, cfg, _print_prompt=MagicMock(return_value="ok")
+            )
+        mock_gh.comment_issue.assert_called_once()
+
+    def test_comment_issue_exception_does_not_raise(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        mock_gh.comment_issue.side_effect = RuntimeError("api error")
+        change = {"task": self._task(), "kind": "dropped"}
+        # Should not raise
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
+        )
 
 
 class TestLaunchSync:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2067,7 +2067,7 @@ class TestReorderTasksBackground:
                     "author": "bob",
                 },
             },
-            "kind": "dropped",
+            "kind": "completed",
         }
         with patch("kennel.events._notify_thread_change") as mock_notify:
             on_changes([change])
@@ -2132,10 +2132,10 @@ class TestNotifyThreadChange:
         t.update(overrides)
         return t
 
-    def test_dropped_posts_comment(self, tmp_path: Path) -> None:
+    def test_completed_posts_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         _notify_thread_change(
             change, cfg, _print_prompt=MagicMock(return_value="Noted!"), _gh=mock_gh
         )
@@ -2160,14 +2160,14 @@ class TestNotifyThreadChange:
         mock_gh = MagicMock()
         task = self._task()
         task["thread"] = {}
-        change = {"task": task, "kind": "dropped"}
+        change = {"task": task, "kind": "completed"}
         _notify_thread_change(change, cfg, _print_prompt=MagicMock(), _gh=mock_gh)
         mock_gh.comment_issue.assert_not_called()
 
-    def test_empty_opus_uses_fallback_for_dropped(self, tmp_path: Path) -> None:
+    def test_empty_opus_uses_fallback_for_completed(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         _notify_thread_change(
             change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
         )
@@ -2201,7 +2201,7 @@ class TestNotifyThreadChange:
             "comment_id": 999,
             "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
         }
-        change = {"task": task, "kind": "dropped"}
+        change = {"task": task, "kind": "completed"}
         _notify_thread_change(
             change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
         )
@@ -2216,14 +2216,14 @@ class TestNotifyThreadChange:
             captured_prompt.append(prompt)
             return "ok"
 
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         _notify_thread_change(change, cfg, _print_prompt=fake_pp, _gh=MagicMock())
         assert "alice" in captured_prompt[0]
 
     def test_gh_none_uses_get_github(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         with patch("kennel.events.get_github", return_value=mock_gh):
             _notify_thread_change(
                 change, cfg, _print_prompt=MagicMock(return_value="ok")
@@ -2234,7 +2234,7 @@ class TestNotifyThreadChange:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         mock_gh.comment_issue.side_effect = RuntimeError("api error")
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         # Should not raise
         _notify_thread_change(
             change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
@@ -2243,7 +2243,7 @@ class TestNotifyThreadChange:
     def test_default_print_prompt_uses_claude(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "dropped"}
+        change = {"task": self._task(), "kind": "completed"}
         with patch("kennel.events.claude.print_prompt", return_value="Auto reply"):
             _notify_thread_change(change, cfg, _gh=mock_gh)
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Auto reply")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1863,14 +1863,16 @@ class TestCreateTask:
                 repo_cfg,
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "abc1234 add thing",
-                _reorder_background_fn=lambda wd, cs, cfg: reorder_called.append(
-                    (wd, cs, cfg)
+                _reorder_background_fn=lambda wd, cs, cfg, rc, reg: (
+                    reorder_called.append((wd, cs, cfg, rc, reg))
                 ),
             )
         assert len(reorder_called) == 1
         assert reorder_called[0][0] == tmp_path
         assert reorder_called[0][1] == "abc1234 add thing"
         assert reorder_called[0][2] is cfg
+        assert reorder_called[0][3] is repo_cfg
+        assert reorder_called[0][4] is None  # no registry passed
 
     def test_spec_task_does_not_trigger_reorder(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1918,7 +1920,9 @@ class TestCreateTask:
                 repo_cfg,
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "custom summary",
-                _reorder_background_fn=lambda wd, cs, cfg: summaries.append(cs),
+                _reorder_background_fn=lambda wd, cs, cfg, rc, reg: summaries.append(
+                    cs
+                ),
             )
         assert summaries == ["custom summary"]
 
@@ -2049,6 +2053,36 @@ class TestReorderTasksBackground:
         with patch("kennel.events._notify_thread_change") as mock_notify:
             on_changes([change])
         mock_notify.assert_called_once_with(change, self._cfg(tmp_path), _gh=mock_gh)
+
+    def test_on_inprogress_affected_aborts_worker_via_registry(
+        self, tmp_path: Path
+    ) -> None:
+        started: list = []
+        registry = MagicMock()
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+        )
+        on_inprogress_affected = started[0]._kwargs["_on_inprogress_affected"]
+        on_inprogress_affected()
+        registry.abort_task.assert_called_once_with("owner/repo")
+
+    def test_on_inprogress_affected_not_in_kwargs_when_no_registry(
+        self, tmp_path: Path
+    ) -> None:
+        started: list = []
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+        )
+        assert "_on_inprogress_affected" not in started[0]._kwargs
 
 
 class TestNotifyThreadChange:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -370,29 +370,29 @@ class TestSummarizeAsActionItem:
 
 class TestTriage:
     def test_returns_parsed_category(self, tmp_path: Path) -> None:
-        cat, title = _triage(
+        cat, titles = _triage(
             "please add tests",
             is_bot=False,
             _print_prompt=MagicMock(return_value="ACT: add tests"),
         )
         assert cat == "ACT"
-        assert title == "add tests"
+        assert titles == ["add tests"]
 
     def test_fallback_on_bad_response(self, tmp_path: Path) -> None:
         pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, title = _triage("do stuff", is_bot=False, _print_prompt=pp)
+        cat, titles = _triage("do stuff", is_bot=False, _print_prompt=pp)
         assert cat == "ACT"
-        assert title == "implement the thing"
+        assert titles == ["implement the thing"]
 
     def test_fallback_for_bot(self, tmp_path: Path) -> None:
         pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, title = _triage("do stuff", is_bot=True, _print_prompt=pp)
+        cat, titles = _triage("do stuff", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
-        assert title == "implement the thing"
+        assert titles == ["implement the thing"]
 
     def test_with_context(self, tmp_path: Path) -> None:
         ctx = {"pr_title": "My PR", "file": "foo.py", "diff_hunk": "@@ -1 +1 @@"}
-        cat, title = _triage(
+        cat, titles = _triage(
             "nit comment",
             is_bot=False,
             context=ctx,
@@ -402,21 +402,21 @@ class TestTriage:
 
     def test_unrecognized_category_falls_back(self, tmp_path: Path) -> None:
         pp = MagicMock(side_effect=["WEIRD: something", "do the thing"])
-        cat, title = _triage("hi", is_bot=False, _print_prompt=pp)
+        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
         assert cat == "ACT"
-        assert title == "do the thing"
+        assert titles == ["do the thing"]
 
     def test_timeout_falls_back(self, tmp_path: Path) -> None:
         pp = MagicMock(side_effect=["", "do the thing"])
-        cat, title = _triage("hi", is_bot=True, _print_prompt=pp)
+        cat, titles = _triage("hi", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
 
     def test_task_category_falls_back(self, tmp_path: Path) -> None:
         """TASK is no longer a valid bot category — falls back to DO."""
         pp = MagicMock(side_effect=["TASK: add caching", "add result caching"])
-        cat, title = _triage("cache results", is_bot=True, _print_prompt=pp)
+        cat, titles = _triage("cache results", is_bot=True, _print_prompt=pp)
         assert cat == "DO"
-        assert title == "add result caching"
+        assert titles == ["add result caching"]
 
     def test_bot_categories_in_prompt(self, tmp_path: Path) -> None:
         """Ensure bot-specific categories (DO/DEFER/DUMP) are used when is_bot=True."""
@@ -433,9 +433,49 @@ class TestTriage:
 
     def test_defaults_to_claude_print_prompt(self) -> None:
         with patch("kennel.claude.print_prompt", return_value="ACT: do it") as mock_pp:
-            cat, title = _triage("do it", is_bot=False)
+            cat, titles = _triage("do it", is_bot=False)
         mock_pp.assert_called_once()
         assert cat == "ACT"
+
+    def test_multiple_act_lines_returns_all_titles(self) -> None:
+        response = "ACT: add unit tests\nACT: update documentation"
+        cat, titles = _triage(
+            "please add tests and docs",
+            is_bot=False,
+            _print_prompt=MagicMock(return_value=response),
+        )
+        assert cat == "ACT"
+        assert titles == ["add unit tests", "update documentation"]
+
+    def test_mixed_categories_uses_first(self) -> None:
+        """Only lines matching the first valid category are collected."""
+        response = "ACT: add tests\nDEFER: out of scope"
+        cat, titles = _triage(
+            "comment",
+            is_bot=False,
+            _print_prompt=MagicMock(return_value=response),
+        )
+        assert cat == "ACT"
+        assert titles == ["add tests"]
+
+    def test_zero_act_tasks_falls_back(self) -> None:
+        """ACT with empty title is treated as parse failure → fallback."""
+        pp = MagicMock(side_effect=["ACT: ", "do the thing"])
+        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
+        # empty title → stripped to "" → falsy → no titles collected → fallback
+        assert cat == "ACT"
+        assert titles == ["do the thing"]
+
+    def test_lines_without_colon_are_skipped(self) -> None:
+        """Preamble lines without a colon are ignored; valid lines are still parsed."""
+        response = "thinking\nACT: add unit tests"
+        cat, titles = _triage(
+            "add tests",
+            is_bot=False,
+            _print_prompt=MagicMock(return_value=response),
+        )
+        assert cat == "ACT"
+        assert titles == ["add unit tests"]
 
 
 class TestMaybeReact:
@@ -555,7 +595,7 @@ class TestReplyToComment:
     def test_no_reply_to_returns_act(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="do stuff")
-        posted, cat, title = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+        posted, cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
         assert not posted
         assert cat == "ACT"
 
@@ -565,7 +605,7 @@ class TestReplyToComment:
             prompt="something",
             reply_to={"repo": "a/b", "pr": 1, "comment_id": 5},
         )
-        posted, cat, title = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+        posted, cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
         assert not posted
         assert cat == "ACT"
 
@@ -591,7 +631,7 @@ class TestReplyToComment:
                 return "ACT: add logging"
             return "I will add logging."
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -600,7 +640,7 @@ class TestReplyToComment:
         )
         assert posted
         assert cat == "ACT"
-        assert "logging" in title.lower()
+        assert "logging" in titles[0].lower()
 
     def test_full_flow_ask(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -618,7 +658,7 @@ class TestReplyToComment:
                 return "ASK: need more info"
             return "What specifically?"
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -644,7 +684,7 @@ class TestReplyToComment:
                 return "ANSWER: explain choice"
             return "I did this because..."
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -671,7 +711,7 @@ class TestReplyToComment:
             return "On it!"
 
         mock_gh = MagicMock()
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -680,7 +720,7 @@ class TestReplyToComment:
         )
         assert posted
         assert cat == "DO"
-        assert title == "add result caching"
+        assert titles == ["add result caching"]
         mock_gh.create_issue.assert_not_called()
 
     def test_full_flow_defer(self, tmp_path: Path) -> None:
@@ -701,7 +741,7 @@ class TestReplyToComment:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.return_value = "https://github.com/owner/repo/issues/99"
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -732,7 +772,7 @@ class TestReplyToComment:
                 return "DUMP: not applicable"
             return "Not applicable here."
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -761,7 +801,7 @@ class TestReplyToComment:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.side_effect = RuntimeError("network fail")
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -787,7 +827,7 @@ class TestReplyToComment:
                 return "ACT: do it"
             return ""  # empty reply triggers fallback
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -813,7 +853,7 @@ class TestReplyToComment:
                 return "ACT: do it"
             return ""  # simulates timeout — print_prompt returns "" on failure
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -840,7 +880,9 @@ class TestReplyToComment:
                 comment_body="competing update",
                 is_bot=False,
             )
-            posted, cat, title = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+            posted, cat, titles = reply_to_comment(
+                action, cfg, self._repo_cfg(tmp_path)
+            )
             assert not posted  # locked — no reply sent
             assert cat == "ACT"  # returns without posting
         finally:
@@ -863,7 +905,7 @@ class TestReplyToComment:
                 return "ACT: do it"
             return "ok"
 
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -872,6 +914,34 @@ class TestReplyToComment:
         )
         assert posted
         assert cat == "ACT"
+
+    def test_multiple_tasks_from_one_comment(self, tmp_path: Path) -> None:
+        """A single comment may produce multiple ACT tasks."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 77},
+            comment_body="add tests and update docs",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add unit tests\nACT: update documentation"
+            return "On it!"
+
+        posted, cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            _print_prompt=fake_pp,
+            _gh=MagicMock(),
+        )
+        assert posted
+        assert cat == "ACT"
+        assert titles == ["add unit tests", "update documentation"]
 
 
 class TestReplyToReview:
@@ -997,7 +1067,7 @@ class TestReplyToIssueComment:
                 return "ACT: fix the bug"
             return "I'll fix that."
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1014,7 +1084,7 @@ class TestReplyToIssueComment:
                 return "ASK: unclear"
             return "What do you mean?"
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action("unclear"),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1031,7 +1101,7 @@ class TestReplyToIssueComment:
                 return "ANSWER: it works this way"
             return "Yes, because..."
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action("why?"),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1048,7 +1118,7 @@ class TestReplyToIssueComment:
                 return "DUMP: nope"
             return "That won't work here."
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action("do it differently"),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1068,7 +1138,7 @@ class TestReplyToIssueComment:
         mock_gh = MagicMock()
         mock_gh.get_repo_info.return_value = "owner/repo"
         mock_gh.create_issue.return_value = "https://github.com/owner/repo/issues/5"
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action("big refactor"),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1094,7 +1164,7 @@ class TestReplyToIssueComment:
         mock_gh = MagicMock()
         mock_gh.get_repo_info.return_value = "owner/repo"
         mock_gh.create_issue.side_effect = RuntimeError("network fail")
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action("big refactor"),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1111,7 +1181,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return ""  # empty reply triggers fallback
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1128,7 +1198,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return ""  # simulates timeout — print_prompt returns "" on failure
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
@@ -1155,7 +1225,7 @@ class TestReplyToIssueComment:
 
         mock_gh = MagicMock()
         mock_gh.comment_issue.side_effect = Exception("gh fail")
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -1178,7 +1248,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return "ok"
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -1197,7 +1267,7 @@ class TestReplyToIssueComment:
             return "ok"
 
         with patch("kennel.claude.print_prompt", side_effect=fake_pp) as mock_pp:
-            cat, title = reply_to_issue_comment(
+            cat, titles = reply_to_issue_comment(
                 action, cfg, self._repo_cfg(tmp_path), _gh=MagicMock()
             )
         assert mock_pp.called
@@ -1219,9 +1289,9 @@ class TestReplyToIssueComment:
             return "ok"
 
         with patch(
-            "kennel.events._triage", wraps=lambda *a, **kw: ("ACT", "do it")
+            "kennel.events._triage", wraps=lambda *a, **kw: ("ACT", ["do it"])
         ) as mock_triage:
-            cat, title = reply_to_issue_comment(
+            cat, titles = reply_to_issue_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
@@ -1247,7 +1317,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return "ok"
 
-        cat, title = reply_to_issue_comment(
+        cat, titles = reply_to_issue_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -1255,6 +1325,25 @@ class TestReplyToIssueComment:
             _gh=mock_gh,
         )
         assert cat == "ACT"
+
+    def test_multiple_tasks_from_one_comment(self, tmp_path: Path) -> None:
+        """A top-level comment may produce multiple ACT tasks."""
+        cfg = self._cfg(tmp_path)
+
+        def fake_pp(prompt, model, **kwargs):
+            if "Triage" in prompt:
+                return "ACT: add unit tests\nACT: update documentation"
+            return "On it!"
+
+        cat, titles = reply_to_issue_comment(
+            self._action("add tests and update docs"),
+            cfg,
+            self._repo_cfg(tmp_path),
+            _print_prompt=fake_pp,
+            _gh=MagicMock(),
+        )
+        assert cat == "ACT"
+        assert titles == ["add unit tests", "update documentation"]
 
 
 class TestCreateTask:
@@ -2231,10 +2320,10 @@ class TestReplyToCommentElseBranch:
         # fallback "ACT"/"DO". We need to force an unlisted category past _triage.
         # Monkey-patch _triage directly to return a fake category.
         with (
-            patch("kennel.events._triage", return_value=("UNKNOWN_CAT", "do it")),
+            patch("kennel.events._triage", return_value=("UNKNOWN_CAT", ["do it"])),
             patch("kennel.events.needs_more_context", return_value=False),
         ):
-            posted, cat, title = reply_to_comment(
+            posted, cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
@@ -2263,7 +2352,7 @@ class TestReplyToCommentElseBranch:
 
         mock_gh = MagicMock()
         mock_gh.reply_to_review_comment.side_effect = RuntimeError("network down")
-        posted, cat, title = reply_to_comment(
+        posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
@@ -2381,7 +2470,7 @@ class TestReplyToCommentTerseEnrichment:
         def fake_triage(body, is_bot, context=None, *, _print_prompt=None):
             if context is not None:
                 captured_context.update(context)
-            return ("ACT", "handle same comment")
+            return ("ACT", ["handle same comment"])
 
         mock_gh = MagicMock()
         mock_gh.fetch_sibling_threads.return_value = [
@@ -2453,7 +2542,7 @@ class TestReplyToCommentTerseEnrichment:
             return "On it."
 
         with patch("kennel.events.needs_more_context", return_value=True):
-            posted, cat, title = reply_to_comment(
+            posted, cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
@@ -2479,7 +2568,7 @@ class TestReplyToCommentTerseEnrichment:
         def fake_triage(body, is_bot, context=None, *, _print_prompt=None):
             if context is not None:
                 captured_context.update(context)
-            return ("ACT", "check caret comment")
+            return ("ACT", ["check caret comment"])
 
         mock_gh = MagicMock()
         mock_gh.fetch_sibling_threads.return_value = []

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2019,6 +2019,37 @@ class TestReorderTasksBackground:
         )
         assert started[0]._args == (tmp_path, "feat: add parser")
 
+    def test_on_changes_callback_notifies_thread_changes(self, tmp_path: Path) -> None:
+        started: list = []
+        mock_gh = MagicMock()
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _gh=mock_gh,
+        )
+        on_changes = started[0]._kwargs["_on_changes"]
+        change = {
+            "task": {
+                "id": "t1",
+                "title": "Fix it",
+                "status": "pending",
+                "type": "thread",
+                "thread": {
+                    "repo": "owner/repo",
+                    "pr": 1,
+                    "comment_id": 42,
+                    "url": "https://github.com/owner/repo/pull/1#issuecomment-42",
+                    "author": "bob",
+                },
+            },
+            "kind": "dropped",
+        }
+        with patch("kennel.events._notify_thread_change") as mock_notify:
+            on_changes([change])
+        mock_notify.assert_called_once_with(change, self._cfg(tmp_path), _gh=mock_gh)
+
 
 class TestNotifyThreadChange:
     def _cfg(self, tmp_path: Path) -> Config:
@@ -2156,6 +2187,14 @@ class TestNotifyThreadChange:
         _notify_thread_change(
             change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
         )
+
+    def test_default_print_prompt_uses_claude(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        change = {"task": self._task(), "kind": "dropped"}
+        with patch("kennel.events.claude.print_prompt", return_value="Auto reply"):
+            _notify_thread_change(change, cfg, _gh=mock_gh)
+        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Auto reply")
 
 
 class TestLaunchSync:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,7 +7,9 @@ from kennel.config import Config, RepoConfig
 from kennel.events import (
     Action,
     _comment_lock,
+    _get_commit_summary,
     _is_allowed,
+    _reorder_tasks_background,
     _summarize_as_action_item,
     _triage,
     create_task,
@@ -1724,6 +1726,164 @@ class TestCreateTask:
                 registry=registry,
             )
         registry.abort_task.assert_not_called()
+
+    def test_thread_task_triggers_reorder_background(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 1, "comment_id": 5}
+        fake_task = {
+            "id": "t1",
+            "title": "Comment task",
+            "status": "pending",
+            "type": "thread",
+            "thread": thread,
+        }
+        reorder_called: list[tuple] = []
+        with (
+            patch("kennel.events.add_task", return_value=fake_task),
+            patch("kennel.events.launch_sync"),
+        ):
+            create_task(
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                _get_commit_summary_fn=lambda wd: "abc1234 add thing",
+                _reorder_background_fn=lambda wd, cs: reorder_called.append((wd, cs)),
+            )
+        assert len(reorder_called) == 1
+        assert reorder_called[0][0] == tmp_path
+        assert reorder_called[0][1] == "abc1234 add thing"
+
+    def test_spec_task_does_not_trigger_reorder(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        fake_task = {
+            "id": "t1",
+            "title": "Spec task",
+            "status": "pending",
+            "type": "spec",
+        }
+        reorder_called: list = []
+        with (
+            patch("kennel.events.add_task", return_value=fake_task),
+            patch("kennel.events.launch_sync"),
+        ):
+            create_task(
+                "Spec task",
+                cfg,
+                repo_cfg,
+                _reorder_background_fn=lambda *a: reorder_called.append(a),
+            )
+        assert reorder_called == []
+
+    def test_commit_summary_comes_from_get_commit_summary_fn(
+        self, tmp_path: Path
+    ) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 1, "comment_id": 7}
+        fake_task = {
+            "id": "t1",
+            "title": "t",
+            "status": "pending",
+            "type": "thread",
+            "thread": thread,
+        }
+        summaries: list[str] = []
+        with (
+            patch("kennel.events.add_task", return_value=fake_task),
+            patch("kennel.events.launch_sync"),
+        ):
+            create_task(
+                "t",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                _get_commit_summary_fn=lambda wd: "custom summary",
+                _reorder_background_fn=lambda wd, cs: summaries.append(cs),
+            )
+        assert summaries == ["custom summary"]
+
+
+class TestGetCommitSummary:
+    def test_returns_git_log_output(self, tmp_path: Path) -> None:
+        import subprocess as sp
+
+        fake_result = sp.CompletedProcess(
+            args=[], returncode=0, stdout="abc123 add thing\n", stderr=""
+        )
+        with patch(
+            "kennel.events.subprocess.run", return_value=fake_result
+        ) as mock_run:
+            result = _get_commit_summary(tmp_path)
+        assert result == "abc123 add thing"
+        mock_run.assert_called_once_with(
+            ["git", "log", "--oneline", "-20"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+        with patch("kennel.events.subprocess.run", side_effect=FileNotFoundError):
+            result = _get_commit_summary(tmp_path)
+        assert result == ""
+
+    def test_returns_empty_on_timeout(self, tmp_path: Path) -> None:
+        import subprocess as sp
+
+        with patch(
+            "kennel.events.subprocess.run",
+            side_effect=sp.TimeoutExpired(cmd="git", timeout=10),
+        ):
+            result = _get_commit_summary(tmp_path)
+        assert result == ""
+
+    def test_returns_empty_stdout_when_git_fails(self, tmp_path: Path) -> None:
+        import subprocess as sp
+
+        fake_result = sp.CompletedProcess(
+            args=[], returncode=128, stdout="", stderr="not a git repo"
+        )
+        with patch("kennel.events.subprocess.run", return_value=fake_result):
+            result = _get_commit_summary(tmp_path)
+        assert result == ""
+
+
+class TestReorderTasksBackground:
+    def test_starts_daemon_thread(self, tmp_path: Path) -> None:
+        started: list = []
+        _reorder_tasks_background(
+            tmp_path, "some commits", _start=lambda t: started.append(t)
+        )
+        assert len(started) == 1
+        t = started[0]
+        assert t.daemon is True
+
+    def test_thread_name_includes_dir_name(self, tmp_path: Path) -> None:
+        started: list = []
+        _reorder_tasks_background(
+            tmp_path, "commits", _start=lambda t: started.append(t)
+        )
+        assert tmp_path.name in started[0].name
+
+    def test_thread_target_is_reorder_tasks(self, tmp_path: Path) -> None:
+        from kennel.tasks import reorder_tasks
+
+        started: list = []
+        _reorder_tasks_background(
+            tmp_path, "commits", _start=lambda t: started.append(t)
+        )
+        assert started[0]._target is reorder_tasks
+
+    def test_thread_args_are_work_dir_and_commit_summary(self, tmp_path: Path) -> None:
+        started: list = []
+        _reorder_tasks_background(
+            tmp_path, "feat: add parser", _start=lambda t: started.append(t)
+        )
+        assert started[0]._args == (tmp_path, "feat: add parser")
 
 
 class TestLaunchSync:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -169,6 +169,29 @@ class TestDispatchReviewComment:
         assert result.reply_to is not None
         assert result.comment_body == "fix this"
 
+    def test_reply_to_includes_author(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        payload = {
+            **_payload(),
+            "action": "created",
+            "comment": {
+                "id": 124,
+                "body": "nit",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com/comment",
+                "path": "test.py",
+                "line": 1,
+                "diff_hunk": "@@ -1 +1 @@",
+            },
+            "pull_request": {"number": 5, "title": "My PR", "body": ""},
+        }
+        result = dispatch(
+            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        )
+        assert result is not None
+        assert result.reply_to is not None
+        assert result.reply_to["author"] == "owner"
+
     def test_self_comment_ignored(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         payload = {
@@ -273,6 +296,7 @@ class TestDispatchIssueComment:
             result.thread["url"]
             == "https://github.com/owner/repo/pull/10#issuecomment-456"
         )
+        assert result.thread["author"] == "owner"
 
     def test_non_pr_ignored(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
@@ -2019,6 +2043,7 @@ class TestNotifyThreadChange:
                 "pr": 42,
                 "comment_id": 999,
                 "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
+                "author": "alice",
             },
         }
         t.update(overrides)
@@ -2065,6 +2090,7 @@ class TestNotifyThreadChange:
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "Fix the thing" in body
+        assert "@alice" in body
 
     def test_empty_opus_uses_fallback_for_modified(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2080,6 +2106,36 @@ class TestNotifyThreadChange:
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "New title" in body
+        assert "@alice" in body
+
+    def test_fallback_no_author_omits_mention(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        task = self._task()
+        task["thread"] = {
+            "repo": "owner/repo",
+            "pr": 42,
+            "comment_id": 999,
+            "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
+        }
+        change = {"task": task, "kind": "dropped"}
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+        )
+        body = mock_gh.comment_issue.call_args[0][2]
+        assert "@" not in body
+
+    def test_author_in_opus_instruction(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        captured_prompt: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            captured_prompt.append(prompt)
+            return "ok"
+
+        change = {"task": self._task(), "kind": "dropped"}
+        _notify_thread_change(change, cfg, _print_prompt=fake_pp, _gh=MagicMock())
+        assert "alice" in captured_prompt[0]
 
     def test_gh_none_uses_get_github(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2001,7 +2001,6 @@ class TestReorderTasksBackground:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -2113,7 +2112,6 @@ class TestNotifyThreadChange:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -9,6 +9,7 @@ from kennel.prompts import (
     issue_reply_instruction,
     reply_context_block,
     reply_instruction,
+    rescope_prompt,
     triage_categories,
     triage_context_block,
     triage_prompt,
@@ -584,6 +585,121 @@ class TestPromptsPickupCommentPrompt:
 
     def test_returns_string(self) -> None:
         assert isinstance(Prompts("persona").pickup_comment_prompt("title"), str)
+
+
+# ── rescope_prompt ────────────────────────────────────────────────────────────
+
+
+class TestRescopePrompt:
+    def _task(
+        self,
+        title: str,
+        task_id: str = "1",
+        task_type: str = "spec",
+        status: str = "pending",
+        description: str = "",
+    ) -> dict:
+        return {
+            "id": task_id,
+            "title": title,
+            "type": task_type,
+            "status": status,
+            "description": description,
+        }
+
+    def test_includes_pending_tasks_json(self) -> None:
+        tasks = [self._task("Add feature", task_id="1")]
+        result = rescope_prompt(tasks, "")
+        assert "Add feature" in result
+        assert '"id": "1"' in result
+
+    def test_excludes_completed_from_pending_json(self) -> None:
+        tasks = [
+            self._task("Done task", task_id="1", status="completed"),
+            self._task("Todo task", task_id="2"),
+        ]
+        result = rescope_prompt(tasks, "")
+        # Completed appears in the completed block, not the pending JSON
+        assert '"id": "2"' in result
+        assert '"id": "1"' not in result.split("Pending tasks")[1]
+
+    def test_completed_titles_listed_in_completed_block(self) -> None:
+        tasks = [
+            self._task("Already done", task_id="1", status="completed"),
+            self._task("Still pending", task_id="2"),
+        ]
+        result = rescope_prompt(tasks, "")
+        assert "Already done" in result.split("Pending tasks")[0]
+
+    def test_no_completed_tasks_shows_none(self) -> None:
+        tasks = [self._task("Only pending", task_id="1")]
+        result = rescope_prompt(tasks, "")
+        assert "(none)" in result.split("Pending tasks")[0]
+
+    def test_commit_summary_included(self) -> None:
+        tasks = [self._task("Add tests", task_id="1")]
+        result = rescope_prompt(tasks, "feat: add parser method")
+        assert "feat: add parser method" in result
+
+    def test_empty_commit_summary_shows_none(self) -> None:
+        tasks = [self._task("Add tests", task_id="1")]
+        result = rescope_prompt(tasks, "")
+        assert "(none)" in result
+
+    def test_ci_tasks_must_come_first_rule_stated(self) -> None:
+        tasks = [self._task("Fix CI", task_id="1", task_type="ci")]
+        result = rescope_prompt(tasks, "")
+        assert "ci" in result.lower()
+        assert "first" in result
+
+    def test_json_output_format_instructed(self) -> None:
+        tasks = [self._task("Do something", task_id="1")]
+        result = rescope_prompt(tasks, "")
+        assert '{"tasks": [...]}' in result
+
+    def test_preserve_ids_rule_stated(self) -> None:
+        tasks = [self._task("Task A", task_id="abc-123")]
+        result = rescope_prompt(tasks, "")
+        assert "ID" in result or "id" in result
+        assert "preserve" in result.lower() or "never change" in result.lower()
+
+    def test_remove_covered_tasks_rule_stated(self) -> None:
+        tasks = [self._task("Task A", task_id="1")]
+        result = rescope_prompt(tasks, "commit covering this")
+        assert "commit" in result.lower() or "covered" in result.lower()
+
+    def test_rewrite_spec_on_thread_conflict_rule_stated(self) -> None:
+        tasks = [
+            self._task("Old spec title", task_id="1", task_type="spec"),
+            self._task("New comment task", task_id="2", task_type="thread"),
+        ]
+        result = rescope_prompt(tasks, "")
+        assert "thread" in result.lower() or "rewrite" in result.lower()
+
+    def test_no_other_text_instruction_present(self) -> None:
+        tasks = [self._task("X", task_id="1")]
+        result = rescope_prompt(tasks, "")
+        assert "No other text" in result
+
+    def test_in_progress_tasks_included_in_pending(self) -> None:
+        tasks = [
+            self._task("Running task", task_id="1", status="in_progress"),
+        ]
+        result = rescope_prompt(tasks, "")
+        assert '"id": "1"' in result
+
+    def test_description_included_in_task_json(self) -> None:
+        tasks = [self._task("X", task_id="1", description="important details")]
+        result = rescope_prompt(tasks, "")
+        assert "important details" in result
+
+    def test_empty_task_list(self) -> None:
+        result = rescope_prompt([], "")
+        assert isinstance(result, str)
+        assert "(none)" in result  # both completed and commit summary
+
+
+# ── Prompts.stores_persona ────────────────────────────────────────────────────
 
 
 class TestPromptsStoresPersona:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -197,7 +197,7 @@ class TestTriagePrompt:
 
     def test_includes_example(self) -> None:
         result = triage_prompt("x", is_bot=False)
-        assert "Example:" in result
+        assert "Example" in result
 
     def test_requires_imperative_action_item_title(self) -> None:
         result = triage_prompt("x", is_bot=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -252,7 +252,7 @@ class TestProcessAction:
             },
             "pull_request": {"number": 3, "title": "My PR", "body": "desc"},
         }
-        mock_reply = MagicMock(return_value=(True, "ACT", "add logging"))
+        mock_reply = MagicMock(return_value=(True, "ACT", ["add logging"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = mock_task
@@ -279,7 +279,7 @@ class TestProcessAction:
             },
             "pull_request": {"number": 4, "title": "My PR", "body": ""},
         }
-        mock_reply = MagicMock(return_value=(True, "DUMP", "nope"))
+        mock_reply = MagicMock(return_value=(True, "DUMP", ["nope"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = mock_task
@@ -309,7 +309,7 @@ class TestProcessAction:
         }
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = MagicMock(
-            return_value=(True, "DEFER", "big refactor")
+            return_value=(True, "DEFER", ["big refactor"])
         )
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -341,7 +341,7 @@ class TestProcessAction:
             task_titles.append(title)
 
         WebhookHandler._fn_reply_to_comment = MagicMock(
-            return_value=(True, "DO", "add result caching")
+            return_value=(True, "DO", ["add result caching"])
         )
         WebhookHandler._fn_create_task = capture_task
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -419,7 +419,7 @@ class TestProcessAction:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        mock_ic = MagicMock(return_value=("ACT", "do it"))
+        mock_ic = MagicMock(return_value=("ACT", ["do it"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_issue_comment = mock_ic
         WebhookHandler._fn_create_task = mock_task
@@ -454,7 +454,7 @@ class TestProcessAction:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        mock_ic = MagicMock(return_value=("ANSWER", "because"))
+        mock_ic = MagicMock(return_value=("ANSWER", ["because"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_issue_comment = mock_ic
         WebhookHandler._fn_create_task = mock_task

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -437,6 +437,7 @@ class TestProcessAction:
                 "pr": 11,
                 "comment_id": 300,
                 "url": "https://github.com/owner/repo/pull/11#issuecomment-300",
+                "author": "owner",
             },
             registry=WebhookHandler.registry,
         )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from kennel.tasks import (
+    _apply_reorder,
+    _parse_reorder_response,
     add_task,
     complete_by_id,
     has_pending_tasks_for_comment,
     list_tasks,
     remove_task,
+    reorder_tasks,
     update_task,
 )
 from kennel.types import TaskStatus, TaskType
@@ -268,3 +272,303 @@ class TestRemoveTask:
     def test_returns_false_if_not_found(self, tmp_path: Path) -> None:
         add_task(tmp_path, title="t", task_type=TaskType.SPEC)
         assert not remove_task(tmp_path, "nonexistent")
+
+
+# ── _parse_reorder_response ───────────────────────────────────────────────────
+
+
+class TestParseReorderResponse:
+    def test_parses_valid_json(self) -> None:
+        raw = '{"tasks": [{"id": "1", "title": "Task A", "description": ""}]}'
+        result = _parse_reorder_response(raw)
+        assert result == [{"id": "1", "title": "Task A", "description": ""}]
+
+    def test_parses_json_with_preamble(self) -> None:
+        raw = 'Here are the reordered tasks:\n\n{"tasks": [{"id": "1", "title": "Task A", "description": ""}]}'
+        result = _parse_reorder_response(raw)
+        assert result is not None
+        assert result[0]["id"] == "1"
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        assert _parse_reorder_response("not json at all") is None
+
+    def test_returns_none_when_no_tasks_key(self) -> None:
+        assert _parse_reorder_response('{"other": []}') is None
+
+    def test_returns_none_when_tasks_not_list(self) -> None:
+        assert _parse_reorder_response('{"tasks": "not a list"}') is None
+
+    def test_returns_none_for_json_non_dict(self) -> None:
+        # json.loads("null") → None → None.get("tasks") → AttributeError
+        assert _parse_reorder_response("null") is None
+
+    def test_returns_empty_list_when_tasks_is_empty(self) -> None:
+        result = _parse_reorder_response('{"tasks": []}')
+        assert result == []
+
+    def test_parses_multiple_tasks(self) -> None:
+        raw = '{"tasks": [{"id": "1", "title": "A", "description": ""}, {"id": "2", "title": "B", "description": ""}]}'
+        result = _parse_reorder_response(raw)
+        assert result is not None
+        assert len(result) == 2
+
+
+# ── _apply_reorder ────────────────────────────────────────────────────────────
+
+
+class TestApplyReorder:
+    def _t(
+        self,
+        task_id: str,
+        title: str,
+        task_type: str = "spec",
+        status: str = "pending",
+        description: str = "",
+    ) -> dict:
+        t: dict = {
+            "id": task_id,
+            "title": title,
+            "type": task_type,
+            "status": status,
+            "description": description,
+        }
+        return t
+
+    def _item(
+        self, task_id: str, title: str = "", description: str | None = None
+    ) -> dict:
+        d: dict = {"id": task_id, "title": title}
+        if description is not None:
+            d["description"] = description
+        return d
+
+    def test_reorders_two_tasks(self) -> None:
+        current = [self._t("1", "First"), self._t("2", "Second")]
+        items = [self._item("2", "Second"), self._item("1", "First")]
+        result = _apply_reorder(current, items)
+        assert [t["id"] for t in result] == ["2", "1"]
+
+    def test_updates_title_from_opus(self) -> None:
+        current = [self._t("1", "Old title")]
+        items = [self._item("1", "New title")]
+        result = _apply_reorder(current, items)
+        assert result[0]["title"] == "New title"
+
+    def test_preserves_title_when_opus_returns_empty(self) -> None:
+        current = [self._t("1", "Original title")]
+        items = [self._item("1", "")]  # empty title → don't overwrite
+        result = _apply_reorder(current, items)
+        assert result[0]["title"] == "Original title"
+
+    def test_updates_description_from_opus(self) -> None:
+        current = [self._t("1", "Task", description="old desc")]
+        items = [self._item("1", "Task", description="new desc")]
+        result = _apply_reorder(current, items)
+        assert result[0]["description"] == "new desc"
+
+    def test_clears_description_when_opus_sets_empty(self) -> None:
+        current = [self._t("1", "Task", description="something")]
+        items = [self._item("1", "Task", description="")]
+        result = _apply_reorder(current, items)
+        assert result[0]["description"] == ""
+
+    def test_preserves_description_when_key_absent(self) -> None:
+        current = [self._t("1", "Task", description="keep this")]
+        items = [{"id": "1", "title": "Task"}]  # no description key
+        result = _apply_reorder(current, items)
+        assert result[0]["description"] == "keep this"
+
+    def test_ignores_unknown_id_from_opus(self) -> None:
+        current = [self._t("1", "Real task")]
+        items = [self._item("999", "Ghost task"), self._item("1", "Real task")]
+        result = _apply_reorder(current, items)
+        assert len(result) == 1
+        assert result[0]["id"] == "1"
+
+    def test_ignores_duplicate_id_from_opus(self) -> None:
+        current = [self._t("1", "Task")]
+        items = [self._item("1", "Task v1"), self._item("1", "Task v2")]
+        result = _apply_reorder(current, items)
+        assert len([t for t in result if t["id"] == "1"]) == 1
+        assert result[0]["title"] == "Task v1"
+
+    def test_ci_tasks_always_first(self) -> None:
+        current = [
+            self._t("1", "Spec task"),
+            self._t("2", "CI failure", task_type="ci"),
+        ]
+        items = [self._item("1", "Spec task"), self._item("2", "CI failure")]
+        result = _apply_reorder(current, items)
+        assert result[0]["id"] == "2"
+        assert result[1]["id"] == "1"
+
+    def test_in_progress_task_reinstated_at_front(self) -> None:
+        current = [
+            self._t("1", "Active task", status="in_progress"),
+            self._t("2", "Spec task"),
+        ]
+        # Opus dropped task "1" (in_progress)
+        items = [self._item("2", "Spec task")]
+        result = _apply_reorder(current, items)
+        ids = [t["id"] for t in result]
+        assert "1" in ids
+        assert ids.index("1") == 0  # reinstated at front
+
+    def test_completed_tasks_preserved_at_end(self) -> None:
+        current = [
+            self._t("1", "Pending"),
+            self._t("2", "Done", status="completed"),
+        ]
+        items = [self._item("1", "Pending")]
+        result = _apply_reorder(current, items)
+        assert result[-1]["id"] == "2"
+        assert result[-1]["status"] == "completed"
+
+    def test_newly_added_tasks_preserved(self) -> None:
+        current = [self._t("1", "Original"), self._t("2", "New arrival")]
+        original_ids = frozenset({"1"})  # task "2" added after snapshot
+        items = [self._item("1", "Original")]
+        result = _apply_reorder(current, items, original_ids)
+        ids = [t["id"] for t in result]
+        assert "1" in ids
+        assert "2" in ids
+
+    def test_drops_pending_task_from_original_set_not_in_opus_output(self) -> None:
+        current = [self._t("1", "Keep"), self._t("2", "Drop this")]
+        original_ids = frozenset({"1", "2"})
+        items = [self._item("1", "Keep")]  # Opus dropped "2"
+        result = _apply_reorder(current, items, original_ids)
+        assert all(t["id"] != "2" for t in result)
+
+    def test_empty_ordered_items_preserves_completed_and_new(self) -> None:
+        current = [
+            self._t("1", "Completed", status="completed"),
+            self._t("2", "New"),
+        ]
+        original_ids = frozenset({"1"})  # "2" is new
+        result = _apply_reorder(current, [], original_ids)
+        ids = [t["id"] for t in result]
+        assert "1" in ids
+        assert "2" in ids
+
+    def test_preserves_thread_metadata(self) -> None:
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        t = self._t("1", "Thread task", task_type="thread")
+        t["thread"] = thread
+        items = [self._item("1", "Thread task")]
+        result = _apply_reorder([t], items)
+        assert result[0]["thread"] == thread
+
+
+# ── reorder_tasks ─────────────────────────────────────────────────────────────
+
+
+class TestReorderTasks:
+    def _add(self, tmp_path: Path, title: str, task_type=TaskType.SPEC) -> dict:
+        return add_task(tmp_path, title=title, task_type=task_type)
+
+    def _response(self, items: list[dict]) -> str:
+        return json.dumps({"tasks": items})
+
+    def test_skips_when_no_tasks(self, tmp_path: Path) -> None:
+        called = []
+        reorder_tasks(
+            tmp_path, "", _print_prompt=lambda *a, **k: called.append(1) or ""
+        )
+        assert called == []
+
+    def test_skips_on_empty_opus_response(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "Task A")
+        result_before = list_tasks(tmp_path)
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: "")
+        assert list_tasks(tmp_path) == result_before
+
+    def test_skips_on_unparseable_response(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "Task A")
+        result_before = list_tasks(tmp_path)
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: "not json")
+        assert list_tasks(tmp_path) == result_before
+
+    def test_reorders_tasks(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "First")
+        t2 = self._add(tmp_path, "Second")
+        # Opus returns them reversed
+        raw = self._response(
+            [
+                {"id": t2["id"], "title": "Second", "description": ""},
+                {"id": t1["id"], "title": "First", "description": ""},
+            ]
+        )
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        result = list_tasks(tmp_path)
+        assert result[0]["id"] == t2["id"]
+        assert result[1]["id"] == t1["id"]
+
+    def test_updates_title_from_opus(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Old title")
+        raw = self._response(
+            [{"id": t1["id"], "title": "New title", "description": ""}]
+        )
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        assert list_tasks(tmp_path)[0]["title"] == "New title"
+
+    def test_drops_task_opus_excludes(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Keep")
+        t2 = self._add(tmp_path, "Drop")
+        raw = self._response([{"id": t1["id"], "title": "Keep", "description": ""}])
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        result = list_tasks(tmp_path)
+        assert all(t["id"] != t2["id"] for t in result)
+
+    def test_preserves_completed_tasks(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Done")
+        complete_by_id(tmp_path, t1["id"])
+        t2 = self._add(tmp_path, "Pending")
+        raw = self._response([{"id": t2["id"], "title": "Pending", "description": ""}])
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        result = list_tasks(tmp_path)
+        statuses = {t["id"]: t["status"] for t in result}
+        assert statuses[t1["id"]] == "completed"
+
+    def test_rescope_prompt_fn_receives_task_list_and_commit_summary(
+        self, tmp_path: Path
+    ) -> None:
+        self._add(tmp_path, "Task A")
+        captured = {}
+
+        def fake_rescope(task_list, commit_summary):
+            captured["task_list"] = task_list
+            captured["commit_summary"] = commit_summary
+            return "prompt text"
+
+        reorder_tasks(
+            tmp_path,
+            "feat: added thing",
+            _print_prompt=lambda *a, **k: "",
+            _rescope_prompt_fn=fake_rescope,
+        )
+        assert captured["commit_summary"] == "feat: added thing"
+        assert len(captured["task_list"]) == 1
+
+    def test_picks_up_task_added_while_opus_was_thinking(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Original task")
+        new_task_id: list[str] = []
+
+        def slow_print_prompt(prompt, model, **kw):
+            # Simulate a new task arriving while Opus is running
+            t2 = add_task(
+                tmp_path, title="Arrived mid-reorder", task_type=TaskType.SPEC
+            )
+            new_task_id.append(t2["id"])
+            return json.dumps(
+                {
+                    "tasks": [
+                        {"id": t1["id"], "title": "Original task", "description": ""}
+                    ]
+                }
+            )
+
+        reorder_tasks(tmp_path, "", _print_prompt=slow_print_prompt)
+        result = list_tasks(tmp_path)
+        ids = [t["id"] for t in result]
+        assert new_task_id[0] in ids  # not silently dropped

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -420,18 +420,17 @@ class TestApplyReorder:
         assert result[0]["id"] == "2"
         assert result[1]["id"] == "1"
 
-    def test_in_progress_task_dropped_when_opus_excludes_it(self) -> None:
+    def test_in_progress_task_marked_completed_when_opus_excludes_it(self) -> None:
         current = [
             self._t("1", "Active task", status="in_progress"),
             self._t("2", "Spec task"),
         ]
         original_ids = frozenset({"1", "2"})
-        # Opus dropped task "1" (in_progress) — caller will abort the worker
+        # Opus omitted task "1" (in_progress) — marked completed; caller aborts worker
         items = [self._item("2", "Spec task")]
         result = _apply_reorder(current, items, original_ids)
-        ids = [t["id"] for t in result]
-        # in-progress task is dropped; caller (reorder_tasks) detects and signals abort
-        assert "1" not in ids
+        task1 = next(t for t in result if t["id"] == "1")
+        assert task1["status"] == "completed"
 
     def test_completed_tasks_preserved_at_end(self) -> None:
         current = [
@@ -452,12 +451,13 @@ class TestApplyReorder:
         assert "1" in ids
         assert "2" in ids
 
-    def test_drops_pending_task_from_original_set_not_in_opus_output(self) -> None:
-        current = [self._t("1", "Keep"), self._t("2", "Drop this")]
+    def test_marks_pending_task_completed_when_opus_excludes_it(self) -> None:
+        current = [self._t("1", "Keep"), self._t("2", "No longer needed")]
         original_ids = frozenset({"1", "2"})
-        items = [self._item("1", "Keep")]  # Opus dropped "2"
+        items = [self._item("1", "Keep")]  # Opus omitted "2"
         result = _apply_reorder(current, items, original_ids)
-        assert all(t["id"] != "2" for t in result)
+        task2 = next(t for t in result if t["id"] == "2")
+        assert task2["status"] == "completed"
 
     def test_empty_ordered_items_preserves_completed_and_new(self) -> None:
         current = [
@@ -531,13 +531,14 @@ class TestReorderTasks:
         reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
         assert list_tasks(tmp_path)[0]["title"] == "New title"
 
-    def test_drops_task_opus_excludes(self, tmp_path: Path) -> None:
+    def test_marks_completed_task_opus_excludes(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Keep")
-        t2 = self._add(tmp_path, "Drop")
+        t2 = self._add(tmp_path, "No longer needed")
         raw = self._response([{"id": t1["id"], "title": "Keep", "description": ""}])
         reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
         result = list_tasks(tmp_path)
-        assert all(t["id"] != t2["id"] for t in result)
+        task2 = next(t for t in result if t["id"] == t2["id"])
+        assert task2["status"] == "completed"
 
     def test_preserves_completed_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Done")
@@ -592,7 +593,9 @@ class TestReorderTasks:
         ids = [t["id"] for t in result]
         assert new_task_id[0] in ids  # not silently dropped
 
-    def test_on_changes_called_when_thread_task_dropped(self, tmp_path: Path) -> None:
+    def test_on_changes_called_when_thread_task_completed_by_reorder(
+        self, tmp_path: Path
+    ) -> None:
         thread = {
             "repo": "r/r",
             "pr": 1,
@@ -614,7 +617,7 @@ class TestReorderTasks:
             _on_changes=lambda changes: received.extend(changes),
         )
         assert len(received) == 1
-        assert received[0]["kind"] == "dropped"
+        assert received[0]["kind"] == "completed"
         assert received[0]["task"]["id"] == t1["id"]
 
     def test_on_changes_called_when_thread_task_modified(self, tmp_path: Path) -> None:
@@ -664,12 +667,13 @@ class TestReorderTasks:
         )
         t2 = self._add(tmp_path, "Keep")
         raw = self._response([{"id": t2["id"], "title": "Keep", "description": ""}])
-        # Should not raise even though t1 is dropped and _on_changes is None
+        # Should not raise even though t1 is completed and _on_changes is None
         reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw, _on_changes=None)
-        # t1 should be gone
-        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+        # t1 should be marked completed
+        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        assert task1["status"] == "completed"
 
-    def test_on_inprogress_affected_called_when_inprogress_task_dropped(
+    def test_on_inprogress_affected_called_when_inprogress_task_completed(
         self, tmp_path: Path
     ) -> None:
         t1 = self._add(tmp_path, "In-progress task")
@@ -686,8 +690,9 @@ class TestReorderTasks:
             _on_inprogress_affected=lambda: affected.append(1),
         )
         assert affected == [1]
-        # in-progress task is gone from the list
-        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+        # in-progress task is marked completed
+        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        assert task1["status"] == "completed"
 
     def test_on_inprogress_affected_called_when_inprogress_task_modified(
         self, tmp_path: Path
@@ -754,14 +759,15 @@ class TestReorderTasks:
         raw = self._response(
             [{"id": t2["id"], "title": "Keep this", "description": ""}]
         )
-        # Should not raise even though in-progress task is dropped and callback is None
+        # Should not raise even though in-progress task is completed and callback is None
         reorder_tasks(
             tmp_path,
             "",
             _print_prompt=lambda *a, **k: raw,
             _on_inprogress_affected=None,
         )
-        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        assert task1["status"] == "completed"
 
 
 # ── _compute_thread_changes ───────────────────────────────────────────────────
@@ -790,12 +796,12 @@ class TestComputeThreadChanges:
     def _thread(self) -> dict:
         return {"repo": "r/r", "pr": 1, "comment_id": 42, "url": "https://x.com"}
 
-    def test_dropped_thread_task(self) -> None:
+    def test_completed_thread_task(self) -> None:
         original = [self._t("1", "Thread task", thread=self._thread())]
         result: list = []
         changes = _compute_thread_changes(original, result, frozenset({"1"}))
         assert len(changes) == 1
-        assert changes[0]["kind"] == "dropped"
+        assert changes[0]["kind"] == "completed"
         assert changes[0]["task"]["id"] == "1"
 
     def test_modified_title(self) -> None:
@@ -836,10 +842,10 @@ class TestComputeThreadChanges:
 
     def test_multiple_changes_returned(self) -> None:
         thread = self._thread()
-        t1 = self._t("1", "Dropped", thread=thread)
+        t1 = self._t("1", "Covered by commit", thread=thread)
         t2 = self._t("2", "Old", thread=thread)
         r2 = self._t("2", "New", thread=thread)
         changes = _compute_thread_changes([t1, t2], [r2], frozenset({"1", "2"}))
         kinds = {c["kind"] for c in changes}
-        assert "dropped" in kinds
+        assert "completed" in kinds
         assert "modified" in kinds

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -403,17 +403,18 @@ class TestApplyReorder:
         assert result[0]["id"] == "2"
         assert result[1]["id"] == "1"
 
-    def test_in_progress_task_reinstated_at_front(self) -> None:
+    def test_in_progress_task_dropped_when_opus_excludes_it(self) -> None:
         current = [
             self._t("1", "Active task", status="in_progress"),
             self._t("2", "Spec task"),
         ]
-        # Opus dropped task "1" (in_progress)
+        original_ids = frozenset({"1", "2"})
+        # Opus dropped task "1" (in_progress) — caller will abort the worker
         items = [self._item("2", "Spec task")]
-        result = _apply_reorder(current, items)
+        result = _apply_reorder(current, items, original_ids)
         ids = [t["id"] for t in result]
-        assert "1" in ids
-        assert ids.index("1") == 0  # reinstated at front
+        # in-progress task is dropped; caller (reorder_tasks) detects and signals abort
+        assert "1" not in ids
 
     def test_completed_tasks_preserved_at_end(self) -> None:
         current = [
@@ -649,6 +650,100 @@ class TestReorderTasks:
         # Should not raise even though t1 is dropped and _on_changes is None
         reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw, _on_changes=None)
         # t1 should be gone
+        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+
+    def test_on_inprogress_affected_called_when_inprogress_task_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "In-progress task")
+        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        t2 = self._add(tmp_path, "Keep this")
+        raw = self._response(
+            [{"id": t2["id"], "title": "Keep this", "description": ""}]
+        )
+        affected: list[int] = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_inprogress_affected=lambda: affected.append(1),
+        )
+        assert affected == [1]
+        # in-progress task is gone from the list
+        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+
+    def test_on_inprogress_affected_called_when_inprogress_task_modified(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Old title")
+        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [{"id": t1["id"], "title": "New title", "description": ""}]
+        )
+        affected: list[int] = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_inprogress_affected=lambda: affected.append(1),
+        )
+        assert affected == [1]
+        # task reset to pending with new title
+        result = list_tasks(tmp_path)
+        assert result[0]["title"] == "New title"
+        assert result[0]["status"] == str(TaskStatus.PENDING)
+
+    def test_on_inprogress_affected_not_called_when_inprogress_task_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Stable task")
+        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [{"id": t1["id"], "title": "Stable task", "description": ""}]
+        )
+        affected: list[int] = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_inprogress_affected=lambda: affected.append(1),
+        )
+        assert affected == []
+        # task still in_progress (unchanged by Opus)
+        result = list_tasks(tmp_path)
+        assert result[0]["status"] == str(TaskStatus.IN_PROGRESS)
+
+    def test_on_inprogress_affected_not_called_when_no_inprogress_task(
+        self, tmp_path: Path
+    ) -> None:
+        self._add(tmp_path, "Pending task")
+        t2 = self._add(tmp_path, "Keep this")
+        raw = self._response(
+            [{"id": t2["id"], "title": "Keep this", "description": ""}]
+        )
+        affected: list[int] = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_inprogress_affected=lambda: affected.append(1),
+        )
+        assert affected == []
+
+    def test_on_inprogress_affected_none_does_not_error(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "In-progress task")
+        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        t2 = self._add(tmp_path, "Keep this")
+        raw = self._response(
+            [{"id": t2["id"], "title": "Keep this", "description": ""}]
+        )
+        # Should not raise even though in-progress task is dropped and callback is None
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_inprogress_affected=None,
+        )
         assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,6 +7,7 @@ import pytest
 
 from kennel.tasks import (
     _apply_reorder,
+    _compute_thread_changes,
     _parse_reorder_response,
     add_task,
     complete_by_id,
@@ -572,3 +573,161 @@ class TestReorderTasks:
         result = list_tasks(tmp_path)
         ids = [t["id"] for t in result]
         assert new_task_id[0] in ids  # not silently dropped
+
+    def test_on_changes_called_when_thread_task_dropped(self, tmp_path: Path) -> None:
+        thread = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 99,
+            "url": "https://example.com",
+        }
+        t1 = add_task(
+            tmp_path, title="Thread task", task_type=TaskType.THREAD, thread=thread
+        )
+        t2 = self._add(tmp_path, "Keep this")
+        received: list = []
+        raw = self._response(
+            [{"id": t2["id"], "title": "Keep this", "description": ""}]
+        )
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_changes=lambda changes: received.extend(changes),
+        )
+        assert len(received) == 1
+        assert received[0]["kind"] == "dropped"
+        assert received[0]["task"]["id"] == t1["id"]
+
+    def test_on_changes_called_when_thread_task_modified(self, tmp_path: Path) -> None:
+        thread = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 99,
+            "url": "https://example.com",
+        }
+        t1 = add_task(
+            tmp_path, title="Old title", task_type=TaskType.THREAD, thread=thread
+        )
+        received: list = []
+        raw = self._response(
+            [{"id": t1["id"], "title": "New title", "description": ""}]
+        )
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_changes=lambda changes: received.extend(changes),
+        )
+        assert len(received) == 1
+        assert received[0]["kind"] == "modified"
+        assert received[0]["new_title"] == "New title"
+
+    def test_on_changes_not_called_when_no_thread_tasks_changed(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Spec task")
+        received: list = []
+        raw = self._response(
+            [{"id": t1["id"], "title": "Spec task", "description": ""}]
+        )
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_changes=lambda changes: received.extend(changes),
+        )
+        assert received == []
+
+    def test_on_changes_none_does_not_error(self, tmp_path: Path) -> None:
+        thread = {"repo": "r/r", "pr": 1, "comment_id": 42, "url": "https://x.com"}
+        t1 = add_task(
+            tmp_path, title="Thread task", task_type=TaskType.THREAD, thread=thread
+        )
+        t2 = self._add(tmp_path, "Keep")
+        raw = self._response([{"id": t2["id"], "title": "Keep", "description": ""}])
+        # Should not raise even though t1 is dropped and _on_changes is None
+        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw, _on_changes=None)
+        # t1 should be gone
+        assert all(t["id"] != t1["id"] for t in list_tasks(tmp_path))
+
+
+# ── _compute_thread_changes ───────────────────────────────────────────────────
+
+
+class TestComputeThreadChanges:
+    def _t(
+        self,
+        task_id: str,
+        title: str,
+        status: str = "pending",
+        thread: dict | None = None,
+        description: str = "",
+    ) -> dict:
+        t: dict = {
+            "id": task_id,
+            "title": title,
+            "type": "thread" if thread else "spec",
+            "status": status,
+            "description": description,
+        }
+        if thread:
+            t["thread"] = thread
+        return t
+
+    def _thread(self) -> dict:
+        return {"repo": "r/r", "pr": 1, "comment_id": 42, "url": "https://x.com"}
+
+    def test_dropped_thread_task(self) -> None:
+        original = [self._t("1", "Thread task", thread=self._thread())]
+        result: list = []
+        changes = _compute_thread_changes(original, result, frozenset({"1"}))
+        assert len(changes) == 1
+        assert changes[0]["kind"] == "dropped"
+        assert changes[0]["task"]["id"] == "1"
+
+    def test_modified_title(self) -> None:
+        original = [self._t("1", "Old title", thread=self._thread())]
+        result = [self._t("1", "New title", thread=self._thread())]
+        changes = _compute_thread_changes(original, result, frozenset({"1"}))
+        assert len(changes) == 1
+        assert changes[0]["kind"] == "modified"
+        assert changes[0]["new_title"] == "New title"
+
+    def test_modified_description(self) -> None:
+        original = [self._t("1", "Task", thread=self._thread(), description="old")]
+        result = [self._t("1", "Task", thread=self._thread(), description="new")]
+        changes = _compute_thread_changes(original, result, frozenset({"1"}))
+        assert len(changes) == 1
+        assert changes[0]["kind"] == "modified"
+        assert changes[0]["new_description"] == "new"
+
+    def test_unchanged_thread_task_not_reported(self) -> None:
+        t = self._t("1", "Task", thread=self._thread())
+        changes = _compute_thread_changes([t], [t], frozenset({"1"}))
+        assert changes == []
+
+    def test_spec_task_not_reported_even_if_dropped(self) -> None:
+        t = self._t("1", "Spec task")  # no thread
+        changes = _compute_thread_changes([t], [], frozenset({"1"}))
+        assert changes == []
+
+    def test_completed_task_not_reported(self) -> None:
+        t = self._t("1", "Done", status="completed", thread=self._thread())
+        changes = _compute_thread_changes([t], [], frozenset({"1"}))
+        assert changes == []
+
+    def test_task_not_in_original_ids_not_reported(self) -> None:
+        t = self._t("1", "New task", thread=self._thread())
+        changes = _compute_thread_changes([t], [], frozenset())
+        assert changes == []
+
+    def test_multiple_changes_returned(self) -> None:
+        thread = self._thread()
+        t1 = self._t("1", "Dropped", thread=thread)
+        t2 = self._t("2", "Old", thread=thread)
+        r2 = self._t("2", "New", thread=thread)
+        changes = _compute_thread_changes([t1, t2], [r2], frozenset({"1", "2"}))
+        kinds = {c["kind"] for c in changes}
+        assert "dropped" in kinds
+        assert "modified" in kinds

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4324,10 +4324,12 @@ class TestPickNextTask:
         ci = self._task("Fix tests", task_type="ci")
         assert _pick_next_task([thread_task, ci]) is ci
 
-    def test_thread_type_takes_priority_over_spec(self) -> None:
+    def test_thread_type_uses_list_order_same_as_spec(self) -> None:
         regular = self._task("Regular work", task_type="spec")
         thread_task = self._task("PR comment: rename var", task_type="thread")
-        assert _pick_next_task([regular, thread_task]) is thread_task
+        # Thread tasks no longer jump the queue — first in list wins.
+        assert _pick_next_task([regular, thread_task]) is regular
+        assert _pick_next_task([thread_task, regular]) is thread_task
 
     def test_returns_first_pending_when_no_special(self) -> None:
         first = self._task("First task")
@@ -7331,7 +7333,7 @@ class TestFormatWorkQueue:
         assert "CI failure: lint" in lines[0]
         assert "Normal task" in lines[1]
 
-    def test_thread_task_has_priority_over_other_pending(self) -> None:
+    def test_thread_task_preserves_list_order_same_as_spec(self) -> None:
         tasks = [
             {"title": "Normal", "status": "pending", "type": "spec"},
             {
@@ -7343,8 +7345,9 @@ class TestFormatWorkQueue:
         ]
         result = _format_work_queue(tasks)
         lines = [ln for ln in result.splitlines() if "- [ ]" in ln]
-        assert "Thread task" in lines[0]
-        assert "Normal" in lines[1]
+        # Thread tasks no longer jump the queue — list order is preserved.
+        assert "Normal" in lines[0]
+        assert "Thread task" in lines[1]
 
     def test_thread_task_with_url_becomes_link(self) -> None:
         tasks = [


### PR DESCRIPTION
Adds dynamic task reordering via Opus dependency analysis when new PR comment tasks arrive mid-work. A `rescope_prompt()` builder in prompts.py feeds the current task list and commit history to Opus, `reorder_tasks()` in tasks.py applies the reordered result while preserving IDs/statuses/thread metadata and keeping CI tasks first, and `create_task()` in events.py triggers rescoping only for thread-type tasks (skipping initial setup). Documentation in CLAUDE.md is updated to reflect the new behavior.

Fixes #165.

---

## Work queue

<!-- WORK_QUEUE_START -->
- [ ] Update CLAUDE.md to document dynamic task reordering **→ next** <!-- type:spec -->

<details><summary>Completed (3)</summary>

- [x] Cancel in-progress task and restart on new next task when rescoping affects current task <!-- type:thread -->
- [x] Elevate PR comment tasks to spec-level priority in task ordering <!-- type:thread -->
- [x] Mark tasks done if no longer applicable during rescoping <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->