### PR TITLE
Sanitize multi-line task titles and harden PR body rehydration

### DIFF
--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -83,6 +83,7 @@ def add_task(
     """
     if not isinstance(task_type, TaskType):
         raise TypeError(f"task_type must be TaskType, got {type(task_type).__name__}")
+    title = " ".join(title.split())
     task: dict[str, Any] = {
         "id": f"{int(time.time() * 1000)}-{random.randint(0, 9999):04d}",
         "title": title,

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1188,8 +1188,9 @@ class Worker:
 
         Extracts unchecked task items (``- [ ] ...``) between
         ``WORK_QUEUE_START`` and ``WORK_QUEUE_END`` markers and adds them via
-        :func:`~kennel.tasks.add_task`.  Each line must contain a
-        ``<!-- type:X -->`` comment; raises ``ValueError`` if missing.
+        :func:`~kennel.tasks.add_task`.  Lines without a ``<!-- type:X -->``
+        comment are skipped with a warning (e.g. stale multi-line task bodies
+        from older PR bodies).
 
         No-op if tasks.json is already non-empty, or if no markers /
         unchecked items are found.
@@ -1213,7 +1214,8 @@ class Worker:
             rest = m.group(1)
             type_match = re.search(r"<!-- type:(\w+) -->", rest)
             if not type_match:
-                raise ValueError(f"missing <!-- type:X --> in task line: {line!r}")
+                log.warning("skipping task line without type marker: %r", line)
+                continue
             raw_type = type_match.group(1)
             task_type = TaskType(raw_type)
             title = re.sub(r"\s*<!-- type:\w+ -->\s*", "", rest)

--- a/sub/setup.md
+++ b/sub/setup.md
@@ -14,6 +14,8 @@ uv run --project /home/rhencke/workspace/kennel kennel task <work_dir> add spec 
 ```
 Where `<work_dir>` is from the Context section.
 
+**Task titles must be short one-line summaries** — imperative verb-first, under 80 characters. Like `Add Dependabot routes and default handlers` or `Gitea: dependency-graph endpoints and tests`. NOT multi-paragraph specs with file lists, endpoint tables, or instructions. The title appears in `kennel status`, PR work queues, and log lines — it needs to fit on one line. Details belong in the implementation itself, not the task title.
+
 The `spec` argument is the task type — always use `spec` for planned tasks. Other types (`thread`, `ci`) are created by the system, never by you.
 
 **CRITICAL**: Always use the `kennel task add` CLI command to create tasks. NEVER write to tasks.json directly — no `echo`, no `Write` tool, no `cat >`. The CLI handles locking, validation, and ID generation. Direct writes bypass all of this and create broken tasks.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -61,6 +61,23 @@ class TestAddTask:
         assert t1["id"] == t2["id"]
         assert len(list_tasks(tmp_path)) == 1
 
+    def test_sanitizes_multiline_title(self, tmp_path: Path) -> None:
+        task = add_task(
+            tmp_path,
+            title="first line\n\nsecond paragraph\n- bullet\n- another",
+            task_type=TaskType.SPEC,
+        )
+        assert task["title"] == "first line second paragraph - bullet - another"
+        assert "\n" not in task["title"]
+
+    def test_collapses_whitespace_in_title(self, tmp_path: Path) -> None:
+        task = add_task(
+            tmp_path,
+            title="  too   many    spaces  \t\there  ",
+            task_type=TaskType.SPEC,
+        )
+        assert task["title"] == "too many spaces here"
+
     def test_does_not_deduplicate_completed_tasks(self, tmp_path: Path) -> None:
         t1 = add_task(tmp_path, title="done task", task_type=TaskType.SPEC)
         complete_by_id(tmp_path, t1["id"])

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2953,20 +2953,26 @@ class TestSeedTasksFromPrBody:
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_not_called()
 
-    def test_raises_on_missing_type_comment(self, tmp_path: Path) -> None:
+    def test_skips_lines_without_type_comment(self, tmp_path: Path, caplog) -> None:
+        import logging
+
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {
             "body": (
                 "<!-- WORK_QUEUE_START -->\n"
+                "- [ ] Task with type <!-- type:spec -->\n"
                 "- [ ] Task without type\n"
                 "<!-- WORK_QUEUE_END -->"
             )
         }
         with (
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            pytest.raises(ValueError, match="missing <!-- type:X -->"),
+            patch("kennel.worker.tasks.add_task") as mock_add,
+            caplog.at_level(logging.WARNING, logger="kennel"),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
+        assert mock_add.call_count == 1
+        assert "without type marker" in caplog.text
 
     def test_logs_info_with_task_count(self, tmp_path: Path, caplog) -> None:
         import logging


### PR DESCRIPTION
## Summary

Three interlocking fixes for a worker crash loop triggered by bloated multi-paragraph task titles:

1. **`add_task` sanitizes titles** — collapses whitespace and newlines into single spaces, guaranteeing single-line titles
2. **`seed_tasks_from_pr_body` hardened** — logs a warning and skips unmarked task lines instead of raising \`ValueError\`, preventing worker crashes on stale PR bodies
3. **\`sub/setup.md\` updated** — tells the planning sub-Claude to write short one-line task titles (imperative, under 80 chars), not multi-paragraph specs

The sanitization prevents the bad state from being created; the rehydration hardening prevents crashes from existing bad state; the prompt fix stops fido from producing the bloated titles in the first place.

Closes #243, #238

## Test plan
- [x] 1285 tests pass, 100% coverage
- [x] New test: \`add_task\` collapses newlines and multi-spaces
- [x] Updated test: \`seed_tasks_from_pr_body\` skips unmarked lines with warning instead of raising