### PR TITLE
Run kennel from a separate runner clone (#198)

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -121,9 +121,11 @@ For each managed repo (kennel, confusio, fidocancode.github.io):
 - Verify: branch matches PR, tasks match PR body, workspace is clean
 
 ### Step 9: Restart kennel
+Kennel runs from the **runner clone** at `/home/rhencke/kennel-runner/`, not the workspace clone. The runner is always on `main`, never on a feature branch. Launch via the local launcher:
 ```bash
-/home/rhencke/workspace/kennel/.venv/bin/kennel --port 9000 --secret-file ~/.kennel-secret --self-repo rhencke/kennel rhencke/confusio:/home/rhencke/workspace/confusio rhencke/kennel:/home/rhencke/workspace/kennel >> ~/log/kennel.log 2>&1 & disown
-sleep 5 && /home/rhencke/workspace/kennel/.venv/bin/kennel status
+/home/rhencke/start-kennel.sh >> ~/log/kennel.log 2>&1 &
+disown
+sleep 5 && /home/rhencke/kennel-runner/.venv/bin/kennel status
 ```
 
 Update GitHub status: `uv run kennel gh-status set "kennel restarted — back on watch duty"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,25 +5,36 @@ GitHub webhook listener + fido orchestrator. Receives GitHub events, triages com
 ## Architecture
 
 ```
-kennel (single process)
+kennel (single process, runs from /home/rhencke/kennel-runner/)
   ├─ HTTP server: receives webhooks, routes by repo
   ├─ Per-repo fido workers: bash work.sh (temporary, becoming Python threads)
   ├─ Per-repo task sync: tasks.json → PR body
-  └─ Self-restart: exec on kennel repo merge
+  └─ Self-restart: git pull runner clone, exec uv run kennel
 ```
 
 Multi-repo: one kennel process handles multiple repos. Each repo has its own tasks.json, lock files, and worker process.
 
 **Concurrency model**: one fido per repo, one issue per fido, one PR per issue. Fido finishes the current issue (PR merged or closed) before picking up the next. Two repos = two fidos max, running in parallel, each on their own issue.
 
+## Runner vs workspace clones
+
+Kennel runs from a dedicated **runner clone** at `/home/rhencke/kennel-runner/`, separate from the **workspace clone** at `/home/rhencke/workspace/kennel/`.
+
+- **Runner clone** — always on `main`, never dirty, never has feature branches. Kennel imports its Python code from here. Self-restart does `git pull` here.
+- **Workspace clone** — where fido edits source files, commits, and pushes feature branches. Never used to run the server.
+
+Launching: `/home/rhencke/start-kennel.sh` (local, outside git) execs `uv run kennel ...` from the runner clone. The `start.sh` files inside both clones are for reference/local dev only.
+
+Self-restart logic: `_self_restart` in `server.py` derives the runner clone from `Path(__file__).resolve().parents[1]`, checks the git remote matches the merged PR's repo, pulls with exponential backoff (10s → 30s → 60s, 10-minute budget), then `os.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])` with cwd set to the runner clone. This replaces the previous in-place restart that ran `git reset --hard` in the workspace clone and clobbered fido's in-progress work.
+
 ## Running
 
 ```bash
-./start.sh
-# or:
-uv run kennel --port 9000 --secret-file ~/.kennel-secret \
-  rhencke/confusio:/path/to/confusio \
-  rhencke/kennel:/path/to/kennel
+/home/rhencke/start-kennel.sh
+# or directly from the runner clone:
+cd /home/rhencke/kennel-runner && uv run kennel --port 9000 --secret-file ~/.kennel-secret \
+  rhencke/confusio:/home/rhencke/workspace/confusio \
+  rhencke/kennel:/home/rhencke/workspace/kennel
 ```
 
 ## Testing

--- a/kennel/config.py
+++ b/kennel/config.py
@@ -21,7 +21,6 @@ class Config:
     repos: dict[str, RepoConfig]  # keyed by full_name
     allowed_bots: frozenset[str]
     log_level: str
-    self_repo: str | None  # which repo is kennel itself (for self-restart)
     sub_dir: Path  # path to sub/ skill files
 
     @classmethod
@@ -45,11 +44,6 @@ class Config:
         )
         parser.add_argument(
             "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
-        )
-        parser.add_argument(
-            "--self-repo",
-            default=None,
-            help="Repo name that is kennel itself (for self-restart on merge)",
         )
         parser.add_argument(
             "repos",
@@ -83,6 +77,5 @@ class Config:
                 b.strip() for b in args.allowed_bots.split(",") if b.strip()
             ),
             log_level=args.log_level.upper(),
-            self_repo=args.self_repo,
             sub_dir=Path(__file__).resolve().parent.parent / "sub",
         )

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -5,9 +5,12 @@ import hmac
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import threading
+import time
+from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
@@ -28,21 +31,103 @@ log = logging.getLogger(__name__)
 
 _replied_comments: set[int] = set()
 
-_RESTART_CMDS: list[list[str]] = [
-    ["git", "reset", "--hard"],
-    ["git", "clean", "-fd"],
-    ["git", "checkout", "main"],
-    ["git", "pull"],
-]
+# Exponential backoff for git pull during self-restart: 10s, 30s, 60s
+# with a 10-minute total budget. Retries stop once the cumulative delay
+# exceeds _PULL_BUDGET_SECONDS, even if a retry window remains.
+_PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
+_PULL_BUDGET_SECONDS: float = 600.0
 
 
-def _run_git_cmd(work_dir: Path, cmd: list[str], *, _run=subprocess.run) -> bool:
+def _runner_dir() -> Path:
+    """Return the runner clone directory — where the running kennel code lives."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _get_self_repo(
+    runner_dir: Path,
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str | None:
+    """Return 'owner/repo' from the runner clone's origin remote, or None on error.
+
+    Handles both SSH (``git@github.com:owner/repo.git``) and HTTPS
+    (``https://github.com/owner/repo.git``) remote URLs.
+    """
     try:
-        _run(cmd, cwd=str(work_dir), capture_output=True, check=True)
-    except subprocess.CalledProcessError as e:
-        log.error("self-restart: git command failed (%d): %s", e.returncode, cmd)
-        return False
-    return True
+        result = _run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(runner_dir),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        log.error("self-restart: failed to read origin remote: %s", e)
+        return None
+    url = result.stdout.strip()
+    m = re.search(r"[:/]([^:/]+/[^/]+?)(?:\.git)?$", url)
+    if not m:
+        log.error("self-restart: could not parse owner/repo from remote url: %r", url)
+        return None
+    return m.group(1)
+
+
+def _pull_with_backoff(
+    runner_dir: Path,
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    _sleep: Callable[[float], None] = time.sleep,
+    _monotonic: Callable[[], float] = time.monotonic,
+) -> bool:
+    """Run ``git pull`` in *runner_dir* with exponential backoff on failure.
+
+    Retries with delays from :data:`_PULL_BACKOFF_DELAYS` (10s, 30s, 60s)
+    and a total budget of :data:`_PULL_BUDGET_SECONDS` (10 minutes).  Logs
+    each attempt and the elapsed time.  Returns ``True`` on success,
+    ``False`` if every retry fails or the budget is exhausted.
+    """
+    start = _monotonic()
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            _run(
+                ["git", "pull"],
+                cwd=str(runner_dir),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            log.info(
+                "self-restart: git pull succeeded on attempt %d (%.1fs elapsed)",
+                attempt,
+                _monotonic() - start,
+            )
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            elapsed = _monotonic() - start
+            log.error(
+                "self-restart: git pull attempt %d failed after %.1fs: %s",
+                attempt,
+                elapsed,
+                e,
+            )
+            if attempt > len(_PULL_BACKOFF_DELAYS):
+                log.error(
+                    "self-restart: git pull exhausted %d retries in %.1fs — giving up",
+                    attempt,
+                    elapsed,
+                )
+                return False
+            delay = _PULL_BACKOFF_DELAYS[attempt - 1]
+            if elapsed + delay > _PULL_BUDGET_SECONDS:
+                log.error(
+                    "self-restart: git pull would exceed %.0fs budget — giving up",
+                    _PULL_BUDGET_SECONDS,
+                )
+                return False
+            log.info("self-restart: sleeping %ds before retry", delay)
+            _sleep(delay)
 
 
 class WebhookHandler(BaseHTTPRequestHandler):
@@ -55,8 +140,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_reply_to_issue_comment = reply_to_issue_comment
     _fn_create_task = create_task
     _fn_launch_worker = launch_worker
-    _fn_subprocess_run = subprocess.run
-    _fn_os_execv = os.execv
+    _fn_runner_dir = _runner_dir
+    _fn_get_self_repo = _get_self_repo
+    _fn_pull_with_backoff = _pull_with_backoff
+    _fn_os_chdir = os.chdir
+    _fn_os_execvp = os.execvp
 
     def do_POST(self) -> None:
         content_length = int(self.headers.get("Content-Length", 0))
@@ -99,16 +187,16 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # Respond immediately — don't block on dispatch
         self._respond(200, "ok")
 
-        # Check for self-restart (kennel repo merged)
+        # Check for self-restart (kennel repo merged).  _self_restart itself
+        # verifies via the runner clone's git remote that the webhook's repo
+        # actually matches kennel — if so it execs a new process and never
+        # returns.  For other merged PRs (e.g. fido's own work) it's a no-op.
         if (
-            self.config.self_repo
-            and repo_name == self.config.self_repo
-            and event == "pull_request"
+            event == "pull_request"
             and payload.get("action") == "closed"
             and payload.get("pull_request", {}).get("merged")
         ):
             self._self_restart(repo_name)
-            return
 
         if not repo_cfg:
             log.debug("ignoring webhook for unregistered repo: %s", repo_name)
@@ -182,16 +270,21 @@ class WebhookHandler(BaseHTTPRequestHandler):
             log.exception("error processing action")
 
     def _self_restart(self, repo_name: str) -> None:
-        repo_cfg = self.config.repos.get(repo_name)
-        if repo_cfg:
-            log.info("kennel repo %s merged — pulling and restarting", repo_name)
-            self.registry.stop_and_join(repo_name)
-            for cmd in _RESTART_CMDS:
-                if not _run_git_cmd(
-                    repo_cfg.work_dir, cmd, _run=type(self)._fn_subprocess_run
-                ):
-                    return
-            type(self)._fn_os_execv(sys.argv[0], sys.argv)
+        runner_dir = type(self)._fn_runner_dir()
+        self_repo = type(self)._fn_get_self_repo(runner_dir)
+        if self_repo != repo_name:
+            return  # Not our repo — nothing to do.
+        log.info(
+            "kennel repo %s merged — pulling runner clone at %s",
+            repo_name,
+            runner_dir,
+        )
+        self.registry.stop_and_join(repo_name)
+        if not type(self)._fn_pull_with_backoff(runner_dir):
+            log.error("self-restart: git pull gave up — running old version")
+            return
+        type(self)._fn_os_chdir(runner_dir)
+        type(self)._fn_os_execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
 
     def do_GET(self) -> None:
         if self.path == "/status":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,22 +127,6 @@ class TestFromArgs:
         assert "owner/repo1" in cfg.repos
         assert "owner/repo2" in cfg.repos
 
-    def test_self_repo(self, tmp_path: Path) -> None:
-        secret_file = tmp_path / "secret"
-        secret_file.write_text("s")
-        repo_dir = tmp_path / "repo"
-        repo_dir.mkdir()
-        cfg = Config.from_args(
-            [
-                "--self-repo",
-                "owner/repo",
-                "--secret-file",
-                str(secret_file),
-                f"owner/repo:{repo_dir}",
-            ]
-        )
-        assert cfg.self_repo == "owner/repo"
-
     def test_sub_dir_points_to_package_parent(self, tmp_path: Path) -> None:
         secret_file = tmp_path / "secret"
         secret_file.write_text("s")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,7 +29,6 @@ def _config(tmp_path: Path) -> Config:
         repos={},
         allowed_bots=frozenset({"copilot[bot]"}),
         log_level="WARNING",
-        self_repo=None,
         sub_dir=tmp_path / "sub",
     )
 
@@ -443,7 +442,6 @@ class TestMaybeReact:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -507,7 +505,6 @@ class TestMaybeReact:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=sub_dir,
         )
         captured = {}
@@ -542,7 +539,6 @@ class TestReplyToComment:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -879,7 +875,6 @@ class TestReplyToReview:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -971,7 +966,6 @@ class TestReplyToIssueComment:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -1262,7 +1256,6 @@ class TestCreateTask:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -1283,7 +1276,6 @@ class TestCreateTask:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -1304,7 +1296,6 @@ class TestCreateTask:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -1734,7 +1725,6 @@ class TestLaunchSync:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -1898,7 +1888,6 @@ class TestMaybeReactGhException:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
         mock_gh = MagicMock()
@@ -1922,7 +1911,6 @@ class TestReplyToCommentElseBranch:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -1995,7 +1983,6 @@ class TestReplyToReviewAlreadyRepliedTracking:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -2070,7 +2057,6 @@ class TestReplyToCommentTerseEnrichment:
             repos={},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,6 @@ def _config(tmp_path: Path) -> Config:
         repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
         allowed_bots=frozenset({"copilot[bot]"}),
         log_level="WARNING",
-        self_repo=None,
         sub_dir=tmp_path / "sub",
     )
 
@@ -42,8 +41,11 @@ def _restore_handler_fns():
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
         "_fn_create_task": WebhookHandler._fn_create_task,
         "_fn_launch_worker": WebhookHandler._fn_launch_worker,
-        "_fn_subprocess_run": WebhookHandler._fn_subprocess_run,
-        "_fn_os_execv": WebhookHandler._fn_os_execv,
+        "_fn_runner_dir": WebhookHandler._fn_runner_dir,
+        "_fn_get_self_repo": WebhookHandler._fn_get_self_repo,
+        "_fn_pull_with_backoff": WebhookHandler._fn_pull_with_backoff,
+        "_fn_os_chdir": WebhookHandler._fn_os_chdir,
+        "_fn_os_execvp": WebhookHandler._fn_os_execvp,
     }
     yield
     for attr, val in saved.items():
@@ -489,7 +491,6 @@ class TestRun:
             repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -592,7 +593,6 @@ class TestRun:
             },
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -640,7 +640,6 @@ class TestRun:
             repos={"owner/myrepo": RepoConfig(name="owner/myrepo", work_dir=tmp_path)},
             allowed_bots=frozenset(),
             log_level="WARNING",
-            self_repo=None,
             sub_dir=tmp_path / "sub",
         )
 
@@ -678,7 +677,6 @@ def _self_restart_cfg(tmp_path: Path) -> Config:
         repos={"owner/kennel": RepoConfig(name="owner/kennel", work_dir=tmp_path)},
         allowed_bots=frozenset(),
         log_level="WARNING",
-        self_repo="owner/kennel",
         sub_dir=tmp_path / "sub",
     )
 
@@ -693,8 +691,145 @@ _MERGE_PAYLOAD = {
 }
 
 
+class TestGetSelfRepo:
+    def test_parses_ssh_remote(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(
+            return_value=MagicMock(
+                stdout="git@github.com:owner/kennel.git\n", returncode=0
+            )
+        )
+        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+
+    def test_parses_https_remote(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(
+            return_value=MagicMock(
+                stdout="https://github.com/owner/kennel.git\n", returncode=0
+            )
+        )
+        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+
+    def test_parses_remote_without_git_suffix(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(
+            return_value=MagicMock(
+                stdout="https://github.com/owner/kennel\n", returncode=0
+            )
+        )
+        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+
+    def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
+        assert _get_self_repo(tmp_path, _run=mock_run) is None
+
+    def test_returns_none_on_file_not_found(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(side_effect=FileNotFoundError())
+        assert _get_self_repo(tmp_path, _run=mock_run) is None
+
+    def test_returns_none_on_unparseable_url(self, tmp_path: Path) -> None:
+        from kennel.server import _get_self_repo
+
+        mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n", returncode=0))
+        assert _get_self_repo(tmp_path, _run=mock_run) is None
+
+
+class TestRunnerDir:
+    def test_returns_package_parent(self) -> None:
+        from kennel.server import _runner_dir
+
+        result = _runner_dir()
+        assert (result / "kennel" / "server.py").exists()
+
+
+class TestPullWithBackoff:
+    def test_success_on_first_try(self, tmp_path: Path) -> None:
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        mock_sleep = MagicMock()
+        assert _pull_with_backoff(
+            tmp_path, _run=mock_run, _sleep=mock_sleep, _monotonic=lambda: 0.0
+        )
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_success_after_retry(self, tmp_path: Path) -> None:
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(
+            side_effect=[
+                subprocess.CalledProcessError(1, []),
+                MagicMock(returncode=0),
+            ]
+        )
+        mock_sleep = MagicMock()
+        times = iter([0.0, 1.0, 1.0])
+        assert _pull_with_backoff(
+            tmp_path,
+            _run=mock_run,
+            _sleep=mock_sleep,
+            _monotonic=lambda: next(times),
+        )
+        assert mock_run.call_count == 2
+        mock_sleep.assert_called_once_with(10)
+
+    def test_gives_up_after_all_retries_fail(self, tmp_path: Path) -> None:
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
+        mock_sleep = MagicMock()
+        times = iter([0.0, 1.0, 1.0, 12.0, 12.0, 43.0, 43.0, 104.0])
+        assert not _pull_with_backoff(
+            tmp_path,
+            _run=mock_run,
+            _sleep=mock_sleep,
+            _monotonic=lambda: next(times),
+        )
+        # 4 attempts: initial + 3 retries
+        assert mock_run.call_count == 4
+        # 3 sleeps at 10s, 30s, 60s between retries
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [10, 30, 60]
+
+    def test_gives_up_when_budget_exhausted(self, tmp_path: Path) -> None:
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
+        mock_sleep = MagicMock()
+        # First attempt at t=0, elapsed=595; next delay of 10s would exceed 600s budget.
+        times = iter([0.0, 595.0, 595.0])
+        assert not _pull_with_backoff(
+            tmp_path,
+            _run=mock_run,
+            _sleep=mock_sleep,
+            _monotonic=lambda: next(times),
+        )
+        # Slept zero times because budget was exhausted before any sleep.
+        mock_sleep.assert_not_called()
+
+    def test_returns_false_on_file_not_found(self, tmp_path: Path) -> None:
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(side_effect=FileNotFoundError())
+        mock_sleep = MagicMock()
+        times = iter([0.0, 1.0, 1.0, 12.0, 12.0, 43.0, 43.0, 104.0])
+        assert not _pull_with_backoff(
+            tmp_path,
+            _run=mock_run,
+            _sleep=mock_sleep,
+            _monotonic=lambda: next(times),
+        )
+
+
 class TestSelfRestart:
-    """Tests for the self-restart flow (self_repo merge triggers exec)."""
+    """Tests for the self-restart flow."""
 
     def _make_server(self, tmp_path: Path):
         cfg = _self_restart_cfg(tmp_path)
@@ -707,74 +842,93 @@ class TestSelfRestart:
         t.start()
         return srv, f"http://127.0.0.1:{port}", cfg, mock_registry
 
-    def test_self_restart_triggers_on_kennel_merge(self, tmp_path: Path) -> None:
+    def test_triggers_exec_on_matching_repo(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            mock_run = MagicMock(return_value=MagicMock(returncode=0))
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+            WebhookHandler._fn_pull_with_backoff = lambda _d: True
+            mock_chdir = MagicMock()
             mock_exec = MagicMock()
-            WebhookHandler._fn_subprocess_run = mock_run
-            WebhookHandler._fn_os_execv = mock_exec
+            WebhookHandler._fn_os_chdir = mock_chdir
+            WebhookHandler._fn_os_execvp = mock_exec
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
             time.sleep(0.2)
-            mock_exec.assert_called_once()
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
-            calls = mock_run.call_args_list
-            cmds = [c.args[0] for c in calls]
-            assert ["git", "checkout", "main"] in cmds, (
-                "expected git checkout main before pull"
-            )
-            assert ["git", "reset", "--hard"] in cmds, (
-                "expected git reset --hard before pull"
-            )
-            assert ["git", "clean", "-fd"] in cmds, "expected git clean -fd before pull"
-            assert ["git", "pull"] in cmds, "expected git pull"
-            reset_idx = cmds.index(["git", "reset", "--hard"])
-            clean_idx = cmds.index(["git", "clean", "-fd"])
-            checkout_idx = cmds.index(["git", "checkout", "main"])
-            pull_idx = cmds.index(["git", "pull"])
-            assert reset_idx < clean_idx, "reset must precede clean"
-            assert clean_idx < checkout_idx, "clean must precede checkout main"
-            assert checkout_idx < pull_idx, "checkout main must precede pull"
+            mock_chdir.assert_called_once_with(tmp_path)
+            mock_exec.assert_called_once()
+            args = mock_exec.call_args.args
+            assert args[0] == "uv"
+            assert args[1][:3] == ["uv", "run", "kennel"]
         finally:
             srv.shutdown()
 
-    def test_self_restart_stop_and_join_precedes_git(self, tmp_path: Path) -> None:
+    def test_skips_when_self_repo_mismatch(self, tmp_path: Path) -> None:
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "other/repo"
+            mock_pull = MagicMock()
+            mock_exec = MagicMock()
+            WebhookHandler._fn_pull_with_backoff = mock_pull
+            WebhookHandler._fn_os_execvp = mock_exec
+            _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            time.sleep(0.2)
+            mock_registry.stop_and_join.assert_not_called()
+            mock_pull.assert_not_called()
+            mock_exec.assert_not_called()
+        finally:
+            srv.shutdown()
+
+    def test_skips_when_self_repo_unknown(self, tmp_path: Path) -> None:
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: None
+            mock_exec = MagicMock()
+            WebhookHandler._fn_os_execvp = mock_exec
+            _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            time.sleep(0.2)
+            mock_registry.stop_and_join.assert_not_called()
+            mock_exec.assert_not_called()
+        finally:
+            srv.shutdown()
+
+    def test_skips_exec_when_pull_gives_up(self, tmp_path: Path) -> None:
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+            WebhookHandler._fn_pull_with_backoff = lambda _d: False
+            mock_exec = MagicMock()
+            WebhookHandler._fn_os_execvp = mock_exec
+            _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            time.sleep(0.2)
+            mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
+            mock_exec.assert_not_called()
+        finally:
+            srv.shutdown()
+
+    def test_stop_and_join_precedes_pull(self, tmp_path: Path) -> None:
         call_order: list[str] = []
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         mock_registry.stop_and_join.side_effect = lambda *_a, **_kw: call_order.append(
             "stop_and_join"
         )
         try:
-            mock_run = MagicMock(
-                side_effect=lambda *_a, **_kw: (
-                    call_order.append("git") or MagicMock(returncode=0)
-                )
-            )
-            WebhookHandler._fn_subprocess_run = mock_run
-            WebhookHandler._fn_os_execv = MagicMock()
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+
+            def fake_pull(_d):
+                call_order.append("pull")
+                return True
+
+            WebhookHandler._fn_pull_with_backoff = fake_pull
+            WebhookHandler._fn_os_chdir = MagicMock()
+            WebhookHandler._fn_os_execvp = MagicMock()
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             time.sleep(0.2)
         finally:
             srv.shutdown()
-        assert call_order[0] == "stop_and_join", (
-            "stop_and_join must come before any git command"
-        )
-        assert "git" in call_order[1:], "git commands must follow stop_and_join"
-
-    def test_self_restart_aborts_on_git_failure(self, tmp_path: Path) -> None:
-        srv, url, cfg, mock_registry = self._make_server(tmp_path)
-        try:
-            mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
-            mock_exec = MagicMock()
-            WebhookHandler._fn_subprocess_run = mock_run
-            WebhookHandler._fn_os_execv = mock_exec
-            # First command fails; subsequent commands and exec should be skipped.
-            status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
-            assert status == 200
-            time.sleep(0.2)
-            mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
-            mock_run.assert_called_once()
-            mock_exec.assert_not_called()
-        finally:
-            srv.shutdown()
+        assert call_order == ["stop_and_join", "pull"]


### PR DESCRIPTION
## Summary

Self-restart used to run `git reset --hard && git clean -fd && git checkout main && git pull` against the workspace clone fido edits. This clobbered fido's in-progress work whenever a kennel PR merged. Now self-restart pulls a dedicated **runner clone** at `/home/rhencke/kennel-runner/` that is always on main, never dirty, never on a feature branch.

### Changes

- **`_self_restart` rewritten**: derives the runner dir from `Path(__file__).parents[1]`, compares the webhook repo_name to the runner clone's `origin` remote via new `_get_self_repo`. No more `--self-repo` flag.
- **Drops destructive commands**: runner is never dirty, so `git pull` alone is sufficient. No more `reset --hard`, `clean -fd`, `checkout main`.
- **Exponential backoff on pull failures**: `_pull_with_backoff` retries at 10s → 30s → 60s with a 10-minute total budget. Gives up loudly and keeps running the old version.
- **Exec via `uv run`**: restart execs `uv run kennel ...` from the runner dir instead of re-execing `sys.argv[0]`, so updated dependencies from the pulled `pyproject.toml` are picked up.
- **Drops `--self-repo` CLI flag** and `self_repo` Config field entirely.
- **CLAUDE.md** gets a new "Runner vs workspace clones" section.
- **Guarddog skill** Step 9 points at the new `/home/rhencke/start-kennel.sh` local launcher.

Closes #198

## Test plan

- [x] 1298 tests pass, 100% coverage
- [x] New `TestGetSelfRepo` — SSH, HTTPS, no-suffix URLs, subprocess error, FileNotFoundError, unparseable URL
- [x] New `TestRunnerDir` — verifies `Path(__file__).parents[1]` gives the clone root
- [x] New `TestPullWithBackoff` — first-try success, retry success, give-up after retries, give-up when budget exhausted, FileNotFoundError
- [x] Rewritten `TestSelfRestart` — matching repo triggers exec, mismatch/unknown repo skips, pull give-up skips exec, stop_and_join precedes pull
- [ ] Manual: after merge, pull runner clone, launch from runner, merge a no-op kennel PR, confirm self-restart logs show "pulling runner clone at /home/rhencke/kennel-runner" and workspace clone is untouched