### PR TITLE
Listen to collaborator reviews, not just repo-owner slug (#247)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -296,6 +296,22 @@ class GH:
         data = self._get("/user")
         return data["login"]
 
+    def get_collaborators(self, repo: str) -> list[str]:
+        """Return logins of collaborators with write+ permission on *repo*.
+
+        Filters to users whose permission level is ``admin``, ``maintain``, or
+        ``push`` (GitHub's ``write`` equivalent).  Preserves the order returned
+        by the API so callers can use ``[0]`` as a stable "primary reviewer".
+        """
+        result: list[str] = []
+        for user in self._paginate(f"{self.BASE}/repos/{repo}/collaborators"):
+            perm = user.get("role_name") or ""
+            if perm in ("admin", "maintain", "write"):
+                login = user.get("login")
+                if login:
+                    result.append(login)
+        return result
+
     def get_repo_info(
         self,
         cwd: Path | str | None = None,
@@ -588,6 +604,10 @@ class GitHub:
     def get_user(self) -> str:
         """Return the authenticated GitHub username."""
         return self._gh.get_user()
+
+    def get_collaborators(self, repo: str) -> list[str]:
+        """Return logins of collaborators with write+ permission on *repo*."""
+        return self._gh.get_collaborators(repo)
 
     def get_default_branch(
         self, cwd: Path | str | None = None, runner: Any = subprocess.run

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -84,10 +84,16 @@ class RepoContext:
     """GitHub repo metadata discovered at worker startup."""
 
     repo: str  # "owner/repo"
-    owner: str
+    owner: str  # URL slug (used in API paths); NOT the human reviewer
     repo_name: str
-    gh_user: str  # authenticated GitHub username
+    gh_user: str  # authenticated GitHub username (the bot itself)
     default_branch: str
+    collaborators: tuple[str, ...] = ()  # humans with write+, bot excluded
+
+    @property
+    def primary_reviewer(self) -> str:
+        """First collaborator — the default reviewer to request reviews from."""
+        return self.collaborators[0] if self.collaborators else self.owner
 
 
 @dataclass
@@ -388,12 +394,16 @@ class Worker:
         owner, repo_name = repo.split("/", 1)
         gh_user = self.gh.get_user()
         default_branch = self.gh.get_default_branch(cwd=self.work_dir)
+        collaborators = tuple(
+            c for c in self.gh.get_collaborators(repo) if c != gh_user
+        )
         return RepoContext(
             repo=repo,
             owner=owner,
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch=default_branch,
+            collaborators=collaborators,
         )
 
     def get_current_issue(self, fido_dir: Path, repo: str) -> int | None:
@@ -857,7 +867,7 @@ class Worker:
         self,
         threads_data: dict[str, Any],
         gh_user: str,
-        owner: str,
+        collaborators: tuple[str, ...],
     ) -> list[dict[str, Any]]:
         """Return unresolved review threads for the comments sub-Claude.
 
@@ -865,7 +875,7 @@ class Worker:
         - it is not resolved,
         - it has at least one comment,
         - the last commenter is not *gh_user* (awaiting a response), and
-        - the last commenter is either *owner* or ends with ``[bot]``.
+        - the last commenter is either in *collaborators* or ends with ``[bot]``.
         """
         nodes = (
             threads_data.get("data", {})
@@ -886,7 +896,7 @@ class Worker:
             last_author = last_comment.get("author", {}).get("login", "")
             if last_author == gh_user:
                 continue
-            if last_author != owner and not last_author.endswith("[bot]"):
+            if last_author not in collaborators and not last_author.endswith("[bot]"):
                 continue
             result.append(
                 {
@@ -971,7 +981,9 @@ class Worker:
         threads_data = self.gh.get_review_threads(
             repo_ctx.owner, repo_ctx.repo_name, pr_number
         )
-        threads = self._filter_threads(threads_data, repo_ctx.gh_user, repo_ctx.owner)
+        threads = self._filter_threads(
+            threads_data, repo_ctx.gh_user, repo_ctx.collaborators
+        )
         if not threads:
             return False
         log.info("unresolved threads: %d", len(threads))
@@ -1304,10 +1316,12 @@ class Worker:
         is_draft = reviews_data.get("isDraft", False)
         requested_reviewers = reviews_data.get("requestedReviewers", [])
 
-        owner_reviews = [
-            r for r in reviews if r.get("author", {}).get("login") == repo_ctx.owner
+        collab_reviews = [
+            r
+            for r in reviews
+            if r.get("author", {}).get("login") in repo_ctx.collaborators
         ]
-        _latest_decisive = latest_decisive_review(owner_reviews)
+        _latest_decisive = latest_decisive_review(collab_reviews)
         latest_state = (
             _latest_decisive.get("state", "NONE") if _latest_decisive else "NONE"
         )
@@ -1346,7 +1360,7 @@ class Worker:
             return 0
 
         if latest_state == "CHANGES_REQUESTED":
-            if not should_rerequest_review(owner_reviews, commits):
+            if not should_rerequest_review(collab_reviews, commits):
                 log.info(
                     "PR #%s: CHANGES_REQUESTED review newer than latest commit — skipping re-request",
                     pr_number,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -89,6 +89,18 @@ class TestGitHubClass:
         mock_s.get.return_value = mock_resp
         assert gh.get_user() == "fido"
 
+    def test_get_collaborators_delegates(self) -> None:
+        gh, mock_s = self._github()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"login": "alice", "role_name": "admin"},
+            {"login": "bob", "role_name": "write"},
+            {"login": "carol", "role_name": "read"},
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        assert gh.get_collaborators("owner/repo") == ["alice", "bob"]
+
     def test_get_default_branch_delegates(self) -> None:
         gh, mock_s = self._github()
         remote_resp = _completed("https://github.com/o/r.git\n")
@@ -1066,6 +1078,57 @@ class TestGHClass:
         url = mock_s.get.call_args.args[0]
         assert url.endswith("/user")
         assert result == "fido"
+
+    def test_get_collaborators_filters_by_permission(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"login": "admin-user", "role_name": "admin"},
+            {"login": "maint-user", "role_name": "maintain"},
+            {"login": "write-user", "role_name": "write"},
+            {"login": "triage-user", "role_name": "triage"},
+            {"login": "read-user", "role_name": "read"},
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.get_collaborators("owner/repo")
+        assert result == ["admin-user", "maint-user", "write-user"]
+        url = mock_s.get.call_args.args[0]
+        assert url.endswith("/repos/owner/repo/collaborators")
+
+    def test_get_collaborators_preserves_order(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"login": "second", "role_name": "write"},
+            {"login": "first", "role_name": "admin"},
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        # API order preserved — caller uses [0] as "primary reviewer"
+        assert gh.get_collaborators("o/r") == ["second", "first"]
+
+    def test_get_collaborators_skips_users_missing_login(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"role_name": "admin"},
+            {"login": "alice", "role_name": "write"},
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        assert gh.get_collaborators("o/r") == ["alice"]
+
+    def test_get_collaborators_handles_missing_role(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {"login": "alice"},
+            {"login": "bob", "role_name": "admin"},
+        ]
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        assert gh.get_collaborators("o/r") == ["bob"]
 
     def test_get_repo_info_https(self) -> None:
         gh = GH("test-token")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -238,12 +238,25 @@ class TestRepoContext:
             repo_name="myrepo",
             gh_user="bot",
             default_branch="main",
+            collaborators=("alice", "carol"),
         )
         assert ctx.repo == "alice/myrepo"
         assert ctx.owner == "alice"
         assert ctx.repo_name == "myrepo"
         assert ctx.gh_user == "bot"
         assert ctx.default_branch == "main"
+        assert ctx.collaborators == ("alice", "carol")
+        assert ctx.primary_reviewer == "alice"
+
+    def test_collaborators_default_empty(self) -> None:
+        ctx = RepoContext(
+            repo="alice/repo",
+            owner="alice",
+            repo_name="repo",
+            gh_user="bot",
+            default_branch="main",
+        )
+        assert ctx.collaborators == ()
 
 
 class TestWorker:
@@ -252,12 +265,16 @@ class TestWorker:
         repo: str = "owner/myrepo",
         user: str = "fido-bot",
         branch: str = "main",
+        collaborators: list[str] | None = None,
     ) -> MagicMock:
         gh = MagicMock()
         gh.get_repo_info.return_value = repo
         gh.get_user.return_value = user
         gh.get_default_branch.return_value = branch
         gh.get_pr.return_value = {"body": ""}
+        gh.get_collaborators.return_value = (
+            collaborators if collaborators is not None else ["owner"]
+        )
         return gh
 
     # --- discover_repo_context ---
@@ -307,6 +324,28 @@ class TestWorker:
         result = Worker(tmp_path, gh).discover_repo_context()
         assert result.owner == "org"
         assert result.repo_name == "repo"
+
+    def test_discover_collaborators(self, tmp_path: Path) -> None:
+        gh = self._make_gh(collaborators=["alice", "bob"])
+        result = Worker(tmp_path, gh).discover_repo_context()
+        assert result.collaborators == ("alice", "bob")
+
+    def test_discover_filters_bot_from_collaborators(self, tmp_path: Path) -> None:
+        gh = self._make_gh(user="fido-bot", collaborators=["alice", "fido-bot", "bob"])
+        result = Worker(tmp_path, gh).discover_repo_context()
+        assert result.collaborators == ("alice", "bob")
+        assert "fido-bot" not in result.collaborators
+
+    def test_primary_reviewer_first_collaborator(self, tmp_path: Path) -> None:
+        gh = self._make_gh(collaborators=["alice", "bob"])
+        result = Worker(tmp_path, gh).discover_repo_context()
+        assert result.primary_reviewer == "alice"
+
+    def test_primary_reviewer_falls_back_to_owner(self, tmp_path: Path) -> None:
+        gh = self._make_gh(user="fido-bot", collaborators=["fido-bot"])
+        result = Worker(tmp_path, gh).discover_repo_context()
+        assert result.collaborators == ()
+        assert result.primary_reviewer == result.owner
 
     # --- set_status ---
 
@@ -1026,6 +1065,7 @@ class TestWorkerFindNextIssue:
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch="main",
+            collaborators=(owner,),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -2323,6 +2363,7 @@ class TestFindOrCreatePr:
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch=default_branch,
+            collaborators=(owner,),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -3278,6 +3319,7 @@ class TestHandleCi:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
+            collaborators=("owner",),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -3729,13 +3771,13 @@ class TestFilterThreads:
 
     def test_returns_empty_when_no_nodes(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        assert w._filter_threads({}, "fido-bot", "owner") == []
+        assert w._filter_threads({}, "fido-bot", ("owner",)) == []
 
     def test_excludes_resolved_threads(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(resolved=True)
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", "owner") == []
+        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
 
     def test_excludes_threads_where_last_author_is_gh_user(
         self, tmp_path: Path
@@ -3743,7 +3785,7 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="fido-bot", last_body="done")
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", "owner") == []
+        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
 
     def test_excludes_threads_where_last_author_is_neither_owner_nor_bot(
         self, tmp_path: Path
@@ -3751,20 +3793,27 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="random-user", last_body="comment")
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", "owner") == []
+        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
 
     def test_includes_thread_from_owner(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
         assert len(result) == 1
 
     def test_includes_thread_from_bot(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="my-app[bot]", last_body="bot comment")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
+        assert len(result) == 1
+
+    def test_includes_thread_from_any_collaborator(self, tmp_path: Path) -> None:
+        w = self._make_worker(tmp_path)
+        node = self._make_node(last_author="bob")
+        data = self._make_threads_data([node])
+        result = w._filter_threads(data, "fido-bot", ("alice", "bob", "carol"))
         assert len(result) == 1
 
     def test_maps_fields_correctly(self, tmp_path: Path) -> None:
@@ -3779,7 +3828,7 @@ class TestFilterThreads:
             url="https://github.com/x",
         )
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
         assert result[0]["id"] == "tid-42"
         assert result[0]["first_author"] == "owner"
         assert result[0]["first_db_id"] == 99
@@ -3793,21 +3842,21 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(first_author="my-app[bot]", last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
         assert result[0]["is_bot"] is True
 
     def test_is_bot_false_when_first_author_is_human(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(first_author="owner", last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
         assert result[0]["is_bot"] is False
 
     def test_excludes_threads_with_no_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = {"id": "x", "isResolved": False, "comments": {"nodes": []}}
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", "owner") == []
+        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
 
     def test_total_counts_all_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
@@ -3825,7 +3874,7 @@ class TestFilterThreads:
             ],
         )
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", "owner")
+        result = w._filter_threads(data, "fido-bot", ("owner",))
         assert result[0]["total"] == 3
 
 
@@ -3843,6 +3892,7 @@ class TestResolveAddressedThreads:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
+            collaborators=("owner",),
         )
 
     def _make_threads_data(self, nodes: list) -> dict:
@@ -4053,6 +4103,7 @@ class TestHandleThreads:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
+            collaborators=("owner",),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -4714,6 +4765,7 @@ class TestExecuteTask:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
+            collaborators=("owner",),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -5833,6 +5885,7 @@ class TestHandlePromoteMerge:
             repo_name="myrepo",
             gh_user="fido-bot",
             default_branch="main",
+            collaborators=(owner,),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

\`handle_promote_merge\` filtered PR reviews by \`repo_ctx.owner\` (the URL slug from the repo's \`owner/repo\` full name). For \`rhencke/confusio\` and \`rhencke/kennel\` that works because the slug is the human reviewer. For \`FidoCanCode/fidocancode.github.io\`, the slug is the bot itself — reviews by \`rhencke\` (the actual human) were filtered out, and fido never merged approved PRs.

## Changes

- **New \`GH.get_collaborators(repo)\`** — queries \`/repos/{repo}/collaborators\`, filters to write+ permissions (admin/maintain/write), preserves API order so \`[0]\` is a stable "primary reviewer".
- **\`RepoContext\` grows a \`collaborators: tuple[str, ...]\` field** and a \`primary_reviewer\` property that returns \`collaborators[0]\` or falls back to \`owner\`.
- **\`discover_repo_context\`** calls \`get_collaborators\` and filters the bot itself (\`gh_user\`) out of the list.
- **\`handle_promote_merge\`** filters reviews by \`author in collaborators\` instead of \`author == owner\`, and uses \`primary_reviewer\` for \`add_pr_reviewer\` calls.
- **\`_filter_threads\`** accepts a \`collaborators\` tuple and matches \`last_author\` against it instead of a single owner string.

Closes #247

## Test plan

- [x] 1309 tests pass, 100% coverage
- [x] New \`TestDiscoverRepoContext\`: collaborators discovered, bot filtered out, primary_reviewer picks first, falls back to owner
- [x] New \`TestFilterThreads::test_includes_thread_from_any_collaborator\` — thread from non-primary collaborator is included
- [x] New \`GH.get_collaborators\` tests — permission filtering, order preservation, missing login/role
- [ ] Manual: after merge, fido merges \`FidoCanCode/fidocancode.github.io#14\` (previously approved by rhencke but stuck)