### PR TITLE
Cache RepoMembership at server startup, share with webhook dispatch (#250)

### DIFF
--- a/kennel/config.py
+++ b/kennel/config.py
@@ -2,16 +2,34 @@ from __future__ import annotations
 
 import argparse
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class RepoMembership:
+    """Cached membership info for a repo — who gets to direct fido's work.
+
+    Populated once at server startup (``server.populate_memberships``) via
+    ``GH.get_collaborators``, then shared as a field on both
+    :class:`RepoConfig` (used by event dispatch at webhook time) and
+    :class:`~kennel.worker.RepoContext` (used by workers at task execution
+    time).  Single source of truth for "who is allowed to comment on or
+    approve fido's PRs on this repo".
+
+    The bot account itself is always excluded from ``collaborators``.
+    """
+
+    collaborators: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
 class RepoConfig:
     name: str  # "rhencke/confusio"
     work_dir: Path  # /home/rhencke/workspace/confusio
+    membership: RepoMembership = field(default_factory=RepoMembership)
 
 
 @dataclass(frozen=True)

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -36,10 +36,13 @@ class Action:
     )
 
 
-def _is_allowed(user: str, payload: dict[str, Any], config: Config) -> bool:
-    """Check if user is the repo owner or an allowed bot."""
-    owner = payload.get("repository", {}).get("owner", {}).get("login", "")
-    return user == owner or user in config.allowed_bots
+def _is_allowed(user: str, repo_cfg: RepoConfig, config: Config) -> bool:
+    """Check if user is a repo collaborator or an allowed bot.
+
+    ``repo_cfg.membership.collaborators`` is populated at server startup
+    (``server.populate_memberships``) and excludes the bot itself.
+    """
+    return user in repo_cfg.membership.collaborators or user in config.allowed_bots
 
 
 def dispatch(
@@ -72,7 +75,7 @@ def dispatch(
         review_id = review.get("id")
         if not number:
             return None
-        if not _is_allowed(user, payload, config):
+        if not _is_allowed(user, repo_cfg, config):
             log.debug("ignoring review on PR #%s by %s (not allowed)", number, user)
             return None
         log.info("review on PR #%s: %s by %s", number, state, user)
@@ -94,7 +97,7 @@ def dispatch(
             return None
         if not number:
             return None
-        if not _is_allowed(user, payload, config):
+        if not _is_allowed(user, repo_cfg, config):
             log.debug("ignoring comment on PR #%s by %s (not allowed)", number, user)
             return None
         comment_body = comment.get("body", "") or ""
@@ -130,7 +133,7 @@ def dispatch(
         if user.lower() in ("fidocancode", "fido-can-code"):
             log.debug("ignoring own comment on PR")
             return None
-        if not _is_allowed(user, payload, config):
+        if not _is_allowed(user, repo_cfg, config):
             log.debug("ignoring comment by %s (not allowed)", user)
             return None
         number = issue.get("number")

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -405,11 +405,18 @@ class GH:
         data = self._get(f"/repos/{repo}/pulls/{pr}")
         return data.get("body") or ""
 
-    def add_pr_reviewer(self, repo: str, pr: int | str, reviewer: str) -> None:
-        """Add a reviewer to a PR."""
+    def add_pr_reviewers(self, repo: str, pr: int | str, reviewers: list[str]) -> None:
+        """Request review from one or more users on a PR.
+
+        GitHub's API accepts a list in a single call, so there is no
+        singular form — always pass the full set of collaborators to
+        request from.
+        """
+        if not reviewers:
+            return
         self._post(
             f"/repos/{repo}/pulls/{pr}/requested_reviewers",
-            reviewers=[reviewer],
+            reviewers=list(reviewers),
         )
 
     def pr_checks(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
@@ -687,9 +694,9 @@ class GitHub:
         """Return just the PR body text."""
         return self._gh.get_pr_body(repo, pr)
 
-    def add_pr_reviewer(self, repo: str, pr: int | str, reviewer: str) -> None:
-        """Add a reviewer to a PR."""
-        self._gh.add_pr_reviewer(repo, pr, reviewer)
+    def add_pr_reviewers(self, repo: str, pr: int | str, reviewers: list[str]) -> None:
+        """Request review from one or more users on a PR."""
+        self._gh.add_pr_reviewers(repo, pr, reviewers)
 
     def pr_checks(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return check statuses for a PR."""

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -123,7 +123,13 @@ def _make_thread(
     _WorkerThread=WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with a live GitHub client."""
-    return _WorkerThread(repo_cfg.work_dir, repo_cfg.name, _GitHub(), registry)
+    return _WorkerThread(
+        repo_cfg.work_dir,
+        repo_cfg.name,
+        _GitHub(),
+        registry,
+        repo_cfg.membership,
+    )
 
 
 def make_registry(

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import hmac
 import json
@@ -14,7 +15,7 @@ from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
-from kennel.config import Config, RepoConfig
+from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.events import (
     create_task,
     dispatch,
@@ -23,6 +24,7 @@ from kennel.events import (
     reply_to_issue_comment,
     reply_to_review,
 )
+from kennel.github import GitHub
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.worker import RepoContextFilter, RepoNameFilter
 
@@ -320,6 +322,26 @@ class WebhookHandler(BaseHTTPRequestHandler):
         pass
 
 
+def populate_memberships(
+    config: Config, *, _gh_factory: Callable[[], GitHub] = GitHub
+) -> None:
+    """Fetch collaborators for each repo once at startup and store on RepoConfig.
+
+    Mutates ``config.repos`` in place — each :class:`RepoConfig` is replaced
+    with a new instance carrying a populated :class:`RepoMembership`.  Uses
+    one GitHub client instance for all repos.  Bot account (gh_user) is
+    excluded from every collaborator set.
+    """
+    gh = _gh_factory()
+    bot_user = gh.get_user()
+    for name, repo_cfg in list(config.repos.items()):
+        collabs = frozenset(c for c in gh.get_collaborators(name) if c != bot_user)
+        log.info("%s: collaborators = %s", name, sorted(collabs) or "(none)")
+        config.repos[name] = dataclasses.replace(
+            repo_cfg, membership=RepoMembership(collaborators=collabs)
+        )
+
+
 def run(
     *,
     _from_args=Config.from_args,
@@ -328,6 +350,7 @@ def run(
     _path_home=Path.home,
     _basic_config=logging.basicConfig,
     _stderr=sys.stderr,
+    _populate_memberships=populate_memberships,
 ) -> None:
     config = _from_args()
 
@@ -355,6 +378,8 @@ def run(
         datefmt="%H:%M:%S",
         handlers=handlers,
     )
+
+    _populate_memberships(config)
 
     WebhookHandler.config = config
     WebhookHandler.registry = _make_registry(config.repos)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -9,11 +9,12 @@ import re
 import subprocess
 import threading
 from contextlib import AbstractContextManager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Protocol
 
 from kennel import claude, hooks, tasks
+from kennel.config import RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts
 from kennel.state import (
@@ -88,12 +89,12 @@ class RepoContext:
     repo_name: str
     gh_user: str  # authenticated GitHub username (the bot itself)
     default_branch: str
-    collaborators: tuple[str, ...] = ()  # humans with write+, bot excluded
+    membership: RepoMembership = field(default_factory=RepoMembership)
 
     @property
-    def primary_reviewer(self) -> str:
-        """First collaborator — the default reviewer to request reviews from."""
-        return self.collaborators[0] if self.collaborators else self.owner
+    def collaborators(self) -> frozenset[str]:
+        """Shortcut for ``self.membership.collaborators``."""
+        return self.membership.collaborators
 
 
 @dataclass
@@ -338,12 +339,14 @@ class Worker:
         abort_task: threading.Event | None = None,
         repo_name: str = "",
         registry: ActivityReporter | None = None,
+        membership: RepoMembership | None = None,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
         self._abort_task = abort_task if abort_task is not None else threading.Event()
         self._repo_name = repo_name
         self._registry = registry
+        self._membership = membership if membership is not None else RepoMembership()
 
     def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
         """Return the absolute .git directory for self.work_dir."""
@@ -389,21 +392,23 @@ class Worker:
     # ------------------------------------------------------------------
 
     def discover_repo_context(self) -> RepoContext:
-        """Discover repo metadata for self.work_dir using the GitHub API."""
+        """Discover repo metadata for self.work_dir using the GitHub API.
+
+        The membership (collaborators list) is taken from ``self._membership``,
+        which is populated at kennel server startup — no per-iteration API
+        call for collaborators.
+        """
         repo = self.gh.get_repo_info(cwd=self.work_dir)
         owner, repo_name = repo.split("/", 1)
         gh_user = self.gh.get_user()
         default_branch = self.gh.get_default_branch(cwd=self.work_dir)
-        collaborators = tuple(
-            c for c in self.gh.get_collaborators(repo) if c != gh_user
-        )
         return RepoContext(
             repo=repo,
             owner=owner,
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch=default_branch,
-            collaborators=collaborators,
+            membership=self._membership,
         )
 
     def get_current_issue(self, fido_dir: Path, repo: str) -> int | None:
@@ -1366,17 +1371,19 @@ class Worker:
                     pr_number,
                 )
                 return 0
-            if repo_ctx.owner not in requested_reviewers:
+            missing = sorted(repo_ctx.collaborators - set(requested_reviewers))
+            if missing:
                 checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
                 required = self.gh.get_required_checks(
                     repo_ctx.repo, repo_ctx.default_branch
                 )
                 if ci_ready_for_review(checks, required):
                     log.info(
-                        "PR #%s: changes requested — all addressed, CI passing — re-requesting review",
+                        "PR #%s: changes requested — all addressed, CI passing — re-requesting review from %s",
                         pr_number,
+                        ", ".join(missing),
                     )
-                    self.gh.add_pr_reviewer(repo_ctx.repo, pr_number, repo_ctx.owner)
+                    self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
                 else:
                     log.info(
                         "PR #%s: changes requested — all addressed, but CI not yet passing — deferring re-request",
@@ -1403,7 +1410,8 @@ class Worker:
                 return 0
             log.info("PR #%s: work complete — marking ready", pr_number)
             self.gh.pr_ready(repo_ctx.repo, pr_number)
-            if repo_ctx.owner not in requested_reviewers:
+            missing = sorted(repo_ctx.collaborators - set(requested_reviewers))
+            if missing:
                 checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
                 required = self.gh.get_required_checks(
                     repo_ctx.repo, repo_ctx.default_branch
@@ -1412,9 +1420,9 @@ class Worker:
                     log.info(
                         "PR #%s: CI passing — requesting review from %s",
                         pr_number,
-                        repo_ctx.owner,
+                        ", ".join(missing),
                     )
-                    self.gh.add_pr_reviewer(repo_ctx.repo, pr_number, repo_ctx.owner)
+                    self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
                 else:
                     log.info(
                         "PR #%s: CI not yet passing — deferring review request",
@@ -1422,7 +1430,8 @@ class Worker:
                     )
             return 1
 
-        if repo_ctx.owner not in requested_reviewers and latest_state == "NONE":
+        missing = sorted(repo_ctx.collaborators - set(requested_reviewers))
+        if missing and latest_state == "NONE":
             checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
             required = self.gh.get_required_checks(
                 repo_ctx.repo, repo_ctx.default_branch
@@ -1431,9 +1440,9 @@ class Worker:
                 log.info(
                     "PR #%s: CI passing — requesting review from %s",
                     pr_number,
-                    repo_ctx.owner,
+                    ", ".join(missing),
                 )
-                self.gh.add_pr_reviewer(repo_ctx.repo, pr_number, repo_ctx.owner)
+                self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
             else:
                 log.info(
                     "PR #%s: CI not yet passing — waiting before requesting review",
@@ -1529,12 +1538,14 @@ class WorkerThread(threading.Thread):
         repo_name: str,
         gh: GitHub,
         registry: ActivityReporter | None = None,
+        membership: RepoMembership | None = None,
     ) -> None:
         super().__init__(name=f"worker-{work_dir.name}", daemon=True)
         self.work_dir = work_dir
         self._repo_name = repo_name
         self._gh = gh
         self._registry = registry
+        self._membership = membership if membership is not None else RepoMembership()
         self._wake = threading.Event()
         self._abort_task = threading.Event()
         self._stop = False
@@ -1564,6 +1575,7 @@ class WorkerThread(threading.Thread):
                     self._abort_task,
                     self._repo_name,
                     self._registry,
+                    self._membership,
                 ).run()
             except Exception:
                 log.exception("WorkerThread %s: unexpected error", self.name)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,13 @@ def _config(tmp_path: Path) -> Config:
 
 
 def _repo_cfg(tmp_path: Path) -> RepoConfig:
-    return RepoConfig(name="owner/repo", work_dir=tmp_path)
+    from kennel.config import RepoMembership
+
+    return RepoConfig(
+        name="owner/repo",
+        work_dir=tmp_path,
+        membership=RepoMembership(collaborators=frozenset({"owner"})),
+    )
 
 
 def _payload(repo_owner: str = "owner") -> dict:
@@ -91,20 +97,43 @@ class TestNeedsMoreContext:
 
 
 class TestIsAllowed:
-    def test_owner_allowed(self, tmp_path: Path) -> None:
-        cfg = _config(tmp_path)
-        payload = _payload("owner")
-        assert _is_allowed("owner", payload, cfg)
+    def _repo_cfg(
+        self, tmp_path: Path, collaborators: frozenset[str] = frozenset({"owner"})
+    ) -> RepoConfig:
+        from kennel.config import RepoMembership
 
-    def test_bot_allowed(self, tmp_path: Path) -> None:
+        return RepoConfig(
+            name="owner/repo",
+            work_dir=tmp_path,
+            membership=RepoMembership(collaborators=collaborators),
+        )
+
+    def test_collaborator_allowed(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        payload = _payload("owner")
-        assert _is_allowed("copilot[bot]", payload, cfg)
+        rc = self._repo_cfg(tmp_path)
+        assert _is_allowed("owner", rc, cfg)
+
+    def test_any_collaborator_allowed(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        rc = self._repo_cfg(
+            tmp_path, collaborators=frozenset({"alice", "bob", "rhencke"})
+        )
+        assert _is_allowed("rhencke", rc, cfg)
+
+    def test_bot_allowed_even_without_collab(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        rc = self._repo_cfg(tmp_path, collaborators=frozenset())
+        assert _is_allowed("copilot[bot]", rc, cfg)
 
     def test_random_user_denied(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        payload = _payload("owner")
-        assert not _is_allowed("rando", payload, cfg)
+        rc = self._repo_cfg(tmp_path)
+        assert not _is_allowed("rando", rc, cfg)
+
+    def test_empty_collaborators_denies_all_humans(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        rc = self._repo_cfg(tmp_path, collaborators=frozenset())
+        assert not _is_allowed("anyone", rc, cfg)
 
 
 class TestDispatchPing:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -273,12 +273,17 @@ class TestGitHubClass:
         result = gh.get_pr_body("o/r", 10)
         assert result == "some body"
 
-    def test_add_pr_reviewer_delegates(self) -> None:
+    def test_add_pr_reviewers_delegates(self) -> None:
         gh, mock_s = self._github()
         mock_resp = MagicMock()
         mock_s.post.return_value = mock_resp
-        gh.add_pr_reviewer("o/r", 10, "alice")
-        assert mock_s.post.call_args.kwargs["json"]["reviewers"] == ["alice"]
+        gh.add_pr_reviewers("o/r", 10, ["alice", "bob"])
+        assert mock_s.post.call_args.kwargs["json"]["reviewers"] == ["alice", "bob"]
+
+    def test_add_pr_reviewers_empty_is_noop(self) -> None:
+        gh, mock_s = self._github()
+        gh.add_pr_reviewers("o/r", 10, [])
+        mock_s.post.assert_not_called()
 
     def test_pr_checks_delegates(self) -> None:
         gh, mock_s = self._github()
@@ -1292,14 +1297,22 @@ class TestGHClass:
         result = gh.get_pr_body("o/r", 10)
         assert result == ""
 
-    def test_add_pr_reviewer(self) -> None:
+    def test_add_pr_reviewers(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()
         mock_s.post.return_value = mock_resp
-        gh.add_pr_reviewer("o/r", 10, "rhencke")
+        gh.add_pr_reviewers("o/r", 10, ["rhencke", "alice"])
         url = mock_s.post.call_args.args[0]
         assert "repos/o/r/pulls/10/requested_reviewers" in url
-        assert mock_s.post.call_args.kwargs["json"]["reviewers"] == ["rhencke"]
+        assert mock_s.post.call_args.kwargs["json"]["reviewers"] == [
+            "rhencke",
+            "alice",
+        ]
+
+    def test_add_pr_reviewers_empty_skips_post(self) -> None:
+        gh, mock_s = self._gh()
+        gh.add_pr_reviewers("o/r", 10, [])
+        mock_s.post.assert_not_called()
 
     def test_pr_checks_returns_list(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -265,8 +265,14 @@ class TestMakeThread:
         result = _make_thread(
             cfg, mock_registry, _GitHub=mock_gh_cls, _WorkerThread=mock_wt_cls
         )
+        from kennel.config import RepoMembership
+
         mock_wt_cls.assert_called_once_with(
-            tmp_path, "foo/bar", mock_gh_cls.return_value, mock_registry
+            tmp_path,
+            "foo/bar",
+            mock_gh_cls.return_value,
+            mock_registry,
+            RepoMembership(),
         )
         assert result is mock_wt_cls.return_value
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,10 +19,18 @@ from kennel.server import WebhookHandler
 
 
 def _config(tmp_path: Path) -> Config:
+    from kennel.config import RepoMembership
+
     return Config(
         port=0,  # will bind to random port
         secret=b"test-secret",
-        repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+        repos={
+            "owner/repo": RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                membership=RepoMembership(collaborators=frozenset({"owner"})),
+            ),
+        },
         allowed_bots=frozenset({"copilot[bot]"}),
         log_level="WARNING",
         sub_dir=tmp_path / "sub",
@@ -481,6 +489,75 @@ class TestProcessAction:
         # server still alive — no crash
 
 
+class TestPopulateMemberships:
+    def test_populates_from_get_collaborators(self, tmp_path: Path) -> None:
+        from kennel.config import RepoMembership
+        from kennel.server import populate_memberships
+
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={
+                "owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path),
+            },
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_gh = MagicMock()
+        mock_gh.get_user.return_value = "fido-bot"
+        mock_gh.get_collaborators.return_value = ["alice", "bob"]
+        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        assert cfg.repos["owner/repo"].membership == RepoMembership(
+            collaborators=frozenset({"alice", "bob"})
+        )
+
+    def test_filters_bot_user_from_collaborators(self, tmp_path: Path) -> None:
+        from kennel.server import populate_memberships
+
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={
+                "owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path),
+            },
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_gh = MagicMock()
+        mock_gh.get_user.return_value = "fido-bot"
+        mock_gh.get_collaborators.return_value = ["alice", "fido-bot", "bob"]
+        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        result = cfg.repos["owner/repo"].membership.collaborators
+        assert result == frozenset({"alice", "bob"})
+        assert "fido-bot" not in result
+
+    def test_iterates_all_repos(self, tmp_path: Path) -> None:
+        from kennel.server import populate_memberships
+
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={
+                "o/r1": RepoConfig(name="o/r1", work_dir=tmp_path),
+                "o/r2": RepoConfig(name="o/r2", work_dir=tmp_path),
+            },
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_gh = MagicMock()
+        mock_gh.get_user.return_value = "bot"
+        mock_gh.get_collaborators.side_effect = lambda name: {
+            "o/r1": ["alice"],
+            "o/r2": ["bob", "carol"],
+        }[name]
+        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        assert cfg.repos["o/r1"].membership.collaborators == frozenset({"alice"})
+        assert cfg.repos["o/r2"].membership.collaborators == frozenset({"bob", "carol"})
+
+
 class TestRun:
     """Tests for the run() entry point."""
 
@@ -507,6 +584,7 @@ class TestRun:
             _make_registry=MagicMock(),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -530,6 +608,7 @@ class TestRun:
             _make_registry=MagicMock(),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
+            _populate_memberships=MagicMock(),
         )
 
         assert len(captured_kwargs) == 1
@@ -554,6 +633,7 @@ class TestRun:
             _make_registry=MagicMock(),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
+            _populate_memberships=MagicMock(),
         )
 
         assert len(captured_handlers) >= 1
@@ -576,6 +656,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _stderr=mock_stderr,
+            _populate_memberships=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -610,6 +691,7 @@ class TestRun:
             _make_registry=MagicMock(),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
+            _populate_memberships=MagicMock(),
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -657,6 +739,7 @@ class TestRun:
             _make_registry=MagicMock(),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
+            _populate_memberships=MagicMock(),
         )
 
         repo_handler = next(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from kennel.config import RepoMembership
 from kennel.state import (
     _resolve_git_dir,
     clear_state,
@@ -238,15 +239,14 @@ class TestRepoContext:
             repo_name="myrepo",
             gh_user="bot",
             default_branch="main",
-            collaborators=("alice", "carol"),
+            membership=RepoMembership(collaborators=frozenset({"alice", "carol"})),
         )
         assert ctx.repo == "alice/myrepo"
         assert ctx.owner == "alice"
         assert ctx.repo_name == "myrepo"
         assert ctx.gh_user == "bot"
         assert ctx.default_branch == "main"
-        assert ctx.collaborators == ("alice", "carol")
-        assert ctx.primary_reviewer == "alice"
+        assert ctx.collaborators == frozenset({"alice", "carol"})
 
     def test_collaborators_default_empty(self) -> None:
         ctx = RepoContext(
@@ -256,7 +256,7 @@ class TestRepoContext:
             gh_user="bot",
             default_branch="main",
         )
-        assert ctx.collaborators == ()
+        assert ctx.collaborators == frozenset()
 
 
 class TestWorker:
@@ -265,16 +265,12 @@ class TestWorker:
         repo: str = "owner/myrepo",
         user: str = "fido-bot",
         branch: str = "main",
-        collaborators: list[str] | None = None,
     ) -> MagicMock:
         gh = MagicMock()
         gh.get_repo_info.return_value = repo
         gh.get_user.return_value = user
         gh.get_default_branch.return_value = branch
         gh.get_pr.return_value = {"body": ""}
-        gh.get_collaborators.return_value = (
-            collaborators if collaborators is not None else ["owner"]
-        )
         return gh
 
     # --- discover_repo_context ---
@@ -325,27 +321,22 @@ class TestWorker:
         assert result.owner == "org"
         assert result.repo_name == "repo"
 
-    def test_discover_collaborators(self, tmp_path: Path) -> None:
-        gh = self._make_gh(collaborators=["alice", "bob"])
-        result = Worker(tmp_path, gh).discover_repo_context()
-        assert result.collaborators == ("alice", "bob")
+    def test_discover_uses_injected_membership(self, tmp_path: Path) -> None:
+        gh = self._make_gh()
+        membership = RepoMembership(collaborators=frozenset({"alice", "bob"}))
+        result = Worker(tmp_path, gh, membership=membership).discover_repo_context()
+        assert result.membership is membership
+        assert result.collaborators == frozenset({"alice", "bob"})
 
-    def test_discover_filters_bot_from_collaborators(self, tmp_path: Path) -> None:
-        gh = self._make_gh(user="fido-bot", collaborators=["alice", "fido-bot", "bob"])
+    def test_discover_default_membership_empty(self, tmp_path: Path) -> None:
+        gh = self._make_gh()
         result = Worker(tmp_path, gh).discover_repo_context()
-        assert result.collaborators == ("alice", "bob")
-        assert "fido-bot" not in result.collaborators
+        assert result.collaborators == frozenset()
 
-    def test_primary_reviewer_first_collaborator(self, tmp_path: Path) -> None:
-        gh = self._make_gh(collaborators=["alice", "bob"])
-        result = Worker(tmp_path, gh).discover_repo_context()
-        assert result.primary_reviewer == "alice"
-
-    def test_primary_reviewer_falls_back_to_owner(self, tmp_path: Path) -> None:
-        gh = self._make_gh(user="fido-bot", collaborators=["fido-bot"])
-        result = Worker(tmp_path, gh).discover_repo_context()
-        assert result.collaborators == ()
-        assert result.primary_reviewer == result.owner
+    def test_discover_does_not_call_get_collaborators(self, tmp_path: Path) -> None:
+        gh = self._make_gh()
+        Worker(tmp_path, gh).discover_repo_context()
+        gh.get_collaborators.assert_not_called()
 
     # --- set_status ---
 
@@ -1065,7 +1056,7 @@ class TestWorkerFindNextIssue:
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch="main",
-            collaborators=(owner,),
+            membership=RepoMembership(collaborators=frozenset({owner})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -2363,7 +2354,7 @@ class TestFindOrCreatePr:
             repo_name=repo_name,
             gh_user=gh_user,
             default_branch=default_branch,
-            collaborators=(owner,),
+            membership=RepoMembership(collaborators=frozenset({owner})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -3319,7 +3310,7 @@ class TestHandleCi:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
-            collaborators=("owner",),
+            membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -3771,13 +3762,13 @@ class TestFilterThreads:
 
     def test_returns_empty_when_no_nodes(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        assert w._filter_threads({}, "fido-bot", ("owner",)) == []
+        assert w._filter_threads({}, "fido-bot", frozenset({"owner"})) == []
 
     def test_excludes_resolved_threads(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(resolved=True)
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
+        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
 
     def test_excludes_threads_where_last_author_is_gh_user(
         self, tmp_path: Path
@@ -3785,7 +3776,7 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="fido-bot", last_body="done")
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
+        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
 
     def test_excludes_threads_where_last_author_is_neither_owner_nor_bot(
         self, tmp_path: Path
@@ -3793,27 +3784,29 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="random-user", last_body="comment")
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
+        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
 
     def test_includes_thread_from_owner(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert len(result) == 1
 
     def test_includes_thread_from_bot(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="my-app[bot]", last_body="bot comment")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert len(result) == 1
 
     def test_includes_thread_from_any_collaborator(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(last_author="bob")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("alice", "bob", "carol"))
+        result = w._filter_threads(
+            data, "fido-bot", frozenset({"alice", "bob", "carol"})
+        )
         assert len(result) == 1
 
     def test_maps_fields_correctly(self, tmp_path: Path) -> None:
@@ -3828,7 +3821,7 @@ class TestFilterThreads:
             url="https://github.com/x",
         )
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["id"] == "tid-42"
         assert result[0]["first_author"] == "owner"
         assert result[0]["first_db_id"] == 99
@@ -3842,21 +3835,21 @@ class TestFilterThreads:
         w = self._make_worker(tmp_path)
         node = self._make_node(first_author="my-app[bot]", last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["is_bot"] is True
 
     def test_is_bot_false_when_first_author_is_human(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = self._make_node(first_author="owner", last_author="owner")
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["is_bot"] is False
 
     def test_excludes_threads_with_no_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = {"id": "x", "isResolved": False, "comments": {"nodes": []}}
         data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", ("owner",)) == []
+        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
 
     def test_total_counts_all_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
@@ -3874,7 +3867,7 @@ class TestFilterThreads:
             ],
         )
         data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", ("owner",))
+        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["total"] == 3
 
 
@@ -3892,7 +3885,7 @@ class TestResolveAddressedThreads:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
-            collaborators=("owner",),
+            membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
 
     def _make_threads_data(self, nodes: list) -> dict:
@@ -4103,7 +4096,7 @@ class TestHandleThreads:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
-            collaborators=("owner",),
+            membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -4765,7 +4758,7 @@ class TestExecuteTask:
             repo_name="repo",
             gh_user="fido-bot",
             default_branch="main",
-            collaborators=("owner",),
+            membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -5885,7 +5878,7 @@ class TestHandlePromoteMerge:
             repo_name="myrepo",
             gh_user="fido-bot",
             default_branch="main",
-            collaborators=(owner,),
+            membership=RepoMembership(collaborators=frozenset({owner})),
         )
 
     def _fido_dir(self, tmp_path: Path) -> Path:
@@ -6151,7 +6144,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_changes_requested_ci_failing_skips_reviewer(self, tmp_path: Path) -> None:
         """CI not passing — re-request deferred until CI is green."""
@@ -6164,7 +6157,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = ["ci"]
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_changes_requested_ci_failing_returns_0(self, tmp_path: Path) -> None:
         """CI not passing — returns 0 (waiting for CI)."""
@@ -6228,7 +6221,7 @@ class TestHandlePromoteMerge:
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         # APPROVED is latest — should merge, not re-request
         gh.pr_merge.assert_called_once()
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     # --- CHANGES_REQUESTED then APPROVED merge scenario ---
 
@@ -6462,7 +6455,7 @@ class TestHandlePromoteMerge:
         }
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_changes_requested_newer_than_commit_returns_0(
         self, tmp_path: Path
@@ -6507,7 +6500,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_changes_requested_older_than_commit_returns_0(
         self, tmp_path: Path
@@ -6548,7 +6541,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once()
+        gh.add_pr_reviewers.assert_called_once()
 
     def test_changes_requested_no_commits_re_requests(self, tmp_path: Path) -> None:
         """No commits in data — fall back to re-requesting."""
@@ -6569,7 +6562,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once()
+        gh.add_pr_reviewers.assert_called_once()
 
     def test_changes_requested_newer_than_commit_logs_skip(
         self, tmp_path: Path, caplog
@@ -6616,7 +6609,7 @@ class TestHandlePromoteMerge:
         }
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     # --- decisive review state (APPROVED/CHANGES_REQUESTED vs COMMENTED) ---
 
@@ -6660,7 +6653,7 @@ class TestHandlePromoteMerge:
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_changes_requested_then_commented_rerequests(self, tmp_path: Path) -> None:
         """CHANGES_REQUESTED followed by COMMENTED: decisive state is
@@ -6679,7 +6672,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_changes_requested_then_commented_does_not_merge(
         self, tmp_path: Path
@@ -6735,7 +6728,7 @@ class TestHandlePromoteMerge:
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with patch("kennel.worker.tasks.list_tasks", return_value=completed):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_draft_with_completed_tasks_returns_1(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -6761,7 +6754,7 @@ class TestHandlePromoteMerge:
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with patch("kennel.worker.tasks.list_tasks", return_value=completed):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_draft_pending_tasks_block_promote(self, tmp_path: Path) -> None:
         """Pending tasks prevent promote — all tasks must be complete."""
@@ -6797,7 +6790,7 @@ class TestHandlePromoteMerge:
             "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_draft_promote_ci_not_passing_defers_review(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -6811,7 +6804,7 @@ class TestHandlePromoteMerge:
             "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_draft_promote_ci_not_passing_still_calls_pr_ready(
         self, tmp_path: Path
@@ -6857,7 +6850,7 @@ class TestHandlePromoteMerge:
             "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_draft_promote_uses_default_branch_for_required_checks(
         self, tmp_path: Path
@@ -6885,7 +6878,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = ["ci / test"]
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_called_once_with("rhencke/myrepo", 9, "rhencke")
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
     def test_non_draft_no_review_ci_not_passing_skips_review(
         self, tmp_path: Path
@@ -6899,7 +6892,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = ["ci / test"]
         with patch("kennel.worker.tasks.list_tasks", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_non_draft_no_review_returns_0(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -6931,7 +6924,7 @@ class TestHandlePromoteMerge:
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_checks.assert_not_called()
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_non_draft_commented_review_polls_ci(self, tmp_path: Path) -> None:
         """COMMENTED review has no decisive state — treated as NONE, CI polled."""
@@ -7124,7 +7117,7 @@ class TestHandlePromoteMerge:
         ]
         with patch("kennel.worker.tasks.list_tasks", return_value=tasks_list):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_pending_ask_non_draft_review_not_requested(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -7132,7 +7125,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
         with patch("kennel.worker.tasks.list_tasks", return_value=[self._ask_task()]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_pending_ask_changes_requested_rerequest_skipped(
         self, tmp_path: Path
@@ -7144,7 +7137,7 @@ class TestHandlePromoteMerge:
         )
         with patch("kennel.worker.tasks.list_tasks", return_value=[self._ask_task()]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewer.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_pending_ask_returns_zero(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -7955,7 +7948,13 @@ class TestWorkerThread:
         captured: list = []
 
         def fake_worker_init(
-            self_w, work_dir, gh, abort_task=None, repo_name="", registry=None
+            self_w,
+            work_dir,
+            gh,
+            abort_task=None,
+            repo_name="",
+            registry=None,
+            membership=None,
         ):
             captured.append(abort_task)
             self_w.work_dir = work_dir


### PR DESCRIPTION
## Summary

\`events._is_allowed\` filtered top-level PR comments by \`repository.owner.login\` — for \`FidoCanCode/fidocancode.github.io\` that is the bot itself, so rhencke's comments were silently dropped before reaching the worker. Same shape as #247 but on the webhook dispatch path instead of the review path.

## Changes

- **New \`RepoMembership\` dataclass** (in \`kennel/config.py\`) holds the cached \`collaborators: frozenset[str]\` for a repo. Shared as a field on both \`RepoConfig\` (used by event dispatch at webhook time) and \`RepoContext\` (used by workers at task execution time).
- **\`server.populate_memberships\`** runs once at startup, calls \`GH.get_collaborators\` for every managed repo, and stores the result on \`RepoConfig.membership\` (mutating the \`Config.repos\` dict in place via \`dataclasses.replace\`). The bot's own login is filtered out.
- **\`events._is_allowed\`** signature changed from \`(user, payload, config)\` to \`(user, repo_cfg, config)\` and now checks \`user in repo_cfg.membership.collaborators or user in config.allowed_bots\`.
- **\`GH.add_pr_reviewers\`** (plural) replaces \`add_pr_reviewer\`. GitHub's API accepts a list — request review from all collaborators in one call. The "primary reviewer" concept from #249 is removed entirely; any collaborator's approval is decisive, and review requests fan out to everyone who isn't already requested.
- **\`Worker\` no longer calls \`gh.get_collaborators\` per iteration** — membership is injected at construction time from the cached \`RepoConfig\`.
- **\`_filter_threads\`** now takes a \`frozenset\` of collaborators.
- Owner is **never** considered a collaborator by fallback — if no humans have write+ access, no one is allowed.

Closes #250

## Test plan

- [x] 1315 tests pass, 100% coverage
- [x] New \`TestPopulateMemberships\` — happy path, bot filtered, all repos iterated
- [x] New \`TestIsAllowed\` covers any collaborator allowed, empty collaborators denies all humans (bots still allowed)
- [x] \`add_pr_reviewers\` empty list is a no-op (no API call)
- [ ] Manual: rhencke comments on a fido PR in \`FidoCanCode/fidocancode.github.io\` → fido picks it up