### PR TITLE
seed_tasks_from_pr_body skips completed [x] tasks (#253)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1203,11 +1203,13 @@ class Worker:
     def seed_tasks_from_pr_body(self, repo: str, pr_number: int) -> None:
         """Seed tasks.json from the PR body work-queue markers if tasks.json is empty.
 
-        Extracts unchecked task items (``- [ ] ...``) between
+        Extracts ONLY unchecked task items (``- [ ] ...``) between
         ``WORK_QUEUE_START`` and ``WORK_QUEUE_END`` markers and adds them via
-        :func:`~kennel.tasks.add_task`.  Lines without a ``<!-- type:X -->``
-        comment are skipped with a warning (e.g. stale multi-line task bodies
-        from older PR bodies).
+        :func:`~kennel.tasks.add_task`.  Completed (``- [x]``) tasks are
+        skipped — the work is already in the git history; re-creating them
+        as pending would send fido into a "no commits produced" retry loop.
+        Lines without a ``<!-- type:X -->`` comment are skipped with a
+        warning (e.g. stale multi-line task bodies from older PR bodies).
 
         No-op if tasks.json is already non-empty, or if no markers /
         unchecked items are found.
@@ -1225,7 +1227,7 @@ class Worker:
             return
         parsed: list[tuple[str, TaskType]] = []
         for line in match.group(1).splitlines():
-            m = re.match(r"^- \[[ x]\] (.+)$", line)
+            m = re.match(r"^- \[ \] (.+)$", line)
             if not m:
                 continue
             rest = m.group(1)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2942,6 +2942,43 @@ class TestSeedTasksFromPrBody:
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         assert mock_add.call_count == 3
 
+    def test_skips_completed_tasks(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {
+            "body": (
+                "<!-- WORK_QUEUE_START -->\n"
+                "- [x] Already done <!-- type:spec -->\n"
+                "- [x] Also done <!-- type:spec -->\n"
+                "- [ ] Still pending <!-- type:spec -->\n"
+                "<!-- WORK_QUEUE_END -->"
+            )
+        }
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.worker.tasks.add_task") as mock_add,
+        ):
+            worker.seed_tasks_from_pr_body("owner/repo", 1)
+        # Only the unchecked task should have been added
+        assert mock_add.call_count == 1
+        assert mock_add.call_args.args[1] == "Still pending"
+
+    def test_skips_all_when_only_completed(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {
+            "body": (
+                "<!-- WORK_QUEUE_START -->\n"
+                "- [x] Done one <!-- type:spec -->\n"
+                "- [x] Done two <!-- type:spec -->\n"
+                "<!-- WORK_QUEUE_END -->"
+            )
+        }
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.worker.tasks.add_task") as mock_add,
+        ):
+            worker.seed_tasks_from_pr_body("owner/repo", 1)
+        mock_add.assert_not_called()
+
     def test_strips_next_marker(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {


### PR DESCRIPTION
## Summary

The regex \`^- \[[ x]\] (.+)$\` matched both checked and unchecked task lines, so a fresh seed (after a workspace restore wiped \`tasks.json\`) re-created every "Completed (N)" task as pending. Fido would then loop "no commits produced" on each, since the work was already in git.

Confusio PR #100 demonstrated this multiple times this session — 24 dependabot backends came back as pending after every restore, even though all 24 commits exist on the branch.

## Fix

One regex character: \`\[[ x]\]\` → \`\[ \]\`. Only unchecked tasks get seeded; completed tasks are represented by their git history, not by re-pending.

Closes #253

## Test plan

- [x] 1327 tests pass, 100% coverage
- [x] New \`test_skips_completed_tasks\` — mixed [x] and [ ] body, only [ ] is seeded
- [x] New \`test_skips_all_when_only_completed\` — no add_task calls when every line is [x]