### PR TITLE
execute_task: break retry loop when task externally completed

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1162,6 +1162,18 @@ class Worker:
         # Resume loop: let Claude cook until commits appear
         attempt = 0
         while head_before == head_after:
+            # If the task was completed externally (e.g. via `kennel task
+            # complete`) while we were waiting, stop retrying — the work is
+            # already recorded as done and no commits will ever appear.
+            current_task_list = tasks.list_tasks(self.work_dir)
+            if not any(
+                t["id"] == task["id"] and t.get("status") == TaskStatus.PENDING
+                for t in current_task_list
+            ):
+                log.info(
+                    "task externally completed — stopping retry (id=%s)", task["id"]
+                )
+                break
             attempt += 1
             if session_id:
                 log.info(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5276,6 +5276,46 @@ class TestExecuteTask:
         assert mock_run.call_count == 4
         mock_complete.assert_called_once()
 
+    def test_breaks_retry_loop_when_task_externally_completed(
+        self, tmp_path: Path
+    ) -> None:
+        # Task is pending on first list_tasks call (execute_task picks it up),
+        # then externally completed before the retry loop re-checks — loop
+        # should break without calling claude_run a second time.
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Already done task")
+        completed_task = {**task, "status": "completed"}
+        # HEAD never changes — no commits will ever appear.
+        git_mock = MagicMock(
+            side_effect=lambda args, **kw: MagicMock(
+                returncode=0,
+                stdout="aaa" if args == ["rev-parse", "HEAD"] else "",
+                stderr="",
+            )
+        )
+        list_tasks_calls = iter([[task], [completed_task]])
+        with (
+            patch(
+                "kennel.worker.tasks.list_tasks",
+                side_effect=lambda *a, **kw: next(list_tasks_calls),
+            ),
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch(
+                "kennel.worker.claude_run", return_value=("sess-1", "output")
+            ) as mock_run,
+            patch.object(worker, "_git", git_mock),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
+        # claude_run called exactly once (initial dispatch), not again after break
+        mock_run.assert_called_once()
+        # complete_by_id still called (idempotent — task already completed externally)
+        mock_complete.assert_called_once_with(tmp_path, task["id"])
+
     def test_resumes_setup_session_when_present_in_state(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)


### PR DESCRIPTION
## Problem

When `execute_task` dispatches a task that was already externally completed (e.g. manually marked done via `kennel task complete`), Claude responds with "already done" and produces no commits. The `while head_before == head_after` retry loop then spins forever because it never re-checks the task's status in `tasks.json`.

Observed: confusio PR #100, task "Add Dependabot routes and default handlers" looped 16+ times before kennel was killed.

Closes #257.

## Fix

At the top of the retry loop, re-read `tasks.json` and break out if the task is no longer `pending`. Since `complete_by_id` is idempotent and `ensure_pushed`/`_squash_wip_commit` are no-ops when HEAD hasn't moved, the post-loop cleanup path handles this correctly without additional guards.

## Test plan
- [x] New test: `test_breaks_retry_loop_when_task_externally_completed`
- [x] All 1328 tests pass
- [x] 100% coverage