### PR TITLE
Self-restart: hard-reset runner to origin/main, defer worker teardown (#268)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -83,7 +83,14 @@ def _pull_with_backoff(
     _sleep: Callable[[float], None] = time.sleep,
     _monotonic: Callable[[], float] = time.monotonic,
 ) -> bool:
-    """Run ``git pull`` in *runner_dir* with exponential backoff on failure.
+    """Sync the runner clone to ``origin/main`` with exponential backoff.
+
+    Uses ``git fetch origin main`` followed by ``git reset --hard origin/main``
+    so the runner clone is forcibly synced to the remote — no merge strategy
+    needed, no failure on local divergence.  The runner clone is supposed to
+    be read-only (fido never commits there), so a destructive reset is safe
+    and the only way to recover from accidental local commits or detached
+    state.
 
     Retries with delays from :data:`_PULL_BACKOFF_DELAYS` (10s, 30s, 60s)
     and a total budget of :data:`_PULL_BUDGET_SECONDS` (10 minutes).  Logs
@@ -96,14 +103,21 @@ def _pull_with_backoff(
         attempt += 1
         try:
             _run(
-                ["git", "pull"],
+                ["git", "fetch", "origin", "main"],
+                cwd=str(runner_dir),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            _run(
+                ["git", "reset", "--hard", "origin/main"],
                 cwd=str(runner_dir),
                 capture_output=True,
                 text=True,
                 check=True,
             )
             log.info(
-                "self-restart: git pull succeeded on attempt %d (%.1fs elapsed)",
+                "self-restart: runner synced on attempt %d (%.1fs elapsed)",
                 attempt,
                 _monotonic() - start,
             )
@@ -111,14 +125,14 @@ def _pull_with_backoff(
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
             elapsed = _monotonic() - start
             log.error(
-                "self-restart: git pull attempt %d failed after %.1fs: %s",
+                "self-restart: runner sync attempt %d failed after %.1fs: %s",
                 attempt,
                 elapsed,
                 e,
             )
             if attempt > len(_PULL_BACKOFF_DELAYS):
                 log.error(
-                    "self-restart: git pull exhausted %d retries in %.1fs — giving up",
+                    "self-restart: runner sync exhausted %d retries in %.1fs — giving up",
                     attempt,
                     elapsed,
                 )
@@ -126,7 +140,7 @@ def _pull_with_backoff(
             delay = _PULL_BACKOFF_DELAYS[attempt - 1]
             if elapsed + delay > _PULL_BUDGET_SECONDS:
                 log.error(
-                    "self-restart: git pull would exceed %.0fs budget — giving up",
+                    "self-restart: runner sync would exceed %.0fs budget — giving up",
                     _PULL_BUDGET_SECONDS,
                 )
                 return False
@@ -279,14 +293,18 @@ class WebhookHandler(BaseHTTPRequestHandler):
         if self_repo != repo_name:
             return  # Not our repo — nothing to do.
         log.info(
-            "kennel repo %s merged — pulling runner clone at %s",
+            "kennel repo %s merged — syncing runner clone at %s",
             repo_name,
             runner_dir,
         )
-        self.registry.stop_and_join(repo_name)
+        # Sync runner BEFORE tearing down the worker.  If the sync fails we
+        # log and return without touching the running workers — fido on the
+        # kennel repo keeps running its old code rather than being silently
+        # left without a worker thread.
         if not type(self)._fn_pull_with_backoff(runner_dir):
-            log.error("self-restart: git pull gave up — running old version")
+            log.error("self-restart: runner sync gave up — running old version")
             return
+        self.registry.stop_and_join(repo_name)
         type(self)._fn_os_chdir(runner_dir)
         type(self)._fn_os_execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -923,15 +923,21 @@ class TestPullWithBackoff:
         assert _pull_with_backoff(
             tmp_path, _run=mock_run, _sleep=mock_sleep, _monotonic=lambda: 0.0
         )
-        mock_run.assert_called_once()
+        # Each sync attempt runs two git commands: fetch + reset.
+        assert mock_run.call_count == 2
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert cmds[0] == ["git", "fetch", "origin", "main"]
+        assert cmds[1] == ["git", "reset", "--hard", "origin/main"]
         mock_sleep.assert_not_called()
 
     def test_success_after_retry(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
+        # First attempt: fetch fails.  Second attempt: fetch + reset both succeed.
         mock_run = MagicMock(
             side_effect=[
                 subprocess.CalledProcessError(1, []),
+                MagicMock(returncode=0),
                 MagicMock(returncode=0),
             ]
         )
@@ -943,12 +949,33 @@ class TestPullWithBackoff:
             _sleep=mock_sleep,
             _monotonic=lambda: next(times),
         )
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         mock_sleep.assert_called_once_with(10)
+
+    def test_recovers_from_divergent_local(self, tmp_path: Path) -> None:
+        """The whole point of using fetch+reset: divergent local branch is fine.
+
+        Previously git pull would fail with `fatal: Need to specify how to
+        reconcile divergent branches` and the runner would never sync.  With
+        reset --hard the local state is forcibly replaced, so the worker
+        catches up regardless of how the runner clone got into a weird state.
+        """
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        mock_sleep = MagicMock()
+        assert _pull_with_backoff(
+            tmp_path, _run=mock_run, _sleep=mock_sleep, _monotonic=lambda: 0.0
+        )
+        assert ["git", "reset", "--hard", "origin/main"] in [
+            c.args[0] for c in mock_run.call_args_list
+        ]
+        mock_sleep.assert_not_called()
 
     def test_gives_up_after_all_retries_fail(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
+        # Fetch fails on every attempt — 4 attempts total.
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
         mock_sleep = MagicMock()
         times = iter([0.0, 1.0, 1.0, 12.0, 12.0, 43.0, 43.0, 104.0])
@@ -958,10 +985,33 @@ class TestPullWithBackoff:
             _sleep=mock_sleep,
             _monotonic=lambda: next(times),
         )
-        # 4 attempts: initial + 3 retries
+        # 4 attempts × 1 failing fetch each = 4 calls.
         assert mock_run.call_count == 4
-        # 3 sleeps at 10s, 30s, 60s between retries
+        # 3 sleeps at 10s, 30s, 60s between retries.
         assert [c.args[0] for c in mock_sleep.call_args_list] == [10, 30, 60]
+
+    def test_reset_failure_retries(self, tmp_path: Path) -> None:
+        """Fetch succeeds but reset fails — both commands matter for the result."""
+        from kennel.server import _pull_with_backoff
+
+        mock_run = MagicMock(
+            side_effect=[
+                MagicMock(returncode=0),  # fetch
+                subprocess.CalledProcessError(1, []),  # reset
+                MagicMock(returncode=0),  # fetch retry
+                MagicMock(returncode=0),  # reset retry
+            ]
+        )
+        mock_sleep = MagicMock()
+        times = iter([0.0, 1.0, 1.0])
+        assert _pull_with_backoff(
+            tmp_path,
+            _run=mock_run,
+            _sleep=mock_sleep,
+            _monotonic=lambda: next(times),
+        )
+        assert mock_run.call_count == 4
+        mock_sleep.assert_called_once_with(10)
 
     def test_gives_up_when_budget_exhausted(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
@@ -1060,7 +1110,14 @@ class TestSelfRestart:
         finally:
             srv.shutdown()
 
-    def test_skips_exec_when_pull_gives_up(self, tmp_path: Path) -> None:
+    def test_pull_failure_leaves_worker_alone(self, tmp_path: Path) -> None:
+        """When pull gives up, do NOT tear down the worker thread.
+
+        Previously the worker for the merged repo was stopped before the
+        pull, and stayed stopped after pull failure — silently leaving
+        kennel without a fido worker on its own repo.  Now the pull runs
+        first and the worker is only torn down on success.
+        """
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path
@@ -1070,12 +1127,14 @@ class TestSelfRestart:
             WebhookHandler._fn_os_execvp = mock_exec
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             time.sleep(0.2)
-            mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
+            mock_registry.stop_and_join.assert_not_called()
             mock_exec.assert_not_called()
         finally:
             srv.shutdown()
 
-    def test_stop_and_join_precedes_pull(self, tmp_path: Path) -> None:
+    def test_pull_precedes_stop_and_join(self, tmp_path: Path) -> None:
+        """Pull MUST run before stop_and_join, so a failed pull leaves the
+        worker intact."""
         call_order: list[str] = []
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         mock_registry.stop_and_join.side_effect = lambda *_a, **_kw: call_order.append(
@@ -1096,4 +1155,4 @@ class TestSelfRestart:
             time.sleep(0.2)
         finally:
             srv.shutdown()
-        assert call_order == ["stop_and_join", "pull"]
+        assert call_order == ["pull", "stop_and_join"]


### PR DESCRIPTION
## Summary

Two compounding bugs in the self-restart path manifested when [PR #236](https://github.com/rhencke/kennel/pull/236) merged tonight.

### Bug 1: \`git pull\` fails on divergent runner clone

\`_pull_with_backoff\` used \`git pull\`. The runner clone is supposed to be read-only, but if it ever drifts even one commit (which happened tonight), every subsequent pull fails with \`fatal: Need to specify how to reconcile divergent branches\` (exit 128). The retry loop never recovers because the same error repeats every attempt. From the kennel log:

\`\`\`
09:40:21 kennel repo rhencke/kennel merged — pulling runner clone
09:40:49 self-restart: git pull attempt 1 failed after 3.6s: ... exit status 128
09:41:03 self-restart: git pull attempt 2 failed after 16.8s: ... exit status 128
09:41:36 self-restart: git pull attempt 3 failed after 50.0s: ... exit status 128
09:42:39 self-restart: git pull attempt 4 failed after 113.3s: ... exit status 128
09:42:39 self-restart: git pull exhausted 4 retries in 113.3s — giving up
\`\`\`

**Fix**: replace \`git pull\` with \`git fetch origin main && git reset --hard origin/main\` so the runner is forcibly synced regardless of local state.

### Bug 2: failed pull leaves the worker thread permanently dead

\`_self_restart\` called \`stop_and_join(repo_name)\` BEFORE the pull. When the pull failed, the function returned but the worker thread for the merged repo was already torn down — silently leaving kennel without a fido worker on its own repo, with no log line indicating why.

After tonight's failed self-restart, \`/proc/<pid>/task\` showed only 3 threads:
\`\`\`
kennel
worker-confusio
worker-fidocanc
\`\`\`
No \`worker-kennel\`. Confusio and blog kept iterating; kennel fido was just gone.

**Fix**: move \`stop_and_join\` AFTER the pull succeeds. A failed pull leaves the worker intact and the existing code keeps running.

Closes #268

## Test plan

- [x] 1425 tests pass, 100% coverage
- [x] Updated \`TestPullWithBackoff\` for the fetch+reset 2-call pattern
- [x] New \`test_recovers_from_divergent_local\` documenting the regression we hit
- [x] New \`test_reset_failure_retries\` — fetch succeeds but reset fails, retry runs both
- [x] Renamed \`test_skips_exec_when_pull_gives_up\` → \`test_pull_failure_leaves_worker_alone\`, asserts \`stop_and_join\` is NOT called on pull failure
- [x] Renamed \`test_stop_and_join_precedes_pull\` → \`test_pull_precedes_stop_and_join\`, asserts the new ordering