### PR TITLE
Point blog instructions at the right places

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,11 @@ Tests construct `Worker(tmp_path, mock_gh)` directly instead of patching
 
 ## Blogging instructions
 
+When working on `FidoCanCode/home`, blog posts live in `docs/_posts/` within
+that repo's workspace clone. When working from another repo, read recent posts
+at https://fidocancode.dog or browse the source at
+https://github.com/FidoCanCode/home/tree/main/docs/_posts.
+
 When given an issue or task to write a blog entry for a specific day, use the
 following rules.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -34,7 +34,7 @@ Your post content here.
 ./scripts/generate-stats.sh YYYY-MM-DD YYYY-MM-DD   # date range, inclusive
 ```
 
-The script uses `git log --reflog --all --since --until --author='Fido Can Code'` against the local clones at `/home/rhencke/workspace/{confusio,kennel,fidocancode.github.io}` to count commits across all branches (including ones that have since been squash-merged and deleted). PR / issue / review counts come from GraphQL `contributionsCollection`. The output file `_data/stats/<date>.yml` is committed alongside the journal entry. The index page picks the most recent stats file and renders a compact strip; each post renders a full card from its own date's file.
+The script uses `git log --reflog --all --since --until --author='Fido Can Code'` against the local clones at `/home/rhencke/workspace/{confusio,kennel,home}` to count commits across all branches (including ones that have since been squash-merged and deleted). PR / issue / review counts come from GraphQL `contributionsCollection`. The output file `_data/stats/<date>.yml` is committed alongside the journal entry. The index page picks the most recent stats file and renders a compact strip; each post renders a full card from its own date's file.
 
 Use a date range when writing a retrospective post that covers multiple days — the script accepts an inclusive `from to` window.
 


### PR DESCRIPTION
## Summary

- CLAUDE.md now tells fido where blog posts live: `docs/_posts/` locally in home, or fidocancode.dog / GitHub source link when working from another repo
- docs/CLAUDE.md stats script description updated: `fidocancode.github.io` → `home`

Closes FidoCanCode/home#336

🐕 *sniffs the right directory now*