### PR TITLE
Pull runner clone on startup, restart on push to default branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,12 @@ Tests construct `Worker(tmp_path, mock_gh)` directly instead of patching
 
 ## Blogging instructions
 
-When working on `FidoCanCode/home`, blog posts live in `docs/_posts/` within
-that repo's workspace clone. When working from another repo, read recent posts
-at https://fidocancode.dog or browse the source at
-https://github.com/FidoCanCode/home/tree/main/docs/_posts.
+Fido can read his own blog detailing his past development trials and triumphs
+any time he wants:
+
+- Local files in `docs/_posts/` (when working on `FidoCanCode/home`)
+- Published at https://fidocancode.dog
+- Source on GitHub at https://github.com/FidoCanCode/home/tree/main/docs/_posts
 
 When given an issue or task to write a blog entry for a specific day, use the
 following rules.

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -76,6 +76,25 @@ def _get_self_repo(
     return m.group(1)
 
 
+def _get_head(
+    runner_dir: Path,
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str | None:
+    """Return the current HEAD commit hash of the runner clone, or None on error."""
+    try:
+        result = _run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(runner_dir),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError, FileNotFoundError:
+        return None
+
+
 def _pull_with_backoff(
     runner_dir: Path,
     *,
@@ -160,6 +179,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_launch_worker = launch_worker
     _fn_runner_dir = _runner_dir
     _fn_get_self_repo = _get_self_repo
+    _fn_get_head = _get_head
     _fn_pull_with_backoff = _pull_with_backoff
     _fn_os_chdir = os.chdir
     _fn_os_execvp = os.execvp
@@ -205,16 +225,24 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # Respond immediately — don't block on dispatch
         self._respond(200, "ok")
 
-        # Check for self-restart (kennel repo merged).  _self_restart itself
-        # verifies via the runner clone's git remote that the webhook's repo
-        # actually matches kennel — if so it execs a new process and never
-        # returns.  For other merged PRs (e.g. fido's own work) it's a no-op.
+        # Check for self-restart: merged PR or push to default branch.
+        # _self_restart verifies via the runner clone's git remote that the
+        # webhook's repo actually matches kennel — if so it execs a new
+        # process and never returns.  For non-kennel repos it's a no-op.
         if (
             event == "pull_request"
             and payload.get("action") == "closed"
             and payload.get("pull_request", {}).get("merged")
         ):
-            self._self_restart(repo_name)
+            self._self_restart(repo_name, reason="PR merged")
+
+        default_branch = payload.get("repository", {}).get("default_branch", "")
+        if (
+            event == "push"
+            and default_branch
+            and payload.get("ref") == f"refs/heads/{default_branch}"
+        ):
+            self._self_restart(repo_name, reason=f"push to {default_branch}")
 
         if not repo_cfg:
             log.debug("ignoring webhook for unregistered repo: %s", repo_name)
@@ -287,13 +315,14 @@ class WebhookHandler(BaseHTTPRequestHandler):
         except Exception:
             log.exception("error processing action")
 
-    def _self_restart(self, repo_name: str) -> None:
+    def _self_restart(self, repo_name: str, *, reason: str = "") -> None:
         runner_dir = type(self)._fn_runner_dir()
         self_repo = type(self)._fn_get_self_repo(runner_dir)
         if self_repo != repo_name:
             return  # Not our repo — nothing to do.
         log.info(
-            "kennel repo %s merged — syncing runner clone at %s",
+            "self-restart: %s on %s — syncing runner clone at %s",
+            reason,
             repo_name,
             runner_dir,
         )
@@ -302,8 +331,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # kennel repo keeps running its old code rather than being silently
         # left without a worker thread.
         if not type(self)._fn_pull_with_backoff(runner_dir):
-            log.error("self-restart: runner sync gave up — running old version")
+            log.error("self-restart: gave up — running old version (%s)", reason)
             return
+        log.info(
+            "self-restart: runner synced — stopping workers and re-execing (%s)", reason
+        )
         self.registry.stop_and_join(repo_name)
         type(self)._fn_os_chdir(runner_dir)
         type(self)._fn_os_execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
@@ -362,6 +394,33 @@ def populate_memberships(
         )
 
 
+def _startup_pull(
+    *,
+    _runner_dir: Callable[[], Path] = _runner_dir,
+    _get_head: Callable[..., str | None] = _get_head,
+    _pull: Callable[..., bool] = _pull_with_backoff,
+    _execvp: Callable[..., None] = os.execvp,
+) -> None:
+    """Sync the runner clone on startup and re-exec if HEAD changed."""
+    runner_dir = _runner_dir()
+    head_before = _get_head(runner_dir)
+    if not _pull(runner_dir):
+        log.warning("startup: runner sync failed — continuing with current code")
+        return
+    head_after = _get_head(runner_dir)
+    if head_before and head_after and head_before != head_after:
+        log.info(
+            "startup: runner updated %s → %s — re-execing",
+            head_before[:12],
+            head_after[:12],
+        )
+        _execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
+    elif head_before and head_after:
+        log.info("startup: runner already up to date at %s", head_before[:12])
+    else:
+        log.info("startup: runner synced (could not compare HEAD)")
+
+
 def run(
     *,
     _from_args=Config.from_args,
@@ -373,6 +432,7 @@ def run(
     _populate_memberships=populate_memberships,
     _signal=signal.signal,
     _kill_active_children=kill_active_children,
+    _startup_pull=_startup_pull,
 ) -> None:
     config = _from_args()
 
@@ -400,6 +460,8 @@ def run(
         datefmt="%H:%M:%S",
         handlers=handlers,
     )
+
+    _startup_pull()
 
     _populate_memberships(config)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,6 +51,7 @@ def _restore_handler_fns():
         "_fn_launch_worker": WebhookHandler._fn_launch_worker,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
         "_fn_get_self_repo": WebhookHandler._fn_get_self_repo,
+        "_fn_get_head": WebhookHandler._fn_get_head,
         "_fn_pull_with_backoff": WebhookHandler._fn_pull_with_backoff,
         "_fn_os_chdir": WebhookHandler._fn_os_chdir,
         "_fn_os_execvp": WebhookHandler._fn_os_execvp,
@@ -586,6 +587,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -606,6 +608,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
         )
@@ -631,6 +634,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
         )
@@ -656,6 +660,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=mock_kill,
         )
@@ -691,6 +696,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         assert len(captured_kwargs) == 1
@@ -716,6 +722,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         assert len(captured_handlers) >= 1
@@ -739,6 +746,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _stderr=mock_stderr,
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -774,6 +782,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -822,6 +831,7 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
         )
 
         repo_handler = next(
@@ -850,9 +860,19 @@ _MERGE_PAYLOAD = {
     "repository": {
         "full_name": "owner/kennel",
         "owner": {"login": "owner"},
+        "default_branch": "main",
     },
     "action": "closed",
     "pull_request": {"number": 1, "merged": True},
+}
+
+_PUSH_PAYLOAD = {
+    "repository": {
+        "full_name": "owner/kennel",
+        "owner": {"login": "owner"},
+        "default_branch": "main",
+    },
+    "ref": "refs/heads/main",
 }
 
 
@@ -904,6 +924,26 @@ class TestGetSelfRepo:
 
         mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n", returncode=0))
         assert _get_self_repo(tmp_path, _run=mock_run) is None
+
+
+class TestGetHead:
+    def test_returns_sha(self, tmp_path: Path) -> None:
+        from kennel.server import _get_head
+
+        run = MagicMock(return_value=MagicMock(stdout="abc123def456\n"))
+        assert _get_head(tmp_path, _run=run) == "abc123def456"
+
+    def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
+        from kennel.server import _get_head
+
+        run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
+        assert _get_head(tmp_path, _run=run) is None
+
+    def test_returns_none_on_file_not_found(self, tmp_path: Path) -> None:
+        from kennel.server import _get_head
+
+        run = MagicMock(side_effect=FileNotFoundError())
+        assert _get_head(tmp_path, _run=run) is None
 
 
 class TestRunnerDir:
@@ -1043,6 +1083,59 @@ class TestPullWithBackoff:
         )
 
 
+class TestStartupPull:
+    def test_reexecs_when_head_changes(self) -> None:
+        from kennel.server import _startup_pull
+
+        heads = iter(["aaa", "bbb"])
+        mock_exec = MagicMock()
+        _startup_pull(
+            _runner_dir=lambda: Path("/fake"),
+            _get_head=lambda _d: next(heads),
+            _pull=lambda _d: True,
+            _execvp=mock_exec,
+        )
+        mock_exec.assert_called_once()
+        assert mock_exec.call_args.args[0] == "uv"
+
+    def test_skips_exec_when_head_unchanged(self) -> None:
+        from kennel.server import _startup_pull
+
+        mock_exec = MagicMock()
+        _startup_pull(
+            _runner_dir=lambda: Path("/fake"),
+            _get_head=lambda _d: "same_sha",
+            _pull=lambda _d: True,
+            _execvp=mock_exec,
+        )
+        mock_exec.assert_not_called()
+
+    def test_continues_on_pull_failure(self) -> None:
+        from kennel.server import _startup_pull
+
+        mock_exec = MagicMock()
+        _startup_pull(
+            _runner_dir=lambda: Path("/fake"),
+            _get_head=lambda _d: "aaa",
+            _pull=lambda _d: False,
+            _execvp=mock_exec,
+        )
+        mock_exec.assert_not_called()
+
+    def test_execs_when_head_unknown(self) -> None:
+        from kennel.server import _startup_pull
+
+        mock_exec = MagicMock()
+        _startup_pull(
+            _runner_dir=lambda: Path("/fake"),
+            _get_head=lambda _d: None,
+            _pull=lambda _d: True,
+            _execvp=mock_exec,
+        )
+        # Can't compare HEAD — but pull succeeded, so log and continue
+        mock_exec.assert_not_called()
+
+
 class TestSelfRestart:
     """Tests for the self-restart flow."""
 
@@ -1156,3 +1249,36 @@ class TestSelfRestart:
         finally:
             srv.shutdown()
         assert call_order == ["pull", "stop_and_join"]
+
+    def test_push_to_default_branch_triggers_restart(self, tmp_path: Path) -> None:
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+            WebhookHandler._fn_pull_with_backoff = lambda _d: True
+            mock_chdir = MagicMock()
+            mock_exec = MagicMock()
+            WebhookHandler._fn_os_chdir = mock_chdir
+            WebhookHandler._fn_os_execvp = mock_exec
+            _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
+            time.sleep(0.2)
+            mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
+            mock_exec.assert_called_once()
+        finally:
+            srv.shutdown()
+
+    def test_push_to_non_default_branch_ignored(self, tmp_path: Path) -> None:
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            mock_pull = MagicMock()
+            mock_exec = MagicMock()
+            WebhookHandler._fn_pull_with_backoff = mock_pull
+            WebhookHandler._fn_os_execvp = mock_exec
+            payload = {**_PUSH_PAYLOAD, "ref": "refs/heads/feature-branch"}
+            _post_webhook(url, cfg, "push", payload)
+            time.sleep(0.2)
+            mock_pull.assert_not_called()
+            mock_exec.assert_not_called()
+        finally:
+            srv.shutdown()


### PR DESCRIPTION
## Summary

- **Startup pull**: kennel now syncs the runner clone on boot and re-execs if HEAD changed — no more stale code after a reboot
- **Push-to-default-branch restart**: webhooks for pushes to the default branch trigger self-restart, not just merged-PR events
- Added `_get_head()` and `_startup_pull()` with full DI for testability
- Updated CLAUDE.md blog access guidance with all three ways to read past posts

Fixes #246

## Test plan

- [x] 1434 tests pass, 100% coverage
- [x] Startup pull re-execs when HEAD changes
- [x] Startup pull skips exec when HEAD unchanged
- [x] Startup pull continues gracefully on pull failure
- [x] Push to default branch triggers restart
- [x] Push to non-default branch ignored
- [x] All existing self-restart tests still pass

*wags tail* no more cold starts with stale kibble