### PR TITLE
RCA: worker dies after successful launch — liveness check insufficient (closes #71)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -41,26 +41,6 @@ _replied_comments: set[int] = set()
 # exceeds _PULL_BUDGET_SECONDS, even if a retry window remains.
 _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
-_WATCHDOG_INTERVAL: float = 30.0
-
-
-def _start_watchdog_thread(
-    registry: WorkerRegistry,
-    repos: dict[str, RepoConfig],
-    *,
-    _interval: float = _WATCHDOG_INTERVAL,
-) -> threading.Thread:
-    """Start a daemon thread that periodically runs the watchdog."""
-    watchdog = Watchdog(registry, repos)
-
-    def _loop() -> None:
-        while True:
-            time.sleep(_interval)
-            watchdog.run()
-
-    t = threading.Thread(target=_loop, daemon=True, name="watchdog")
-    t.start()
-    return t
 
 
 def _runner_dir() -> Path:
@@ -454,7 +434,7 @@ def run(
     _signal=signal.signal,
     _kill_active_children=kill_active_children,
     _startup_pull=_startup_pull,
-    _start_watchdog=_start_watchdog_thread,
+    _Watchdog=Watchdog,
 ) -> None:
     config = _from_args()
 
@@ -490,7 +470,7 @@ def run(
     WebhookHandler.config = config
     registry = _make_registry(config.repos)
     WebhookHandler.registry = registry
-    _start_watchdog(registry, config.repos)
+    _Watchdog(registry, config.repos).start_thread()
 
     server = _HTTPServer(("", config.port), WebhookHandler)
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -28,6 +28,7 @@ from kennel.events import (
 )
 from kennel.github import GitHub
 from kennel.registry import WorkerRegistry, make_registry
+from kennel.watchdog import Watchdog
 from kennel.worker import RepoContextFilter, RepoNameFilter
 
 log = logging.getLogger(__name__)
@@ -40,6 +41,26 @@ _replied_comments: set[int] = set()
 # exceeds _PULL_BUDGET_SECONDS, even if a retry window remains.
 _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
+_WATCHDOG_INTERVAL: float = 30.0
+
+
+def _start_watchdog_thread(
+    registry: WorkerRegistry,
+    repos: dict[str, RepoConfig],
+    *,
+    _interval: float = _WATCHDOG_INTERVAL,
+) -> threading.Thread:
+    """Start a daemon thread that periodically runs the watchdog."""
+    watchdog = Watchdog(registry, repos)
+
+    def _loop() -> None:
+        while True:
+            time.sleep(_interval)
+            watchdog.run()
+
+    t = threading.Thread(target=_loop, daemon=True, name="watchdog")
+    t.start()
+    return t
 
 
 def _runner_dir() -> Path:
@@ -433,6 +454,7 @@ def run(
     _signal=signal.signal,
     _kill_active_children=kill_active_children,
     _startup_pull=_startup_pull,
+    _start_watchdog=_start_watchdog_thread,
 ) -> None:
     config = _from_args()
 
@@ -466,7 +488,9 @@ def run(
     _populate_memberships(config)
 
     WebhookHandler.config = config
-    WebhookHandler.registry = _make_registry(config.repos)
+    registry = _make_registry(config.repos)
+    WebhookHandler.registry = registry
+    _start_watchdog(registry, config.repos)
 
     server = _HTTPServer(("", config.port), WebhookHandler)
 

--- a/kennel/watchdog.py
+++ b/kennel/watchdog.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import logging
+import threading
+import time
 
 from kennel.config import RepoConfig
 from kennel.registry import WorkerRegistry
 
 log = logging.getLogger(__name__)
+
+_WATCHDOG_INTERVAL: float = 30.0
 
 
 class Watchdog:
@@ -32,6 +36,20 @@ class Watchdog:
                 log.info("thread for %s is not alive — restarting", repo_name)
                 self.registry.start(repo_cfg)
         return 0
+
+    def start_thread(
+        self, *, _interval: float = _WATCHDOG_INTERVAL
+    ) -> threading.Thread:
+        """Start a single daemon thread that periodically checks all repos."""
+
+        def _loop() -> None:
+            while True:
+                time.sleep(_interval)
+                self.run()
+
+        t = threading.Thread(target=_loop, daemon=True, name="watchdog")
+        t.start()
+        return t
 
 
 def run(registry: WorkerRegistry, repos: dict[str, RepoConfig]) -> int:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -852,7 +852,7 @@ class TestRun:
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         mock_registry = MagicMock()
         mock_make_registry = MagicMock(return_value=mock_registry)
-        mock_start_watchdog = MagicMock()
+        mock_watchdog_cls = MagicMock()
 
         run(
             _from_args=lambda: fake_cfg,
@@ -862,58 +862,11 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
-            _start_watchdog=mock_start_watchdog,
+            _Watchdog=mock_watchdog_cls,
         )
 
-        mock_start_watchdog.assert_called_once_with(mock_registry, fake_cfg.repos)
-
-
-class TestStartWatchdogThread:
-    def _repos(self, tmp_path: Path) -> dict:
-        return {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-
-    def test_returns_daemon_thread(self, tmp_path: Path) -> None:
-        from kennel.server import _start_watchdog_thread
-
-        mock_registry = MagicMock()
-        mock_registry.is_alive.return_value = True
-        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
-        assert t.daemon
-
-    def test_thread_name_is_watchdog(self, tmp_path: Path) -> None:
-        from kennel.server import _start_watchdog_thread
-
-        mock_registry = MagicMock()
-        mock_registry.is_alive.return_value = True
-        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
-        assert t.name == "watchdog"
-
-    def test_thread_is_alive(self, tmp_path: Path) -> None:
-        from kennel.server import _start_watchdog_thread
-
-        mock_registry = MagicMock()
-        mock_registry.is_alive.return_value = True
-        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
-        assert t.is_alive()
-
-    def test_calls_watchdog_run_periodically(self, tmp_path: Path) -> None:
-        from kennel.server import _start_watchdog_thread
-
-        mock_registry = MagicMock()
-        mock_registry.is_alive.return_value = True
-        _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=0.01)
-        time.sleep(0.1)
-        mock_registry.is_alive.assert_called()
-
-    def test_restarts_dead_worker(self, tmp_path: Path) -> None:
-        from kennel.server import _start_watchdog_thread
-
-        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
-        mock_registry = MagicMock()
-        mock_registry.is_alive.return_value = False
-        _start_watchdog_thread(mock_registry, {"owner/repo": repo_cfg}, _interval=0.01)
-        time.sleep(0.1)
-        mock_registry.start.assert_called_with(repo_cfg)
+        mock_watchdog_cls.assert_called_once_with(mock_registry, fake_cfg.repos)
+        mock_watchdog_cls.return_value.start_thread.assert_called_once()
 
 
 def _self_restart_cfg(tmp_path: Path) -> Config:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -844,6 +844,77 @@ class TestRun:
         assert isinstance(repo_handler, logging.FileHandler)
         assert repo_handler.baseFilename.endswith("kennel-myrepo.log")
 
+    def test_run_starts_watchdog_with_registry_and_repos(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = self._fake_cfg(tmp_path)
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_registry = MagicMock()
+        mock_make_registry = MagicMock(return_value=mock_registry)
+        mock_start_watchdog = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=mock_make_registry,
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _start_watchdog=mock_start_watchdog,
+        )
+
+        mock_start_watchdog.assert_called_once_with(mock_registry, fake_cfg.repos)
+
+
+class TestStartWatchdogThread:
+    def _repos(self, tmp_path: Path) -> dict:
+        return {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+
+    def test_returns_daemon_thread(self, tmp_path: Path) -> None:
+        from kennel.server import _start_watchdog_thread
+
+        mock_registry = MagicMock()
+        mock_registry.is_alive.return_value = True
+        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
+        assert t.daemon
+
+    def test_thread_name_is_watchdog(self, tmp_path: Path) -> None:
+        from kennel.server import _start_watchdog_thread
+
+        mock_registry = MagicMock()
+        mock_registry.is_alive.return_value = True
+        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
+        assert t.name == "watchdog"
+
+    def test_thread_is_alive(self, tmp_path: Path) -> None:
+        from kennel.server import _start_watchdog_thread
+
+        mock_registry = MagicMock()
+        mock_registry.is_alive.return_value = True
+        t = _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=60.0)
+        assert t.is_alive()
+
+    def test_calls_watchdog_run_periodically(self, tmp_path: Path) -> None:
+        from kennel.server import _start_watchdog_thread
+
+        mock_registry = MagicMock()
+        mock_registry.is_alive.return_value = True
+        _start_watchdog_thread(mock_registry, self._repos(tmp_path), _interval=0.01)
+        time.sleep(0.1)
+        mock_registry.is_alive.assert_called()
+
+    def test_restarts_dead_worker(self, tmp_path: Path) -> None:
+        from kennel.server import _start_watchdog_thread
+
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        mock_registry = MagicMock()
+        mock_registry.is_alive.return_value = False
+        _start_watchdog_thread(mock_registry, {"owner/repo": repo_cfg}, _interval=0.01)
+        time.sleep(0.1)
+        mock_registry.start.assert_called_with(repo_cfg)
+
 
 def _self_restart_cfg(tmp_path: Path) -> Config:
     return Config(

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -81,6 +82,44 @@ class TestWatchdogRun:
 
 
 # ── module-level run() ─────────────────────────────────────────────────────────
+
+
+class TestStartThread:
+    def _repos(self, tmp_path: Path) -> dict:
+        return {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+
+    def test_returns_daemon_thread(self, tmp_path: Path) -> None:
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        assert t.daemon
+
+    def test_thread_name_is_watchdog(self, tmp_path: Path) -> None:
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        assert t.name == "watchdog"
+
+    def test_thread_is_alive(self, tmp_path: Path) -> None:
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        assert t.is_alive()
+
+    def test_calls_run_periodically(self, tmp_path: Path) -> None:
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=0.01)
+        time.sleep(0.1)
+        registry.is_alive.assert_called()
+
+    def test_restarts_dead_worker(self, tmp_path: Path) -> None:
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        registry = MagicMock()
+        registry.is_alive.return_value = False
+        Watchdog(registry, {"owner/repo": repo_cfg}).start_thread(_interval=0.01)
+        time.sleep(0.1)
+        registry.start.assert_called_with(repo_cfg)
 
 
 class TestModuleLevelRun:


### PR DESCRIPTION
RCA: worker dies after successful launch — liveness check insufficient (closes #71)

Fixes #71.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] [Consolidate per-repo watchdog threads into a single shared watchdog thread](https://github.com/FidoCanCode/home/pull/358#discussion_r3073472445) <!-- type:thread -->
- [x] Integrate Watchdog into server runtime as periodic daemon thread <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->