### PR TITLE
Re-evaluate task list and PR description when comments change the plan (closes #93)

### DIFF
--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -7,8 +7,8 @@ import json
 import logging
 from pathlib import Path
 
-from kennel import tasks as _tasks_mod
 from kennel.github import GitHub
+from kennel.tasks import Tasks
 from kennel.types import TaskType
 
 log = logging.getLogger(__name__)
@@ -17,12 +17,11 @@ log = logging.getLogger(__name__)
 class Cmd:
     """CLI command handler with injectable dependencies for testability."""
 
-    def __init__(self, *, github: GitHub | None = None, tasks=_tasks_mod) -> None:
+    def __init__(self, *, github: GitHub | None = None) -> None:
         if github is None:
             github = GitHub()
 
         self._github = github
-        self._tasks = tasks
 
     def _resolve_thread_if_ours(self, thread: dict) -> None:
         """Resolve the review thread if the last reply came from us."""
@@ -84,8 +83,7 @@ class Cmd:
                 thread["repo"] = repo
             if pr is not None:
                 thread["pr"] = pr
-        task = self._tasks.add_task(
-            work_dir,
+        task = Tasks(work_dir).add(
             title=title,
             task_type=task_type,
             description=description,
@@ -95,12 +93,12 @@ class Cmd:
         return task
 
     def complete(self, work_dir: Path, task_id: str) -> None:
-        thread = self._tasks.complete_by_id(work_dir, task_id)
+        thread = Tasks(work_dir).complete_by_id(task_id)
         if thread:
             self._resolve_thread_if_ours(thread)
 
     def list(self, work_dir: Path) -> None:
-        result = self._tasks.list_tasks(work_dir)
+        result = Tasks(work_dir).list()
         print(json.dumps(result, indent=2))
 
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -20,7 +20,7 @@ from kennel.prompts import (
     triage_prompt,
 )
 from kennel.registry import WorkerRegistry
-from kennel.tasks import add_task
+from kennel.tasks import Tasks
 from kennel.types import TaskType
 
 log = logging.getLogger(__name__)
@@ -944,6 +944,7 @@ def create_task(
     *,
     _get_commit_summary_fn=_get_commit_summary,
     _reorder_background_fn=_reorder_tasks_background,
+    _tasks: Tasks | None = None,
 ) -> dict[str, Any]:
     """Write a task to the shared task file, then trigger sync.
 
@@ -962,11 +963,11 @@ def create_task(
 
     Returns the new task dict.
     """
+    if _tasks is None:
+        _tasks = Tasks(repo_cfg.work_dir)
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
-    new_task = add_task(
-        repo_cfg.work_dir, title=prompt, task_type=task_type, thread=thread
-    )
+    new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
     launch_sync(config, repo_cfg)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -648,6 +648,9 @@ def _maybe_abort_for_new_task(
     repo_cfg: RepoConfig,
     new_task: dict[str, Any],
     registry: WorkerRegistry,
+    *,
+    _state=None,
+    _tasks=None,
 ) -> None:
     """Abort the current task if the new task has higher priority.
 
@@ -656,18 +659,20 @@ def _maybe_abort_for_new_task(
     pending for later (ABORT_KEEP).  Equal or lower priority does not
     preempt.
     """
-    from kennel.state import load_state
-    from kennel.tasks import list_tasks
+    from kennel.state import State
+    from kennel.tasks import Tasks
 
-    fido_dir = repo_cfg.work_dir / ".git" / "fido"
-    if not (fido_dir / "state.json").exists():
-        return
-    state = load_state(fido_dir)
+    if _state is None:
+        _state = State(repo_cfg.work_dir / ".git" / "fido")
+    if _tasks is None:
+        _tasks = Tasks(repo_cfg.work_dir)
+
+    state = _state.load()
     current_task_id = state.get("current_task_id")
     if not current_task_id:
         return
 
-    task_list = list_tasks(repo_cfg.work_dir)
+    task_list = _tasks.list()
     current_task = next((t for t in task_list if t["id"] == current_task_id), None)
     if current_task is None:
         return
@@ -795,8 +800,8 @@ def _rewrite_pr_description(
     gh: Any,
     *,
     _print_prompt=None,
-    _list_tasks=None,
-    _load_state_fn=None,
+    _state=None,
+    _tasks=None,
 ) -> None:
     """Rewrite the PR description summary after a successful rescope.
 
@@ -808,22 +813,17 @@ def _rewrite_pr_description(
     Silently skips when there is no active issue, no open PR, no ``---``
     divider in the body, or when Opus returns an empty response.
     """
-    from kennel.state import load_state as _load_state_default
-    from kennel.tasks import list_tasks as _list_tasks_default
+    from kennel.state import State
+    from kennel.tasks import Tasks
 
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
-    if _list_tasks is None:
-        _list_tasks = _list_tasks_default
-    if _load_state_fn is None:
-        _load_state_fn = _load_state_default
+    if _state is None:
+        _state = State(work_dir / ".git" / "fido")
+    if _tasks is None:
+        _tasks = Tasks(work_dir)
 
-    fido_dir = work_dir / ".git" / "fido"
-    if not (fido_dir / "state.json").exists():
-        log.info("_rewrite_pr_description: no state.json — skipping")
-        return
-
-    state = _load_state_fn(fido_dir)
+    state = _state.load()
     issue = state.get("issue")
     if not issue:
         log.info("_rewrite_pr_description: no active issue in state — skipping")
@@ -842,7 +842,7 @@ def _rewrite_pr_description(
         return
 
     pr_number = pr_data["number"]
-    task_list = _list_tasks(work_dir)
+    task_list = _tasks.list()
 
     try:
         body = gh.get_pr_body(repo, pr_number)

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -16,6 +16,7 @@ from kennel.prompts import (
     Prompts,
     issue_reply_instruction,
     reply_instruction,
+    rewrite_description_prompt,
     triage_prompt,
 )
 from kennel.registry import WorkerRegistry
@@ -789,6 +790,90 @@ def _notify_thread_change(
         log.exception("failed to notify thread %s", comment_id)
 
 
+def _rewrite_pr_description(
+    work_dir: Path,
+    gh: Any,
+    *,
+    _print_prompt=None,
+    _list_tasks=None,
+    _load_state_fn=None,
+) -> None:
+    """Rewrite the PR description summary after a successful rescope.
+
+    Fetches the current PR body, asks Opus to rewrite the description section
+    (everything before ``---``) to match the updated task list, and writes the
+    result back.  The work-queue section (``<!-- WORK_QUEUE_START/END -->``) is
+    preserved unchanged.
+
+    Silently skips when there is no active issue, no open PR, no ``---``
+    divider in the body, or when Opus returns an empty response.
+    """
+    from kennel.state import load_state as _load_state_default
+    from kennel.tasks import list_tasks as _list_tasks_default
+
+    if _print_prompt is None:
+        _print_prompt = claude.print_prompt
+    if _list_tasks is None:
+        _list_tasks = _list_tasks_default
+    if _load_state_fn is None:
+        _load_state_fn = _load_state_default
+
+    fido_dir = work_dir / ".git" / "fido"
+    if not (fido_dir / "state.json").exists():
+        log.info("_rewrite_pr_description: no state.json — skipping")
+        return
+
+    state = _load_state_fn(fido_dir)
+    issue = state.get("issue")
+    if not issue:
+        log.info("_rewrite_pr_description: no active issue in state — skipping")
+        return
+
+    try:
+        repo = gh.get_repo_info(cwd=work_dir)
+        user = gh.get_user()
+    except Exception:
+        log.exception("_rewrite_pr_description: failed to get repo info")
+        return
+
+    pr_data = gh.find_pr(repo, issue, user)
+    if pr_data is None or pr_data.get("state") != "OPEN":
+        log.info("_rewrite_pr_description: no open PR for issue #%s — skipping", issue)
+        return
+
+    pr_number = pr_data["number"]
+    task_list = _list_tasks(work_dir)
+
+    try:
+        body = gh.get_pr_body(repo, pr_number)
+    except Exception:
+        log.exception("_rewrite_pr_description: failed to get PR body")
+        return
+
+    divider = "\n\n---\n\n"
+    if divider not in body:
+        log.info(
+            "_rewrite_pr_description: no --- divider in PR #%s body — skipping",
+            pr_number,
+        )
+        return
+
+    prompt = rewrite_description_prompt(body, task_list)
+    new_desc = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    if not new_desc:
+        log.warning("_rewrite_pr_description: Opus returned empty — skipping")
+        return
+
+    rest = body.split(divider, 1)[1]
+    new_body = f"{new_desc.strip()}{divider}{rest}"
+
+    try:
+        gh.edit_pr_body(repo, pr_number, new_body)
+        log.info("_rewrite_pr_description: PR #%s description updated", pr_number)
+    except Exception:
+        log.exception("_rewrite_pr_description: failed to update PR body")
+
+
 def _reorder_tasks_background(
     work_dir: Path,
     commit_summary: str,
@@ -798,6 +883,8 @@ def _reorder_tasks_background(
     *,
     _start=threading.Thread.start,
     _gh=None,
+    _print_prompt=None,
+    _rewrite_fn=None,
 ) -> None:
     """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread.
 
@@ -809,16 +896,24 @@ def _reorder_tasks_background(
     ``_on_inprogress_affected`` callback that aborts the running worker whenever
     the in-progress task is dropped or modified by the rescope, so the worker
     loop restarts on the new next task.
+
+    Passes an ``_on_done`` callback that rewrites the PR description after a
+    successful reorder, so the human-facing summary stays in sync with the
+    updated plan.
     """
     from kennel.tasks import reorder_tasks
 
     gh = _gh if _gh is not None else get_github()
+    rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
 
     def on_changes(changes: list[dict[str, Any]]) -> None:
         for change in changes:
             _notify_thread_change(change, config, _gh=gh)
 
-    kwargs: dict[str, Any] = {"_on_changes": on_changes}
+    def on_done() -> None:
+        rewrite_fn(work_dir, gh, _print_prompt=_print_prompt)
+
+    kwargs: dict[str, Any] = {"_on_changes": on_changes, "_on_done": on_done}
     if registry is not None and repo_cfg is not None:
 
         def on_inprogress_affected() -> None:

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -24,6 +24,11 @@ from kennel.types import TaskType
 
 log = logging.getLogger(__name__)
 
+# Per-work_dir coalescing state for _reorder_tasks_background.
+# Ensures at most one Opus call in-flight + one pending per repo.
+_reorder_coalesce: dict[str, dict] = {}
+_reorder_coalesce_lock = threading.Lock()
+
 
 @dataclass
 class Action:
@@ -855,6 +860,38 @@ def _rewrite_pr_description(
         log.exception("_rewrite_pr_description: failed to update PR body")
 
 
+def _make_reorder_kwargs(
+    work_dir: Path,
+    config: Config,
+    repo_cfg: RepoConfig | None,
+    registry: WorkerRegistry | None,
+    gh: Any,
+    print_prompt: Any,
+    rewrite_fn: Any,
+) -> dict[str, Any]:
+    """Build the kwargs dict for a :func:`~kennel.tasks.reorder_tasks` call."""
+
+    def on_changes(changes: list[dict[str, Any]]) -> None:
+        for change in changes:
+            _notify_thread_change(change, config, _gh=gh)
+
+    def on_done() -> None:
+        rewrite_fn(work_dir, gh, _print_prompt=print_prompt)
+
+    kwargs: dict[str, Any] = {"_on_changes": on_changes, "_on_done": on_done}
+    if registry is not None and repo_cfg is not None:
+
+        def on_inprogress_affected() -> None:
+            log.info(
+                "reorder_tasks_background: in-progress task affected — aborting %s",
+                repo_cfg.name,
+            )
+            registry.abort_task(repo_cfg.name)
+
+        kwargs["_on_inprogress_affected"] = on_inprogress_affected
+    return kwargs
+
+
 def _reorder_tasks_background(
     work_dir: Path,
     commit_summary: str,
@@ -866,8 +903,16 @@ def _reorder_tasks_background(
     _gh=None,
     _print_prompt=None,
     _rewrite_fn=None,
+    _reorder_fn=None,
+    _coalesce_state: dict | None = None,
 ) -> None:
     """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread.
+
+    Coalesces concurrent calls: if a reorder thread is already running for
+    *work_dir*, the new trigger is recorded as pending rather than spawning
+    another thread.  When the running thread finishes it checks for a pending
+    run and, if one exists, executes it before exiting — so at most one Opus
+    call is in-flight plus one queued per repo.
 
     Passes an ``_on_changes`` callback so that any thread tasks dropped or
     modified during rescoping trigger a notification reply to the original
@@ -882,34 +927,42 @@ def _reorder_tasks_background(
     successful reorder, so the human-facing summary stays in sync with the
     updated plan.
     """
-    from kennel.tasks import reorder_tasks
+    from kennel.tasks import reorder_tasks as _reorder_tasks
 
+    reorder = _reorder_fn if _reorder_fn is not None else _reorder_tasks
     gh = _gh if _gh is not None else get_github()
     rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
+    state = _coalesce_state if _coalesce_state is not None else _reorder_coalesce
 
-    def on_changes(changes: list[dict[str, Any]]) -> None:
-        for change in changes:
-            _notify_thread_change(change, config, _gh=gh)
+    key = str(work_dir)
+    kwargs = _make_reorder_kwargs(
+        work_dir, config, repo_cfg, registry, gh, _print_prompt, rewrite_fn
+    )
 
-    def on_done() -> None:
-        rewrite_fn(work_dir, gh, _print_prompt=_print_prompt)
+    with _reorder_coalesce_lock:
+        entry = state.setdefault(key, {"running": False, "pending": None})
+        if entry["running"]:
+            # Coalesce: latest call wins; the running thread will do one more pass.
+            entry["pending"] = (commit_summary, kwargs)
+            return
+        entry["running"] = True
+        entry["pending"] = None
 
-    kwargs: dict[str, Any] = {"_on_changes": on_changes, "_on_done": on_done}
-    if registry is not None and repo_cfg is not None:
-
-        def on_inprogress_affected() -> None:
-            log.info(
-                "reorder_tasks_background: in-progress task affected — aborting %s",
-                repo_cfg.name,
-            )
-            registry.abort_task(repo_cfg.name)
-
-        kwargs["_on_inprogress_affected"] = on_inprogress_affected
+    def run_loop() -> None:
+        cs = commit_summary
+        kw = kwargs
+        while True:
+            reorder(work_dir, cs, **kw)
+            with _reorder_coalesce_lock:
+                pending = state[key].get("pending")
+                if pending is None:
+                    state[key]["running"] = False
+                    return
+                state[key]["pending"] = None
+                cs, kw = pending
 
     t = threading.Thread(
-        target=reorder_tasks,
-        args=(work_dir, commit_summary),
-        kwargs=kwargs,
+        target=run_loop,
         name=f"reorder-{work_dir.name}",
         daemon=True,
     )

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -16,7 +16,6 @@ from kennel.prompts import (
     Prompts,
     issue_reply_instruction,
     reply_instruction,
-    rewrite_description_prompt,
     triage_prompt,
 )
 from kennel.registry import WorkerRegistry
@@ -805,19 +804,17 @@ def _rewrite_pr_description(
 ) -> None:
     """Rewrite the PR description summary after a successful rescope.
 
-    Fetches the current PR body, asks Opus to rewrite the description section
-    (everything before ``---``) to match the updated task list, and writes the
-    result back.  The work-queue section (``<!-- WORK_QUEUE_START/END -->``) is
-    preserved unchanged.
+    Delegates to :func:`kennel.worker._write_pr_description` so that initial
+    PR creation and post-rescope rewrites share one code path.
 
-    Silently skips when there is no active issue, no open PR, no ``---``
-    divider in the body, or when Opus returns an empty response.
+    Silently skips when there is no active issue or no open PR for it.
+    Skips (and logs) when the PR body fetch fails or when the shared writer
+    skips (no ``---`` divider, or Opus returned empty).
     """
     from kennel.state import State
     from kennel.tasks import Tasks
+    from kennel.worker import _write_pr_description
 
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
     if _state is None:
         _state = State(work_dir / ".git" / "fido")
     if _tasks is None:
@@ -850,26 +847,10 @@ def _rewrite_pr_description(
         log.exception("_rewrite_pr_description: failed to get PR body")
         return
 
-    divider = "\n\n---\n\n"
-    if divider not in body:
-        log.info(
-            "_rewrite_pr_description: no --- divider in PR #%s body — skipping",
-            pr_number,
-        )
-        return
-
-    prompt = rewrite_description_prompt(body, task_list)
-    new_desc = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
-    if not new_desc:
-        log.warning("_rewrite_pr_description: Opus returned empty — skipping")
-        return
-
-    rest = body.split(divider, 1)[1]
-    new_body = f"{new_desc.strip()}{divider}{rest}"
-
     try:
-        gh.edit_pr_body(repo, pr_number, new_body)
-        log.info("_rewrite_pr_description: PR #%s description updated", pr_number)
+        _write_pr_description(
+            gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
+        )
     except Exception:
         log.exception("_rewrite_pr_description: failed to update PR body")
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -799,6 +799,15 @@ def _notify_thread_change(
         log.exception("failed to notify thread %s", comment_id)
 
 
+def _task_snapshot(task_list: list[dict[str, Any]]) -> list[tuple]:
+    """Summarise task_list as an ordered list of (id, status, title) tuples.
+
+    Used by :func:`_rewrite_pr_description` to detect whether the task list
+    changed while Opus was generating the PR description.
+    """
+    return [(t["id"], t.get("status", ""), t.get("title", "")) for t in task_list]
+
+
 def _rewrite_pr_description(
     work_dir: Path,
     gh: Any,
@@ -806,6 +815,7 @@ def _rewrite_pr_description(
     _print_prompt=None,
     _state=None,
     _tasks=None,
+    _max_retries: int = 3,
 ) -> None:
     """Rewrite the PR description summary after a successful rescope.
 
@@ -815,6 +825,11 @@ def _rewrite_pr_description(
     Silently skips when there is no active issue or no open PR for it.
     Skips (and logs) when the PR body fetch fails or when the shared writer
     skips (no ``---`` divider, or Opus returned empty).
+
+    Retries up to *_max_retries* times when the task list changes while Opus
+    is generating the description, so the written description always reflects
+    the state of the task list at the moment Opus returned.  The PR body is
+    re-fetched on each retry so the work-queue section stays current.
     """
     from kennel.state import State
     from kennel.tasks import Tasks
@@ -844,20 +859,44 @@ def _rewrite_pr_description(
         return
 
     pr_number = pr_data["number"]
-    task_list = _tasks.list()
 
-    try:
-        body = gh.get_pr_body(repo, pr_number)
-    except Exception:
-        log.exception("_rewrite_pr_description: failed to get PR body")
-        return
+    for attempt in range(_max_retries):
+        task_list = _tasks.list()
+        snapshot_before = _task_snapshot(task_list)
 
-    try:
-        _write_pr_description(
-            gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
+        try:
+            body = gh.get_pr_body(repo, pr_number)
+        except Exception:
+            log.exception("_rewrite_pr_description: failed to get PR body")
+            return
+
+        try:
+            written = _write_pr_description(
+                gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
+            )
+        except Exception:
+            log.exception("_rewrite_pr_description: failed to update PR body")
+            return
+
+        if not written:
+            return
+
+        snapshot_after = _task_snapshot(_tasks.list())
+        if snapshot_after == snapshot_before:
+            return
+
+        log.info(
+            "_rewrite_pr_description: task list changed during rewrite — retrying"
+            " (attempt %d/%d)",
+            attempt + 1,
+            _max_retries,
         )
-    except Exception:
-        log.exception("_rewrite_pr_description: failed to update PR body")
+
+    log.warning(
+        "_rewrite_pr_description: task list still changing after %d attempts"
+        " — description may be slightly stale",
+        _max_retries,
+    )
 
 
 def _make_reorder_kwargs(

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -272,6 +272,53 @@ def rescope_prompt(
     )
 
 
+# ── PR description rewrite ───────────────────────────────────────────────────
+
+
+def rewrite_description_prompt(
+    pr_body: str,
+    task_list: list[dict[str, Any]],
+) -> str:
+    """Build an Opus prompt to rewrite the PR description after rescoping.
+
+    Presents the current PR description section and the updated task list,
+    then asks Opus to rewrite only the descriptive summary while preserving
+    required structural lines like ``Fixes #N``.
+
+    The caller is responsible for substituting the result back into the PR
+    body, keeping the work-queue section intact.
+    """
+    divider = "\n\n---\n\n"
+    if divider in pr_body:
+        description_section = pr_body.split(divider)[0]
+    elif "<!-- WORK_QUEUE_START -->" in pr_body:
+        description_section = pr_body.split("<!-- WORK_QUEUE_START -->")[0].strip()
+    else:
+        description_section = pr_body
+
+    pending = [t for t in task_list if t.get("status") != "completed"]
+
+    def _fmt(t: dict[str, Any]) -> str:
+        title = t.get("title", "")
+        desc = t.get("description", "")
+        return f"- {title}" + (f": {desc}" if desc else "")
+
+    task_block = "\n".join(_fmt(t) for t in pending) if pending else "(none)"
+
+    return (
+        "You are rewriting the description section of a pull request after the plan changed.\n\n"
+        "Current PR description section:\n"
+        f"{description_section.strip()}\n\n"
+        "Updated task list (pending work):\n"
+        f"{task_block}\n\n"
+        "Rewrite the descriptive summary to match the updated plan. Rules:\n"
+        "1. Keep it to 2-3 sentences.\n"
+        "2. Preserve any 'Fixes #N.' lines exactly as they appear — do not add, remove, or modify them.\n"
+        "3. Do not include work queue content, markdown headers, or HTML comments.\n"
+        "4. Output ONLY the replacement description text — no preamble, no explanation."
+    )
+
+
 # ── Prompts DI class ──────────────────────────────────────────────────────────
 
 

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -39,6 +39,31 @@ def clear_state(fido_dir: Path) -> None:
         (fido_dir / "state.json").unlink(missing_ok=True)
 
 
+class State:
+    """Encapsulates fido state.json operations for a single worker directory.
+
+    Abstracts all file access so callers never touch the filesystem directly.
+    Instantiate with the fido_dir path and inject wherever state is needed.
+    """
+
+    def __init__(self, fido_dir: Path) -> None:
+        self._fido_dir = fido_dir
+
+    def load(self) -> dict[str, Any]:
+        """Return state dict, or {} when the directory or state file is absent."""
+        if not self._fido_dir.exists():
+            return {}
+        return load_state(self._fido_dir)
+
+    def save(self, data: dict[str, Any]) -> None:
+        """Write *data* to state.json."""
+        save_state(self._fido_dir, data)
+
+    def clear(self) -> None:
+        """Remove state.json."""
+        clear_state(self._fido_dir)
+
+
 def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
     """Return the absolute .git directory for *work_dir*."""
     result = _run(

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -5,9 +5,65 @@ from __future__ import annotations
 import fcntl
 import json
 import subprocess
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any, Generator
+
+
+class JsonFileStore(ABC):
+    """Abstract base class for JSON-backed file stores.
+
+    Provides a :meth:`modify` context manager for atomic read-modify-write
+    under an exclusive ``flock``.  Subclasses must implement
+    :attr:`_data_path`; they may optionally override :attr:`_lock_path`
+    (defaults to the same file as the data) and :meth:`_default` (the value
+    yielded when the data file is absent or empty, defaults to ``{}``).
+
+    Usage::
+
+        class MyStore(JsonFileStore):
+            @property
+            def _data_path(self) -> Path:
+                return self._dir / "data.json"
+
+        with MyStore().modify() as data:
+            data["key"] = "value"
+    """
+
+    @property
+    @abstractmethod
+    def _data_path(self) -> Path:
+        """Path to the JSON data file."""
+
+    @property
+    def _lock_path(self) -> Path:
+        """Path to the flock target file.  Defaults to :attr:`_data_path`."""
+        return self._data_path
+
+    def _default(self) -> Any:
+        """Value yielded when the data file is absent or empty."""
+        return {}
+
+    @contextmanager
+    def modify(self) -> Generator[Any, None, None]:
+        """Atomic read-modify-write: hold the exclusive flock for the entire block.
+
+        Yields the current JSON data (or the result of :meth:`_default` when
+        the file is absent or empty).  Any mutations are written back when the
+        ``with`` block exits, while the exclusive lock is still held —
+        preventing interleaved concurrent modifications.
+        """
+        lock_path = self._lock_path
+        data_path = self._data_path
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.touch(exist_ok=True)
+        with open(lock_path) as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            text = data_path.read_text() if data_path.exists() else ""
+            data = json.loads(text) if text.strip() else self._default()
+            yield data
+            data_path.write_text(json.dumps(data))
 
 
 def _state_lock(fido_dir: Path, exclusive: bool = False) -> IO[str]:
@@ -40,15 +96,28 @@ def clear_state(fido_dir: Path) -> None:
         (fido_dir / "state.json").unlink(missing_ok=True)
 
 
-class State:
+class State(JsonFileStore):
     """Encapsulates fido state.json operations for a single worker directory.
 
     Abstracts all file access so callers never touch the filesystem directly.
     Instantiate with the fido_dir path and inject wherever state is needed.
+
+    Inherits :meth:`~JsonFileStore.modify` for atomic read-modify-write.
+    The lock is held on ``state.lock`` (separate from the data file) so that
+    shared reads via :func:`load_state` are not blocked by concurrent
+    ``modify`` calls.
     """
 
     def __init__(self, fido_dir: Path) -> None:
         self._fido_dir = fido_dir
+
+    @property
+    def _data_path(self) -> Path:
+        return self._fido_dir / "state.json"
+
+    @property
+    def _lock_path(self) -> Path:
+        return self._fido_dir / "state.lock"
 
     def load(self) -> dict[str, Any]:
         """Return state dict, or {} when the directory or state file is absent."""
@@ -63,25 +132,6 @@ class State:
     def clear(self) -> None:
         """Remove state.json."""
         clear_state(self._fido_dir)
-
-    @contextmanager
-    def modify(self) -> Generator[dict[str, Any], None, None]:
-        """Atomic read-modify-write: hold the exclusive lock for the entire operation.
-
-        Yields the current state dict.  Any mutations are written back when
-        the ``with`` block exits, while the exclusive lock is still held —
-        preventing interleaved concurrent modifications.
-
-        Usage::
-
-            with state.modify() as data:
-                data["key"] = "value"
-        """
-        with _state_lock(self._fido_dir, exclusive=True):
-            state_path = self._fido_dir / "state.json"
-            data = json.loads(state_path.read_text()) if state_path.exists() else {}
-            yield data
-            state_path.write_text(json.dumps(data))
 
 
 def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import fcntl
 import json
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Generator
 
 
 def _state_lock(fido_dir: Path, exclusive: bool = False) -> IO[str]:
@@ -62,6 +63,25 @@ class State:
     def clear(self) -> None:
         """Remove state.json."""
         clear_state(self._fido_dir)
+
+    @contextmanager
+    def modify(self) -> Generator[dict[str, Any], None, None]:
+        """Atomic read-modify-write: hold the exclusive lock for the entire operation.
+
+        Yields the current state dict.  Any mutations are written back when
+        the ``with`` block exits, while the exclusive lock is still held —
+        preventing interleaved concurrent modifications.
+
+        Usage::
+
+            with state.modify() as data:
+                data["key"] = "value"
+        """
+        with _state_lock(self._fido_dir, exclusive=True):
+            state_path = self._fido_dir / "state.json"
+            data = json.loads(state_path.read_text()) if state_path.exists() else {}
+            yield data
+            state_path.write_text(json.dumps(data))
 
 
 def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -619,3 +619,18 @@ def sync_tasks_background(
         daemon=True,
     )
     _start(t)
+
+
+class Tasks:
+    """Encapsulates task file operations for a single worker directory.
+
+    Abstracts all file access so callers never touch the filesystem directly.
+    Instantiate with the work_dir path and inject wherever tasks are needed.
+    """
+
+    def __init__(self, work_dir: Path) -> None:
+        self._work_dir = work_dir
+
+    def list(self) -> list[dict[str, Any]]:
+        """Return all tasks."""
+        return list_tasks(self._work_dir)

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -514,6 +514,7 @@ def reorder_tasks(
     _rescope_prompt_fn=_rescope_prompt_default,
     _on_changes=None,
     _on_inprogress_affected=None,
+    _on_done=None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
 
@@ -536,6 +537,9 @@ def reorder_tasks(
     the caller can abort the running worker and restart on the new next task.
     When the in-progress task is modified its status is reset to ``pending`` so
     the worker loop picks it up again with the updated title/description.
+
+    If *_on_done* is provided, it is called after a successful reorder write so
+    callers can trigger follow-up work (e.g. rewriting the PR description).
     """
     task_list = list_tasks(work_dir)
     if not task_list:
@@ -599,6 +603,9 @@ def reorder_tasks(
         _on_inprogress_affected()
 
     log.info("reorder_tasks: applied reorder — %d tasks", len(result))
+
+    if _on_done is not None:
+        _on_done()
 
 
 def sync_tasks_background(

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -634,3 +634,37 @@ class Tasks:
     def list(self) -> list[dict[str, Any]]:
         """Return all tasks."""
         return list_tasks(self._work_dir)
+
+    def add(
+        self,
+        title: str,
+        task_type: TaskType,
+        description: str = "",
+        status: TaskStatus = TaskStatus.PENDING,
+        thread: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Add a task. Returns the new (or existing duplicate) task."""
+        return add_task(
+            self._work_dir,
+            title,
+            task_type,
+            description=description,
+            status=status,
+            thread=thread,
+        )
+
+    def complete_by_id(self, task_id: str) -> dict[str, Any] | None:
+        """Mark a task completed. Returns its thread dict or None."""
+        return complete_by_id(self._work_dir, task_id)
+
+    def has_pending_for_comment(self, comment_id: int | str) -> bool:
+        """Return True if any pending task references *comment_id*."""
+        return has_pending_tasks_for_comment(self._work_dir, comment_id)
+
+    def remove(self, task_id: str) -> bool:
+        """Remove a task. Returns True if found."""
+        return remove_task(self._work_dir, task_id)
+
+    def update(self, task_id: str, status: TaskStatus) -> bool:
+        """Update a task's status. Returns True if found."""
+        return update_task(self._work_dir, task_id, status)

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -16,7 +16,7 @@ from typing import Any
 from kennel.claude import print_prompt as _claude_print_prompt
 from kennel.github import GitHub
 from kennel.prompts import rescope_prompt as _rescope_prompt_default
-from kennel.state import _resolve_git_dir, load_state
+from kennel.state import JsonFileStore, _resolve_git_dir, load_state
 from kennel.types import TaskStatus, TaskType
 
 log = logging.getLogger(__name__)
@@ -621,15 +621,25 @@ def sync_tasks_background(
     _start(t)
 
 
-class Tasks:
+class Tasks(JsonFileStore):
     """Encapsulates task file operations for a single worker directory.
 
     Abstracts all file access so callers never touch the filesystem directly.
     Instantiate with the work_dir path and inject wherever tasks are needed.
+
+    Inherits :meth:`~JsonFileStore.modify` for atomic read-modify-write of
+    the entire task list.
     """
 
     def __init__(self, work_dir: Path) -> None:
         self._work_dir = work_dir
+
+    @property
+    def _data_path(self) -> Path:
+        return _task_file(self._work_dir)
+
+    def _default(self) -> list:
+        return []
 
     def list(self) -> list[dict[str, Any]]:
         """Return all tasks."""

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -23,6 +23,7 @@ from kennel.state import (
     load_state,
     save_state,
 )
+from kennel.tasks import Tasks
 from kennel.types import TaskStatus, TaskType
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
@@ -336,6 +337,7 @@ class Worker:
         repo_name: str = "",
         registry: ActivityReporter | None = None,
         membership: RepoMembership | None = None,
+        _tasks: Tasks | None = None,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
@@ -343,6 +345,7 @@ class Worker:
         self._repo_name = repo_name
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
+        self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
 
     def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
         """Return the absolute .git directory for self.work_dir."""
@@ -575,7 +578,7 @@ class Worker:
         """
         assert setup_session_id, "setup_session_id must be non-empty"
         plain = f"{request}\n\nFixes #{issue}."
-        task_list = tasks.list_tasks(self.work_dir)
+        task_list = self._tasks.list()
         pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
 
         continuation_prompt = (
@@ -642,11 +645,11 @@ class Worker:
                 self._git(["checkout", slug])
             except subprocess.CalledProcessError:
                 self._git(["checkout", "-b", slug, "--track", f"{remote}/{slug}"])
-            task_list = tasks.list_tasks(self.work_dir)
+            task_list = self._tasks.list()
             if not task_list:
                 # Try seeding from PR body first (recovers from state reset)
                 self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
-                task_list = tasks.list_tasks(self.work_dir)
+                task_list = self._tasks.list()
             if not task_list:
                 log.info("PR #%s has no tasks — running setup", pr_number)
                 context = (
@@ -664,7 +667,7 @@ class Worker:
                 state = load_state(fido_dir)
                 state["setup_session_id"] = session_id
                 save_state(fido_dir, state)
-                if not tasks.list_tasks(self.work_dir):
+                if not self._tasks.list():
                     log.warning(
                         "setup produced no tasks — skipping PR #%s, will retry",
                         pr_number,
@@ -715,7 +718,7 @@ class Worker:
         state["setup_session_id"] = session_id
         save_state(fido_dir, state)
 
-        if not tasks.list_tasks(self.work_dir):
+        if not self._tasks.list():
             log.warning("setup produced no tasks — skipping PR creation, will retry")
             return None
 
@@ -732,7 +735,7 @@ class Worker:
         )
         pr_number = int(url.rstrip("/").split("/")[-1])
         task_count = len(
-            [t for t in tasks.list_tasks(self.work_dir) if t.get("status") == "pending"]
+            [t for t in self._tasks.list() if t.get("status") == "pending"]
         )
         log.info("PR: #%s opened with %d tasks", pr_number, task_count)
         log.info("PR: #%s  %s", pr_number, url)
@@ -951,10 +954,7 @@ class Worker:
             comment_ids = [
                 c.get("databaseId") for c in comments if c.get("databaseId") is not None
             ]
-            if any(
-                tasks.has_pending_tasks_for_comment(self.work_dir, cid)
-                for cid in comment_ids
-            ):
+            if any(self._tasks.has_pending_for_comment(cid) for cid in comment_ids):
                 log.info(
                     "skipping resolve for thread %s — pending sibling tasks remain",
                     node.get("id", ""),
@@ -1091,7 +1091,7 @@ class Worker:
         """
         log.info("task aborted: %s", task_title)
         self.git_clean()
-        tasks.remove_task(self.work_dir, task_id)
+        self._tasks.remove(task_id)
         state = load_state(fido_dir)
         state.pop("current_task_id", None)
         save_state(fido_dir, state)
@@ -1115,7 +1115,7 @@ class Worker:
         task was found.
         """
         log.info("checking: tasks")
-        task_list = tasks.list_tasks(self.work_dir)
+        task_list = self._tasks.list()
         task = _pick_next_task(task_list)
         if task is None:
             return False
@@ -1161,7 +1161,7 @@ class Worker:
             # If the task was completed externally (e.g. via `kennel task
             # complete`) while we were waiting, stop retrying — the work is
             # already recorded as done and no commits will ever appear.
-            current_task_list = tasks.list_tasks(self.work_dir)
+            current_task_list = self._tasks.list()
             if not any(
                 t["id"] == task["id"] and t.get("status") == TaskStatus.PENDING
                 for t in current_task_list
@@ -1201,7 +1201,7 @@ class Worker:
         self._squash_wip_commit("origin", slug, repo_ctx.default_branch)
         pushed = self.ensure_pushed("origin", slug)
         if pushed is not False:
-            tasks.complete_by_id(self.work_dir, task["id"])
+            self._tasks.complete_by_id(task["id"])
             state = load_state(fido_dir)
             state.pop("current_task_id", None)
             save_state(fido_dir, state)
@@ -1222,7 +1222,7 @@ class Worker:
         No-op if tasks.json is already non-empty, or if no markers /
         unchecked items are found.
         """
-        if tasks.list_tasks(self.work_dir):
+        if self._tasks.list():
             return  # already have tasks — nothing to seed
         pr_data = self.gh.get_pr(repo, pr_number)
         body = pr_data.get("body") or ""
@@ -1253,7 +1253,7 @@ class Worker:
         if not parsed:
             return
         for title, task_type in parsed:
-            tasks.add_task(self.work_dir, title, task_type=task_type)
+            self._tasks.add(title, task_type)
         log.info("seeded %d tasks from PR body", len(parsed))
 
     def post_pickup_comment(
@@ -1341,7 +1341,7 @@ class Worker:
             _latest_decisive.get("state", "NONE") if _latest_decisive else "NONE"
         )
         is_approved = latest_state == "APPROVED"
-        task_list = tasks.list_tasks(self.work_dir)
+        task_list = self._tasks.list()
         pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
 
         # Merge only if: approved + not draft + no pending tasks

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -16,7 +16,7 @@ from typing import IO, Any, Protocol
 from kennel import claude, hooks, tasks
 from kennel.config import RepoMembership
 from kennel.github import GitHub
-from kennel.prompts import Prompts
+from kennel.prompts import Prompts, rewrite_description_prompt
 from kennel.state import (
     State,
     _resolve_git_dir,
@@ -319,6 +319,75 @@ def ci_ready_for_review(
     return all(states.get(name) == "SUCCESS" for name in required_checks)
 
 
+def _write_pr_description(
+    gh: Any,
+    repo: str,
+    pr_number: int,
+    issue: int,
+    task_list: list[dict[str, Any]],
+    existing_body: str = "",
+    *,
+    _print_prompt=None,
+) -> bool:
+    """Write or rewrite the PR description.
+
+    Handles both initial PR creation (``existing_body=""``; builds work-queue
+    section from *task_list*) and post-rescope rewrites (``existing_body``
+    contains the current body; preserves the rest section after the ``---``
+    divider).
+
+    Generates the description via Opus and writes it back via
+    ``gh.edit_pr_body``.  Returns ``True`` if the body was written,
+    ``False`` when skipped (no divider in an existing body, or Opus returned
+    empty).
+    """
+    if _print_prompt is None:
+        _print_prompt = claude.print_prompt
+
+    divider = "\n\n---\n\n"
+
+    # For a rewrite, only proceed when the divider is present so we know
+    # where the description section ends.  For initial write (empty body)
+    # skip this guard and build the rest section fresh.
+    if existing_body and divider not in existing_body:
+        log.info(
+            "_write_pr_description: no --- divider in PR #%s body — skipping", pr_number
+        )
+        return False
+
+    # Preserve the existing rest section or build the work-queue from scratch.
+    if divider in existing_body:
+        rest = existing_body.split(divider, 1)[1]
+    else:
+        pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
+        next_task = _pick_next_task(task_list)
+        if pending:
+            lines = [
+                f"- [ ] {t['title']}{' **→ next**' if t is next_task else ''}"
+                for t in pending
+            ]
+            queue = "\n".join(lines)
+        else:
+            queue = "<!-- no tasks yet -->"
+        rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
+
+    prompt = rewrite_description_prompt(existing_body, task_list)
+    new_desc = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    if not new_desc:
+        log.warning("_write_pr_description: Opus returned empty — skipping")
+        return False
+
+    # Ensure "Fixes #N" is always present (Opus preserves it for rewrites via
+    # prompt rules; for initial writes we append it here).
+    if f"Fixes #{issue}" not in new_desc:
+        new_desc = f"{new_desc.rstrip()}\n\nFixes #{issue}."
+
+    new_body = f"{new_desc.strip()}{divider}{rest}"
+    gh.edit_pr_body(repo, pr_number, new_body)
+    log.info("_write_pr_description: PR #%s description written", pr_number)
+    return True
+
+
 class Worker:
     """Fido worker for a single repository.
 
@@ -560,53 +629,6 @@ class Worker:
         else:
             log.info("git clean: nothing to remove")
 
-    def _build_pr_body(
-        self,
-        request: str,
-        issue: int,
-        *,
-        setup_session_id: str,
-    ) -> str:
-        """Build the draft PR body: generated description + work-queue section.
-
-        Continues *setup_session_id* (the planning session) so Opus writes the
-        description with full context from everything it just planned.  Falls
-        back to plain text if Claude returns nothing.  Appends the pending task
-        list inside the ``WORK_QUEUE_START/END`` markers.
-        """
-        assert setup_session_id, "setup_session_id must be non-empty"
-        plain = f"{request}\n\nFixes #{issue}."
-        task_list = self._tasks.list()
-        pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
-
-        continuation_prompt = (
-            "Based on the planning above, write a specific 2-3 sentence pull"
-            " request description for this PR. Reference the concrete tasks by"
-            " name. No markdown headers. Do not include a 'Fixes #N.' line."
-        )
-        desc = claude.resume_status(setup_session_id, continuation_prompt, timeout=60)
-
-        if desc:
-            desc = f"{desc.rstrip()}\n\nFixes #{issue}."
-        else:
-            log.warning("Opus returned no description — falling back to plain text")
-            desc = plain
-
-        next_task = _pick_next_task(task_list)
-        if pending:
-            lines = []
-            for t in pending:
-                marker = " **→ next**" if t is next_task else ""
-                lines.append(f"- [ ] {t['title']}{marker}")
-            queue = "\n".join(lines)
-        else:
-            queue = "<!-- no tasks yet -->"
-
-        return (
-            f"{desc}\n\n---\n\n## Work queue\n\n"
-            f"<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
-        )
-
     def find_or_create_pr(
         self,
         fido_dir: Path,
@@ -718,18 +740,19 @@ class Worker:
             log.warning("setup produced no tasks — skipping PR creation, will retry")
             return None
 
-        # Build PR body with tasks already populated by setup
-        pr_body = self._build_pr_body(request, issue, setup_session_id=session_id)
-
-        # Create draft PR
+        # Create draft PR, then write the description using the same function
+        # used for post-rescope rewrites so both paths share one code path.
         url = self.gh.create_pr(
             repo_ctx.repo,
             request,
-            pr_body,
+            f"Fixes #{issue}.",
             repo_ctx.default_branch,
             slug,
         )
         pr_number = int(url.rstrip("/").split("/")[-1])
+        _write_pr_description(
+            self.gh, repo_ctx.repo, pr_number, issue, self._tasks.list()
+        )
         task_count = len(
             [t for t in self._tasks.list() if t.get("status") == "pending"]
         )

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -18,10 +18,8 @@ from kennel.config import RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts
 from kennel.state import (
+    State,
     _resolve_git_dir,
-    clear_state,
-    load_state,
-    save_state,
 )
 from kennel.tasks import Tasks
 from kennel.types import TaskStatus, TaskType
@@ -416,14 +414,14 @@ class Worker:
         If state.json records an issue that has been CLOSED on GitHub, the state
         is cleared (advancing to the next issue) and None is returned.
         """
-        state = load_state(fido_dir)
-        issue = state.get("issue")
+        state_obj = State(fido_dir)
+        issue = state_obj.load().get("issue")
         if issue is None:
             return None
         issue_data = self.gh.view_issue(repo, issue)
         if issue_data["state"] == "CLOSED":
             log.info("issue #%s: closed — advancing", issue)
-            clear_state(fido_dir)
+            state_obj.clear()
             return None
         return int(issue)
 
@@ -523,7 +521,7 @@ class Worker:
                 number = issue["number"]
                 title = issue["title"]
                 log.info("starting issue #%s: %s", number, title)
-                save_state(fido_dir, {"issue": number})
+                State(fido_dir).save({"issue": number})
                 self.set_status(f"Picking up issue #{number}: {title}")
                 return number
 
@@ -664,9 +662,8 @@ class Worker:
                 build_prompt(fido_dir, "setup", context)
                 session_id = claude_start(fido_dir, cwd=self.work_dir)
                 log.info("setup session: %s", session_id)
-                state = load_state(fido_dir)
-                state["setup_session_id"] = session_id
-                save_state(fido_dir, state)
+                with State(fido_dir).modify() as state:
+                    state["setup_session_id"] = session_id
                 if not self._tasks.list():
                     log.warning(
                         "setup produced no tasks — skipping PR #%s, will retry",
@@ -714,9 +711,8 @@ class Worker:
         build_prompt(fido_dir, "setup", context)
         session_id = claude_start(fido_dir, cwd=self.work_dir)
         log.info("setup session: %s", session_id)
-        state = load_state(fido_dir)
-        state["setup_session_id"] = session_id
-        save_state(fido_dir, state)
+        with State(fido_dir).modify() as state:
+            state["setup_session_id"] = session_id
 
         if not self._tasks.list():
             log.warning("setup produced no tasks — skipping PR creation, will retry")
@@ -1092,9 +1088,8 @@ class Worker:
         log.info("task aborted: %s", task_title)
         self.git_clean()
         self._tasks.remove(task_id)
-        state = load_state(fido_dir)
-        state.pop("current_task_id", None)
-        save_state(fido_dir, state)
+        with State(fido_dir).modify() as state:
+            state.pop("current_task_id", None)
         self._abort_task.clear()
         tasks.sync_tasks(self.work_dir, self.gh)
 
@@ -1141,10 +1136,9 @@ class Worker:
         context = "\n".join(context_parts)
         build_prompt(fido_dir, "task", context)
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
-        state = load_state(fido_dir)
-        setup_session_id = state.get("setup_session_id", "")
-        state["current_task_id"] = task["id"]
-        save_state(fido_dir, state)
+        with State(fido_dir).modify() as state:
+            setup_session_id = state.get("setup_session_id", "")
+            state["current_task_id"] = task["id"]
         session_id, output = claude_run(
             fido_dir, session_id=setup_session_id, cwd=self.work_dir
         )
@@ -1194,17 +1188,15 @@ class Worker:
                 return True
 
         if session_id:
-            state = load_state(fido_dir)
-            state["setup_session_id"] = session_id
-            save_state(fido_dir, state)
+            with State(fido_dir).modify() as state:
+                state["setup_session_id"] = session_id
 
         self._squash_wip_commit("origin", slug, repo_ctx.default_branch)
         pushed = self.ensure_pushed("origin", slug)
         if pushed is not False:
             self._tasks.complete_by_id(task["id"])
-            state = load_state(fido_dir)
-            state.pop("current_task_id", None)
-            save_state(fido_dir, state)
+            with State(fido_dir).modify() as state:
+                state.pop("current_task_id", None)
             tasks.sync_tasks(self.work_dir, self.gh)
         return True
 
@@ -1358,7 +1350,7 @@ class Worker:
             log.info("PR #%s approved by %s — merging", pr_number, repo_ctx.owner)
             self.gh.pr_merge(repo_ctx.repo, pr_number, squash=True)
             (fido_dir / "tasks.json").write_text("[]")
-            clear_state(fido_dir)
+            State(fido_dir).clear()
             self._git(["checkout", repo_ctx.default_branch])
             self._git(
                 ["pull", "origin", repo_ctx.default_branch, "--ff-only"], check=False

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,6 +11,7 @@ from kennel.events import (
     _is_allowed,
     _notify_thread_change,
     _reorder_tasks_background,
+    _rewrite_pr_description,
     _summarize_as_action_item,
     _triage,
     create_task,
@@ -2103,6 +2104,46 @@ class TestReorderTasksBackground:
         )
         assert "_on_inprogress_affected" not in started[0]._kwargs
 
+    def test_on_done_kwarg_calls_rewrite_fn(self, tmp_path: Path) -> None:
+        started: list = []
+        rewrite_calls: list = []
+
+        def mock_rewrite(*a, **kw):
+            rewrite_calls.append((a, kw))
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _rewrite_fn=mock_rewrite,
+        )
+        on_done = started[0]._kwargs["_on_done"]
+        on_done()
+        assert len(rewrite_calls) == 1
+        args, kwargs = rewrite_calls[0]
+        assert args[0] == tmp_path
+
+    def test_on_done_passes_print_prompt_to_rewrite_fn(self, tmp_path: Path) -> None:
+        started: list = []
+        rewrite_calls: list = []
+        fake_pp = MagicMock()
+
+        def mock_rewrite(*a, **kw):
+            rewrite_calls.append(kw)
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _rewrite_fn=mock_rewrite,
+            _print_prompt=fake_pp,
+        )
+        on_done = started[0]._kwargs["_on_done"]
+        on_done()
+        assert rewrite_calls[0].get("_print_prompt") is fake_pp
+
 
 class TestNotifyThreadChange:
     def _cfg(self, tmp_path: Path) -> Config:
@@ -2728,3 +2769,193 @@ class TestReplyToCommentTerseEnrichment:
             )
 
         assert "sibling_threads" not in captured_context
+
+
+# ── _rewrite_pr_description ───────────────────────────────────────────────────
+
+
+class TestRewritePrDescription:
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _setup_state(self, tmp_path: Path, issue: int = 42) -> None:
+        import json
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True, exist_ok=True)
+        (fido_dir / "state.json").write_text(json.dumps({"issue": issue}))
+
+    def _pr_body(self, desc: str = "Does something useful.\n\nFixes #42.") -> str:
+        return (
+            f"{desc}\n\n---\n\n## Work queue\n\n"
+            "<!-- WORK_QUEUE_START -->\n- [ ] do a thing\n<!-- WORK_QUEUE_END -->"
+        )
+
+    def _mock_gh(self, body: str | None = None) -> MagicMock:
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido"
+        gh.find_pr.return_value = {"number": 99, "state": "OPEN"}
+        gh.get_pr_body.return_value = body if body is not None else self._pr_body()
+        return gh
+
+    def test_skips_when_no_state_file(self, tmp_path: Path) -> None:
+        # No .git/fido/state.json created
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(tmp_path, mock_gh, _print_prompt=MagicMock())
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_when_no_issue_in_state(self, tmp_path: Path) -> None:
+        import json
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True, exist_ok=True)
+        (fido_dir / "state.lock").touch()
+        (fido_dir / "state.json").write_text(json.dumps({}))
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {},
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_on_get_repo_exception(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        mock_gh.get_repo_info.side_effect = RuntimeError("network error")
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {"issue": 42},
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_when_no_open_pr(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        mock_gh.find_pr.return_value = None
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {"issue": 42},
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_when_pr_not_open(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        mock_gh.find_pr.return_value = {"number": 99, "state": "MERGED"}
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {"issue": 42},
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_on_get_pr_body_exception(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        mock_gh.get_pr_body.side_effect = RuntimeError("API error")
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_when_no_divider_in_body(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh(
+            body="No divider here. <!-- WORK_QUEUE_START -->x<!-- WORK_QUEUE_END -->"
+        )
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_skips_when_opus_returns_empty(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value=""),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+
+    def test_updates_pr_body_with_new_description(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New description.\n\nFixes #42."),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        mock_gh.edit_pr_body.assert_called_once()
+        new_body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "New description." in new_body
+
+    def test_preserves_work_queue_section(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="Updated description.\n\nFixes #42."),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        new_body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "<!-- WORK_QUEUE_START -->" in new_body
+        assert "do a thing" in new_body
+        assert "<!-- WORK_QUEUE_END -->" in new_body
+
+    def test_description_replaces_only_before_divider(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="Fresh desc.\n\nFixes #42."),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )
+        new_body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "Does something useful." not in new_body
+        assert "Fresh desc." in new_body
+        assert "## Work queue" in new_body
+
+    def test_handles_edit_pr_body_exception(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        mock_gh.edit_pr_body.side_effect = RuntimeError("write failed")
+        # Should not propagate the exception
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _load_state_fn=lambda _: {"issue": 42},
+            _list_tasks=lambda _: [],
+        )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2789,23 +2789,6 @@ class TestReplyToCommentTerseEnrichment:
 
 
 class TestRewritePrDescription:
-    def _cfg(self, tmp_path: Path) -> Config:
-        return Config(
-            port=9000,
-            secret=b"test",
-            repos={},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-
-    def _setup_state(self, tmp_path: Path, issue: int = 42) -> None:
-        import json
-
-        fido_dir = tmp_path / ".git" / "fido"
-        fido_dir.mkdir(parents=True, exist_ok=True)
-        (fido_dir / "state.json").write_text(json.dumps({"issue": issue}))
-
     def _pr_body(self, desc: str = "Does something useful.\n\nFixes #42.") -> str:
         return (
             f"{desc}\n\n---\n\n## Work queue\n\n"
@@ -2820,79 +2803,72 @@ class TestRewritePrDescription:
         gh.get_pr_body.return_value = body if body is not None else self._pr_body()
         return gh
 
-    def test_skips_when_no_state_file(self, tmp_path: Path) -> None:
-        # No .git/fido/state.json created
-        mock_gh = self._mock_gh()
-        _rewrite_pr_description(tmp_path, mock_gh, _print_prompt=MagicMock())
-        mock_gh.edit_pr_body.assert_not_called()
+    def _mock_state(self, issue: int | None = 42) -> MagicMock:
+        state = MagicMock()
+        state.load.return_value = {"issue": issue} if issue else {}
+        return state
+
+    def _mock_tasks(self, task_list: list | None = None) -> MagicMock:
+        tasks = MagicMock()
+        tasks.list.return_value = task_list if task_list is not None else []
+        return tasks
 
     def test_skips_when_no_issue_in_state(self, tmp_path: Path) -> None:
-        import json
-
-        fido_dir = tmp_path / ".git" / "fido"
-        fido_dir.mkdir(parents=True, exist_ok=True)
-        (fido_dir / "state.lock").touch()
-        (fido_dir / "state.json").write_text(json.dumps({}))
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {},
+            _state=self._mock_state(issue=None),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_on_get_repo_exception(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         mock_gh.get_repo_info.side_effect = RuntimeError("network error")
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {"issue": 42},
+            _state=self._mock_state(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_no_open_pr(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         mock_gh.find_pr.return_value = None
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {"issue": 42},
+            _state=self._mock_state(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_pr_not_open(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         mock_gh.find_pr.return_value = {"number": 99, "state": "MERGED"}
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {"issue": 42},
+            _state=self._mock_state(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_on_get_pr_body_exception(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         mock_gh.get_pr_body.side_effect = RuntimeError("API error")
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_no_divider_in_body(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh(
             body="No divider here. <!-- WORK_QUEUE_START -->x<!-- WORK_QUEUE_END -->"
         )
@@ -2900,46 +2876,43 @@ class TestRewritePrDescription:
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_opus_returns_empty(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(return_value=""),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_updates_pr_body_with_new_description(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(return_value="New description.\n\nFixes #42."),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         mock_gh.edit_pr_body.assert_called_once()
         new_body = mock_gh.edit_pr_body.call_args[0][2]
         assert "New description." in new_body
 
     def test_preserves_work_queue_section(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(return_value="Updated description.\n\nFixes #42."),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         new_body = mock_gh.edit_pr_body.call_args[0][2]
         assert "<!-- WORK_QUEUE_START -->" in new_body
@@ -2947,14 +2920,13 @@ class TestRewritePrDescription:
         assert "<!-- WORK_QUEUE_END -->" in new_body
 
     def test_description_replaces_only_before_divider(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(return_value="Fresh desc.\n\nFixes #42."),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
         new_body = mock_gh.edit_pr_body.call_args[0][2]
         assert "Does something useful." not in new_body
@@ -2962,7 +2934,6 @@ class TestRewritePrDescription:
         assert "## Work queue" in new_body
 
     def test_handles_edit_pr_body_exception(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         mock_gh.edit_pr_body.side_effect = RuntimeError("write failed")
         # Should not propagate the exception
@@ -2970,18 +2941,17 @@ class TestRewritePrDescription:
             tmp_path,
             mock_gh,
             _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
-            _load_state_fn=lambda _: {"issue": 42},
-            _list_tasks=lambda _: [],
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
         )
 
     def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
-        self._setup_state(tmp_path)
         mock_gh = self._mock_gh()
         with patch("kennel.claude.print_prompt", return_value="") as mock_pp:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _load_state_fn=lambda _: {"issue": 42},
-                _list_tasks=lambda _: [],
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
             )
         mock_pp.assert_called_once()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1395,46 +1395,6 @@ class TestReplyToIssueComment:
 
 
 class TestCreateTask:
-    def test_calls_add_task_and_launch_sync(self, tmp_path: Path) -> None:
-        cfg = Config(
-            port=9000,
-            secret=b"test",
-            repos={},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
-        with (
-            patch("kennel.events.add_task") as mock_add,
-            patch("kennel.events.launch_sync") as mock_sync,
-        ):
-            create_task("do something", cfg, repo_cfg)
-        mock_add.assert_called_once_with(
-            tmp_path, title="do something", task_type=ANY, thread=None
-        )
-        mock_sync.assert_called_once_with(cfg, repo_cfg)
-
-    def test_passes_thread(self, tmp_path: Path) -> None:
-        cfg = Config(
-            port=9000,
-            secret=b"test",
-            repos={},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
-        thread = {"repo": "a/b", "pr": 1, "comment_id": 5}
-        with (
-            patch("kennel.events.add_task") as mock_add,
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("do something", cfg, repo_cfg, thread=thread)
-        mock_add.assert_called_once_with(
-            tmp_path, title="do something", task_type=ANY, thread=thread
-        )
-
     def _cfg(self, tmp_path: Path) -> Config:
         return Config(
             port=9000,
@@ -1450,6 +1410,38 @@ class TestCreateTask:
         d.mkdir(parents=True, exist_ok=True)
         return d
 
+    def _mock_tasks(self, add_return: dict | None = None) -> MagicMock:
+        t = MagicMock()
+        t.add.return_value = add_return or {
+            "id": "t1",
+            "title": "task",
+            "status": "pending",
+            "type": "spec",
+        }
+        return t
+
+    def test_calls_add_task_and_launch_sync(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        mock_tasks = self._mock_tasks()
+        with patch("kennel.events.launch_sync") as mock_sync:
+            create_task("do something", cfg, repo_cfg, _tasks=mock_tasks)
+        mock_tasks.add.assert_called_once_with(
+            title="do something", task_type=ANY, thread=None
+        )
+        mock_sync.assert_called_once_with(cfg, repo_cfg)
+
+    def test_passes_thread(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 5}
+        mock_tasks = self._mock_tasks()
+        with patch("kennel.events.launch_sync"):
+            create_task("do something", cfg, repo_cfg, thread=thread, _tasks=mock_tasks)
+        mock_tasks.add.assert_called_once_with(
+            title="do something", task_type=ANY, thread=thread
+        )
+
     def test_returns_created_task(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -1459,11 +1451,9 @@ class TestCreateTask:
             "status": "pending",
             "type": "spec",
         }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            result = create_task("do something", cfg, repo_cfg)
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            result = create_task("do something", cfg, repo_cfg, _tasks=mock_tasks)
         assert result == fake_task
 
     def test_no_abort_without_registry(self, tmp_path: Path) -> None:
@@ -1494,11 +1484,11 @@ class TestCreateTask:
             "thread": thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("Comment task", cfg, repo_cfg, thread=thread)  # no registry
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "Comment task", cfg, repo_cfg, thread=thread, _tasks=mock_tasks
+            )  # no registry
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_new_task_has_no_thread(self, tmp_path: Path) -> None:
@@ -1527,12 +1517,14 @@ class TestCreateTask:
             "type": "spec",
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
-                "Another plain task", cfg, repo_cfg, registry=registry
+                "Another plain task",
+                cfg,
+                repo_cfg,
+                registry=registry,
+                _tasks=mock_tasks,
             )  # no thread
         registry.abort_task.assert_not_called()
 
@@ -1554,11 +1546,16 @@ class TestCreateTask:
             "thread": thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("Comment task", cfg, repo_cfg, thread=thread, registry=registry)
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_current_task_has_thread(self, tmp_path: Path) -> None:
@@ -1593,16 +1590,15 @@ class TestCreateTask:
             "thread": new_thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "New thread task",
                 cfg,
                 repo_cfg,
                 thread=new_thread,
                 registry=registry,
+                _tasks=mock_tasks,
             )
         registry.abort_task.assert_not_called()
 
@@ -1619,11 +1615,16 @@ class TestCreateTask:
             "thread": thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("Comment task", cfg, repo_cfg, thread=thread, registry=registry)
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_current_task_not_in_tasks_json(self, tmp_path: Path) -> None:
@@ -1643,11 +1644,16 @@ class TestCreateTask:
             "thread": thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("Comment task", cfg, repo_cfg, thread=thread, registry=registry)
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_state_has_no_current_task(self, tmp_path: Path) -> None:
@@ -1667,11 +1673,16 @@ class TestCreateTask:
             "thread": thread,
         }
         registry = MagicMock()
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task("Comment task", cfg, repo_cfg, thread=thread, registry=registry)
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_not_called()
 
     def _setup_abort_scenario(
@@ -1715,16 +1726,15 @@ class TestCreateTask:
             "type": "thread",
             "thread": thread,
         }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "Comment task",
                 cfg,
                 repo_cfg,
                 thread=thread,
                 registry=registry,
+                _tasks=mock_tasks,
             )
         registry.abort_task.assert_called_once_with("owner/repo")
         # ABORT_KEEP: current task stays in tasks.json
@@ -1745,16 +1755,15 @@ class TestCreateTask:
             "type": "thread",
             "thread": thread,
         }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "Comment task",
                 cfg,
                 repo_cfg,
                 thread=thread,
                 registry=registry,
+                _tasks=mock_tasks,
             )
         registry.abort_task.assert_called_once_with("owner/repo")
         # task should still be in tasks.json (ABORT_KEEP)
@@ -1774,16 +1783,15 @@ class TestCreateTask:
             "type": "thread",
             "thread": thread,
         }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "Comment task",
                 cfg,
                 repo_cfg,
                 thread=thread,
                 registry=registry,
+                _tasks=mock_tasks,
             )
         registry.abort_task.assert_not_called()
 
@@ -1793,22 +1801,10 @@ class TestCreateTask:
         import json
 
         registry, fido_dir = self._setup_abort_scenario(tmp_path, "thread")
-        fake_task = {
-            "id": "t-ci",
-            "title": "CI fix",
-            "status": "pending",
-            "type": "ci",
-        }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task(
-                "CI fix",
-                cfg,
-                repo_cfg,
-                registry=registry,
-            )
+        fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task("CI fix", cfg, repo_cfg, registry=registry, _tasks=mock_tasks)
         registry.abort_task.assert_called_once_with("owner/repo")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -1819,22 +1815,10 @@ class TestCreateTask:
         import json
 
         registry, fido_dir = self._setup_abort_scenario(tmp_path, "spec")
-        fake_task = {
-            "id": "t-ci",
-            "title": "CI fix",
-            "status": "pending",
-            "type": "ci",
-        }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
-            create_task(
-                "CI fix",
-                cfg,
-                repo_cfg,
-                registry=registry,
-            )
+        fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
+            create_task("CI fix", cfg, repo_cfg, registry=registry, _tasks=mock_tasks)
         registry.abort_task.assert_called_once_with("owner/repo")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -1850,15 +1834,10 @@ class TestCreateTask:
             "status": "pending",
             "type": "spec",
         }
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
-                "New spec task",
-                cfg,
-                repo_cfg,
-                registry=registry,
+                "New spec task", cfg, repo_cfg, registry=registry, _tasks=mock_tasks
             )
         registry.abort_task.assert_not_called()
 
@@ -1874,10 +1853,8 @@ class TestCreateTask:
             "thread": thread,
         }
         reorder_called: list[tuple] = []
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "Comment task",
                 cfg,
@@ -1887,6 +1864,7 @@ class TestCreateTask:
                 _reorder_background_fn=lambda wd, cs, cfg, rc, reg: (
                     reorder_called.append((wd, cs, cfg, rc, reg))
                 ),
+                _tasks=mock_tasks,
             )
         assert len(reorder_called) == 1
         assert reorder_called[0][0] == tmp_path
@@ -1905,15 +1883,14 @@ class TestCreateTask:
             "type": "spec",
         }
         reorder_called: list = []
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "Spec task",
                 cfg,
                 repo_cfg,
                 _reorder_background_fn=lambda *a: reorder_called.append(a),
+                _tasks=mock_tasks,
             )
         assert reorder_called == []
 
@@ -1923,12 +1900,12 @@ class TestCreateTask:
         """Normal (non-thread) task creation never triggers a PR description rewrite."""
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        mock_tasks = self._mock_tasks()
         with (
-            patch("kennel.events.add_task"),
             patch("kennel.events.launch_sync"),
             patch("kennel.events._rewrite_pr_description") as mock_rewrite,
         ):
-            create_task("Spec task", cfg, repo_cfg)  # thread=None
+            create_task("Spec task", cfg, repo_cfg, _tasks=mock_tasks)  # thread=None
         mock_rewrite.assert_not_called()
 
     def test_commit_summary_comes_from_get_commit_summary_fn(
@@ -1945,10 +1922,8 @@ class TestCreateTask:
             "thread": thread,
         }
         summaries: list[str] = []
-        with (
-            patch("kennel.events.add_task", return_value=fake_task),
-            patch("kennel.events.launch_sync"),
-        ):
+        mock_tasks = self._mock_tasks(fake_task)
+        with patch("kennel.events.launch_sync"):
             create_task(
                 "t",
                 cfg,
@@ -1958,8 +1933,20 @@ class TestCreateTask:
                 _reorder_background_fn=lambda wd, cs, cfg, rc, reg: summaries.append(
                     cs
                 ),
+                _tasks=mock_tasks,
             )
         assert summaries == ["custom summary"]
+
+    def test_default_tasks_creates_task_in_file(self, tmp_path: Path) -> None:
+        """When _tasks is not passed, create_task constructs Tasks(work_dir) itself."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with patch("kennel.events.launch_sync"):
+            result = create_task("do a thing", cfg, repo_cfg)
+        assert result["title"] == "do a thing"
+        from kennel.tasks import list_tasks
+
+        assert any(t["title"] == "do a thing" for t in list_tasks(tmp_path))
 
 
 class TestGetCommitSummary:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2973,3 +2973,15 @@ class TestRewritePrDescription:
             _load_state_fn=lambda _: {"issue": 42},
             _list_tasks=lambda _: [],
         )
+
+    def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
+        self._setup_state(tmp_path)
+        mock_gh = self._mock_gh()
+        with patch("kennel.claude.print_prompt", return_value="") as mock_pp:
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _load_state_fn=lambda _: {"issue": 42},
+                _list_tasks=lambda _: [],
+            )
+        mock_pp.assert_called_once()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2942,3 +2942,16 @@ class TestRewritePrDescription:
                 _tasks=self._mock_tasks(),
             )
         mock_pp.assert_called_once()
+
+    def test_defaults_to_state(self, tmp_path: Path) -> None:
+        mock_gh = self._mock_gh()
+        mock_state = self._mock_state(issue=None)
+        with patch("kennel.state.State", return_value=mock_state) as mock_state_cls:
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(),
+                _tasks=self._mock_tasks(),
+            )
+        mock_state_cls.assert_called_once_with(tmp_path / ".git" / "fido")
+        mock_gh.edit_pr_body.assert_not_called()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1917,6 +1917,20 @@ class TestCreateTask:
             )
         assert reorder_called == []
 
+    def test_spec_task_does_not_call_rewrite_pr_description(
+        self, tmp_path: Path
+    ) -> None:
+        """Normal (non-thread) task creation never triggers a PR description rewrite."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with (
+            patch("kennel.events.add_task"),
+            patch("kennel.events.launch_sync"),
+            patch("kennel.events._rewrite_pr_description") as mock_rewrite,
+        ):
+            create_task("Spec task", cfg, repo_cfg)  # thread=None
+        mock_rewrite.assert_not_called()
+
     def test_commit_summary_comes_from_get_commit_summary_fn(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2006,13 +2006,29 @@ class TestReorderTasksBackground:
             sub_dir=tmp_path / "sub",
         )
 
+    def _run_thread(self, started: list) -> None:
+        """Run the captured thread's target synchronously."""
+        started[0]._target()
+
+    def _capture_reorder_calls(self) -> tuple[list, callable]:
+        """Return (calls_list, mock_reorder_fn) that records (work_dir, cs, kwargs)."""
+        calls: list = []
+
+        def mock_reorder(work_dir, commit_summary, **kwargs):
+            calls.append((work_dir, commit_summary, kwargs))
+
+        return calls, mock_reorder
+
     def test_starts_daemon_thread(self, tmp_path: Path) -> None:
         started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
             tmp_path,
             "some commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
         assert len(started) == 1
         t = started[0]
@@ -2020,41 +2036,50 @@ class TestReorderTasksBackground:
 
     def test_thread_name_includes_dir_name(self, tmp_path: Path) -> None:
         started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
-            tmp_path, "commits", self._cfg(tmp_path), _start=lambda t: started.append(t)
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
         assert tmp_path.name in started[0].name
 
-    def test_thread_target_is_reorder_tasks(self, tmp_path: Path) -> None:
-        from kennel.tasks import reorder_tasks
-
+    def test_thread_calls_reorder_with_work_dir_and_commit_summary(
+        self, tmp_path: Path
+    ) -> None:
         started: list = []
-        _reorder_tasks_background(
-            tmp_path, "commits", self._cfg(tmp_path), _start=lambda t: started.append(t)
-        )
-        assert started[0]._target is reorder_tasks
-
-    def test_thread_args_are_work_dir_and_commit_summary(self, tmp_path: Path) -> None:
-        started: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
             tmp_path,
             "feat: add parser",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        assert started[0]._args == (tmp_path, "feat: add parser")
+        self._run_thread(started)
+        assert len(calls) == 1
+        assert calls[0][0] == tmp_path
+        assert calls[0][1] == "feat: add parser"
 
     def test_on_changes_callback_notifies_thread_changes(self, tmp_path: Path) -> None:
         started: list = []
         mock_gh = MagicMock()
+        calls, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
             _gh=mock_gh,
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        on_changes = started[0]._kwargs["_on_changes"]
+        self._run_thread(started)
+        on_changes = calls[0][2]["_on_changes"]
         change = {
             "task": {
                 "id": "t1",
@@ -2081,6 +2106,7 @@ class TestReorderTasksBackground:
         started: list = []
         registry = MagicMock()
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        calls, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
             tmp_path,
             "commits",
@@ -2088,8 +2114,11 @@ class TestReorderTasksBackground:
             repo_cfg=repo_cfg,
             registry=registry,
             _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        on_inprogress_affected = started[0]._kwargs["_on_inprogress_affected"]
+        self._run_thread(started)
+        on_inprogress_affected = calls[0][2]["_on_inprogress_affected"]
         on_inprogress_affected()
         registry.abort_task.assert_called_once_with("owner/repo")
 
@@ -2097,17 +2126,22 @@ class TestReorderTasksBackground:
         self, tmp_path: Path
     ) -> None:
         started: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        assert "_on_inprogress_affected" not in started[0]._kwargs
+        self._run_thread(started)
+        assert "_on_inprogress_affected" not in calls[0][2]
 
     def test_on_done_kwarg_calls_rewrite_fn(self, tmp_path: Path) -> None:
         started: list = []
         rewrite_calls: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
 
         def mock_rewrite(*a, **kw):
             rewrite_calls.append((a, kw))
@@ -2118,8 +2152,11 @@ class TestReorderTasksBackground:
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        on_done = started[0]._kwargs["_on_done"]
+        self._run_thread(started)
+        on_done = calls[0][2]["_on_done"]
         on_done()
         assert len(rewrite_calls) == 1
         args, kwargs = rewrite_calls[0]
@@ -2129,6 +2166,7 @@ class TestReorderTasksBackground:
         started: list = []
         rewrite_calls: list = []
         fake_pp = MagicMock()
+        calls, mock_reorder = self._capture_reorder_calls()
 
         def mock_rewrite(*a, **kw):
             rewrite_calls.append(kw)
@@ -2140,10 +2178,169 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
             _print_prompt=fake_pp,
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
         )
-        on_done = started[0]._kwargs["_on_done"]
+        self._run_thread(started)
+        on_done = calls[0][2]["_on_done"]
         on_done()
         assert rewrite_calls[0].get("_print_prompt") is fake_pp
+
+    def test_coalesces_when_already_running(self, tmp_path: Path) -> None:
+        """Second call while first is running marks pending, does not spawn thread."""
+        state: dict = {}
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+
+        # First call — marks running, spawns thread
+        _reorder_tasks_background(
+            tmp_path,
+            "cs1",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        assert len(started) == 1
+        assert state[str(tmp_path)]["running"] is True
+
+        # Second call while thread has not run yet — should coalesce, not spawn
+        _reorder_tasks_background(
+            tmp_path,
+            "cs2",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        assert len(started) == 1  # no second thread spawned
+        assert state[str(tmp_path)]["pending"] is not None
+        assert state[str(tmp_path)]["pending"][0] == "cs2"
+
+    def test_coalesced_call_reruns_after_first_completes(self, tmp_path: Path) -> None:
+        """Thread loops once for the pending coalesced call, then stops."""
+        state: dict = {}
+        started: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs1",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        # Simulate a second trigger arriving before the thread runs
+        _reorder_tasks_background(
+            tmp_path,
+            "cs2",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        # Run the single thread — should execute reorder twice (cs1 then cs2)
+        self._run_thread(started)
+        assert len(calls) == 2
+        assert calls[0][1] == "cs1"
+        assert calls[1][1] == "cs2"
+        assert state[str(tmp_path)]["running"] is False
+        assert state[str(tmp_path)]["pending"] is None
+
+    def test_only_last_pending_call_is_preserved(self, tmp_path: Path) -> None:
+        """Multiple coalesced callers: only the last pending commit_summary is used."""
+        state: dict = {}
+        started: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
+
+        for cs in ("cs1", "cs2", "cs3", "cs4"):
+            _reorder_tasks_background(
+                tmp_path,
+                cs,
+                self._cfg(tmp_path),
+                _start=lambda t: started.append(t),
+                _reorder_fn=mock_reorder,
+                _coalesce_state=state,
+            )
+        # Only one thread spawned; pending holds cs4 (the latest)
+        assert len(started) == 1
+        assert state[str(tmp_path)]["pending"][0] == "cs4"
+        self._run_thread(started)
+        # Ran cs1 (first call) then cs4 (latest pending); cs2 and cs3 dropped
+        assert len(calls) == 2
+        assert calls[0][1] == "cs1"
+        assert calls[1][1] == "cs4"
+
+    def test_running_flag_cleared_after_no_pending(self, tmp_path: Path) -> None:
+        """After a normal run with no pending call, running is set to False."""
+        state: dict = {}
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        self._run_thread(started)
+        assert state[str(tmp_path)]["running"] is False
+
+    def test_second_call_after_first_completes_spawns_new_thread(
+        self, tmp_path: Path
+    ) -> None:
+        """Once the first thread finishes, a subsequent call spawns a fresh thread."""
+        state: dict = {}
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs1",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        self._run_thread(started)  # first thread completes
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs2",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        assert len(started) == 2  # new thread spawned
+
+    def test_different_work_dirs_do_not_interfere(self, tmp_path: Path) -> None:
+        """Coalescing is per work_dir; different dirs get independent threads."""
+        state: dict = {}
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+
+        _reorder_tasks_background(
+            dir_a,
+            "cs",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        _reorder_tasks_background(
+            dir_b,
+            "cs",
+            self._cfg(tmp_path),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=state,
+        )
+        assert len(started) == 2  # each dir gets its own thread
 
 
 class TestNotifyThreadChange:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,6 +13,7 @@ from kennel.events import (
     _reorder_tasks_background,
     _rewrite_pr_description,
     _summarize_as_action_item,
+    _task_snapshot,
     _triage,
     create_task,
     dispatch,
@@ -3152,3 +3153,134 @@ class TestRewritePrDescription:
             )
         mock_state_cls.assert_called_once_with(tmp_path / ".git" / "fido")
         mock_gh.edit_pr_body.assert_not_called()
+
+    def test_does_not_retry_when_task_list_unchanged(self, tmp_path: Path) -> None:
+        """When task list is stable, description is written exactly once."""
+        task = {"id": "t1", "status": "pending", "title": "Do a thing"}
+        tasks = MagicMock()
+        tasks.list.return_value = [task]  # same list every call
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _state=self._mock_state(),
+            _tasks=tasks,
+        )
+        mock_gh.edit_pr_body.assert_called_once()
+
+    def test_retries_when_task_list_changes_during_opus(self, tmp_path: Path) -> None:
+        """If task list changes while Opus runs, the description is rewritten."""
+        task_before = {"id": "t1", "status": "pending", "title": "Do a thing"}
+        task_after = {"id": "t2", "status": "pending", "title": "New task"}
+        tasks = MagicMock()
+        # list() called: before attempt 1, after attempt 1, before attempt 2, after attempt 2
+        tasks.list.side_effect = [
+            [task_before],  # snapshot before attempt 1
+            [task_after],  # snapshot after attempt 1 (changed → retry)
+            [task_after],  # snapshot before attempt 2
+            [task_after],  # snapshot after attempt 2 (stable → done)
+        ]
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _state=self._mock_state(),
+            _tasks=tasks,
+        )
+        assert mock_gh.edit_pr_body.call_count == 2
+
+    def test_stops_after_max_retries(self, tmp_path: Path) -> None:
+        """Never retries more than _max_retries times even if task list keeps changing."""
+        tasks = MagicMock()
+        call_count = [0]
+
+        def ever_changing():
+            n = call_count[0]
+            call_count[0] += 1
+            return [{"id": str(n), "status": "pending", "title": f"task {n}"}]
+
+        tasks.list.side_effect = ever_changing
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _state=self._mock_state(),
+            _tasks=tasks,
+            _max_retries=3,
+        )
+        assert mock_gh.edit_pr_body.call_count == 3
+
+    def test_no_retry_when_write_skipped(self, tmp_path: Path) -> None:
+        """When _write_pr_description returns False (e.g. no divider), no retry."""
+        task_before = {"id": "t1", "status": "pending", "title": "Before"}
+        task_after = {"id": "t2", "status": "pending", "title": "After"}
+        tasks = MagicMock()
+        tasks.list.side_effect = [
+            [task_before],  # snapshot before
+            [task_after],  # snapshot after (would differ — but write was skipped)
+        ]
+        mock_gh = self._mock_gh(body="No divider here. Nothing.")
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _state=self._mock_state(),
+            _tasks=tasks,
+        )
+        mock_gh.edit_pr_body.assert_not_called()
+        assert tasks.list.call_count == 1  # no after-snapshot read
+
+    def test_refetches_pr_body_on_retry(self, tmp_path: Path) -> None:
+        """PR body is re-fetched on each attempt so work-queue stays current."""
+        task_before = {"id": "t1", "status": "pending", "title": "Before"}
+        task_after = {"id": "t2", "status": "pending", "title": "After"}
+        tasks = MagicMock()
+        tasks.list.side_effect = [
+            [task_before],
+            [task_after],  # changed → retry
+            [task_after],
+            [task_after],  # stable
+        ]
+        mock_gh = self._mock_gh()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _state=self._mock_state(),
+            _tasks=tasks,
+        )
+        assert mock_gh.get_pr_body.call_count == 2  # once per attempt
+
+
+# ── _task_snapshot ────────────────────────────────────────────────────────────
+
+
+class TestTaskSnapshot:
+    def test_returns_id_status_title_tuples(self) -> None:
+        tasks = [
+            {"id": "a", "status": "pending", "title": "Do A"},
+            {"id": "b", "status": "completed", "title": "Done B"},
+        ]
+        assert _task_snapshot(tasks) == [
+            ("a", "pending", "Do A"),
+            ("b", "completed", "Done B"),
+        ]
+
+    def test_empty_list(self) -> None:
+        assert _task_snapshot([]) == []
+
+    def test_missing_fields_default_to_empty_string(self) -> None:
+        tasks = [{"id": "x"}]
+        assert _task_snapshot(tasks) == [("x", "", "")]
+
+    def test_order_is_preserved(self) -> None:
+        tasks = [
+            {"id": "z", "status": "pending", "title": "Z"},
+            {"id": "a", "status": "pending", "title": "A"},
+        ]
+        result = _task_snapshot(tasks)
+        assert result[0][0] == "z"
+        assert result[1][0] == "a"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -10,6 +10,7 @@ from kennel.prompts import (
     reply_context_block,
     reply_instruction,
     rescope_prompt,
+    rewrite_description_prompt,
     triage_categories,
     triage_context_block,
     triage_prompt,
@@ -714,3 +715,107 @@ class TestPromptsStoresPersona:
         assert "persona A" in p1.status_text_prompt(activities)
         assert "persona B" in p2.status_text_prompt(activities)
         assert "persona A" not in p2.status_text_prompt(activities)
+
+
+# ── rewrite_description_prompt ────────────────────────────────────────────────
+
+
+class TestRewriteDescriptionPrompt:
+    def _task(
+        self,
+        title: str,
+        task_id: str = "1",
+        status: str = "pending",
+        description: str = "",
+    ) -> dict:
+        return {
+            "id": task_id,
+            "title": title,
+            "status": status,
+            "description": description,
+        }
+
+    def _body(self, desc: str = "Does something useful.\n\nFixes #5.") -> str:
+        return (
+            f"{desc}\n\n---\n\n## Work queue\n\n"
+            "<!-- WORK_QUEUE_START -->\n- [ ] do a thing\n<!-- WORK_QUEUE_END -->"
+        )
+
+    def test_includes_current_description(self) -> None:
+        result = rewrite_description_prompt(
+            self._body("Implements the feature.\n\nFixes #7."),
+            [self._task("New task")],
+        )
+        assert "Implements the feature." in result
+
+    def test_excludes_work_queue_section_from_context(self) -> None:
+        result = rewrite_description_prompt(self._body(), [self._task("A task")])
+        assert "WORK_QUEUE_START" not in result
+        assert "do a thing" not in result
+
+    def test_includes_pending_tasks(self) -> None:
+        result = rewrite_description_prompt(
+            self._body(),
+            [self._task("Add caching layer")],
+        )
+        assert "Add caching layer" in result
+
+    def test_excludes_completed_tasks(self) -> None:
+        result = rewrite_description_prompt(
+            self._body(),
+            [
+                self._task("Done already", status="completed"),
+                self._task("Still pending"),
+            ],
+        )
+        assert "Done already" not in result
+
+    def test_empty_pending_shows_none(self) -> None:
+        result = rewrite_description_prompt(
+            self._body(),
+            [self._task("Finished", status="completed")],
+        )
+        assert "(none)" in result
+
+    def test_task_description_included(self) -> None:
+        result = rewrite_description_prompt(
+            self._body(),
+            [self._task("Cache results", description="use Redis")],
+        )
+        assert "use Redis" in result
+
+    def test_fixes_line_preservation_rule_stated(self) -> None:
+        result = rewrite_description_prompt(self._body(), [])
+        assert "Fixes #N" in result or "Fixes #" in result
+        assert "preserve" in result.lower() or "exactly" in result.lower()
+
+    def test_no_work_queue_content_rule_stated(self) -> None:
+        result = rewrite_description_prompt(self._body(), [])
+        assert "work queue" in result.lower()
+
+    def test_output_only_constraint_stated(self) -> None:
+        result = rewrite_description_prompt(self._body(), [])
+        assert "ONLY" in result or "only" in result
+        assert "preamble" in result or "no preamble" in result
+
+    def test_extracts_description_at_divider(self) -> None:
+        body = "My description.\n\nFixes #3.\n\n---\n\nStuff below divider."
+        result = rewrite_description_prompt(body, [])
+        assert "My description." in result
+        assert "Stuff below divider." not in result
+
+    def test_fallback_to_wq_marker_when_no_divider(self) -> None:
+        body = "Short desc.\n<!-- WORK_QUEUE_START -->\n- [ ] task\n<!-- WORK_QUEUE_END -->"
+        result = rewrite_description_prompt(body, [])
+        assert "Short desc." in result
+        assert "WORK_QUEUE_START" not in result
+
+    def test_fallback_to_full_body_when_no_markers(self) -> None:
+        body = "Plain description with no markers."
+        result = rewrite_description_prompt(body, [])
+        assert "Plain description with no markers." in result
+
+    def test_empty_task_list(self) -> None:
+        result = rewrite_description_prompt(self._body(), [])
+        assert isinstance(result, str)
+        assert "(none)" in result

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -769,6 +769,50 @@ class TestReorderTasks:
         task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
         assert task1["status"] == "completed"
 
+    def test_on_done_called_after_successful_reorder(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Task A")
+        raw = self._response([{"id": t1["id"], "title": "Task A", "description": ""}])
+        done_calls: list = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: raw,
+            _on_done=lambda: done_calls.append(1),
+        )
+        assert done_calls == [1]
+
+    def test_on_done_not_called_when_no_tasks(self, tmp_path: Path) -> None:
+        done_calls: list = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: "{}",
+            _on_done=lambda: done_calls.append(1),
+        )
+        assert done_calls == []
+
+    def test_on_done_not_called_on_empty_opus_response(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "Task A")
+        done_calls: list = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: "",
+            _on_done=lambda: done_calls.append(1),
+        )
+        assert done_calls == []
+
+    def test_on_done_not_called_on_unparseable_response(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "Task A")
+        done_calls: list = []
+        reorder_tasks(
+            tmp_path,
+            "",
+            _print_prompt=lambda *a, **k: "not json at all",
+            _on_done=lambda: done_calls.append(1),
+        )
+        assert done_calls == []
+
 
 # ── _compute_thread_changes ───────────────────────────────────────────────────
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -906,3 +906,48 @@ class TestTasks:
         result = Tasks(work_dir).list()
         assert len(result) == 1
         assert result[0]["title"] == "Task A"
+
+    def test_add_delegates_to_add_task(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        task = Tasks(work_dir).add("Task B", TaskType.CI)
+        assert task["title"] == "Task B"
+        assert task["type"] == "ci"
+
+    def test_complete_by_id_delegates(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        task = add_task(work_dir, "Task C", TaskType.SPEC)
+        Tasks(work_dir).complete_by_id(task["id"])
+        assert list_tasks(work_dir)[0]["status"] == "completed"
+
+    def test_has_pending_for_comment_delegates(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        add_task(work_dir, "Task D", TaskType.THREAD, thread={"comment_id": 7})
+        assert Tasks(work_dir).has_pending_for_comment(7) is True
+        assert Tasks(work_dir).has_pending_for_comment(99) is False
+
+    def test_remove_delegates(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        task = add_task(work_dir, "Task E", TaskType.SPEC)
+        assert Tasks(work_dir).remove(task["id"]) is True
+        assert list_tasks(work_dir) == []
+
+    def test_update_delegates(self, tmp_path: Path) -> None:
+        from kennel.types import TaskStatus, TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        task = add_task(work_dir, "Task F", TaskType.SPEC)
+        Tasks(work_dir).update(task["id"], TaskStatus.IN_PROGRESS)
+        assert list_tasks(work_dir)[0]["status"] == "in_progress"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from kennel.tasks import (
+    Tasks,
     _apply_reorder,
     _compute_thread_changes,
     _parse_reorder_response,
@@ -893,3 +894,15 @@ class TestComputeThreadChanges:
         kinds = {c["kind"] for c in changes}
         assert "completed" in kinds
         assert "modified" in kinds
+
+
+class TestTasks:
+    def test_list_delegates_to_list_tasks(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        add_task(work_dir, "Task A", TaskType.SPEC)
+        result = Tasks(work_dir).list()
+        assert len(result) == 1
+        assert result[0]["title"] == "Task A"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -951,3 +951,19 @@ class TestTasks:
         task = add_task(work_dir, "Task F", TaskType.SPEC)
         Tasks(work_dir).update(task["id"], TaskStatus.IN_PROGRESS)
         assert list_tasks(work_dir)[0]["status"] == "in_progress"
+
+    def test_modify_yields_empty_list_when_no_tasks(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        with Tasks(work_dir).modify() as tasks:
+            assert tasks == []
+
+    def test_modify_persists_changes(self, tmp_path: Path) -> None:
+        from kennel.types import TaskType
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        add_task(work_dir, "Existing task", TaskType.SPEC)
+        with Tasks(work_dir).modify() as tasks:
+            tasks[0]["title"] = "Modified task"
+        assert list_tasks(work_dir)[0]["title"] == "Modified task"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13,6 +13,7 @@ import pytest
 
 from kennel.config import RepoMembership
 from kennel.state import (
+    State,
     _resolve_git_dir,
     clear_state,
     load_state,
@@ -1615,6 +1616,33 @@ class TestClearState:
         save_state(fido_dir, {"issue": 10})
         clear_state(fido_dir)
         assert load_state(fido_dir) == {}
+
+
+class TestState:
+    def test_load_returns_empty_when_fido_dir_absent(self, tmp_path: Path) -> None:
+        state = State(tmp_path / "nonexistent")
+        assert state.load() == {}
+
+    def test_load_returns_state_when_present(self, tmp_path: Path) -> None:
+        import json
+
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        (fido_dir / "state.json").write_text(json.dumps({"issue": 7}))
+        assert State(fido_dir).load() == {"issue": 7}
+
+    def test_save_persists_data(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        State(fido_dir).save({"issue": 42})
+        assert load_state(fido_dir) == {"issue": 42}
+
+    def test_clear_removes_state_file(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).clear()
+        assert not (fido_dir / "state.json").exists()
 
 
 class TestBuildPrompt:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2955,7 +2955,12 @@ class TestSeedTasksFromPrBody:
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_called_once_with(
-            tmp_path, "Fix the bug", task_type=TaskType.SPEC
+            tmp_path,
+            "Fix the bug",
+            TaskType.SPEC,
+            description=ANY,
+            status=ANY,
+            thread=ANY,
         )
 
     def test_adds_multiple_tasks(self, tmp_path: Path) -> None:
@@ -3034,7 +3039,7 @@ class TestSeedTasksFromPrBody:
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
             patch(
                 "kennel.worker.tasks.add_task",
-                side_effect=lambda wd, t, **kw: received.append(t),
+                side_effect=lambda wd, t, tt, **kw: received.append(t),
             ),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 5)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7774,6 +7774,26 @@ class TestSyncTasks:
         assert "Do it" in new_body
         assert "old" not in new_body
 
+    def test_description_section_preserved_after_sync(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
+        desc = "My PR description.\n\nFixes #1."
+        body = (
+            f"{desc}\n\n---\n\n## Work queue\n\n"
+            "<!-- WORK_QUEUE_START -->\nold queue\n<!-- WORK_QUEUE_END -->"
+        )
+        gh.get_pr_body.return_value = body
+        task = {"title": "Do it", "status": "pending", "type": "spec"}
+        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        gh.edit_pr_body.assert_called_once()
+        new_body = gh.edit_pr_body.call_args[0][2]
+        assert "My PR description." in new_body
+        assert "Fixes #1." in new_body
+
     def test_skips_edit_when_no_queue_markers(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,6 +38,7 @@ from kennel.worker import (
     _sanitize_slug,
     _sanitize_status_text,
     _thread_repo,
+    _write_pr_description,
     acquire_lock,
     build_prompt,
     ci_ready_for_review,
@@ -2181,182 +2182,167 @@ class TestGitClean:
         assert order == ["checkout", "clean"]
 
 
-class TestBuildPrBody:
-    """Tests for Worker._build_pr_body."""
-
-    def _make_worker(self, tmp_path: Path) -> "Worker":
-        return Worker(tmp_path, MagicMock())
+class TestWritePrDescription:
+    """Tests for the module-level _write_pr_description function."""
 
     def _pending_task(self, title: str, task_type: str = "spec") -> dict:
         return {"id": "1", "title": title, "status": "pending", "type": task_type}
 
-    def test_returns_string(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="PR desc."),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body(
-                "Fix the thing (closes #1)", 1, setup_session_id="s"
-            )
-        assert isinstance(result, str)
+    def _call(
+        self,
+        gh,
+        task_list=None,
+        existing_body="",
+        print_return="Desc.\n\nFixes #1.",
+        issue=1,
+        pr_number=42,
+    ):
+        mock_pp = MagicMock(return_value=print_return)
+        return (
+            _write_pr_description(
+                gh,
+                "owner/repo",
+                pr_number,
+                issue,
+                task_list or [],
+                existing_body,
+                _print_prompt=mock_pp,
+            ),
+            mock_pp,
+        )
 
-    def test_raises_if_setup_session_id_empty(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with pytest.raises(AssertionError):
-            worker._build_pr_body("req", 1, setup_session_id="")
+    def test_writes_to_github(self) -> None:
+        gh = MagicMock()
+        self._call(gh)
+        gh.edit_pr_body.assert_called_once()
 
-    def test_contains_work_queue_start_marker(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "<!-- WORK_QUEUE_START -->" in result
+    def test_returns_true_when_written(self) -> None:
+        gh = MagicMock()
+        result, _ = self._call(gh)
+        assert result is True
 
-    def test_contains_work_queue_end_marker(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "<!-- WORK_QUEUE_END -->" in result
+    def test_returns_false_when_opus_empty(self) -> None:
+        gh = MagicMock()
+        result, _ = self._call(gh, print_return="")
+        assert result is False
+        gh.edit_pr_body.assert_not_called()
 
-    def test_pending_tasks_shown_as_checkboxes(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        pending = [self._pending_task("Write tests"), self._pending_task("Fix lint")]
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=pending),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "- [ ] Write tests" in result
-        assert "- [ ] Fix lint" in result
+    def test_returns_false_when_no_divider_in_existing_body(self) -> None:
+        gh = MagicMock()
+        result, _ = self._call(gh, existing_body="no divider here")
+        assert result is False
+        gh.edit_pr_body.assert_not_called()
 
-    def test_first_task_has_next_marker(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        pending = [self._pending_task("First task"), self._pending_task("Second task")]
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=pending),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "- [ ] First task **→ next**" in result
+    def test_initial_write_contains_work_queue_start_marker(self) -> None:
+        gh = MagicMock()
+        self._call(gh)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "<!-- WORK_QUEUE_START -->" in body
 
-    def test_second_task_has_no_next_marker(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        pending = [self._pending_task("First task"), self._pending_task("Second task")]
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=pending),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "- [ ] Second task **→ next**" not in result
-        assert "- [ ] Second task\n" in result or result.endswith("- [ ] Second task")
+    def test_initial_write_contains_work_queue_end_marker(self) -> None:
+        gh = MagicMock()
+        self._call(gh)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "<!-- WORK_QUEUE_END -->" in body
 
-    def test_next_marker_follows_pick_next_task_priority(self, tmp_path: Path) -> None:
+    def test_initial_write_contains_separator(self) -> None:
+        gh = MagicMock()
+        self._call(gh)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "---" in body
+
+    def test_pending_tasks_shown_as_checkboxes(self) -> None:
+        gh = MagicMock()
+        tasks = [self._pending_task("Write tests"), self._pending_task("Fix lint")]
+        self._call(gh, task_list=tasks)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "- [ ] Write tests" in body
+        assert "- [ ] Fix lint" in body
+
+    def test_first_task_has_next_marker(self) -> None:
+        gh = MagicMock()
+        tasks = [self._pending_task("First task"), self._pending_task("Second task")]
+        self._call(gh, task_list=tasks)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "- [ ] First task **→ next**" in body
+
+    def test_second_task_has_no_next_marker(self) -> None:
+        gh = MagicMock()
+        tasks = [self._pending_task("First task"), self._pending_task("Second task")]
+        self._call(gh, task_list=tasks)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "- [ ] Second task **→ next**" not in body
+        assert "- [ ] Second task\n" in body or body.endswith("- [ ] Second task")
+
+    def test_next_marker_follows_pick_next_task_priority(self) -> None:
         """CI failure task second in list should still get the → next marker."""
-        worker = self._make_worker(tmp_path)
+        gh = MagicMock()
         regular = self._pending_task("Regular work")
         ci = {"id": "2", "title": "CI failure: lint", "status": "pending", "type": "ci"}
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[regular, ci]),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "- [ ] CI failure: lint **→ next**" in result
-        assert "- [ ] Regular work **→ next**" not in result
+        self._call(gh, task_list=[regular, ci])
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "- [ ] CI failure: lint **→ next**" in body
+        assert "- [ ] Regular work **→ next**" not in body
 
-    def test_no_tasks_shows_placeholder(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "<!-- no tasks yet -->" in result
+    def test_no_tasks_shows_placeholder(self) -> None:
+        gh = MagicMock()
+        self._call(gh, task_list=[])
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "<!-- no tasks yet -->" in body
 
-    def test_falls_back_to_plain_when_claude_returns_empty(
-        self, tmp_path: Path, caplog
-    ) -> None:
-        import logging
-
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value=""),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            caplog.at_level(logging.WARNING, logger="kennel"),
-        ):
-            result = worker._build_pr_body("Fix auth", 7, setup_session_id="s")
-        assert "Fix auth" in result
-        assert "Fixes #7." in result
-        assert "falling back" in caplog.text.lower()
-
-    def test_contains_separator(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="desc"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "---" in result
-
-    def test_desc_has_fixes_line_appended(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.resume_status", return_value="Specific summary."
-            ),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            result = worker._build_pr_body("req", 99, setup_session_id="s")
-        assert "Specific summary." in result
-        assert "Fixes #99." in result
-
-    def test_skips_completed_tasks(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
+    def test_skips_completed_tasks(self) -> None:
+        gh = MagicMock()
         task_list = [
             {"id": "1", "title": "Done task", "status": "completed"},
             {"id": "2", "title": "Pending task", "status": "pending"},
         ]
-        with (
-            patch("kennel.worker.claude.resume_status", return_value="d"),
-            patch("kennel.worker.tasks.list_tasks", return_value=task_list),
-        ):
-            result = worker._build_pr_body("req", 1, setup_session_id="s")
-        assert "Done task" not in result
-        assert "Pending task" in result
+        self._call(gh, task_list=task_list)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Done task" not in body
+        assert "Pending task" in body
 
-    def test_resume_status_passes_session_id_and_prompt(self, tmp_path: Path) -> None:
-        worker = self._make_worker(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.resume_status", return_value="d"
-            ) as mock_resume,
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-        ):
-            worker._build_pr_body("req", 1, setup_session_id="my-session")
-        args = mock_resume.call_args
-        assert args[0][0] == "my-session"
-        assert "specific" in args[0][1].lower()
+    def test_fixes_line_appended_when_missing(self) -> None:
+        gh = MagicMock()
+        self._call(
+            gh, print_return="Summary without fixes line.", issue=99, pr_number=5
+        )
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Fixes #99." in body
 
-    def test_falls_back_to_plain_when_resume_returns_empty(
-        self, tmp_path: Path, caplog
-    ) -> None:
-        import logging
+    def test_fixes_line_not_duplicated_when_present(self) -> None:
+        gh = MagicMock()
+        self._call(
+            gh,
+            print_return="Summary.\n\nFixes #1.",
+            issue=1,
+        )
+        body = gh.edit_pr_body.call_args[0][2]
+        assert body.count("Fixes #1.") == 1
 
-        worker = self._make_worker(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_status", return_value=""),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            caplog.at_level(logging.WARNING, logger="kennel"),
-        ):
-            result = worker._build_pr_body("Fix it", 5, setup_session_id="sess")
-        assert "Fix it" in result
-        assert "Fixes #5." in result
-        assert "falling back" in caplog.text.lower()
+    def test_rewrite_preserves_rest_section(self) -> None:
+        gh = MagicMock()
+        existing = (
+            "Old description.\n\nFixes #1.\n\n---\n\n"
+            "## Work queue\n\n<!-- WORK_QUEUE_START -->\n"
+            "- [ ] do a thing\n<!-- WORK_QUEUE_END -->"
+        )
+        self._call(gh, existing_body=existing)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "do a thing" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
+        assert "Old description." not in body
+
+    def test_rewrite_skips_when_no_divider(self) -> None:
+        gh = MagicMock()
+        result, _ = self._call(gh, existing_body="no divider here")
+        assert result is False
+        gh.edit_pr_body.assert_not_called()
+
+    def test_defaults_to_claude_print_prompt(self) -> None:
+        gh = MagicMock()
+        with patch("kennel.claude.print_prompt", return_value="") as mock_pp:
+            _write_pr_description(gh, "owner/repo", 1, 1, [])
+        mock_pp.assert_called_once()
 
 
 class TestFindOrCreatePr:
@@ -2606,7 +2592,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "Do thing", "status": "pending"}],
@@ -2632,7 +2618,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -2651,7 +2637,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", mock_start),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -2669,7 +2655,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", return_value="s"),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -2687,7 +2673,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="pr-body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "t", "status": "pending"}],
@@ -2697,32 +2683,10 @@ class TestFindOrCreatePr:
         gh.create_pr.assert_called_once_with(
             "owner/proj",
             "Do the work (closes #7)",
-            "pr-body",
+            ANY,
             "main",
             "do-work",
         )
-
-    def test_no_pr_passes_setup_session_id_to_build_pr_body(
-        self, tmp_path: Path
-    ) -> None:
-        worker, gh = self._make_worker(tmp_path)
-        gh.find_pr.return_value = None
-        gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
-        fido_dir = self._fido_dir(tmp_path)
-        mock_build_body = MagicMock(return_value="body")
-        with (
-            patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="br"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_start", return_value="planning-session-id"),
-            patch.object(worker, "_build_pr_body", mock_build_body),
-            patch(
-                "kennel.worker.tasks.list_tasks",
-                return_value=[{"title": "t", "status": "pending"}],
-            ),
-        ):
-            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 3, "Do it")
-        assert mock_build_body.call_args[1]["setup_session_id"] == "planning-session-id"
 
     def test_no_pr_git_operations_in_order(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -2740,7 +2704,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -2767,7 +2731,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="slug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch("kennel.worker.tasks.list_tasks", return_value=[]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -2793,7 +2757,7 @@ class TestFindOrCreatePr:
             ),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "t", "status": "pending"}],
@@ -2833,7 +2797,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="setup-sess-new"),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "t", "status": "pending"}],
@@ -2856,7 +2820,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="setup-sess-new"),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "t", "status": "pending"}],
@@ -2879,7 +2843,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
-            patch.object(worker, "_build_pr_body", return_value="body"),
+            patch("kennel.worker._write_pr_description"),
             patch(
                 "kennel.worker.tasks.list_tasks",
                 return_value=[{"title": "t", "status": "pending"}],


### PR DESCRIPTION
Re-evaluate task list and PR description when comments change the plan (closes #93)

Fixes #93.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (10)</summary>

- [x] [Writing the PR description and rewriting the PR description should be the same function](https://github.com/FidoCanCode/home/pull/363#discussion_r3073911475) <!-- type:thread -->
- [x] [Audit and harden rescoping path for concurrent task creation](https://github.com/FidoCanCode/home/pull/363#discussion_r3073885678) <!-- type:thread -->
- [x] [Retry PR description rewrite when task list changes during the rewrite operation](https://github.com/FidoCanCode/home/pull/363#discussion_r3073902139) <!-- type:thread -->
- [x] [Extract a shared base class from Tasks and State that provides the `modify` context manager](https://github.com/FidoCanCode/home/pull/363#discussion_r3074231622) <!-- type:thread -->
- [x] [All state manipulation should be done through a State class with zero direct file access](https://github.com/FidoCanCode/home/pull/363#discussion_r3073891915) <!-- type:thread -->
- [x] [Migrate all remaining direct task-file call sites to the new State class](https://github.com/FidoCanCode/home/pull/363#discussion_r3073976693) <!-- type:thread -->
- [x] [Add file locking to protect against race conditions in state loading/saving](https://github.com/FidoCanCode/home/pull/363#discussion_r3073878934) <!-- type:thread -->
- [x] Add prompt builder for PR description rewrite after rescoping <!-- type:spec -->
- [x] Rewrite PR description when rescoping materially changes the plan <!-- type:spec -->
- [x] Skip PR description rewrite on normal task completion <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->