### PR TITLE
Thread reply posted as top-level PR comment instead of in-thread, with unnecessary @mention (closes #365)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -729,9 +729,9 @@ def _notify_thread_change(
     analysis.  Uses Opus (in Fido's voice) to generate the message; falls back
     to a plain factual note if Opus returns nothing.
 
-    Posts via the issue comments API so the notification appears regardless of
-    whether the original comment was an inline review comment or a top-level
-    PR comment.
+    For review comments (comment_type='pulls') replies in-thread via the pull
+    review comment API; for issue comments (comment_type='issues') posts via
+    the issue comments API.
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
@@ -744,13 +744,13 @@ def _notify_thread_change(
     pr = thread.get("pr")
     url = thread.get("url", "")
     author = thread.get("author", "")
+    comment_type = thread.get("comment_type", "issues")
     if not (comment_id and repo and pr):
         return
 
     kind = change["kind"]
     original_title = task.get("title", "")
     prompts = Prompts(_load_persona(config))
-    mention = f"@{author} " if author else ""
 
     if kind == "completed":
         instruction = (
@@ -759,12 +759,11 @@ def _notify_thread_change(
             f"Original task: {original_title}\n"
             f"Comment author: {author or '(unknown)'}\n"
             f"Comment: {url}\n\n"
-            "Write a very brief PR comment notifying the comment author (mention them "
-            "with @username if known) that their task has been marked done because it "
-            "was covered by recent commits. Reference the comment URL."
+            "Write a very brief reply notifying the commenter that their task has been "
+            "marked done because it was covered by recent commits. Reference the comment URL."
         )
         fallback = (
-            f"{mention}FYI — the task from your comment ('{original_title}') has been "
+            f"FYI — the task from your comment ('{original_title}') has been "
             f"marked done: it was covered by recent commits."
         )
     else:
@@ -776,12 +775,11 @@ def _notify_thread_change(
             f"Updated task: {new_title}\n"
             f"Comment author: {author or '(unknown)'}\n"
             f"Comment: {url}\n\n"
-            "Write a very brief PR comment notifying the comment author (mention them "
-            "with @username if known) that their original task has been updated. "
-            "Reference the comment URL."
+            "Write a very brief reply notifying the commenter that their original task "
+            "has been updated. Reference the comment URL."
         )
         fallback = (
-            f"{mention}FYI — the task from your comment has been updated to: "
+            f"FYI — the task from your comment has been updated to: "
             f"'{new_title}' based on new requirements."
         )
 
@@ -795,7 +793,10 @@ def _notify_thread_change(
         body = fallback
 
     try:
-        gh.comment_issue(repo, pr, body)
+        if comment_type == "pulls":
+            gh.reply_to_review_comment(repo, pr, body, comment_id)
+        else:
+            gh.comment_issue(repo, pr, body)
         log.info("notified thread %s (%s)", comment_id, kind)
     except Exception:
         log.exception("failed to notify thread %s", comment_id)

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -118,6 +118,7 @@ def dispatch(
                 "comment_id": comment_id,
                 "url": comment.get("html_url", ""),
                 "author": user,
+                "comment_type": "pulls",
             },
             comment_body=comment_body,
             is_bot=is_bot,
@@ -165,6 +166,7 @@ def dispatch(
                 "comment_id": comment_id,
                 "url": comment.get("html_url", ""),
                 "author": user,
+                "comment_type": "issues",
             }
             if number and comment_id
             else None,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2369,6 +2369,7 @@ class TestNotifyThreadChange:
                 "comment_id": 999,
                 "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
                 "author": "alice",
+                "comment_type": "issues",
             },
         }
         t.update(overrides)
@@ -2415,7 +2416,7 @@ class TestNotifyThreadChange:
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "Fix the thing" in body
-        assert "@alice" in body
+        assert "@" not in body
 
     def test_empty_opus_uses_fallback_for_modified(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2431,24 +2432,48 @@ class TestNotifyThreadChange:
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "New title" in body
-        assert "@alice" in body
+        assert "@" not in body
 
-    def test_fallback_no_author_omits_mention(self, tmp_path: Path) -> None:
+    def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
-        task["thread"] = {
-            "repo": "owner/repo",
-            "pr": 42,
-            "comment_id": 999,
-            "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
-        }
+        task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+            change,
+            cfg,
+            _print_prompt=MagicMock(return_value="In-thread reply"),
+            _gh=mock_gh,
         )
-        body = mock_gh.comment_issue.call_args[0][2]
-        assert "@" not in body
+        mock_gh.reply_to_review_comment.assert_called_once_with(
+            "owner/repo", 42, "In-thread reply", 999
+        )
+        mock_gh.comment_issue.assert_not_called()
+
+    def test_review_comment_exception_does_not_raise(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        mock_gh.reply_to_review_comment.side_effect = RuntimeError("network")
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
+        change = {"task": task, "kind": "completed"}
+        # Should not raise
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
+        )
+
+    def test_no_comment_type_defaults_to_issue_comment(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        task = self._task()
+        del task["thread"]["comment_type"]
+        change = {"task": task, "kind": "completed"}
+        _notify_thread_change(
+            change, cfg, _print_prompt=MagicMock(return_value="Fallback"), _gh=mock_gh
+        )
+        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Fallback")
+        mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_author_in_opus_instruction(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -221,6 +221,7 @@ class TestDispatchReviewComment:
         assert result is not None
         assert result.reply_to is not None
         assert result.reply_to["author"] == "owner"
+        assert result.reply_to["comment_type"] == "pulls"
 
     def test_self_comment_ignored(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
@@ -327,6 +328,7 @@ class TestDispatchIssueComment:
             == "https://github.com/owner/repo/pull/10#issuecomment-456"
         )
         assert result.thread["author"] == "owner"
+        assert result.thread["comment_type"] == "issues"
 
     def test_non_pr_ignored(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -449,6 +449,7 @@ class TestProcessAction:
                 "comment_id": 300,
                 "url": "https://github.com/owner/repo/pull/11#issuecomment-300",
                 "author": "owner",
+                "comment_type": "issues",
             },
             registry=WebhookHandler.registry,
         )


### PR DESCRIPTION
Now I have full context. The updated tasks are about adding `comment_type` to thread metadata and fixing `_notify_thread_change` to reply in-thread without @mentions. Here's the rewritten description:

Thread-type task notifications currently post as top-level PR comments using the issue comment API, and include unnecessary @mentions. This adds `comment_type` metadata to thread tasks during dispatch and uses it in `_notify_thread_change` to reply in the correct review thread via the pull request comment reply API, dropping the redundant @mention.

Fixes #365.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add comment_type to thread metadata in dispatch and task creation <!-- type:spec -->
- [x] Fix _notify_thread_change to reply in-thread and drop @mention <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->