### PR TITLE
Investigate and fix empty Claude outputs (status updates, PR descriptions) (closes #366)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -138,26 +138,46 @@ def extract_result_text(output: str) -> str:
 # ── Simple print calls (no tool use) ─────────────────────────────────────────
 
 
+_EMPTY_RETRY_COUNT = 2
+_EMPTY_RETRY_DELAY = 1.0
+
+
 def print_prompt(
     prompt: str,
     model: str,
     system_prompt: str | None = None,
     timeout: int = 30,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    _sleep: Callable[[float], None] = time.sleep,
 ) -> str:
     """Run claude --print with a prompt, return stdout (empty string on failure).
 
     Uses -p to pass the prompt as a positional argument (no tool access).
+    Retries up to ``_EMPTY_RETRY_COUNT`` times (with a short delay) when
+    Claude exits 0 but produces no output, to handle transient empty responses.
     """
     args: list[str] = ["--model", model, "--print"]
     if system_prompt is not None:
         args += ["--system-prompt", system_prompt]
     args += ["-p", prompt]
-    try:
-        result = _claude(*args, timeout=timeout, runner=runner)
-        return result.stdout.strip() if result.returncode == 0 else ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
+    for attempt in range(_EMPTY_RETRY_COUNT + 1):
+        try:
+            result = _claude(*args, timeout=timeout, runner=runner)
+            if result.returncode != 0:
+                return ""
+            text = result.stdout.strip()
+            if text:
+                return text
+            if attempt < _EMPTY_RETRY_COUNT:
+                log.warning(
+                    "print_prompt: empty output on attempt %d — retrying",
+                    attempt + 1,
+                )
+                _sleep(_EMPTY_RETRY_DELAY)
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            return ""
+    log.warning("print_prompt: empty output after %d attempts", _EMPTY_RETRY_COUNT + 1)
+    return ""
 
 
 def print_prompt_json(
@@ -426,35 +446,53 @@ def generate_status_with_session(
     model: str = "claude-opus-4-6",
     timeout: int = 15,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    _sleep: Callable[[float], None] = time.sleep,
 ) -> tuple[str, str]:
     """Generate a GitHub status, returning (status_text, session_id).
 
     Uses stream-json output format to capture the session_id alongside the
     response text, enabling follow-up calls (e.g., ``resume_status`` to
     shorten a long response).  Returns ``("", "")`` on failure.
+    Retries up to ``_EMPTY_RETRY_COUNT`` times when Claude exits 0 but
+    produces no output.
     """
-    try:
-        result = _claude(
-            "--model",
-            model,
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions",
-            "--system-prompt",
-            system_prompt,
-            "--print",
-            "-p",
-            prompt,
-            timeout=timeout,
-            runner=runner,
-        )
-        if result.returncode != 0:
+    for attempt in range(_EMPTY_RETRY_COUNT + 1):
+        try:
+            result = _claude(
+                "--model",
+                model,
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--dangerously-skip-permissions",
+                "--system-prompt",
+                system_prompt,
+                "--print",
+                "-p",
+                prompt,
+                timeout=timeout,
+                runner=runner,
+            )
+            if result.returncode != 0:
+                return "", ""
+            raw = result.stdout.strip()
+            text = extract_result_text(raw)
+            sid = extract_session_id(raw)
+            if text:
+                return text, sid
+            if attempt < _EMPTY_RETRY_COUNT:
+                log.warning(
+                    "generate_status_with_session: empty output on attempt %d — retrying",
+                    attempt + 1,
+                )
+                _sleep(_EMPTY_RETRY_DELAY)
+        except subprocess.TimeoutExpired, FileNotFoundError:
             return "", ""
-        raw = result.stdout.strip()
-        return extract_result_text(raw), extract_session_id(raw)
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return "", ""
+    log.warning(
+        "generate_status_with_session: empty output after %d attempts",
+        _EMPTY_RETRY_COUNT + 1,
+    )
+    return "", ""
 
 
 def resume_status(

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -168,6 +168,9 @@ def print_prompt(
             text = result.stdout.strip()
             if text:
                 return text
+            if result.stderr:
+                log.warning("print_prompt: stderr=%r", result.stderr[:200])
+            log.debug("print_prompt: stdout=%r", result.stdout[:200])
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "print_prompt: empty output on attempt %d — retrying",
@@ -480,6 +483,11 @@ def generate_status_with_session(
             sid = extract_session_id(raw)
             if text:
                 return text, sid
+            if result.stderr:
+                log.warning(
+                    "generate_status_with_session: stderr=%r", result.stderr[:200]
+                )
+            log.debug("generate_status_with_session: stdout=%r", result.stdout[:200])
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "generate_status_with_session: empty output on attempt %d — retrying",

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -338,8 +338,8 @@ def _write_pr_description(
 
     Generates the description via Opus and writes it back via
     ``gh.edit_pr_body``.  Returns ``True`` if the body was written,
-    ``False`` when skipped (no divider in an existing body, or Opus returned
-    empty).
+    ``False`` when skipped (no divider in an existing body).  When Opus
+    returns empty, falls back to a plain-text ``"Working on #N."`` line.
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
@@ -374,8 +374,10 @@ def _write_pr_description(
     prompt = rewrite_description_prompt(existing_body, task_list)
     new_desc = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
     if not new_desc:
-        log.warning("_write_pr_description: Opus returned empty — skipping")
-        return False
+        log.warning(
+            "_write_pr_description: Opus returned empty — using plain-text fallback"
+        )
+        new_desc = f"Working on #{issue}."
 
     # Ensure "Fixes #N" is always present (Opus preserves it for rewrites via
     # prompt rules; for initial writes we append it here).
@@ -509,8 +511,8 @@ class Worker:
         Makes two separate Opus calls: the first generates short status text
         (≤80 chars), the second picks an emoji.  If the text exceeds 80
         characters, retries up to 3 times in the same session to shorten it,
-        then truncates as a last resort.  Silently skips if Claude returns an
-        empty response for the text call.
+        then truncates as a last resort.  Falls back to ``what[:80]`` if
+        Claude returns an empty response for the text call.
         """
         persona_path = _sub_dir_fn() / "persona.md"
         try:
@@ -541,8 +543,11 @@ class Worker:
                 system_prompt=prompts.status_text_system_prompt(),
             )
             if not text:
-                log.warning("set_status: claude returned empty — skipping")
-                return
+                log.warning(
+                    "set_status: claude returned empty — using plain-text fallback"
+                )
+                text = what[:80]
+                session_id = ""
 
             text = _sanitize_status_text(text)
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -69,15 +69,55 @@ class TestPrintPrompt:
 
     def test_returns_empty_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed("err", returncode=1))
-        assert print_prompt("hi", "claude-opus-4-6", runner=mock_run) == ""
+        mock_sleep = MagicMock()
+        assert (
+            print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
+            == ""
+        )
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_returns_empty_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
-        assert print_prompt("hi", "claude-opus-4-6", runner=mock_run) == ""
+        mock_sleep = MagicMock()
+        assert (
+            print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
+            == ""
+        )
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_returns_empty_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert print_prompt("hi", "claude-opus-4-6", runner=mock_run) == ""
+        mock_sleep = MagicMock()
+        assert (
+            print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
+            == ""
+        )
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_retries_on_empty_output_then_succeeds(self) -> None:
+        mock_run = MagicMock(
+            side_effect=[_completed(""), _completed(""), _completed("hello")]
+        )
+        mock_sleep = MagicMock()
+        assert (
+            print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
+            == "hello"
+        )
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_returns_empty_after_all_retries_exhausted(self) -> None:
+        mock_run = MagicMock(return_value=_completed(""))
+        mock_sleep = MagicMock()
+        assert (
+            print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
+            == ""
+        )
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
 
     def test_includes_system_prompt(self) -> None:
         mock_run = MagicMock(return_value=_completed("ok"))
@@ -718,24 +758,30 @@ class TestGenerateStatusWithSession:
 
     def test_returns_empty_pair_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        assert generate_status_with_session("doing stuff", "sys", runner=mock_run) == (
-            "",
-            "",
-        )
+        mock_sleep = MagicMock()
+        assert generate_status_with_session(
+            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+        ) == ("", "")
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_returns_empty_pair_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert generate_status_with_session("doing stuff", "sys", runner=mock_run) == (
-            "",
-            "",
-        )
+        mock_sleep = MagicMock()
+        assert generate_status_with_session(
+            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+        ) == ("", "")
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_returns_empty_pair_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert generate_status_with_session("doing stuff", "sys", runner=mock_run) == (
-            "",
-            "",
-        )
+        mock_sleep = MagicMock()
+        assert generate_status_with_session(
+            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+        ) == ("", "")
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
 
     def test_passes_correct_flags(self) -> None:
         mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
@@ -767,12 +813,17 @@ class TestGenerateStatusWithSession:
         assert "claude-opus-4-6" in cmd
         assert mock_run.call_args.kwargs["timeout"] == 15
 
-    def test_returns_empty_text_when_no_result_field(self) -> None:
+    def test_returns_empty_pair_when_no_result_field_after_retries(self) -> None:
         no_result = '{"type":"result","session_id":"sid"}'
         mock_run = MagicMock(return_value=_completed(no_result))
-        text, sid = generate_status_with_session("working", "sys", runner=mock_run)
+        mock_sleep = MagicMock()
+        text, sid = generate_status_with_session(
+            "working", "sys", runner=mock_run, _sleep=mock_sleep
+        )
         assert text == ""
-        assert sid == "sid"
+        assert sid == ""
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
 
     def test_returns_empty_session_when_no_session_id(self) -> None:
         no_sid = '{"type":"result","result":"🐶\\nwoof"}'
@@ -780,6 +831,34 @@ class TestGenerateStatusWithSession:
         text, sid = generate_status_with_session("working", "sys", runner=mock_run)
         assert text == "🐶\nwoof"
         assert sid == ""
+
+    def test_retries_on_empty_output_then_succeeds(self) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(
+            side_effect=[
+                _completed(empty_line),
+                _completed(empty_line),
+                _completed(self._RESULT_LINE),
+            ]
+        )
+        mock_sleep = MagicMock()
+        text, sid = generate_status_with_session(
+            "working", "sys", runner=mock_run, _sleep=mock_sleep
+        )
+        assert text == "🐶\ncoding"
+        assert sid == "sess-42"
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_returns_empty_pair_after_all_retries_exhausted(self) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        mock_sleep = MagicMock()
+        assert generate_status_with_session(
+            "working", "sys", runner=mock_run, _sleep=mock_sleep
+        ) == ("", "")
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
 
 
 class TestGenerateStatusEmoji:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -27,10 +28,10 @@ from kennel.claude import (
 
 
 def _completed(
-    stdout: str = "", returncode: int = 0
+    stdout: str = "", returncode: int = 0, stderr: str = ""
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(
-        args=[], returncode=returncode, stdout=stdout, stderr=""
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
     )
 
 
@@ -145,6 +146,24 @@ class TestPrintPrompt:
         mock_run = MagicMock(return_value=_completed("ok"))
         print_prompt("q", "claude-opus-4-6", timeout=7, runner=mock_run)
         assert mock_run.call_args.kwargs["timeout"] == 7
+
+    def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
+        mock_run = MagicMock(return_value=_completed("", stderr="Rate limit exceeded"))
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+        assert "Rate limit exceeded" in caplog.text
+
+    def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
+        mock_run = MagicMock(return_value=_completed("   \n  "))
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+        assert "stdout=" in caplog.text
+
+    def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
+        mock_run = MagicMock(return_value=_completed(""))
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+        assert "stderr=" not in caplog.text
 
 
 class TestPrintPromptJson:
@@ -859,6 +878,35 @@ class TestGenerateStatusWithSession:
         ) == ("", "")
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
+
+    def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(
+            return_value=_completed(empty_line, stderr="Rate limit exceeded")
+        )
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            generate_status_with_session(
+                "working", "sys", runner=mock_run, _sleep=MagicMock()
+            )
+        assert "Rate limit exceeded" in caplog.text
+
+    def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            generate_status_with_session(
+                "working", "sys", runner=mock_run, _sleep=MagicMock()
+            )
+        assert "stdout=" in caplog.text
+
+    def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            generate_status_with_session(
+                "working", "sys", runner=mock_run, _sleep=MagicMock()
+            )
+        assert "stderr=" not in caplog.text
 
 
 class TestGenerateStatusEmoji:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3093,7 +3093,9 @@ class TestRewritePrDescription:
         )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_skips_when_opus_returns_empty(self, tmp_path: Path) -> None:
+    def test_uses_plain_text_fallback_when_opus_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
         mock_gh = self._mock_gh()
         _rewrite_pr_description(
             tmp_path,
@@ -3102,7 +3104,9 @@ class TestRewritePrDescription:
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
-        mock_gh.edit_pr_body.assert_not_called()
+        mock_gh.edit_pr_body.assert_called_once()
+        body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "Working on #42." in body
 
     def test_updates_pr_body_with_new_description(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -381,13 +381,17 @@ class TestWorker:
         )
         gh.set_user_status.assert_called_once_with("napping", "😴", busy=False)
 
-    def test_set_status_skips_when_claude_returns_empty(self, tmp_path: Path) -> None:
+    def test_set_status_uses_what_as_fallback_when_claude_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(tmp_path, gh).set_status(
             "idle", **self._ss(tmp_path, text="", session_id="")
         )
-        gh.set_user_status.assert_not_called()
+        gh.set_user_status.assert_called_once()
+        call_args = gh.set_user_status.call_args[0]
+        assert call_args[0] == "idle"
 
     def test_set_status_emoji_fallback_when_empty(self, tmp_path: Path) -> None:
         # generate_status_emoji returns empty → :dog: fallback
@@ -488,7 +492,7 @@ class TestWorker:
             Worker(tmp_path, gh).set_status(
                 "idle", **self._ss(tmp_path, text="", session_id="")
             )
-        assert "empty" in caplog.text
+        assert "fallback" in caplog.text
 
     def test_set_status_logs_info_on_success(self, tmp_path: Path, caplog) -> None:
         import logging
@@ -2221,11 +2225,13 @@ class TestWritePrDescription:
         result, _ = self._call(gh)
         assert result is True
 
-    def test_returns_false_when_opus_empty(self) -> None:
+    def test_uses_plain_text_fallback_when_opus_empty(self) -> None:
         gh = MagicMock()
-        result, _ = self._call(gh, print_return="")
-        assert result is False
-        gh.edit_pr_body.assert_not_called()
+        result, _ = self._call(gh, print_return="", issue=7)
+        assert result is True
+        gh.edit_pr_body.assert_called_once()
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Working on #7." in body
 
     def test_returns_false_when_no_divider_in_existing_body(self) -> None:
         gh = MagicMock()


### PR DESCRIPTION
Adds retry logic to `print_prompt` for empty-but-successful Claude responses, with diagnostic logging of raw output on empty results and fallback text for PR descriptions and status updates when output is empty.

Fixes #366.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add retry logic to print_prompt for empty-but-successful responses <!-- type:spec -->
- [x] Log raw Claude output on empty responses for diagnostics <!-- type:spec -->
- [x] Add fallback text for PR descriptions and status updates on empty output <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->