### PR TITLE
Make worker-thread exceptions fatal and observable (closes #372)

### DIFF
--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -7,6 +7,7 @@ import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 
 from kennel.config import RepoConfig
 from kennel.github import GitHub
@@ -22,6 +23,15 @@ class WorkerActivity:
     repo_name: str
     what: str
     busy: bool
+
+
+@dataclass
+class WorkerCrash:
+    """Running record of unexpected worker deaths for one repo."""
+
+    death_count: int
+    last_error: str
+    last_crash_time: datetime
 
 
 class WorkerRegistry:
@@ -44,6 +54,8 @@ class WorkerRegistry:
         self._activities: dict[str, WorkerActivity] = {}
         self._activity_lock = threading.Lock()
         self._status_lock = threading.Lock()
+        self._crashes: dict[str, WorkerCrash] = {}
+        self._crash_lock = threading.Lock()
 
     def start(self, repo_cfg: RepoConfig) -> None:
         """Create and start a WorkerThread for *repo_cfg*."""
@@ -81,6 +93,25 @@ class WorkerRegistry:
         """Return a snapshot of all registered workers' current activities."""
         with self._activity_lock:
             return list(self._activities.values())
+
+    def record_crash(self, repo_name: str, error: str) -> None:
+        """Record an unexpected worker death for *repo_name*.
+
+        Increments the death count and stores the error message and time of
+        the most recent crash.  Safe to call from any thread.
+        """
+        with self._crash_lock:
+            existing = self._crashes.get(repo_name)
+            self._crashes[repo_name] = WorkerCrash(
+                death_count=(existing.death_count + 1 if existing else 1),
+                last_error=error,
+                last_crash_time=datetime.now(),
+            )
+
+    def get_crash_info(self, repo_name: str) -> WorkerCrash | None:
+        """Return crash history for *repo_name*, or None if it has never crashed."""
+        with self._crash_lock:
+            return self._crashes.get(repo_name)
 
     @contextmanager
     def status_update(self) -> Generator[None, None, None]:

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -145,6 +145,11 @@ class WorkerRegistry:
         thread = self._threads.get(repo_name)
         return thread is not None and thread.is_alive()
 
+    def get_thread_crash_error(self, repo_name: str) -> str | None:
+        """Return the crash_error stored on the thread for *repo_name*, or None."""
+        thread = self._threads.get(repo_name)
+        return thread.crash_error if thread is not None else None
+
 
 def _make_thread(
     repo_cfg: RepoConfig,

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -343,10 +343,18 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/status":
-            activities = [
-                {"repo_name": a.repo_name, "what": a.what, "busy": a.busy}
-                for a in self.registry.get_all_activities()
-            ]
+            activities = []
+            for a in self.registry.get_all_activities():
+                crash = self.registry.get_crash_info(a.repo_name)
+                activities.append(
+                    {
+                        "repo_name": a.repo_name,
+                        "what": a.what,
+                        "busy": a.busy,
+                        "crash_count": crash.death_count if crash else 0,
+                        "last_crash_error": crash.last_error if crash else None,
+                    }
+                )
             body = json.dumps(activities).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -217,11 +217,11 @@ def _read_tasks(fido_dir: Path) -> list[dict[str, Any]]:
 def _current_task(task_list: list[dict[str, Any]]) -> str | None:
     """Return the title of the first in_progress task, then the first pending task."""
     for t in task_list:
-        if t.get("status") == "in_progress":
-            return t.get("title")
+        if t["status"] == "in_progress":
+            return t["title"]
     for t in task_list:
-        if t.get("status") == "pending":
-            return t.get("title")
+        if t["status"] == "pending":
+            return t["title"]
     return None
 
 
@@ -248,8 +248,8 @@ def repo_status(repo_config: RepoConfig, worker_what: str | None = None) -> Repo
     issue = state.get("issue")
 
     task_list = _read_tasks(fido_dir)
-    pending = sum(1 for t in task_list if t.get("status") == "pending")
-    completed = sum(1 for t in task_list if t.get("status") == "completed")
+    pending = sum(1 for t in task_list if t["status"] == "pending")
+    completed = sum(1 for t in task_list if t["status"] == "completed")
 
     current = _current_task(task_list)
 

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -25,6 +25,8 @@ class RepoStatus:
     claude_pid: int | None
     claude_uptime: int | None  # seconds
     worker_what: str | None  # activity text from the live registry
+    crash_count: int  # number of unexpected worker deaths since kennel started
+    last_crash_error: str | None  # error from the most recent crash, if any
 
 
 @dataclass
@@ -150,13 +152,17 @@ def _port_from_pid(pid: int) -> int | None:
 
 def _fetch_activities(
     port: int, *, _urlopen: Callable[..., Any] = urllib.request.urlopen
-) -> dict[str, str]:
-    """Query GET /status on the kennel server, returning {repo_name: what}."""
+) -> dict[str, dict[str, Any]]:
+    """Query GET /status, returning {repo_name: {what, crash_count, last_crash_error}}."""
     try:
         with _urlopen(f"http://localhost:{port}/status", timeout=2) as resp:
             data = json.loads(resp.read())
         return {
-            item["repo_name"]: item["what"]
+            item["repo_name"]: {
+                "what": item["what"],
+                "crash_count": item["crash_count"],
+                "last_crash_error": item["last_crash_error"],
+            }
             for item in data
             if "repo_name" in item and "what" in item
         }
@@ -225,7 +231,12 @@ def _current_task(task_list: list[dict[str, Any]]) -> str | None:
     return None
 
 
-def repo_status(repo_config: RepoConfig, worker_what: str | None = None) -> RepoStatus:
+def repo_status(
+    repo_config: RepoConfig,
+    worker_what: str | None = None,
+    crash_count: int = 0,
+    last_crash_error: str | None = None,
+) -> RepoStatus:
     """Collect status for a single repo."""
     git_dir = _git_dir(repo_config.work_dir)
     if git_dir is None:
@@ -239,6 +250,8 @@ def repo_status(repo_config: RepoConfig, worker_what: str | None = None) -> Repo
             claude_pid=None,
             claude_uptime=None,
             worker_what=worker_what,
+            crash_count=crash_count,
+            last_crash_error=last_crash_error,
         )
 
     fido_dir = git_dir / "fido"
@@ -268,6 +281,8 @@ def repo_status(repo_config: RepoConfig, worker_what: str | None = None) -> Repo
         claude_pid=claude_pid,
         claude_uptime=claude_uptime,
         worker_what=worker_what,
+        crash_count=crash_count,
+        last_crash_error=last_crash_error,
     )
 
 
@@ -283,9 +298,17 @@ def collect() -> KennelStatus:
         if port is not None:
             activities = _fetch_activities(port)
 
-    repos = [
-        repo_status(rc, worker_what=activities.get(rc.name)) for rc in repo_configs
-    ]
+    repos = []
+    for rc in repo_configs:
+        info = activities.get(rc.name)
+        repos.append(
+            repo_status(
+                rc,
+                worker_what=info["what"] if info else None,
+                crash_count=info["crash_count"] if info else 0,
+                last_crash_error=info["last_crash_error"] if info else None,
+            )
+        )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
 
 
@@ -333,6 +356,12 @@ def format_status(status: KennelStatus) -> str:
             if repo.claude_uptime is not None:
                 claude_str += f" (running {_format_uptime(repo.claude_uptime)})"
             parts.append(claude_str)
+
+        if repo.crash_count > 0:
+            crash_str = f"crashed {repo.crash_count}x"
+            if repo.last_crash_error:
+                crash_str += f": {repo.last_crash_error}"
+            parts.append(crash_str)
 
         lines.append(f"{repo.name}: {' — '.join(parts)}")
 

--- a/kennel/watchdog.py
+++ b/kennel/watchdog.py
@@ -33,6 +33,9 @@ class Watchdog:
         """Run one watchdog iteration. Returns 0."""
         for repo_name, repo_cfg in self.repos.items():
             if not self.registry.is_alive(repo_name):
+                error = self.registry.get_thread_crash_error(repo_name)
+                if error is not None:
+                    self.registry.record_crash(repo_name, error)
                 log.info("thread for %s is not alive — restarting", repo_name)
                 self.registry.start(repo_cfg)
         return 0

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1546,7 +1546,6 @@ class Worker:
 
 _IDLE_TIMEOUT = 60.0  # seconds to wait when there was no work to do
 _RETRY_TIMEOUT = 5.0  # seconds to wait when the lock was contended
-_ERROR_TIMEOUT = 30.0  # seconds to wait after an unexpected exception
 
 
 class WorkerThread(threading.Thread):
@@ -1556,7 +1555,7 @@ class WorkerThread(threading.Thread):
     - ``Worker.run()`` returns 1 → did work, loop immediately.
     - ``Worker.run()`` returns 0 → idle, wait up to ``_IDLE_TIMEOUT``.
     - ``Worker.run()`` returns 2 → lock held, wait up to ``_RETRY_TIMEOUT``.
-    - Unexpected exception → wait up to ``_ERROR_TIMEOUT``, then retry.
+    - Unexpected exception → propagates, killing the thread (watchdog restarts).
 
     Call :meth:`wake` to interrupt any wait early (e.g. when a webhook arrives).
     Call :meth:`stop` to request a clean shutdown.
@@ -1598,20 +1597,14 @@ class WorkerThread(threading.Thread):
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
         while not self._stop:
-            try:
-                result = Worker(
-                    self.work_dir,
-                    self._gh,
-                    self._abort_task,
-                    self._repo_name,
-                    self._registry,
-                    self._membership,
-                ).run()
-            except Exception:
-                log.exception("WorkerThread %s: unexpected error", self.name)
-                self._wake.wait(timeout=_ERROR_TIMEOUT)
-                self._wake.clear()
-                continue
+            result = Worker(
+                self.work_dir,
+                self._gh,
+                self._abort_task,
+                self._repo_name,
+                self._registry,
+                self._membership,
+            ).run()
 
             if result == 1:
                 # Did work — loop immediately without waiting.

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1578,6 +1578,7 @@ class WorkerThread(threading.Thread):
         self._wake = threading.Event()
         self._abort_task = threading.Event()
         self._stop = False
+        self.crash_error: str | None = None
 
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
@@ -1596,23 +1597,28 @@ class WorkerThread(threading.Thread):
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
-        while not self._stop:
-            result = Worker(
-                self.work_dir,
-                self._gh,
-                self._abort_task,
-                self._repo_name,
-                self._registry,
-                self._membership,
-            ).run()
+        try:
+            while not self._stop:
+                result = Worker(
+                    self.work_dir,
+                    self._gh,
+                    self._abort_task,
+                    self._repo_name,
+                    self._registry,
+                    self._membership,
+                ).run()
 
-            if result == 1:
-                # Did work — loop immediately without waiting.
-                continue
+                if result == 1:
+                    # Did work — loop immediately without waiting.
+                    continue
 
-            timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
-            self._wake.wait(timeout=timeout)
-            self._wake.clear()
+                timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
+                self._wake.wait(timeout=timeout)
+                self._wake.clear()
+        except Exception as exc:
+            self.crash_error = f"{type(exc).__name__}: {exc}"
+            log.exception("WorkerThread %s: unexpected error", self.name)
+            raise
 
 
 def run(work_dir: Path) -> int:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -8,7 +8,13 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from kennel.config import RepoConfig
-from kennel.registry import WorkerActivity, WorkerRegistry, _make_thread, make_registry
+from kennel.registry import (
+    WorkerActivity,
+    WorkerCrash,
+    WorkerRegistry,
+    _make_thread,
+    make_registry,
+)
 
 
 def _repo(name: str, work_dir: Path) -> RepoConfig:
@@ -240,6 +246,84 @@ class TestWorkerRegistry:
             t.join(timeout=5)
 
         assert max_concurrent == 1
+
+    def test_get_crash_info_returns_none_before_any_crash(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_crash_info("foo/bar") is None
+
+    def test_record_crash_stores_error_and_count(self) -> None:
+        reg, _ = self._make_registry()
+        reg.record_crash("foo/bar", "boom")
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert info.death_count == 1
+        assert info.last_error == "boom"
+
+    def test_record_crash_sets_last_crash_time(self) -> None:
+        import datetime as dt
+
+        before = dt.datetime.now()
+        reg, _ = self._make_registry()
+        reg.record_crash("foo/bar", "oops")
+        after = dt.datetime.now()
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert before <= info.last_crash_time <= after
+
+    def test_record_crash_increments_death_count(self) -> None:
+        reg, _ = self._make_registry()
+        reg.record_crash("foo/bar", "err1")
+        reg.record_crash("foo/bar", "err2")
+        reg.record_crash("foo/bar", "err3")
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert info.death_count == 3
+
+    def test_record_crash_updates_last_error(self) -> None:
+        reg, _ = self._make_registry()
+        reg.record_crash("foo/bar", "first")
+        reg.record_crash("foo/bar", "second")
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert info.last_error == "second"
+
+    def test_crash_info_is_per_repo(self) -> None:
+        reg, _ = self._make_registry()
+        reg.record_crash("foo/bar", "bar error")
+        reg.record_crash("foo/baz", "baz error")
+        reg.record_crash("foo/baz", "baz error 2")
+        bar = reg.get_crash_info("foo/bar")
+        baz = reg.get_crash_info("foo/baz")
+        assert bar is not None and bar.death_count == 1
+        assert baz is not None and baz.death_count == 2
+
+    def test_record_crash_is_threadsafe(self) -> None:
+        """Concurrent record_crash calls must not corrupt the death count."""
+        reg, _ = self._make_registry()
+        n = 200
+
+        def crasher() -> None:
+            for _ in range(n):
+                reg.record_crash("foo/bar", "err")
+
+        threads = [threading.Thread(target=crasher) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert info.death_count == 4 * n
+
+    def test_worker_crash_dataclass_fields(self) -> None:
+        import datetime as dt
+
+        ts = dt.datetime(2026, 1, 1, 12, 0, 0)
+        crash = WorkerCrash(death_count=3, last_error="oops", last_crash_time=ts)
+        assert crash.death_count == 3
+        assert crash.last_error == "oops"
+        assert crash.last_crash_time == ts
 
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -137,6 +137,26 @@ class TestWorkerRegistry:
         reg, _ = self._make_registry()
         assert reg.is_alive("unknown/repo") is False
 
+    def test_get_thread_crash_error_returns_none_for_unknown_repo(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_thread_crash_error("unknown/repo") is None
+
+    def test_get_thread_crash_error_returns_thread_crash_error(
+        self, tmp_path: Path
+    ) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.crash_error = "RuntimeError: boom"
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_thread_crash_error("foo/bar") == "RuntimeError: boom"
+
+    def test_get_thread_crash_error_returns_none_when_thread_has_no_error(
+        self, tmp_path: Path
+    ) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.crash_error = None
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_thread_crash_error("foo/bar") is None
+
     def test_report_activity_stores_entry(self) -> None:
         reg, _ = self._make_registry()
         reg.report_activity("foo/bar", "Working on: #1", busy=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -143,12 +143,38 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_all_activities.return_value = [
             WorkerActivity(repo_name="owner/repo", what="Working on: #1", busy=True),
         ]
+        WebhookHandler.registry.get_crash_info.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
         assert data == [
-            {"repo_name": "owner/repo", "what": "Working on: #1", "busy": True}
+            {
+                "repo_name": "owner/repo",
+                "what": "Working on: #1",
+                "busy": True,
+                "crash_count": 0,
+                "last_crash_error": None,
+            }
         ]
+
+    def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
+        from datetime import datetime
+
+        from kennel.registry import WorkerActivity, WorkerCrash
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(repo_name="owner/repo", what="Napping", busy=False),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = WorkerCrash(
+            death_count=3,
+            last_error="RuntimeError: boom",
+            last_crash_time=datetime(2026, 1, 1),
+        )
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["crash_count"] == 3
+        assert data[0]["last_crash_error"] == "RuntimeError: boom"
 
     def test_status_endpoint_empty_when_no_activities(self, server: tuple) -> None:
         url, _ = server

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -277,20 +277,53 @@ class TestFetchActivities:
 
     def test_returns_repo_what_map(self) -> None:
         data = json.dumps(
-            [{"repo_name": "owner/repo", "what": "Working on: #1", "busy": True}]
+            [
+                {
+                    "repo_name": "owner/repo",
+                    "what": "Working on: #1",
+                    "busy": True,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                }
+            ]
         ).encode()
         result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
-        assert result == {"owner/repo": "Working on: #1"}
+        assert result == {
+            "owner/repo": {
+                "what": "Working on: #1",
+                "crash_count": 0,
+                "last_crash_error": None,
+            }
+        }
 
     def test_returns_multiple_repos(self) -> None:
         data = json.dumps(
             [
-                {"repo_name": "a/b", "what": "Napping", "busy": False},
-                {"repo_name": "c/d", "what": "Fixing CI", "busy": True},
+                {
+                    "repo_name": "a/b",
+                    "what": "Napping",
+                    "busy": False,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                },
+                {
+                    "repo_name": "c/d",
+                    "what": "Fixing CI",
+                    "busy": True,
+                    "crash_count": 2,
+                    "last_crash_error": "RuntimeError: boom",
+                },
             ]
         ).encode()
         result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
-        assert result == {"a/b": "Napping", "c/d": "Fixing CI"}
+        assert result == {
+            "a/b": {"what": "Napping", "crash_count": 0, "last_crash_error": None},
+            "c/d": {
+                "what": "Fixing CI",
+                "crash_count": 2,
+                "last_crash_error": "RuntimeError: boom",
+            },
+        }
 
     def test_returns_empty_on_exception(self) -> None:
         mock_urlopen = MagicMock(side_effect=OSError("refused"))
@@ -455,12 +488,29 @@ class TestRepoStatus:
         assert result.claude_pid is None
         assert result.claude_uptime is None
         assert result.worker_what is None
+        assert result.crash_count == 0
+        assert result.last_crash_error is None
 
     def test_no_git_dir_passes_worker_what(self, tmp_path: Path) -> None:
         cfg = self._make_config(tmp_path)
         with patch("kennel.status._git_dir", return_value=None):
             result = repo_status(cfg, worker_what="Napping")
         assert result.worker_what == "Napping"
+
+    def test_crash_count_defaults_to_zero(self, tmp_path: Path) -> None:
+        cfg = self._make_config(tmp_path)
+        with patch("kennel.status._git_dir", return_value=None):
+            result = repo_status(cfg)
+        assert result.crash_count == 0
+
+    def test_crash_fields_passed_through(self, tmp_path: Path) -> None:
+        cfg = self._make_config(tmp_path)
+        with patch("kennel.status._git_dir", return_value=None):
+            result = repo_status(
+                cfg, crash_count=5, last_crash_error="ValueError: oops"
+            )
+        assert result.crash_count == 5
+        assert result.last_crash_error == "ValueError: oops"
 
     def test_with_running_fido_and_issue(self, tmp_path: Path) -> None:
         git_dir = tmp_path / ".git"
@@ -538,6 +588,8 @@ class TestCollect:
             claude_pid=None,
             claude_uptime=None,
             worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
         )
 
     def test_kennel_up_with_uptime(self, tmp_path: Path) -> None:
@@ -572,6 +624,18 @@ class TestCollect:
         assert result.kennel_pid is None
         assert result.kennel_uptime is None
 
+    def _activity_info(
+        self,
+        what: str = "Working on: #1",
+        crash_count: int = 0,
+        last_crash_error: str | None = None,
+    ) -> dict:
+        return {
+            "what": what,
+            "crash_count": crash_count,
+            "last_crash_error": last_crash_error,
+        }
+
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:
         rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
         with (
@@ -581,7 +645,7 @@ class TestCollect:
             patch("kennel.status._port_from_pid", return_value=9000),
             patch(
                 "kennel.status._fetch_activities",
-                return_value={"owner/repo": "Working on: #1"},
+                return_value={"owner/repo": self._activity_info()},
             ) as mock_fetch,
             patch("kennel.status.repo_status", return_value=self._fake_repo_status()),
         ):
@@ -610,14 +674,43 @@ class TestCollect:
             patch("kennel.status._port_from_pid", return_value=9000),
             patch(
                 "kennel.status._fetch_activities",
-                return_value={"owner/repo": "Fixing CI: tests"},
+                return_value={"owner/repo": self._activity_info("Fixing CI: tests")},
             ),
             patch(
                 "kennel.status.repo_status", return_value=self._fake_repo_status()
             ) as mock_rs,
         ):
             collect()
-        mock_rs.assert_called_once_with(rc, worker_what="Fixing CI: tests")
+        mock_rs.assert_called_once_with(
+            rc, worker_what="Fixing CI: tests", crash_count=0, last_crash_error=None
+        )
+
+    def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch(
+                "kennel.status._fetch_activities",
+                return_value={
+                    "owner/repo": self._activity_info(
+                        "Napping", crash_count=3, last_crash_error="ValueError: oops"
+                    )
+                },
+            ),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_rs,
+        ):
+            collect()
+        mock_rs.assert_called_once_with(
+            rc,
+            worker_what="Napping",
+            crash_count=3,
+            last_crash_error="ValueError: oops",
+        )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
         rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -632,7 +725,9 @@ class TestCollect:
             ) as mock_rs,
         ):
             collect()
-        mock_rs.assert_called_once_with(rc, worker_what=None)
+        mock_rs.assert_called_once_with(
+            rc, worker_what=None, crash_count=0, last_crash_error=None
+        )
 
 
 class TestFormatStatus:
@@ -647,6 +742,8 @@ class TestFormatStatus:
             claude_pid=None,
             claude_uptime=None,
             worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
         )
         defaults.update(kwargs)
         return RepoStatus(**defaults)
@@ -752,3 +849,33 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "fido running — Napping — waiting for work" in output
+
+    def test_crash_count_zero_not_shown(self) -> None:
+        repo = self._repo(crash_count=0, last_crash_error=None)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "crashed" not in output
+
+    def test_crash_count_nonzero_shown_with_error(self) -> None:
+        repo = self._repo(crash_count=3, last_crash_error="RuntimeError: boom")
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "crashed 3x: RuntimeError: boom" in output
+
+    def test_crash_count_without_error(self) -> None:
+        repo = self._repo(crash_count=1, last_crash_error=None)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "crashed 1x" in output
+        assert "crashed 1x:" not in output
+
+    def test_crash_info_appears_after_claude_info(self) -> None:
+        repo = self._repo(
+            claude_pid=9999,
+            claude_uptime=60,
+            crash_count=2,
+            last_crash_error="OSError: disk full",
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "claude pid 9999 (running 1m) — crashed 2x: OSError: disk full" in output

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -40,6 +40,7 @@ class TestWatchdogRun:
         repo_cfg = _repo()
         w, registry = _make({"owner/repo": repo_cfg})
         registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = None
         w.run()
         registry.start.assert_called_once_with(repo_cfg)
 
@@ -60,6 +61,7 @@ class TestWatchdogRun:
             return name == "org/alive"
 
         registry.is_alive.side_effect = is_alive
+        registry.get_thread_crash_error.return_value = None
         w.run()
         registry.start.assert_called_once_with(dead_cfg)
 
@@ -69,10 +71,42 @@ class TestWatchdogRun:
         repos = {"org/a": repo_a, "org/b": repo_b}
         w, registry = _make(repos)
         registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = None
         w.run()
         assert registry.start.call_count == 2
         registry.start.assert_any_call(repo_a)
         registry.start.assert_any_call(repo_b)
+
+    def test_records_crash_before_restart_when_crash_error_set(self) -> None:
+        repo_cfg = _repo()
+        w, registry = _make({"owner/repo": repo_cfg})
+        registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = "RuntimeError: boom"
+        w.run()
+        registry.record_crash.assert_called_once_with(
+            "owner/repo", "RuntimeError: boom"
+        )
+        registry.start.assert_called_once_with(repo_cfg)
+
+    def test_record_crash_called_before_start(self) -> None:
+        call_order: list[str] = []
+        repo_cfg = _repo()
+        w, registry = _make({"owner/repo": repo_cfg})
+        registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = "ValueError: oops"
+        registry.record_crash.side_effect = lambda *_: call_order.append("record_crash")
+        registry.start.side_effect = lambda *_: call_order.append("start")
+        w.run()
+        assert call_order == ["record_crash", "start"]
+
+    def test_does_not_record_crash_when_crash_error_is_none(self) -> None:
+        repo_cfg = _repo()
+        w, registry = _make({"owner/repo": repo_cfg})
+        registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = None
+        w.run()
+        registry.record_crash.assert_not_called()
+        registry.start.assert_called_once_with(repo_cfg)
 
     def test_no_repos_is_no_op(self) -> None:
         w, registry = _make({})

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7960,30 +7960,19 @@ class TestWorkerThread:
 
         mock_wake.wait.assert_called_once_with(timeout=wmod._RETRY_TIMEOUT)
 
-    def test_exception_is_caught_and_loop_continues(self, tmp_path: Path) -> None:
-        """An unexpected exception should be caught; loop continues after wait."""
-        import kennel.worker as wmod
-
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_exception_kills_thread(self, tmp_path: Path) -> None:
+        """An unexpected exception propagates and kills the thread."""
         wt = self._make_thread(tmp_path)
-        mock_wake = MagicMock()
-        wt._wake = mock_wake
-        call_count = 0
 
         def fake_worker_run(self_ignored=None) -> int:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise RuntimeError("boom")
-            wt._stop = True
-            return 0
+            raise RuntimeError("boom")
 
         with patch.object(Worker, "run", fake_worker_run):
-            self._run_thread(wt)
+            wt.start()
+            wt.join(timeout=5.0)
 
-        assert call_count == 2
-        assert mock_wake.wait.call_count == 2
-        first_timeout = mock_wake.wait.call_args_list[0].kwargs["timeout"]
-        assert first_timeout == wmod._ERROR_TIMEOUT
+        assert not wt.is_alive()
 
     def test_stop_flag_exits_loop_before_next_iteration(self, tmp_path: Path) -> None:
         """Setting stop before run() starts should cause immediate exit."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7974,6 +7974,51 @@ class TestWorkerThread:
 
         assert not wt.is_alive()
 
+    def test_crash_error_is_none_initially(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt.crash_error is None
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_crash_error_set_on_exception(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+
+        def fake_worker_run(self_ignored=None) -> int:
+            raise ValueError("bad value")
+
+        with patch.object(Worker, "run", fake_worker_run):
+            wt.start()
+            wt.join(timeout=5.0)
+
+        assert wt.crash_error == "ValueError: bad value"
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_crash_error_includes_exception_type(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+
+        def fake_worker_run(self_ignored=None) -> int:
+            raise RuntimeError("boom")
+
+        with patch.object(Worker, "run", fake_worker_run):
+            wt.start()
+            wt.join(timeout=5.0)
+
+        assert wt.crash_error is not None
+        assert wt.crash_error.startswith("RuntimeError:")
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_crash_error_logs_exception(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+
+        def fake_worker_run(self_ignored=None) -> int:
+            raise RuntimeError("boom")
+
+        with patch.object(Worker, "run", fake_worker_run):
+            with patch("kennel.worker.log") as mock_log:
+                wt.start()
+                wt.join(timeout=5.0)
+
+        mock_log.exception.assert_called_once()
+
     def test_stop_flag_exits_loop_before_next_iteration(self, tmp_path: Path) -> None:
         """Setting stop before run() starts should cause immediate exit."""
         wt = self._make_thread(tmp_path)


### PR DESCRIPTION
Adds crash tracking to the worker system so that when a fido thread dies from an unexpected exception, the details are recorded and surfaced in status output. Watchdog captures crash details before restarting dead threads, WorkerRegistry exposes crash history through RepoStatus and format_status output, and defensive `.get()` calls are replaced with direct key access where fields are guaranteed present.

Fixes #71.

Fixes #372.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] [Replace defensive `.get()` calls with direct key access where the field is guaranteed present](https://github.com/FidoCanCode/home/pull/381#issuecomment-4239366640) <!-- type:thread -->
- [x] Expose crash info in RepoStatus and format_status output <!-- type:spec -->
- [x] Add crash-tracking fields to WorkerRegistry <!-- type:spec -->
- [x] Make WorkerThread.run() exit on unexpected exceptions instead of retrying <!-- type:spec -->
- [x] [Stop swallowing exceptions; propagate to top-level handler](https://github.com/FidoCanCode/home/pull/381#issuecomment-4239353469) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->