### PR TITLE
Stop acknowledging webhook work that later fails (closes #373)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -173,6 +173,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     registry: WorkerRegistry
     # Injectable callables — set as class attributes so HTTP-driven tests can
     # replace them without patching module-level names.
+    _fn_get_github = GitHub
     _fn_dispatch = dispatch
     _fn_reply_to_comment = reply_to_comment
     _fn_reply_to_review = reply_to_review
@@ -332,6 +333,27 @@ class WebhookHandler(BaseHTTPRequestHandler):
             type(self)._fn_launch_worker(repo_cfg, self.registry)
         except Exception:
             log.exception("error processing action")
+            self._signal_action_error(action)
+
+    def _signal_action_error(self, action) -> None:
+        """Post a 'confused' reaction on the triggering comment, if any.
+
+        Called when _process_action raises so the comment author sees something
+        went wrong rather than silence.  Reaction failures are caught — if
+        signalling itself fails we log and move on rather than masking the
+        original error.
+        """
+        thread = action.reply_to or action.thread
+        if not thread:
+            return
+        repo = thread.get("repo")
+        comment_id = thread.get("comment_id")
+        comment_type = thread.get("comment_type", "issues")
+        try:
+            gh = type(self)._fn_get_github()
+            gh.add_reaction(repo, comment_type, comment_id, "confused")
+        except Exception:
+            log.exception("failed to post error reaction on comment %s", comment_id)
 
     def _self_restart(self, repo_name: str, *, reason: str = "") -> None:
         runner_dir = type(self)._fn_runner_dir()

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -173,6 +173,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     registry: WorkerRegistry
     # Injectable callables — set as class attributes so HTTP-driven tests can
     # replace them without patching module-level names.
+    _fn_dispatch = dispatch
     _fn_reply_to_comment = reply_to_comment
     _fn_reply_to_review = reply_to_review
     _fn_reply_to_issue_comment = reply_to_issue_comment
@@ -223,34 +224,50 @@ class WebhookHandler(BaseHTTPRequestHandler):
             delivery,
         )
 
-        # Respond immediately — don't block on dispatch
-        self._respond(200, "ok")
-
-        # Check for self-restart: merged PR or push to default branch.
-        # _self_restart verifies via the runner clone's git remote that the
-        # webhook's repo actually matches kennel — if so it execs a new
-        # process and never returns.  For non-kennel repos it's a no-op.
-        if (
+        # Pre-compute self-restart triggers — needed for both registered and
+        # unregistered repos (_self_restart verifies the runner's git remote).
+        default_branch = payload.get("repository", {}).get("default_branch", "")
+        is_pr_merged = (
             event == "pull_request"
             and payload.get("action") == "closed"
-            and payload.get("pull_request", {}).get("merged")
-        ):
-            self._self_restart(repo_name, reason="PR merged")
-
-        default_branch = payload.get("repository", {}).get("default_branch", "")
-        if (
+            and bool(payload.get("pull_request", {}).get("merged"))
+        )
+        is_default_push = (
             event == "push"
-            and default_branch
+            and bool(default_branch)
             and payload.get("ref") == f"refs/heads/{default_branch}"
-        ):
-            self._self_restart(repo_name, reason=f"push to {default_branch}")
+        )
 
         if not repo_cfg:
-            log.debug("ignoring webhook for unregistered repo: %s", repo_name)
+            # Nothing to dispatch — ack immediately, then maybe self-restart.
+            self._respond(200, "ok")
+            if is_pr_merged:
+                self._self_restart(repo_name, reason="PR merged")
+            elif is_default_push:
+                self._self_restart(repo_name, reason=f"push to {default_branch}")
+            else:
+                log.debug("ignoring webhook for unregistered repo: %s", repo_name)
             return
 
-        # Process in background thread so we don't block the server
-        action = dispatch(event, payload, self.config, repo_cfg)
+        # Dispatch BEFORE acknowledging — if dispatch raises, return 500 so
+        # GitHub retries instead of treating the event as successfully handled.
+        try:
+            action = type(self)._fn_dispatch(event, payload, self.config, repo_cfg)
+        except Exception:
+            log.exception("dispatch failed for %s", repo_name)
+            self._respond(500, "dispatch error")
+            return
+
+        # Acknowledge only after dispatch succeeds.
+        self._respond(200, "ok")
+
+        # Self-restart after ack so the response reaches GitHub before exec.
+        if is_pr_merged:
+            self._self_restart(repo_name, reason="PR merged")
+        elif is_default_push:
+            self._self_restart(repo_name, reason=f"push to {default_branch}")
+
+        # Process in background thread so we don't block the server.
         if action:
             threading.Thread(
                 target=self._process_action,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 @pytest.fixture(autouse=True)
 def _restore_handler_fns():
     saved = {
+        "_fn_get_github": WebhookHandler._fn_get_github,
         "_fn_dispatch": WebhookHandler._fn_dispatch,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
@@ -512,11 +513,144 @@ class TestProcessAction:
             "action": "closed",
             "pull_request": {"number": 13, "merged": True},
         }
+        WebhookHandler._fn_get_github = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=Exception("explode"))
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
         time.sleep(0.2)
         # server still alive — no crash
+
+    def test_process_action_error_reacts_on_reply_to(self, server: tuple) -> None:
+        """On exception with a reply_to comment, adds a confused reaction."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 500,
+                "body": "looks bad",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "x.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 20, "title": "T", "body": ""},
+        }
+        mock_gh = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        time.sleep(0.2)
+        mock_gh.add_reaction.assert_called_once_with(
+            "owner/repo", "pulls", 500, "confused"
+        )
+
+    def test_process_action_error_reacts_on_thread(self, server: tuple) -> None:
+        """On exception with a thread comment (issue_comment), adds a confused reaction."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 501,
+                "body": "question?",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/21#issuecomment-501",
+            },
+            "issue": {
+                "number": 21,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        mock_gh = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        _post_webhook(url, cfg, "issue_comment", payload)
+        time.sleep(0.2)
+        mock_gh.add_reaction.assert_called_once_with(
+            "owner/repo", "issues", 501, "confused"
+        )
+
+    def test_process_action_error_no_reaction_without_comment(
+        self, server: tuple
+    ) -> None:
+        """On exception with no comment context (e.g., merged PR), no reaction."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "closed",
+            "pull_request": {"number": 22, "merged": True},
+        }
+        mock_gh_factory = MagicMock()
+        WebhookHandler._fn_get_github = mock_gh_factory
+        WebhookHandler._fn_launch_worker = MagicMock(side_effect=RuntimeError("boom"))
+        _post_webhook(url, cfg, "pull_request", payload)
+        time.sleep(0.2)
+        mock_gh_factory.assert_not_called()
+
+    def test_process_action_error_no_reaction_when_comment_id_missing(
+        self, server: tuple
+    ) -> None:
+        """No reaction when thread has no comment_id (e.g., review submission)."""
+        url, cfg = server
+        # review submission: reply_to=None, thread=None, review_comments set
+        payload = {
+            **self._payload(),
+            "action": "submitted",
+            "review": {
+                "id": 888,
+                "state": "changes_requested",
+                "user": {"login": "owner"},
+            },
+            "pull_request": {"number": 24},
+        }
+        mock_gh_factory = MagicMock()
+        WebhookHandler._fn_get_github = mock_gh_factory
+        WebhookHandler._fn_reply_to_review = MagicMock(side_effect=RuntimeError("boom"))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        _post_webhook(url, cfg, "pull_request_review", payload)
+        time.sleep(0.2)
+        mock_gh_factory.assert_not_called()
+
+    def test_process_action_error_reaction_failure_doesnt_crash(
+        self, server: tuple
+    ) -> None:
+        """add_reaction failure is caught — server stays alive."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 502,
+                "body": "yo",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "x.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 23, "title": "T", "body": ""},
+        }
+        mock_gh = MagicMock()
+        mock_gh.add_reaction.side_effect = RuntimeError("reaction failed")
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=RuntimeError("process boom")
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        assert status == 200
+        time.sleep(0.2)
+        mock_gh.add_reaction.assert_called_once()
 
     def test_dispatch_error_returns_500(self, server: tuple) -> None:
         """When dispatch raises, return 500 so GitHub retries the delivery."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 @pytest.fixture(autouse=True)
 def _restore_handler_fns():
     saved = {
+        "_fn_dispatch": WebhookHandler._fn_dispatch,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
@@ -516,6 +517,52 @@ class TestProcessAction:
         assert status == 200
         time.sleep(0.2)
         # server still alive — no crash
+
+    def test_dispatch_error_returns_500(self, server: tuple) -> None:
+        """When dispatch raises, return 500 so GitHub retries the delivery."""
+        url, cfg = server
+        payload = {**self._payload(), "action": "created"}
+        WebhookHandler._fn_dispatch = MagicMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        assert exc_info.value.code == 500
+
+    def test_dispatch_called_before_ack(self, server: tuple) -> None:
+        """dispatch() must be called before the HTTP response is written."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 999,
+                "body": "hey",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "x.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 99, "title": "T", "body": ""},
+        }
+        call_order: list[str] = []
+
+        def fake_dispatch(*_args, **_kwargs):
+            call_order.append("dispatch")
+            return None
+
+        original_respond = WebhookHandler._respond
+
+        def fake_respond(self, code, msg):
+            call_order.append(f"respond_{code}")
+            original_respond(self, code, msg)
+
+        WebhookHandler._fn_dispatch = fake_dispatch
+        WebhookHandler._respond = fake_respond  # type: ignore[method-assign]
+        try:
+            _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        finally:
+            WebhookHandler._respond = original_respond  # type: ignore[method-assign]
+        assert call_order == ["dispatch", "respond_200"]
 
 
 class TestPopulateMemberships:
@@ -1331,5 +1378,72 @@ class TestSelfRestart:
             time.sleep(0.2)
             mock_pull.assert_not_called()
             mock_exec.assert_not_called()
+        finally:
+            srv.shutdown()
+
+    def _make_unregistered_server(self, tmp_path: Path):
+        """Server whose config does NOT include the kennel repo."""
+        from kennel.config import RepoMembership
+
+        cfg = Config(
+            port=0,
+            secret=b"test-secret",
+            repos={
+                "owner/other": RepoConfig(
+                    name="owner/other",
+                    work_dir=tmp_path,
+                    membership=RepoMembership(collaborators=frozenset()),
+                )
+            },
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_registry = MagicMock()
+        WebhookHandler.config = cfg
+        WebhookHandler.registry = mock_registry
+        srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
+        port = srv.server_address[1]
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        return srv, f"http://127.0.0.1:{port}", cfg
+
+    def test_merged_pr_on_unregistered_repo_triggers_restart(
+        self, tmp_path: Path
+    ) -> None:
+        """Self-restart fires for merged PR even when the repo is not registered."""
+        srv, url, cfg = self._make_unregistered_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+            WebhookHandler._fn_pull_with_backoff = lambda _d: True
+            mock_chdir = MagicMock()
+            mock_exec = MagicMock()
+            WebhookHandler._fn_os_chdir = mock_chdir
+            WebhookHandler._fn_os_execvp = mock_exec
+            status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            assert status == 200
+            time.sleep(0.2)
+            mock_exec.assert_called_once()
+        finally:
+            srv.shutdown()
+
+    def test_push_to_default_on_unregistered_repo_triggers_restart(
+        self, tmp_path: Path
+    ) -> None:
+        """Self-restart fires for push to default branch even when repo is not registered."""
+        srv, url, cfg = self._make_unregistered_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path
+            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
+            WebhookHandler._fn_pull_with_backoff = lambda _d: True
+            mock_chdir = MagicMock()
+            mock_exec = MagicMock()
+            WebhookHandler._fn_os_chdir = mock_chdir
+            WebhookHandler._fn_os_execvp = mock_exec
+            status = _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
+            assert status == 200
+            time.sleep(0.2)
+            mock_exec.assert_called_once()
         finally:
             srv.shutdown()


### PR DESCRIPTION
Harden webhook reliability: defer the HTTP 200 response until after event dispatch succeeds so GitHub retries on transient failures, and surface errors from `_process_action` so problems are visible instead of silently swallowed.

Fixes #373.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] PR comment: add personal life touches to blog posts, update CLAUDE.md <!-- type:thread -->
- [x] [Generate and commit the missing stats file for 2026-04-12](https://github.com/FidoCanCode/home/pull/384#issuecomment-4239514787) <!-- type:thread -->
- [x] [Restore the deleted 2026-04-06.yml stats file without modifications](https://github.com/FidoCanCode/home/pull/384#discussion_r3075739839) <!-- type:thread -->
- [x] [Rewrite the journal entry as a normal daily post instead of a weekly reflection](https://github.com/FidoCanCode/home/pull/384#discussion_r3075712740) <!-- type:thread -->
- [x] [Remove weekly stats file and regenerate stats for 2026-04-12 only](https://github.com/FidoCanCode/home/pull/384#discussion_r3075709436) <!-- type:thread -->
- [x] [Generate and commit the missing stats file for 2026-04-12](https://github.com/FidoCanCode/home/pull/384#issuecomment-4239514787) <!-- type:thread -->
- [x] Write journal entry for 2026-04-12 with stats <!-- type:spec -->
- [x] Defer HTTP 200 until after dispatch succeeds <!-- type:spec -->
- [x] Add visible error handling for _process_action failures <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->