### PR TITLE
Validate GitHub GraphQL responses as required contracts (closes #374)

### DIFF
--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -53,9 +53,9 @@ class Cmd:
             owner, repo_name = repo.split("/", 1)
             threads = self._github.get_review_threads(owner, repo_name, pr)
             for t in threads:
-                if t.get("isResolved"):
+                if t["isResolved"]:
                     continue
-                nodes = t.get("comments", {}).get("nodes", [])
+                nodes = t["comments"]["nodes"]
                 if nodes and nodes[0].get("databaseId") == comment_id:
                     self._github.resolve_thread(t["id"])
                     log.info("thread resolved: %s", t["id"])

--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -51,10 +51,7 @@ class Cmd:
                 return
 
             owner, repo_name = repo.split("/", 1)
-            data = self._github.get_review_threads(owner, repo_name, pr)
-            threads = data["data"]["repository"]["pullRequest"]["reviewThreads"][
-                "nodes"
-            ]
+            threads = self._github.get_review_threads(owner, repo_name, pr)
             for t in threads:
                 if t.get("isResolved"):
                     continue

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -15,6 +15,15 @@ import requests as _requests
 
 log = logging.getLogger(__name__)
 
+
+class GraphQLError(Exception):
+    """Raised when a GitHub GraphQL response contains an errors field."""
+
+    def __init__(self, errors: list[Any]) -> None:
+        super().__init__(f"GraphQL errors: {errors}")
+        self.errors = errors
+
+
 # ── Requests-based GitHub API client ─────────────────────────────────────────
 
 
@@ -81,7 +90,10 @@ class GH:
             json={"query": query, "variables": variables},
         )
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if "errors" in data:
+            raise GraphQLError(data["errors"])
+        return data
 
     def add_reaction(
         self, repo: str, comment_type: str, comment_id: int | str, content: str
@@ -234,9 +246,6 @@ class GH:
                 number=int(issue_number),
                 cursor=cursor,
             )
-            if "errors" in data:
-                log.warning("find_pr GraphQL error: %s", data["errors"])
-                return None
             items = (
                 data.get("data", {})
                 .get("repository", {})

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -246,15 +246,10 @@ class GH:
                 number=int(issue_number),
                 cursor=cursor,
             )
-            items = (
-                data.get("data", {})
-                .get("repository", {})
-                .get("issue", {})
-                .get("timelineItems", {})
-            )
+            items = data["data"]["repository"]["issue"]["timelineItems"]
             if not items:
                 return None
-            for node in items.get("nodes", []):
+            for node in items["nodes"]:
                 typename = node["__typename"]
                 if typename == "CrossReferencedEvent":
                     pr = node.get("source") or {}
@@ -280,10 +275,10 @@ class GH:
                     pr = node.get("subject") or {}
                     if pr.get("__typename") == "PullRequest":
                         sidebar_prs.discard(pr["number"])
-            page_info = items.get("pageInfo", {})
-            if not page_info.get("hasNextPage"):
+            page_info = items["pageInfo"]
+            if not page_info["hasNextPage"]:
                 break
-            cursor = page_info.get("endCursor")
+            cursor = page_info["endCursor"]
         eligible = keyword_prs | sidebar_prs
         for pr_num, pr in pr_cache.items():
             if pr_num not in eligible or pr.get("state") != "OPEN":
@@ -546,8 +541,8 @@ class GH:
 
     def get_review_threads(
         self, owner: str, repo: str, pr: int | str
-    ) -> dict[str, Any]:
-        """Return full review-thread data for a PR (GraphQL)."""
+    ) -> list[dict[str, Any]]:
+        """Return review-thread nodes for a PR."""
         query = (
             "query($owner:String!,$repo:String!,$pr:Int!){"
             "repository(owner:$owner,name:$repo){"
@@ -557,7 +552,8 @@ class GH:
             " comments(first:50){nodes{author{login} body url createdAt databaseId}}"
             "}}}}}"
         )
-        return self._graphql(query, owner=owner, repo=repo, pr=int(pr))
+        data = self._graphql(query, owner=owner, repo=repo, pr=int(pr))
+        return data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
 
     def resolve_thread(self, thread_id: str) -> None:
         """Resolve a review thread via GraphQL mutation."""
@@ -759,8 +755,8 @@ class GitHub:
 
     def get_review_threads(
         self, owner: str, repo: str, pr: int | str
-    ) -> dict[str, Any]:
-        """Return full review-thread data for a PR (GraphQL)."""
+    ) -> list[dict[str, Any]]:
+        """Return review-thread nodes for a PR."""
         return self._gh.get_review_threads(owner, repo, pr)
 
     def resolve_thread(self, thread_id: str) -> None:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -274,8 +274,8 @@ def _auto_complete_ask_tasks(
 
     resolved_ids: set[int] = set()
     for node in nodes:
-        if node.get("isResolved"):
-            comments = node.get("comments", {}).get("nodes", [])
+        if node["isResolved"]:
+            comments = node["comments"]["nodes"]
             if comments and comments[0].get("databaseId"):
                 resolved_ids.add(int(comments[0]["databaseId"]))
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -267,19 +267,13 @@ def _auto_complete_ask_tasks(
 
     try:
         owner, repo_name = repo.split("/", 1)
-        threads_data = gh.get_review_threads(owner, repo_name, pr_number)
+        nodes = gh.get_review_threads(owner, repo_name, pr_number)
     except Exception:
         log.exception("sync_tasks: failed to fetch review threads for ASK resolution")
         return
 
     resolved_ids: set[int] = set()
-    for node in (
-        threads_data.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    ):
+    for node in nodes:
         if node.get("isResolved"):
             comments = node.get("comments", {}).get("nodes", [])
             if comments and comments[0].get("databaseId"):

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -796,24 +796,24 @@ class Worker:
         keywords = {check_name.lower(), "ci", "lint", "format"}
         result = []
         for node in nodes:
-            if node.get("isResolved"):
+            if node["isResolved"]:
                 continue
-            comments = node.get("comments", {}).get("nodes", [])
+            comments = node["comments"]["nodes"]
             if not comments:
                 continue
             last = comments[-1]
-            if last.get("author", {}).get("login") == gh_user:
+            if (last.get("author") or {}).get("login") == gh_user:
                 continue
-            bodies = " ".join(c.get("body", "").lower() for c in comments)
+            bodies = " ".join(c["body"].lower() for c in comments)
             if not any(kw in bodies for kw in keywords):
                 continue
             result.append(
                 {
-                    "first_author": comments[0].get("author", {}).get("login", ""),
-                    "first_body": comments[0].get("body", ""),
-                    "last_author": last.get("author", {}).get("login", ""),
-                    "last_body": last.get("body", ""),
-                    "url": comments[0].get("url", ""),
+                    "first_author": (comments[0].get("author") or {}).get("login", ""),
+                    "first_body": comments[0]["body"],
+                    "last_author": (last.get("author") or {}).get("login", ""),
+                    "last_body": last["body"],
+                    "url": comments[0]["url"],
                 }
             )
         return result
@@ -901,30 +901,29 @@ class Worker:
         """
         result = []
         for node in nodes:
-            if node.get("isResolved"):
+            if node["isResolved"]:
                 continue
-            comments = node.get("comments", {}).get("nodes", [])
+            comments = node["comments"]["nodes"]
             if not comments:
                 continue
             first_comment = comments[0]
             last_comment = comments[-1]
-            last_author = last_comment.get("author", {}).get("login", "")
+            last_author = (last_comment.get("author") or {}).get("login", "")
             if last_author == gh_user:
                 continue
             if last_author not in collaborators and not last_author.endswith("[bot]"):
                 continue
+            first_login = (first_comment.get("author") or {}).get("login", "")
             result.append(
                 {
-                    "id": node.get("id", ""),
-                    "is_bot": first_comment.get("author", {})
-                    .get("login", "")
-                    .endswith("[bot]"),
-                    "first_author": first_comment.get("author", {}).get("login", ""),
+                    "id": node["id"],
+                    "is_bot": first_login.endswith("[bot]"),
+                    "first_author": first_login,
                     "first_db_id": first_comment.get("databaseId"),
-                    "first_body": first_comment.get("body", ""),
+                    "first_body": first_comment["body"],
                     "last_author": last_author,
-                    "last_body": last_comment.get("body", ""),
-                    "url": first_comment.get("url", ""),
+                    "last_body": last_comment["body"],
+                    "url": first_comment["url"],
                     "total": len(comments),
                 }
             )
@@ -947,12 +946,12 @@ class Worker:
         )
         resolved_any = False
         for node in nodes:
-            if node.get("isResolved"):
+            if node["isResolved"]:
                 continue
-            comments = node.get("comments", {}).get("nodes", [])
+            comments = node["comments"]["nodes"]
             if not comments:
                 continue
-            last_author = comments[-1].get("author", {}).get("login", "")
+            last_author = (comments[-1].get("author") or {}).get("login", "")
             if last_author != repo_ctx.gh_user:
                 continue
             comment_ids = [
@@ -961,10 +960,10 @@ class Worker:
             if any(self._tasks.has_pending_for_comment(cid) for cid in comment_ids):
                 log.info(
                     "skipping resolve for thread %s — pending sibling tasks remain",
-                    node.get("id", ""),
+                    node["id"],
                 )
                 continue
-            thread_id = node.get("id", "")
+            thread_id = node["id"]
             self.gh.resolve_thread(thread_id)
             log.info("resolved thread %s", thread_id)
             resolved_any = True

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -781,7 +781,7 @@ class Worker:
 
     def _filter_ci_threads(
         self,
-        threads_data: dict[str, Any],
+        nodes: list[dict[str, Any]],
         gh_user: str,
         check_name: str,
     ) -> list[dict[str, Any]]:
@@ -794,13 +794,6 @@ class Worker:
           "format" (case-insensitive).
         """
         keywords = {check_name.lower(), "ci", "lint", "format"}
-        nodes = (
-            threads_data.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
-            .get("reviewThreads", {})
-            .get("nodes", [])
-        )
         result = []
         for node in nodes:
             if node.get("isResolved"):
@@ -867,10 +860,11 @@ class Worker:
         else:
             failure_log = ""
 
-        threads_data = self.gh.get_review_threads(
-            repo_ctx.owner, repo_ctx.repo_name, pr_number
+        ci_threads = self._filter_ci_threads(
+            self.gh.get_review_threads(repo_ctx.owner, repo_ctx.repo_name, pr_number),
+            repo_ctx.gh_user,
+            check_name,
         )
-        ci_threads = self._filter_ci_threads(threads_data, repo_ctx.gh_user, check_name)
 
         context = (
             f"PR: {pr_number}\n"
@@ -893,7 +887,7 @@ class Worker:
 
     def _filter_threads(
         self,
-        threads_data: dict[str, Any],
+        nodes: list[dict[str, Any]],
         gh_user: str,
         collaborators: tuple[str, ...],
     ) -> list[dict[str, Any]]:
@@ -905,13 +899,6 @@ class Worker:
         - the last commenter is not *gh_user* (awaiting a response), and
         - the last commenter is either in *collaborators* or ends with ``[bot]``.
         """
-        nodes = (
-            threads_data.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
-            .get("reviewThreads", {})
-            .get("nodes", [])
-        )
         result = []
         for node in nodes:
             if node.get("isResolved"):
@@ -955,15 +942,8 @@ class Worker:
 
         Returns ``True`` if at least one thread was resolved.
         """
-        threads_data = self.gh.get_review_threads(
+        nodes = self.gh.get_review_threads(
             repo_ctx.owner, repo_ctx.repo_name, pr_number
-        )
-        nodes = (
-            threads_data.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
-            .get("reviewThreads", {})
-            .get("nodes", [])
         )
         resolved_any = False
         for node in nodes:
@@ -1003,11 +983,10 @@ class Worker:
         ``False`` if there are no actionable threads.
         """
         log.info("checking: threads")
-        threads_data = self.gh.get_review_threads(
-            repo_ctx.owner, repo_ctx.repo_name, pr_number
-        )
         threads = self._filter_threads(
-            threads_data, repo_ctx.gh_user, repo_ctx.collaborators
+            self.gh.get_review_threads(repo_ctx.owner, repo_ctx.repo_name, pr_number),
+            repo_ctx.gh_user,
+            repo_ctx.collaborators,
         )
         if not threads:
             return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,23 +211,13 @@ class TestCmdComplete:
                 "created_at": "2024-01-02T00:00:00Z",
             },
         ]
-        mock_github.get_review_threads.return_value = {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [
-                                {
-                                    "id": "thread_node_abc",
-                                    "isResolved": False,
-                                    "comments": {"nodes": [{"databaseId": 42}]},
-                                }
-                            ]
-                        }
-                    }
-                }
+        mock_github.get_review_threads.return_value = [
+            {
+                "id": "thread_node_abc",
+                "isResolved": False,
+                "comments": {"nodes": [{"databaseId": 42}]},
             }
-        }
+        ]
 
         with caplog.at_level(logging.INFO, logger="kennel"):
             Cmd(github=mock_github).complete(tmp_path, task["id"])
@@ -326,23 +316,13 @@ class TestCmdComplete:
                 "created_at": "2024-01-01T00:00:00Z",
             },
         ]
-        mock_github.get_review_threads.return_value = {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "nodes": [
-                                {
-                                    "id": "thread_node_abc",
-                                    "isResolved": True,
-                                    "comments": {"nodes": [{"databaseId": 42}]},
-                                }
-                            ]
-                        }
-                    }
-                }
+        mock_github.get_review_threads.return_value = [
+            {
+                "id": "thread_node_abc",
+                "isResolved": True,
+                "comments": {"nodes": [{"databaseId": 42}]},
             }
-        }
+        ]
 
         Cmd(github=mock_github).complete(tmp_path, task["id"])
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -9,6 +9,7 @@ import pytest
 from kennel.github import (
     GH,
     GitHub,
+    GraphQLError,
     _get_gh,
     _gh_token,
     get_github,
@@ -538,16 +539,22 @@ class TestGHClass:
         assert body["variables"] == {"login": "fido"}
         assert result == {"data": {}}
 
-    def test_graphql_raises_on_error(self) -> None:
+    def test_graphql_raises_on_http_error(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()
         mock_resp.raise_for_status.side_effect = Exception("500")
         mock_s.post.return_value = mock_resp
-        try:
+        with pytest.raises(Exception, match="500"):
             gh._graphql("query {}")
-            assert False, "should have raised"
-        except Exception as e:
-            assert "500" in str(e)
+
+    def test_graphql_raises_on_payload_error(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"errors": [{"message": "not found"}]}
+        mock_s.post.return_value = mock_resp
+        with pytest.raises(GraphQLError) as exc_info:
+            gh._graphql("query {}")
+        assert exc_info.value.errors == [{"message": "not found"}]
 
     def test_add_reaction_pulls(self) -> None:
         gh, mock_s = self._gh()
@@ -1060,12 +1067,13 @@ class TestGHClass:
         mock_s.post.return_value.json.return_value = self._gql_timeline([node])
         assert gh.find_pr("o/r", 5, "fido") is None
 
-    def test_find_pr_returns_none_on_graphql_error(self) -> None:
+    def test_find_pr_raises_on_graphql_error(self) -> None:
         gh, mock_s = self._gh()
         mock_s.post.return_value.json.return_value = {
             "errors": [{"message": "something went wrong"}]
         }
-        assert gh.find_pr("o/r", 1, "fido") is None
+        with pytest.raises(GraphQLError):
+            gh.find_pr("o/r", 1, "fido")
 
     def test_find_pr_returns_none_on_empty_timeline(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -390,14 +390,14 @@ class TestGitHubClass:
 
     def test_get_review_threads_delegates(self) -> None:
         gh, mock_s = self._github()
-        payload = {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
-        }
+        nodes = [{"id": "T_1", "isResolved": False}]
         mock_resp = MagicMock()
-        mock_resp.json.return_value = payload
+        mock_resp.json.return_value = {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
         mock_s.post.return_value = mock_resp
         result = gh.get_review_threads("o", "r", 10)
-        assert result == payload
+        assert result == nodes
 
     def test_resolve_thread_delegates(self) -> None:
         gh, mock_s = self._github()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3198,11 +3198,6 @@ class TestFilterCiThreads:
     def _make_worker(self, tmp_path: Path) -> Worker:
         return Worker(tmp_path, MagicMock())
 
-    def _make_threads_data(self, nodes: list) -> dict:
-        return {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
-
     def _make_node(
         self,
         *,
@@ -3233,67 +3228,96 @@ class TestFilterCiThreads:
 
     def test_returns_empty_when_no_threads(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        assert w._filter_ci_threads({}, "fido-bot", "test") == []
+        assert w._filter_ci_threads([], "fido-bot", "test") == []
 
     def test_excludes_resolved_threads(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(resolved=True, first_body="ci failing")
-        data = self._make_threads_data([node])
-        assert w._filter_ci_threads(data, "reviewer", "test") == []
+        assert (
+            w._filter_ci_threads(
+                [self._make_node(resolved=True, first_body="ci failing")],
+                "reviewer",
+                "test",
+            )
+            == []
+        )
 
     def test_excludes_threads_where_last_author_is_gh_user(
         self, tmp_path: Path
     ) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="fido-bot", last_body="ci fix")
-        data = self._make_threads_data([node])
-        assert w._filter_ci_threads(data, "fido-bot", "test") == []
+        assert (
+            w._filter_ci_threads(
+                [self._make_node(last_author="fido-bot", last_body="ci fix")],
+                "fido-bot",
+                "test",
+            )
+            == []
+        )
 
     def test_excludes_threads_without_ci_keywords(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="style nit", last_body="please rename var")
-        data = self._make_threads_data([node])
-        assert w._filter_ci_threads(data, "fido-bot", "mycheck") == []
+        assert (
+            w._filter_ci_threads(
+                [
+                    self._make_node(
+                        first_body="style nit", last_body="please rename var"
+                    )
+                ],
+                "fido-bot",
+                "mycheck",
+            )
+            == []
+        )
 
     def test_includes_thread_matching_check_name(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="mycheck is red", last_body="please fix")
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "mycheck")
+        result = w._filter_ci_threads(
+            [self._make_node(first_body="mycheck is red", last_body="please fix")],
+            "fido-bot",
+            "mycheck",
+        )
         assert len(result) == 1
 
     def test_includes_thread_mentioning_ci(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="CI broke after your commit")
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "unrelated-check")
+        result = w._filter_ci_threads(
+            [self._make_node(first_body="CI broke after your commit")],
+            "fido-bot",
+            "unrelated-check",
+        )
         assert len(result) == 1
 
     def test_includes_thread_mentioning_lint(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="lint errors in this file")
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "check")
+        result = w._filter_ci_threads(
+            [self._make_node(first_body="lint errors in this file")],
+            "fido-bot",
+            "check",
+        )
         assert len(result) == 1
 
     def test_includes_thread_mentioning_format(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="format issue here")
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "check")
+        result = w._filter_ci_threads(
+            [self._make_node(first_body="format issue here")], "fido-bot", "check"
+        )
         assert len(result) == 1
 
     def test_maps_fields_correctly(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(
-            first_author="alice",
-            first_body="CI is red",
-            last_author="bob",
-            last_body="still red",
-            url="https://github.com/x",
+        result = w._filter_ci_threads(
+            [
+                self._make_node(
+                    first_author="alice",
+                    first_body="CI is red",
+                    last_author="bob",
+                    last_body="still red",
+                    url="https://github.com/x",
+                )
+            ],
+            "fido-bot",
+            "ci",
         )
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "ci")
         assert result[0] == {
             "first_author": "alice",
             "first_body": "CI is red",
@@ -3304,9 +3328,9 @@ class TestFilterCiThreads:
 
     def test_case_insensitive_keyword_match(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_body="LINT errors found")
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "check")
+        result = w._filter_ci_threads(
+            [self._make_node(first_body="LINT errors found")], "fido-bot", "check"
+        )
         assert len(result) == 1
 
     def test_single_comment_node(self, tmp_path: Path) -> None:
@@ -3323,8 +3347,7 @@ class TestFilterCiThreads:
                 ]
             },
         }
-        data = self._make_threads_data([node])
-        result = w._filter_ci_threads(data, "fido-bot", "check")
+        result = w._filter_ci_threads([node], "fido-bot", "check")
         assert len(result) == 1
         assert result[0]["first_author"] == "alice"
         assert result[0]["last_author"] == "alice"
@@ -3332,8 +3355,7 @@ class TestFilterCiThreads:
     def test_skips_nodes_with_empty_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = {"isResolved": False, "comments": {"nodes": []}}
-        data = self._make_threads_data([node])
-        assert w._filter_ci_threads(data, "fido-bot", "check") == []
+        assert w._filter_ci_threads([node], "fido-bot", "check") == []
 
 
 class TestHandleCi:
@@ -3379,7 +3401,7 @@ class TestHandleCi:
             {"name": "test", "state": "FAILURE", "link": "runs/99"},
         ]
         gh.get_run_log.return_value = "line1\nline2"
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3397,7 +3419,7 @@ class TestHandleCi:
             {"name": "lint", "state": "ERROR", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3415,7 +3437,7 @@ class TestHandleCi:
             {"name": "unit-tests", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status") as mock_status,
@@ -3437,7 +3459,7 @@ class TestHandleCi:
             }
         ]
         gh.get_run_log.return_value = "some log output"
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3454,7 +3476,7 @@ class TestHandleCi:
         gh.pr_checks.return_value = [
             {"name": "build", "state": "FAILURE", "link": "no-run-id-here"},
         ]
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3473,7 +3495,7 @@ class TestHandleCi:
         ]
         long_log = "\n".join(f"line {i}" for i in range(300))
         gh.get_run_log.return_value = long_log
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         captured_context = {}
         with (
@@ -3497,7 +3519,7 @@ class TestHandleCi:
             {"name": "test", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3515,7 +3537,7 @@ class TestHandleCi:
             {"name": "my-check", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3538,7 +3560,7 @@ class TestHandleCi:
             {"name": "test", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3557,7 +3579,7 @@ class TestHandleCi:
             {"name": "my-check", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3575,7 +3597,7 @@ class TestHandleCi:
             {"name": "test", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3595,7 +3617,7 @@ class TestHandleCi:
             {"name": "err-check", "state": "ERROR", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status") as mock_status,
@@ -3616,7 +3638,7 @@ class TestHandleCi:
             {"name": "flaky", "state": "FAILURE", "link": ""},
         ]
         gh.get_run_log.return_value = ""
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -3750,11 +3772,6 @@ class TestFilterThreads:
     def _make_worker(self, tmp_path: Path) -> Worker:
         return Worker(tmp_path, MagicMock())
 
-    def _make_threads_data(self, nodes: list) -> dict:
-        return {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
-
     def _make_node(
         self,
         *,
@@ -3802,66 +3819,85 @@ class TestFilterThreads:
 
     def test_returns_empty_when_no_nodes(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        assert w._filter_threads({}, "fido-bot", frozenset({"owner"})) == []
+        assert w._filter_threads([], "fido-bot", frozenset({"owner"})) == []
 
     def test_excludes_resolved_threads(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(resolved=True)
-        data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
+        assert (
+            w._filter_threads(
+                [self._make_node(resolved=True)], "fido-bot", frozenset({"owner"})
+            )
+            == []
+        )
 
     def test_excludes_threads_where_last_author_is_gh_user(
         self, tmp_path: Path
     ) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="fido-bot", last_body="done")
-        data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
+        assert (
+            w._filter_threads(
+                [self._make_node(last_author="fido-bot", last_body="done")],
+                "fido-bot",
+                frozenset({"owner"}),
+            )
+            == []
+        )
 
     def test_excludes_threads_where_last_author_is_neither_owner_nor_bot(
         self, tmp_path: Path
     ) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="random-user", last_body="comment")
-        data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
+        assert (
+            w._filter_threads(
+                [self._make_node(last_author="random-user", last_body="comment")],
+                "fido-bot",
+                frozenset({"owner"}),
+            )
+            == []
+        )
 
     def test_includes_thread_from_owner(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="owner")
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
+        result = w._filter_threads(
+            [self._make_node(last_author="owner")], "fido-bot", frozenset({"owner"})
+        )
         assert len(result) == 1
 
     def test_includes_thread_from_bot(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="my-app[bot]", last_body="bot comment")
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
+        result = w._filter_threads(
+            [self._make_node(last_author="my-app[bot]", last_body="bot comment")],
+            "fido-bot",
+            frozenset({"owner"}),
+        )
         assert len(result) == 1
 
     def test_includes_thread_from_any_collaborator(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(last_author="bob")
-        data = self._make_threads_data([node])
         result = w._filter_threads(
-            data, "fido-bot", frozenset({"alice", "bob", "carol"})
+            [self._make_node(last_author="bob")],
+            "fido-bot",
+            frozenset({"alice", "bob", "carol"}),
         )
         assert len(result) == 1
 
     def test_maps_fields_correctly(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(
-            node_id="tid-42",
-            first_author="owner",
-            first_db_id=99,
-            first_body="first comment",
-            last_author="owner",
-            last_body="last comment",
-            url="https://github.com/x",
+        result = w._filter_threads(
+            [
+                self._make_node(
+                    node_id="tid-42",
+                    first_author="owner",
+                    first_db_id=99,
+                    first_body="first comment",
+                    last_author="owner",
+                    last_body="last comment",
+                    url="https://github.com/x",
+                )
+            ],
+            "fido-bot",
+            frozenset({"owner"}),
         )
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["id"] == "tid-42"
         assert result[0]["first_author"] == "owner"
         assert result[0]["first_db_id"] == 99
@@ -3873,41 +3909,48 @@ class TestFilterThreads:
 
     def test_is_bot_true_when_first_author_ends_with_bot(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_author="my-app[bot]", last_author="owner")
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
+        result = w._filter_threads(
+            [self._make_node(first_author="my-app[bot]", last_author="owner")],
+            "fido-bot",
+            frozenset({"owner"}),
+        )
         assert result[0]["is_bot"] is True
 
     def test_is_bot_false_when_first_author_is_human(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(first_author="owner", last_author="owner")
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
+        result = w._filter_threads(
+            [self._make_node(first_author="owner", last_author="owner")],
+            "fido-bot",
+            frozenset({"owner"}),
+        )
         assert result[0]["is_bot"] is False
 
     def test_excludes_threads_with_no_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
         node = {"id": "x", "isResolved": False, "comments": {"nodes": []}}
-        data = self._make_threads_data([node])
-        assert w._filter_threads(data, "fido-bot", frozenset({"owner"})) == []
+        assert w._filter_threads([node], "fido-bot", frozenset({"owner"})) == []
 
     def test_total_counts_all_comments(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
-        node = self._make_node(
-            first_author="owner",
-            last_author="owner",
-            last_body="final comment",
-            extra_comments=[
-                {
-                    "author": {"login": "owner"},
-                    "body": "mid",
-                    "url": "u",
-                    "databaseId": 2,
-                }
+        result = w._filter_threads(
+            [
+                self._make_node(
+                    first_author="owner",
+                    last_author="owner",
+                    last_body="final comment",
+                    extra_comments=[
+                        {
+                            "author": {"login": "owner"},
+                            "body": "mid",
+                            "url": "u",
+                            "databaseId": 2,
+                        }
+                    ],
+                )
             ],
+            "fido-bot",
+            frozenset({"owner"}),
         )
-        data = self._make_threads_data([node])
-        result = w._filter_threads(data, "fido-bot", frozenset({"owner"}))
         assert result[0]["total"] == 3
 
 
@@ -3927,11 +3970,6 @@ class TestResolveAddressedThreads:
             default_branch="main",
             membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
-
-    def _make_threads_data(self, nodes: list) -> dict:
-        return {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
 
     def _make_node(
         self,
@@ -3963,15 +4001,14 @@ class TestResolveAddressedThreads:
 
     def test_returns_false_when_no_threads(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is False
         gh.resolve_thread.assert_not_called()
 
     def test_returns_false_when_all_threads_resolved(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        node = self._make_node(resolved=True)
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [self._make_node(resolved=True)]
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is False
         gh.resolve_thread.assert_not_called()
@@ -3980,35 +4017,35 @@ class TestResolveAddressedThreads:
         self, tmp_path: Path
     ) -> None:
         worker, gh = self._make_worker(tmp_path)
-        node = self._make_node(last_author="owner")
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [self._make_node(last_author="owner")]
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is False
         gh.resolve_thread.assert_not_called()
 
     def test_returns_false_when_thread_has_no_comments(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        node = {"id": "t1", "isResolved": False, "comments": {"nodes": []}}
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [
+            {"id": "t1", "isResolved": False, "comments": {"nodes": []}}
+        ]
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is False
         gh.resolve_thread.assert_not_called()
 
     def test_resolves_thread_where_gh_user_is_last_author(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        node = self._make_node(node_id="tid-99", last_author="fido-bot")
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [
+            self._make_node(node_id="tid-99", last_author="fido-bot")
+        ]
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is True
         gh.resolve_thread.assert_called_once_with("tid-99")
 
     def test_resolves_multiple_threads(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        nodes = [
+        gh.get_review_threads.return_value = [
             self._make_node(node_id="t1", last_author="fido-bot"),
             self._make_node(node_id="t2", last_author="fido-bot"),
         ]
-        gh.get_review_threads.return_value = self._make_threads_data(nodes)
         result = worker.resolve_addressed_threads(self._repo_ctx(), 5)
         assert result is True
         assert gh.resolve_thread.call_count == 2
@@ -4017,17 +4054,16 @@ class TestResolveAddressedThreads:
 
     def test_skips_already_resolved_among_mixed(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        nodes = [
+        gh.get_review_threads.return_value = [
             self._make_node(node_id="t1", last_author="fido-bot", resolved=True),
             self._make_node(node_id="t2", last_author="fido-bot"),
         ]
-        gh.get_review_threads.return_value = self._make_threads_data(nodes)
         worker.resolve_addressed_threads(self._repo_ctx(), 1)
         gh.resolve_thread.assert_called_once_with("t2")
 
     def test_calls_get_review_threads_with_correct_args(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         worker.resolve_addressed_threads(self._repo_ctx(), 42)
         gh.get_review_threads.assert_called_once_with("owner", "repo", 42)
 
@@ -4048,7 +4084,7 @@ class TestResolveAddressedThreads:
                 ]
             },
         }
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [node]
         from kennel.types import TaskType
 
         tasks_mod.add_task(
@@ -4081,7 +4117,7 @@ class TestResolveAddressedThreads:
                 ]
             },
         }
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [node]
         # Task references reply comment (id=11), not the root (id=10)
         tasks_mod.add_task(
             tmp_path,
@@ -4107,7 +4143,7 @@ class TestResolveAddressedThreads:
                 ]
             },
         }
-        gh.get_review_threads.return_value = self._make_threads_data([node])
+        gh.get_review_threads.return_value = [node]
         from kennel.types import TaskType
 
         task = tasks_mod.add_task(
@@ -4144,11 +4180,6 @@ class TestHandleThreads:
         d.mkdir(parents=True, exist_ok=True)
         return d
 
-    def _threads_data_with_nodes(self, nodes: list) -> dict:
-        return {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
-
     def _open_thread_node(
         self, *, last_author: str = "owner", first_author: str = "owner"
     ) -> dict:
@@ -4175,14 +4206,14 @@ class TestHandleThreads:
 
     def test_returns_false_when_no_threads(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         assert worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch") is False
 
     def test_returns_true_when_threads_exist(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         node = self._open_thread_node()
-        gh.get_review_threads.return_value = self._threads_data_with_nodes([node])
+        gh.get_review_threads.return_value = [node]
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch("kennel.worker.build_prompt"),
@@ -4194,7 +4225,7 @@ class TestHandleThreads:
 
     def test_calls_get_review_threads_with_correct_args(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.get_review_threads.return_value = {}
+        gh.get_review_threads.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         worker.handle_threads(fido_dir, self._repo_ctx(), 42, "branch")
         gh.get_review_threads.assert_called_once_with("owner", "repo", 42)
@@ -4202,7 +4233,7 @@ class TestHandleThreads:
     def test_builds_comments_prompt(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         node = self._open_thread_node()
-        gh.get_review_threads.return_value = self._threads_data_with_nodes([node])
+        gh.get_review_threads.return_value = [node]
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch("kennel.worker.build_prompt") as mock_bp,
@@ -4219,7 +4250,7 @@ class TestHandleThreads:
     def test_runs_claude(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         node = self._open_thread_node()
-        gh.get_review_threads.return_value = self._threads_data_with_nodes([node])
+        gh.get_review_threads.return_value = [node]
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch("kennel.worker.build_prompt"),
@@ -4232,7 +4263,7 @@ class TestHandleThreads:
     def test_spawns_sync_script(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         node = self._open_thread_node()
-        gh.get_review_threads.return_value = self._threads_data_with_nodes([node])
+        gh.get_review_threads.return_value = [node]
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch("kennel.worker.build_prompt"),
@@ -4247,7 +4278,7 @@ class TestHandleThreads:
 
         worker, gh = self._make_worker(tmp_path)
         node = self._open_thread_node()
-        gh.get_review_threads.return_value = self._threads_data_with_nodes([node])
+        gh.get_review_threads.return_value = [node]
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch("kennel.worker.build_prompt"),
@@ -7561,11 +7592,6 @@ class TestAutoCompleteAskTasks:
             "comments": {"nodes": [{"databaseId": db_id}]},
         }
 
-    def _threads_data(self, nodes: list) -> dict:
-        return {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
-
     def test_no_ask_tasks_does_nothing(self, tmp_path: Path) -> None:
         gh = MagicMock()
         _auto_complete_ask_tasks(
@@ -7576,9 +7602,7 @@ class TestAutoCompleteAskTasks:
     def test_completes_ask_task_when_thread_resolved(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = self._ask_task(42)
-        gh.get_review_threads.return_value = self._threads_data(
-            [self._resolved_node(42)]
-        )
+        gh.get_review_threads.return_value = [self._resolved_node(42)]
         mock_complete = MagicMock()
         _auto_complete_ask_tasks(
             tmp_path,
@@ -7595,9 +7619,9 @@ class TestAutoCompleteAskTasks:
     ) -> None:
         gh = MagicMock()
         task = self._ask_task(42)
-        gh.get_review_threads.return_value = self._threads_data(
-            [{"isResolved": False, "comments": {"nodes": [{"databaseId": 42}]}}]
-        )
+        gh.get_review_threads.return_value = [
+            {"isResolved": False, "comments": {"nodes": [{"databaseId": 42}]}}
+        ]
         mock_complete = MagicMock()
         _auto_complete_ask_tasks(
             tmp_path,
@@ -7631,9 +7655,7 @@ class TestAutoCompleteAskTasks:
             "status": "pending",
             "thread": {"comment_id": 1},
         }
-        gh.get_review_threads.return_value = self._threads_data(
-            [self._resolved_node(1)]
-        )
+        gh.get_review_threads.return_value = [self._resolved_node(1)]
         mock_complete = MagicMock()
         _auto_complete_ask_tasks(
             tmp_path,
@@ -7663,9 +7685,9 @@ class TestAutoCompleteAskTasks:
     def test_resolved_node_without_database_id_skipped(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = self._ask_task(42)
-        gh.get_review_threads.return_value = self._threads_data(
-            [{"isResolved": True, "comments": {"nodes": [{}]}}]
-        )
+        gh.get_review_threads.return_value = [
+            {"isResolved": True, "comments": {"nodes": [{}]}}
+        ]
         mock_complete = MagicMock()
         _auto_complete_ask_tasks(
             tmp_path,


### PR DESCRIPTION
Adds structured error handling to the GitHub GraphQL client. `_graphql()` raises a new `GraphQLError` on API errors, query methods validate and extract their response data, and mutation methods check for errors — removing defensive `.get()` chains from callers.

Fixes #374.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add GraphQLError and error checking to _graphql() <!-- type:spec -->
- [x] Validate and extract data in find_pr, find_issues, get_review_threads <!-- type:spec -->
- [x] Validate responses in mutation methods and remove .get() chains in callers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->