### PR TITLE
Stop turning Claude failure into synthetic tasks (closes #376)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -80,7 +80,11 @@ def _claude(
     )
 
 
-class ClaudeStreamError(Exception):
+class ClaudeError(Exception):
+    """Raised when a Claude subprocess call fails."""
+
+
+class ClaudeStreamError(ClaudeError):
     """Raised by _run_streaming when the subprocess exits with a non-zero code or times out."""
 
     def __init__(self, returncode: int) -> None:
@@ -150,11 +154,12 @@ def print_prompt(
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     _sleep: Callable[[float], None] = time.sleep,
 ) -> str:
-    """Run claude --print with a prompt, return stdout (empty string on failure).
+    """Run claude --print with a prompt, return stdout.
 
     Uses -p to pass the prompt as a positional argument (no tool access).
     Retries up to ``_EMPTY_RETRY_COUNT`` times (with a short delay) when
     Claude exits 0 but produces no output, to handle transient empty responses.
+    Raises ``ClaudeError`` on subprocess failure or empty output after all retries.
     """
     args: list[str] = ["--model", model, "--print"]
     if system_prompt is not None:
@@ -163,24 +168,26 @@ def print_prompt(
     for attempt in range(_EMPTY_RETRY_COUNT + 1):
         try:
             result = _claude(*args, timeout=timeout, runner=runner)
-            if result.returncode != 0:
-                return ""
-            text = result.stdout.strip()
-            if text:
-                return text
-            if result.stderr:
-                log.warning("print_prompt: stderr=%r", result.stderr[:200])
-            log.debug("print_prompt: stdout=%r", result.stdout[:200])
-            if attempt < _EMPTY_RETRY_COUNT:
-                log.warning(
-                    "print_prompt: empty output on attempt %d — retrying",
-                    attempt + 1,
-                )
-                _sleep(_EMPTY_RETRY_DELAY)
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
+        except subprocess.TimeoutExpired:
+            raise ClaudeError("claude timed out") from None
+        except FileNotFoundError:
+            raise ClaudeError("claude CLI not found") from None
+        if result.returncode != 0:
+            raise ClaudeError(f"claude exited {result.returncode}")
+        text = result.stdout.strip()
+        if text:
+            return text
+        if result.stderr:
+            log.warning("print_prompt: stderr=%r", result.stderr[:200])
+        log.debug("print_prompt: stdout=%r", result.stdout[:200])
+        if attempt < _EMPTY_RETRY_COUNT:
+            log.warning(
+                "print_prompt: empty output on attempt %d — retrying",
+                attempt + 1,
+            )
+            _sleep(_EMPTY_RETRY_DELAY)
     log.warning("print_prompt: empty output after %d attempts", _EMPTY_RETRY_COUNT + 1)
-    return ""
+    raise ClaudeError("empty output after retries")
 
 
 def print_prompt_json(
@@ -209,8 +216,6 @@ def print_prompt_json(
     raw = print_prompt(
         prompt, model, system_prompt=full_system, timeout=timeout, runner=runner
     )
-    if not raw:
-        return ""
     # Try parsing whole output, then scan for JSON objects (handles preamble).
     candidates = [raw] + [m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)]
     for candidate in candidates:
@@ -291,8 +296,8 @@ def print_prompt_from_file(
 ) -> str:
     """Run claude --print reading system prompt and user prompt from files.
 
-    Returns stdout on success, empty string on failure.  Kills the process
-    if no output is produced for *idle_timeout* seconds (default 30 min).
+    Returns stdout on success.  Kills the process if no output is produced for
+    *idle_timeout* seconds (default 30 min).  Raises ``ClaudeError`` on failure.
     """
     cmd = [
         "claude",
@@ -310,8 +315,8 @@ def print_prompt_from_file(
         return "".join(
             streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()
-    except ClaudeStreamError, FileNotFoundError:
-        return ""
+    except FileNotFoundError as e:
+        raise ClaudeError("claude CLI not found") from e
 
 
 def resume_session(
@@ -325,8 +330,8 @@ def resume_session(
 ) -> str:
     """Continue an existing claude session by ID, feeding prompt_file on stdin.
 
-    Returns stdout on success, empty string on failure.  Kills the process
-    if no output is produced for *idle_timeout* seconds (default 30 min).
+    Returns stdout on success.  Kills the process if no output is produced for
+    *idle_timeout* seconds (default 30 min).  Raises ``ClaudeError`` on failure.
     """
     cmd = [
         "claude",
@@ -344,8 +349,8 @@ def resume_session(
         return "".join(
             streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()
-    except ClaudeStreamError, FileNotFoundError:
-        return ""
+    except FileNotFoundError as e:
+        raise ClaudeError("claude CLI not found") from e
 
 
 # ── Specialised wrappers used by events.py ───────────────────────────────────
@@ -359,17 +364,22 @@ def triage_comment(
 ) -> str:
     """Ask claude to triage a PR comment. Returns the raw first line of output.
 
-    Returns empty string on timeout or if the CLI is not found.
+    Raises ``ClaudeError`` on subprocess failure or empty output.
     """
     try:
         result = _claude(
             "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip().splitlines()[0]
-        return ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
+    except subprocess.TimeoutExpired:
+        raise ClaudeError("claude timed out") from None
+    except FileNotFoundError:
+        raise ClaudeError("claude CLI not found") from None
+    if result.returncode != 0:
+        raise ClaudeError(f"claude exited {result.returncode}")
+    first = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+    if not first:
+        raise ClaudeError("empty response")
+    return first
 
 
 def generate_reply(
@@ -378,14 +388,22 @@ def generate_reply(
     timeout: int = 30,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> str:
-    """Ask claude to generate a short reply. Returns stripped output or empty string."""
+    """Ask claude to generate a short reply. Returns stripped output.
+
+    Raises ``ClaudeError`` on subprocess failure.  Empty output (exit 0) is
+    returned as an empty string — the caller is responsible for fallback.
+    """
     try:
         result = _claude(
             "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
         )
-        return result.stdout.strip() if result.returncode == 0 else ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
+    except subprocess.TimeoutExpired:
+        raise ClaudeError("claude timed out") from None
+    except FileNotFoundError:
+        raise ClaudeError("claude CLI not found") from None
+    if result.returncode != 0:
+        raise ClaudeError(f"claude exited {result.returncode}")
+    return result.stdout.strip()
 
 
 def generate_branch_name(
@@ -394,16 +412,24 @@ def generate_branch_name(
     timeout: int = 15,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> str:
-    """Ask claude to generate a git branch name slug. Returns first line of output."""
+    """Ask claude to generate a git branch name slug. Returns first line of output.
+
+    Raises ``ClaudeError`` on subprocess failure.  Empty output (exit 0) is
+    returned as an empty string — the caller is responsible for fallback.
+    """
     try:
         result = _claude(
             "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip().splitlines()[0]
-        return ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
+    except subprocess.TimeoutExpired:
+        raise ClaudeError("claude timed out") from None
+    except FileNotFoundError:
+        raise ClaudeError("claude CLI not found") from None
+    if result.returncode != 0:
+        raise ClaudeError(f"claude exited {result.returncode}")
+    if result.stdout.strip():
+        return result.stdout.strip().splitlines()[0]
+    return ""
 
 
 def generate_status(
@@ -455,9 +481,9 @@ def generate_status_with_session(
 
     Uses stream-json output format to capture the session_id alongside the
     response text, enabling follow-up calls (e.g., ``resume_status`` to
-    shorten a long response).  Returns ``("", "")`` on failure.
-    Retries up to ``_EMPTY_RETRY_COUNT`` times when Claude exits 0 but
-    produces no output.
+    shorten a long response).  Retries up to ``_EMPTY_RETRY_COUNT`` times
+    when Claude exits 0 but produces no output.  Raises ``ClaudeError`` on
+    subprocess failure or empty output after all retries.
     """
     for attempt in range(_EMPTY_RETRY_COUNT + 1):
         try:
@@ -476,31 +502,31 @@ def generate_status_with_session(
                 timeout=timeout,
                 runner=runner,
             )
-            if result.returncode != 0:
-                return "", ""
-            raw = result.stdout.strip()
-            text = extract_result_text(raw)
-            sid = extract_session_id(raw)
-            if text:
-                return text, sid
-            if result.stderr:
-                log.warning(
-                    "generate_status_with_session: stderr=%r", result.stderr[:200]
-                )
-            log.debug("generate_status_with_session: stdout=%r", result.stdout[:200])
-            if attempt < _EMPTY_RETRY_COUNT:
-                log.warning(
-                    "generate_status_with_session: empty output on attempt %d — retrying",
-                    attempt + 1,
-                )
-                _sleep(_EMPTY_RETRY_DELAY)
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return "", ""
+        except subprocess.TimeoutExpired:
+            raise ClaudeError("claude timed out") from None
+        except FileNotFoundError:
+            raise ClaudeError("claude CLI not found") from None
+        if result.returncode != 0:
+            raise ClaudeError(f"claude exited {result.returncode}")
+        raw = result.stdout.strip()
+        text = extract_result_text(raw)
+        sid = extract_session_id(raw)
+        if text:
+            return text, sid
+        if result.stderr:
+            log.warning("generate_status_with_session: stderr=%r", result.stderr[:200])
+        log.debug("generate_status_with_session: stdout=%r", result.stdout[:200])
+        if attempt < _EMPTY_RETRY_COUNT:
+            log.warning(
+                "generate_status_with_session: empty output on attempt %d — retrying",
+                attempt + 1,
+            )
+            _sleep(_EMPTY_RETRY_DELAY)
     log.warning(
         "generate_status_with_session: empty output after %d attempts",
         _EMPTY_RETRY_COUNT + 1,
     )
-    return "", ""
+    raise ClaudeError("empty output after retries")
 
 
 def resume_status(
@@ -513,8 +539,9 @@ def resume_status(
     """Resume an existing claude session to refine a status response.
 
     Passes *prompt* as a positional argument (``-p``), so no file is needed.
-    Returns the response text extracted from stream-json output, or an empty
-    string on failure.
+    Returns the response text extracted from stream-json output, or empty
+    string if the result field is absent.  Raises ``ClaudeError`` on
+    subprocess failure.
     """
     try:
         result = _claude(
@@ -532,8 +559,10 @@ def resume_status(
             timeout=timeout,
             runner=runner,
         )
-        if result.returncode != 0:
-            return ""
-        return extract_result_text(result.stdout.strip())
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
+    except subprocess.TimeoutExpired:
+        raise ClaudeError("claude timed out") from None
+    except FileNotFoundError:
+        raise ClaudeError("claude CLI not found") from None
+    if result.returncode != 0:
+        raise ClaudeError(f"claude exited {result.returncode}")
+    return extract_result_text(result.stdout.strip())

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -247,12 +247,17 @@ def maybe_react(
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompts = Prompts(_load_persona(config))
-    reaction = (
-        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6", timeout=15)
-        .lower()
-        .split("\n")[0]
-        .strip()
-    )
+    try:
+        reaction = (
+            _print_prompt(
+                prompts.react_prompt(comment_body), "claude-opus-4-6", timeout=15
+            )
+            .lower()
+            .split("\n")[0]
+            .strip()
+        )
+    except claude.ClaudeError:
+        return
 
     valid = {"+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"}
     if reaction not in valid:
@@ -331,9 +336,15 @@ def reply_to_comment(
             )
 
     # Step 1: Haiku triage
-    category, titles = _triage(
-        comment, action.is_bot, context, _print_prompt=_print_prompt
-    )
+    try:
+        category, titles = _triage(
+            comment, action.is_bot, context, _print_prompt=_print_prompt
+        )
+    except claude.ClaudeError:
+        log.warning("triage failed for comment %s — skipping", cid)
+        if lock_fd:
+            lock_fd.close()
+        return (False, "ACT", [])
     log.info("triage: %s — %s", category, titles)
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply
@@ -353,14 +364,14 @@ def reply_to_comment(
         info["pr"],
         info["comment_id"],
     )
-    body = _print_prompt(
-        prompts.persona_wrap(instr),
-        "claude-opus-4-6",
-        system_prompt=prompts.reply_system_prompt(),
-        timeout=30,
-    )
-
-    if not body:
+    try:
+        body = _print_prompt(
+            prompts.persona_wrap(instr),
+            "claude-opus-4-6",
+            system_prompt=prompts.reply_system_prompt(),
+            timeout=30,
+        )
+    except claude.ClaudeError:
         body = (
             "Looking into this now."
             if category in ("ACT", "DO")
@@ -484,37 +495,11 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
         "to act on alone)?\n\n"
         "Reply with exactly YES or NO."
     )
-    answer = _print_prompt(prompt, "claude-haiku-4-5", timeout=10).upper()
+    try:
+        answer = _print_prompt(prompt, "claude-haiku-4-5", timeout=10).upper()
+    except claude.ClaudeError:
+        return False
     return answer.startswith("YES")
-
-
-_MAX_TITLE_LEN = 80
-
-
-def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
-    """Ask Opus to convert a comment into a short imperative action-item title.
-
-    If the result is too long, asks Claude to shorten it up to 3 times before
-    falling back to hard truncation.
-    """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
-    prompt = (
-        "Convert this PR review comment into a short, imperative task title starting with a verb. "
-        "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
-        f"Comment: {comment_body}"
-    )
-    result = _print_prompt(prompt, "claude-opus-4-6", timeout=15).strip()
-    for _ in range(3):
-        if not result or len(result) <= _MAX_TITLE_LEN:
-            break
-        result = _print_prompt(
-            f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
-            f"Reply with ONLY the shortened title.\n\nTitle: {result}",
-            "claude-opus-4-6",
-            timeout=15,
-        ).strip()
-    return result[:_MAX_TITLE_LEN] if result else comment_body[:_MAX_TITLE_LEN]
 
 
 def _triage(
@@ -550,10 +535,7 @@ def _triage(
             titles.append(title)
     if category is not None and titles:
         return category, titles
-    # Fallback: ACT for humans, DO for bots; summarize comment into action item
-    category = "DO" if is_bot else "ACT"
-    title = _summarize_as_action_item(comment_body, _print_prompt=_print_prompt)
-    return category, [title]
+    raise claude.ClaudeError("triage produced no valid category")
 
 
 def reply_to_issue_comment(
@@ -599,9 +581,13 @@ def reply_to_issue_comment(
         context["conversation"] = conversation_context
 
     prompts = Prompts(_load_persona(config))
-    category, titles = _triage(
-        comment, action.is_bot, context or None, _print_prompt=_print_prompt
-    )
+    try:
+        category, titles = _triage(
+            comment, action.is_bot, context or None, _print_prompt=_print_prompt
+        )
+    except claude.ClaudeError:
+        log.warning("issue comment triage failed — skipping reply")
+        return ("ACT", [])
     log.info("issue comment triage: %s — %s", category, titles)
 
     # For DEFER, open a tracking issue before crafting the reply
@@ -615,13 +601,14 @@ def reply_to_issue_comment(
     )
 
     log.info("generating %s reply for issue comment on PR #%s", category, number)
-    body = _print_prompt(
-        prompts.persona_wrap(instr),
-        "claude-opus-4-6",
-        system_prompt=prompts.reply_system_prompt(),
-        timeout=30,
-    )
-    if not body:
+    try:
+        body = _print_prompt(
+            prompts.persona_wrap(instr),
+            "claude-opus-4-6",
+            system_prompt=prompts.reply_system_prompt(),
+            timeout=30,
+        )
+    except claude.ClaudeError:
         body = "On it!" if category in ("ACT", "DO") else "Noted."
 
     log.info("posting issue comment reply on PR #%s: %s", number, body[:80])

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -31,12 +31,15 @@ def generate_persona_status(
     _print_prompt: Callable[..., str] = claude.print_prompt,
 ) -> str:
     system = f"{persona}\n\n{_STATUS_SYSTEM}" if persona else _STATUS_SYSTEM
-    result = _print_prompt(
-        prompt=f"Rewrite this status in Fido's voice: {message}",
-        model="claude-opus-4-6",
-        system_prompt=system,
-        timeout=15,
-    )
+    try:
+        result = _print_prompt(
+            prompt=f"Rewrite this status in Fido's voice: {message}",
+            model="claude-opus-4-6",
+            system_prompt=system,
+            timeout=15,
+        )
+    except claude.ClaudeError:
+        return message[:80]
     return result if result else message[:80]
 
 
@@ -47,13 +50,16 @@ def generate_persona_emoji(
     _print_prompt_json: Callable[..., str] = claude.print_prompt_json,
 ) -> str:
     system = f"{persona}\n\n{_EMOJI_SYSTEM}" if persona else _EMOJI_SYSTEM
-    result = _print_prompt_json(
-        prompt=f"Pick an emoji for this status: {status_text}",
-        key="emoji",
-        model="claude-opus-4-6",
-        system_prompt=system,
-        timeout=15,
-    )
+    try:
+        result = _print_prompt_json(
+            prompt=f"Pick an emoji for this status: {status_text}",
+            key="emoji",
+            model="claude-opus-4-6",
+            system_prompt=system,
+            timeout=15,
+        )
+    except claude.ClaudeError:
+        return ":dog:"
     return result if result else ":dog:"
 
 

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -31,16 +31,12 @@ def generate_persona_status(
     _print_prompt: Callable[..., str] = claude.print_prompt,
 ) -> str:
     system = f"{persona}\n\n{_STATUS_SYSTEM}" if persona else _STATUS_SYSTEM
-    try:
-        result = _print_prompt(
-            prompt=f"Rewrite this status in Fido's voice: {message}",
-            model="claude-opus-4-6",
-            system_prompt=system,
-            timeout=15,
-        )
-    except claude.ClaudeError:
-        return message[:80]
-    return result if result else message[:80]
+    return _print_prompt(
+        prompt=f"Rewrite this status in Fido's voice: {message}",
+        model="claude-opus-4-6",
+        system_prompt=system,
+        timeout=15,
+    )
 
 
 def generate_persona_emoji(
@@ -50,17 +46,13 @@ def generate_persona_emoji(
     _print_prompt_json: Callable[..., str] = claude.print_prompt_json,
 ) -> str:
     system = f"{persona}\n\n{_EMOJI_SYSTEM}" if persona else _EMOJI_SYSTEM
-    try:
-        result = _print_prompt_json(
-            prompt=f"Pick an emoji for this status: {status_text}",
-            key="emoji",
-            model="claude-opus-4-6",
-            system_prompt=system,
-            timeout=15,
-        )
-    except claude.ClaudeError:
-        return ":dog:"
-    return result if result else ":dog:"
+    return _print_prompt_json(
+        prompt=f"Pick an emoji for this status: {status_text}",
+        key="emoji",
+        model="claude-opus-4-6",
+        system_prompt=system,
+        timeout=15,
+    )
 
 
 def set_gh_status(
@@ -75,8 +67,11 @@ def set_gh_status(
         persona = persona_path.read_text()
     except FileNotFoundError:
         persona = ""
-    text = _generate_persona_status(message, persona)
-    emoji = _generate_persona_emoji(text, persona)
+    try:
+        text = _generate_persona_status(message, persona)
+        emoji = _generate_persona_emoji(text, persona)
+    except claude.ClaudeError:
+        return
     gh = _get_github()
     gh.set_user_status(text, emoji, busy=True)
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from kennel.claude import ClaudeError
 from kennel.claude import print_prompt as _claude_print_prompt
 from kennel.github import GitHub
 from kennel.prompts import rescope_prompt as _rescope_prompt_default
@@ -541,7 +542,11 @@ def reorder_tasks(
 
     original_ids = frozenset(t["id"] for t in task_list)
     prompt = _rescope_prompt_fn(task_list, commit_summary)
-    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    try:
+        raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    except ClaudeError:
+        log.warning("reorder_tasks: Opus failed — skipping")
+        return
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -538,14 +538,13 @@ class Worker:
                 activities = [(self.work_dir.name, what, busy)]
 
             # Call 1: generate status text
-            text, session_id = _generate_status_with_session(
-                prompt=prompts.status_text_prompt(activities),
-                system_prompt=prompts.status_text_system_prompt(),
-            )
-            if not text:
-                log.warning(
-                    "set_status: claude returned empty — using plain-text fallback"
+            try:
+                text, session_id = _generate_status_with_session(
+                    prompt=prompts.status_text_prompt(activities),
+                    system_prompt=prompts.status_text_system_prompt(),
                 )
+            except claude.ClaudeError:
+                log.warning("set_status: claude failed — using plain-text fallback")
                 text = what[:80]
                 session_id = ""
 
@@ -554,10 +553,13 @@ class Worker:
             for _ in range(3):
                 if len(text) <= 80 or not session_id:
                     break
-                retry_raw = _resume_status(
-                    session_id,
-                    f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
-                )
+                try:
+                    retry_raw = _resume_status(
+                        session_id,
+                        f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
+                    )
+                except claude.ClaudeError:
+                    break
                 if not retry_raw:
                     break
                 text = retry_raw.strip()
@@ -566,11 +568,12 @@ class Worker:
                 text = text[:80]
 
             # Call 2: generate emoji
-            emoji = _generate_status_emoji(
-                prompt=prompts.status_emoji_prompt(text),
-                system_prompt=prompts.status_emoji_system_prompt(),
-            )
-            if not emoji:
+            try:
+                emoji = _generate_status_emoji(
+                    prompt=prompts.status_emoji_prompt(text),
+                    system_prompt=prompts.status_emoji_system_prompt(),
+                )
+            except claude.ClaudeError:
                 emoji = ":dog:"
 
             self.gh.set_user_status(text, emoji, busy=busy)
@@ -702,12 +705,15 @@ class Worker:
             return pr_number, slug
 
         # Generate branch slug via Haiku
-        raw_slug = claude.generate_branch_name(
-            "Output ONLY a git branch name: 2-4 lowercase words separated by"
-            " hyphens, no issue numbers, summarising this request."
-            " No explanation, no punctuation, just the branch name."
-            f"\n\nRequest: {request}"
-        )
+        try:
+            raw_slug = claude.generate_branch_name(
+                "Output ONLY a git branch name: 2-4 lowercase words separated by"
+                " hyphens, no issue numbers, summarising this request."
+                " No explanation, no punctuation, just the branch name."
+                f"\n\nRequest: {request}"
+            )
+        except claude.ClaudeError:
+            raw_slug = ""
         slug = _sanitize_slug(raw_slug, request)
         log.info("new branch: %s", slug)
 
@@ -1286,7 +1292,10 @@ class Worker:
 
         prompts = Prompts(persona)
         prompt = prompts.pickup_comment_prompt(issue_title)
-        msg = claude.generate_reply(prompt)
+        try:
+            msg = claude.generate_reply(prompt)
+        except claude.ClaudeError:
+            msg = ""
         if not msg:
             msg = f"Picking up issue: {issue_title}"
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -5,7 +5,10 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from kennel.claude import (
+    ClaudeError,
     ClaudeStreamError,
     _claude,
     _register_child,
@@ -68,33 +71,27 @@ class TestPrintPrompt:
         mock_run = MagicMock(return_value=_completed("  hello world  \n"))
         assert print_prompt("hi", "claude-opus-4-6", runner=mock_run) == "hello world"
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed("err", returncode=1))
         mock_sleep = MagicMock()
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
-            == ""
-        )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
         mock_sleep = MagicMock()
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
-            == ""
-        )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
         mock_sleep = MagicMock()
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
-            == ""
-        )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
@@ -110,13 +107,11 @@ class TestPrintPrompt:
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
 
-    def test_returns_empty_after_all_retries_exhausted(self) -> None:
+    def test_raises_after_all_retries_exhausted(self) -> None:
         mock_run = MagicMock(return_value=_completed(""))
         mock_sleep = MagicMock()
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt("hi", "claude-opus-4-6", runner=mock_run, _sleep=mock_sleep)
-            == ""
-        )
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
 
@@ -150,19 +145,28 @@ class TestPrintPrompt:
     def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
         mock_run = MagicMock(return_value=_completed("", stderr="Rate limit exceeded"))
         with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+            with pytest.raises(ClaudeError):
+                print_prompt(
+                    "q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock()
+                )
         assert "Rate limit exceeded" in caplog.text
 
     def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
         mock_run = MagicMock(return_value=_completed("   \n  "))
         with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+            with pytest.raises(ClaudeError):
+                print_prompt(
+                    "q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock()
+                )
         assert "stdout=" in caplog.text
 
     def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
         mock_run = MagicMock(return_value=_completed(""))
         with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            print_prompt("q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock())
+            with pytest.raises(ClaudeError):
+                print_prompt(
+                    "q", "claude-opus-4-6", runner=mock_run, _sleep=MagicMock()
+                )
         assert "stderr=" not in caplog.text
 
 
@@ -199,35 +203,27 @@ class TestPrintPromptJson:
             == ""
         )
 
-    def test_returns_empty_on_empty_output(self) -> None:
+    def test_raises_on_empty_output(self) -> None:
         mock_run = MagicMock(return_value=_completed(""))
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt_json("q", "description", "claude-opus-4-6", runner=mock_run)
-            == ""
-        )
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(
             return_value=_completed('{"description": "x"}', returncode=1)
         )
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt_json("q", "description", "claude-opus-4-6", runner=mock_run)
-            == ""
-        )
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt_json("q", "description", "claude-opus-4-6", runner=mock_run)
-            == ""
-        )
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert (
+        with pytest.raises(ClaudeError):
             print_prompt_json("q", "description", "claude-opus-4-6", runner=mock_run)
-            == ""
-        )
 
     def test_appends_json_instruction_to_system_prompt(self) -> None:
         mock_run = MagicMock(return_value=_completed('{"description": "x"}'))
@@ -392,29 +388,29 @@ class TestPrintPromptFromFile:
         )
         assert result == "session output"
 
-    def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
-    def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=FileNotFoundError)
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
@@ -452,32 +448,41 @@ class TestResumeSession:
         )
         assert result == "continued"
 
-    def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
-    def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=FileNotFoundError)
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
@@ -513,21 +518,25 @@ class TestTriageComment:
         mock_run = MagicMock(return_value=_completed("ACT: fix the thing\nextra"))
         assert triage_comment("triage this", runner=mock_run) == "ACT: fix the thing"
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed("ACT", returncode=1))
-        assert triage_comment("triage this", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            triage_comment("triage this", runner=mock_run)
 
-    def test_returns_empty_on_empty_output(self) -> None:
+    def test_raises_on_empty_output(self) -> None:
         mock_run = MagicMock(return_value=_completed(""))
-        assert triage_comment("triage this", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            triage_comment("triage this", runner=mock_run)
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert triage_comment("triage", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            triage_comment("triage", runner=mock_run)
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert triage_comment("triage", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            triage_comment("triage", runner=mock_run)
 
     def test_default_model_and_timeout(self) -> None:
         mock_run = MagicMock(return_value=_completed("ACT: thing"))
@@ -551,17 +560,20 @@ class TestGenerateReply:
         mock_run = MagicMock(return_value=_completed("  woof!  \n"))
         assert generate_reply("write a reply", runner=mock_run) == "woof!"
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed("err", returncode=1))
-        assert generate_reply("write", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_reply("write", runner=mock_run)
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
-        assert generate_reply("write", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_reply("write", runner=mock_run)
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert generate_reply("write", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_reply("write", runner=mock_run)
 
     def test_default_model_and_timeout(self) -> None:
         mock_run = MagicMock(return_value=_completed("ok"))
@@ -586,21 +598,24 @@ class TestGenerateBranchName:
             == "add-tests"
         )
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed("slug", returncode=1))
-        assert generate_branch_name("make branch", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_branch_name("make branch", runner=mock_run)
 
     def test_returns_empty_on_empty_output(self) -> None:
         mock_run = MagicMock(return_value=_completed(""))
         assert generate_branch_name("make branch", runner=mock_run) == ""
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert generate_branch_name("make branch", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_branch_name("make branch", runner=mock_run)
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert generate_branch_name("make branch", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            generate_branch_name("make branch", runner=mock_run)
 
     def test_default_model_and_timeout(self) -> None:
         mock_run = MagicMock(return_value=_completed("fix-bug"))
@@ -625,15 +640,15 @@ class TestGenerateStatus:
         result = generate_status("working on #42", "be fido", runner=mock_run)
         assert result == "🐶\ncoding up a storm"
 
-    def test_returns_empty_on_failure(self) -> None:
+    def test_raises_on_failure(self) -> None:
         mock_run = MagicMock(return_value=_completed("", returncode=1))
-        result = generate_status("working", "sys", runner=mock_run)
-        assert result == ""
+        with pytest.raises(ClaudeError):
+            generate_status("working", "sys", runner=mock_run)
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        result = generate_status("working", "sys", runner=mock_run)
-        assert result == ""
+        with pytest.raises(ClaudeError):
+            generate_status("working", "sys", runner=mock_run)
 
     def test_passes_system_prompt(self) -> None:
         mock_run = MagicMock(return_value=_completed("🚀\nworking"))
@@ -775,30 +790,33 @@ class TestGenerateStatusWithSession:
         assert text == "🐶\ncoding"
         assert sid == "sess-42"
 
-    def test_returns_empty_pair_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
         mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
+        with pytest.raises(ClaudeError):
+            generate_status_with_session(
+                "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+            )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
-    def test_returns_empty_pair_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
         mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
+        with pytest.raises(ClaudeError):
+            generate_status_with_session(
+                "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+            )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
-    def test_returns_empty_pair_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
         mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
+        with pytest.raises(ClaudeError):
+            generate_status_with_session(
+                "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
+            )
         mock_run.assert_called_once()
         mock_sleep.assert_not_called()
 
@@ -832,15 +850,14 @@ class TestGenerateStatusWithSession:
         assert "claude-opus-4-6" in cmd
         assert mock_run.call_args.kwargs["timeout"] == 15
 
-    def test_returns_empty_pair_when_no_result_field_after_retries(self) -> None:
+    def test_raises_when_no_result_field_after_retries(self) -> None:
         no_result = '{"type":"result","session_id":"sid"}'
         mock_run = MagicMock(return_value=_completed(no_result))
         mock_sleep = MagicMock()
-        text, sid = generate_status_with_session(
-            "working", "sys", runner=mock_run, _sleep=mock_sleep
-        )
-        assert text == ""
-        assert sid == ""
+        with pytest.raises(ClaudeError):
+            generate_status_with_session(
+                "working", "sys", runner=mock_run, _sleep=mock_sleep
+            )
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
 
@@ -869,13 +886,14 @@ class TestGenerateStatusWithSession:
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
 
-    def test_returns_empty_pair_after_all_retries_exhausted(self) -> None:
+    def test_raises_after_all_retries_exhausted(self) -> None:
         empty_line = '{"type":"result","session_id":"s1"}'
         mock_run = MagicMock(return_value=_completed(empty_line))
         mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "working", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
+        with pytest.raises(ClaudeError):
+            generate_status_with_session(
+                "working", "sys", runner=mock_run, _sleep=mock_sleep
+            )
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
 
@@ -885,27 +903,30 @@ class TestGenerateStatusWithSession:
             return_value=_completed(empty_line, stderr="Rate limit exceeded")
         )
         with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
+            with pytest.raises(ClaudeError):
+                generate_status_with_session(
+                    "working", "sys", runner=mock_run, _sleep=MagicMock()
+                )
         assert "Rate limit exceeded" in caplog.text
 
     def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
         empty_line = '{"type":"result","session_id":"s1"}'
         mock_run = MagicMock(return_value=_completed(empty_line))
         with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
+            with pytest.raises(ClaudeError):
+                generate_status_with_session(
+                    "working", "sys", runner=mock_run, _sleep=MagicMock()
+                )
         assert "stdout=" in caplog.text
 
     def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
         empty_line = '{"type":"result","session_id":"s1"}'
         mock_run = MagicMock(return_value=_completed(empty_line))
         with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
+            with pytest.raises(ClaudeError):
+                generate_status_with_session(
+                    "working", "sys", runner=mock_run, _sleep=MagicMock()
+                )
         assert "stderr=" not in caplog.text
 
 
@@ -915,10 +936,10 @@ class TestGenerateStatusEmoji:
         result = generate_status_emoji("pick emoji", "be fido", runner=mock_run)
         assert result == "🐕"
 
-    def test_returns_empty_on_failure(self) -> None:
+    def test_raises_on_failure(self) -> None:
         mock_run = MagicMock(return_value=_completed("", returncode=1))
-        result = generate_status_emoji("pick emoji", "sys", runner=mock_run)
-        assert result == ""
+        with pytest.raises(ClaudeError):
+            generate_status_emoji("pick emoji", "sys", runner=mock_run)
 
     def test_passes_correct_flags(self) -> None:
         mock_run = MagicMock(return_value=_completed("🐕"))
@@ -943,17 +964,20 @@ class TestResumeStatus:
         result = resume_status("s-1", "please shorten", runner=mock_run)
         assert result == "🐕\nfetching"
 
-    def test_returns_empty_on_nonzero(self) -> None:
+    def test_raises_on_nonzero(self) -> None:
         mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            resume_status("s-1", "shorten", runner=mock_run)
 
-    def test_returns_empty_on_timeout(self) -> None:
+    def test_raises_on_timeout(self) -> None:
         mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            resume_status("s-1", "shorten", runner=mock_run)
 
-    def test_returns_empty_on_file_not_found(self) -> None:
+    def test_raises_on_file_not_found(self) -> None:
         mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
+        with pytest.raises(ClaudeError):
+            resume_status("s-1", "shorten", runner=mock_run)
 
     def test_passes_correct_flags(self) -> None:
         mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+
+from kennel.claude import ClaudeError
 from kennel.config import Config, RepoConfig
 from kennel.events import (
     Action,
@@ -12,7 +15,6 @@ from kennel.events import (
     _notify_thread_change,
     _reorder_tasks_background,
     _rewrite_pr_description,
-    _summarize_as_action_item,
     _task_snapshot,
     _triage,
     create_task,
@@ -79,10 +81,14 @@ class TestNeedsMoreContext:
         )
 
     def test_subprocess_exception_returns_false(self) -> None:
-        assert not needs_more_context("ditto", _print_prompt=MagicMock(return_value=""))
+        assert not needs_more_context(
+            "ditto", _print_prompt=MagicMock(side_effect=ClaudeError("fail"))
+        )
 
     def test_timeout_returns_false(self) -> None:
-        assert not needs_more_context("same", _print_prompt=MagicMock(return_value=""))
+        assert not needs_more_context(
+            "same", _print_prompt=MagicMock(side_effect=ClaudeError("timed out"))
+        )
 
     def test_empty_output_returns_false(self) -> None:
         assert not needs_more_context(
@@ -364,66 +370,6 @@ class TestCommentLock:
         assert path.parent.is_dir()
 
 
-class TestSummarizeAsActionItem:
-    def test_returns_model_result(self) -> None:
-        pp = MagicMock(return_value="add logging to streamed sub-Claude output")
-        result = _summarize_as_action_item(
-            "Ensure we log at that level too.", _print_prompt=pp
-        )
-        assert result == "add logging to streamed sub-Claude output"
-
-    def test_falls_back_to_comment_body_when_empty(self) -> None:
-        pp = MagicMock(return_value="")
-        result = _summarize_as_action_item("short comment", _print_prompt=pp)
-        assert result == "short comment"
-
-    def test_truncates_long_comment_in_fallback(self) -> None:
-        long_comment = "x" * 200
-        pp = MagicMock(return_value="")
-        result = _summarize_as_action_item(long_comment, _print_prompt=pp)
-        assert result == long_comment[:80]
-
-    def test_strips_whitespace_from_result(self) -> None:
-        pp = MagicMock(return_value="  add tests  ")
-        result = _summarize_as_action_item("add tests please", _print_prompt=pp)
-        assert result == "add tests"
-
-    def test_defaults_to_claude_print_prompt(self) -> None:
-        with patch("kennel.claude.print_prompt", return_value="add tests") as mock_pp:
-            result = _summarize_as_action_item("add some tests")
-        mock_pp.assert_called_once()
-        assert result == "add tests"
-
-    def test_short_result_returned_without_retry(self) -> None:
-        short_title = "add unit tests"
-        pp = MagicMock(return_value=short_title)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
-        assert result == short_title
-        pp.assert_called_once()  # no retry needed
-
-    def test_retries_when_result_too_long(self) -> None:
-        long_title = "a" * 81
-        short_title = "add tests"
-        pp = MagicMock(side_effect=[long_title, short_title])
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
-        assert result == short_title
-        assert pp.call_count == 2
-
-    def test_retries_up_to_three_times_then_truncates(self) -> None:
-        long_title = "a" * 81
-        pp = MagicMock(return_value=long_title)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
-        assert result == long_title[:80]
-        assert pp.call_count == 4  # 1 initial + 3 retries
-
-    def test_stops_retrying_once_short_enough(self) -> None:
-        titles = ["a" * 81, "b" * 81, "short title"]
-        pp = MagicMock(side_effect=titles)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
-        assert result == "short title"
-        assert pp.call_count == 3  # 1 initial + 2 retries
-
-
 class TestTriage:
     def test_returns_parsed_category(self, tmp_path: Path) -> None:
         cat, titles = _triage(
@@ -434,17 +380,13 @@ class TestTriage:
         assert cat == "ACT"
         assert titles == ["add tests"]
 
-    def test_fallback_on_bad_response(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, titles = _triage("do stuff", is_bot=False, _print_prompt=pp)
-        assert cat == "ACT"
-        assert titles == ["implement the thing"]
+    def test_raises_on_unparseable_response(self, tmp_path: Path) -> None:
+        with pytest.raises(ClaudeError):
+            _triage("do stuff", is_bot=False, _print_prompt=MagicMock(return_value=""))
 
-    def test_fallback_for_bot(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, titles = _triage("do stuff", is_bot=True, _print_prompt=pp)
-        assert cat == "DO"
-        assert titles == ["implement the thing"]
+    def test_raises_for_bot_on_unparseable_response(self, tmp_path: Path) -> None:
+        with pytest.raises(ClaudeError):
+            _triage("do stuff", is_bot=True, _print_prompt=MagicMock(return_value=""))
 
     def test_with_context(self, tmp_path: Path) -> None:
         ctx = {"pr_title": "My PR", "file": "foo.py", "diff_hunk": "@@ -1 +1 @@"}
@@ -456,23 +398,26 @@ class TestTriage:
         )
         assert cat == "DEFER"
 
-    def test_unrecognized_category_falls_back(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["WEIRD: something", "do the thing"])
-        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
-        assert cat == "ACT"
-        assert titles == ["do the thing"]
+    def test_raises_on_unrecognized_category(self, tmp_path: Path) -> None:
+        with pytest.raises(ClaudeError):
+            _triage(
+                "hi",
+                is_bot=False,
+                _print_prompt=MagicMock(return_value="WEIRD: something"),
+            )
 
-    def test_timeout_falls_back(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "do the thing"])
-        cat, titles = _triage("hi", is_bot=True, _print_prompt=pp)
-        assert cat == "DO"
+    def test_raises_on_empty_response(self, tmp_path: Path) -> None:
+        with pytest.raises(ClaudeError):
+            _triage("hi", is_bot=True, _print_prompt=MagicMock(return_value=""))
 
-    def test_task_category_falls_back(self, tmp_path: Path) -> None:
-        """TASK is no longer a valid bot category — falls back to DO."""
-        pp = MagicMock(side_effect=["TASK: add caching", "add result caching"])
-        cat, titles = _triage("cache results", is_bot=True, _print_prompt=pp)
-        assert cat == "DO"
-        assert titles == ["add result caching"]
+    def test_raises_on_task_category(self, tmp_path: Path) -> None:
+        """TASK is no longer a valid bot category — raises ClaudeError."""
+        with pytest.raises(ClaudeError):
+            _triage(
+                "cache results",
+                is_bot=True,
+                _print_prompt=MagicMock(return_value="TASK: add caching"),
+            )
 
     def test_bot_categories_in_prompt(self, tmp_path: Path) -> None:
         """Ensure bot-specific categories (DO/DEFER/DUMP) are used when is_bot=True."""
@@ -514,13 +459,14 @@ class TestTriage:
         assert cat == "ACT"
         assert titles == ["add tests"]
 
-    def test_zero_act_tasks_falls_back(self) -> None:
-        """ACT with empty title is treated as parse failure → fallback."""
-        pp = MagicMock(side_effect=["ACT: ", "do the thing"])
-        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
-        # empty title → stripped to "" → falsy → no titles collected → fallback
-        assert cat == "ACT"
-        assert titles == ["do the thing"]
+    def test_raises_on_empty_act_title(self) -> None:
+        """ACT with empty title is treated as parse failure → ClaudeError."""
+        with pytest.raises(ClaudeError):
+            _triage(
+                "hi",
+                is_bot=False,
+                _print_prompt=MagicMock(return_value="ACT: "),
+            )
 
     def test_lines_without_colon_are_skipped(self) -> None:
         """Preamble lines without a colon are ignored; valid lines are still parsed."""
@@ -573,27 +519,19 @@ class TestMaybeReact:
         )
         mock_gh.add_reaction.assert_not_called()
 
-    def test_timeout_warns_and_returns(self, tmp_path: Path) -> None:
+    def test_claude_error_returns_early(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
         maybe_react(
             "hi",
             1,
             "pulls",
             "owner/repo",
             cfg,
-            _print_prompt=MagicMock(return_value=""),
+            _print_prompt=MagicMock(side_effect=ClaudeError("fail")),
+            _gh=mock_gh,
         )
-
-    def test_file_not_found_warns_and_returns(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        maybe_react(
-            "hi",
-            1,
-            "pulls",
-            "owner/repo",
-            cfg,
-            _print_prompt=MagicMock(return_value=""),
-        )
+        mock_gh.add_reaction.assert_not_called()
 
     def test_reads_persona_if_present(self, tmp_path: Path) -> None:
         sub_dir = tmp_path / "sub"
@@ -864,7 +802,7 @@ class TestReplyToComment:
         assert posted
         assert cat == "DEFER"
 
-    def test_empty_body_uses_fallback(self, tmp_path: Path) -> None:
+    def test_reply_body_claude_error_uses_fallback(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -878,7 +816,7 @@ class TestReplyToComment:
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: do it"
-            return ""  # empty reply triggers fallback
+            raise ClaudeError("reply failed")
 
         posted, cat, titles = reply_to_comment(
             action,
@@ -890,7 +828,7 @@ class TestReplyToComment:
         assert posted
         assert cat == "ACT"  # still succeeds with fallback body
 
-    def test_claude_timeout_uses_fallback(self, tmp_path: Path) -> None:
+    def test_triage_claude_error_not_posted(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -902,19 +840,20 @@ class TestReplyToComment:
         def fake_pp(prompt, model, **kwargs):
             if model == "claude-haiku-4-5":
                 return "NO"
-            if "Triage" in prompt:
-                return "ACT: do it"
-            return ""  # simulates timeout — print_prompt returns "" on failure
+            raise ClaudeError("triage failed")
 
+        mock_gh = MagicMock()
         posted, cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
+            _gh=mock_gh,
         )
-        assert posted
+        assert not posted
         assert cat == "ACT"
+        assert titles == []
+        mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_lock_race_returns_act(self, tmp_path: Path) -> None:
         """Second call with same comment_id is blocked by lock."""
@@ -1224,13 +1163,13 @@ class TestReplyToIssueComment:
         )
         assert cat == "DEFER"
 
-    def test_empty_body_fallback(self, tmp_path: Path) -> None:
+    def test_reply_body_claude_error_uses_fallback(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
 
         def fake_pp(prompt, model, **kwargs):
             if "Triage" in prompt:
                 return "ACT: do it"
-            return ""  # empty reply triggers fallback
+            raise ClaudeError("reply failed")
 
         cat, titles = reply_to_issue_comment(
             self._action(),
@@ -1241,22 +1180,23 @@ class TestReplyToIssueComment:
         )
         assert cat == "ACT"
 
-    def test_timeout_fallback(self, tmp_path: Path) -> None:
+    def test_triage_claude_error_returns_act(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
 
         def fake_pp(prompt, model, **kwargs):
-            if "Triage" in prompt:
-                return "ACT: do it"
-            return ""  # simulates timeout — print_prompt returns "" on failure
+            raise ClaudeError("triage failed")
 
+        mock_gh = MagicMock()
         cat, titles = reply_to_issue_comment(
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
+            _gh=mock_gh,
         )
         assert cat == "ACT"
+        assert titles == []
+        mock_gh.comment_issue.assert_not_called()
 
     def test_post_exception_does_not_raise(self, tmp_path: Path) -> None:
         """comment_issue failure is caught and does not propagate."""

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from kennel.claude import ClaudeError
 from kennel.gh_status import (
     generate_persona_emoji,
     generate_persona_status,
@@ -27,6 +28,13 @@ class TestGeneratePersonaStatus:
         result = generate_persona_status(
             "at the vet", "persona", _print_prompt=lambda **kw: ""
         )
+        assert result == "at the vet"
+
+    def test_claude_error_falls_back_to_raw(self) -> None:
+        def failing(**kw):
+            raise ClaudeError("fail")
+
+        result = generate_persona_status("at the vet", "persona", _print_prompt=failing)
         assert result == "at the vet"
 
     def test_long_message_truncated_on_fallback(self) -> None:
@@ -52,6 +60,13 @@ class TestGeneratePersonaEmoji:
         result = generate_persona_emoji(
             "test", "persona", _print_prompt_json=lambda **kw: ""
         )
+        assert result == ":dog:"
+
+    def test_claude_error_falls_back_to_dog(self) -> None:
+        def failing(**kw):
+            raise ClaudeError("fail")
+
+        result = generate_persona_emoji("test", "persona", _print_prompt_json=failing)
         assert result == ":dog:"
 
     def test_empty_persona(self) -> None:

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -24,23 +24,12 @@ class TestGeneratePersonaStatus:
         )
         assert result == "sniffing out a bug *tail wag*"
 
-    def test_empty_response_falls_back_to_raw(self) -> None:
-        result = generate_persona_status(
-            "at the vet", "persona", _print_prompt=lambda **kw: ""
-        )
-        assert result == "at the vet"
-
-    def test_claude_error_falls_back_to_raw(self) -> None:
+    def test_claude_error_propagates(self) -> None:
         def failing(**kw):
             raise ClaudeError("fail")
 
-        result = generate_persona_status("at the vet", "persona", _print_prompt=failing)
-        assert result == "at the vet"
-
-    def test_long_message_truncated_on_fallback(self) -> None:
-        long_msg = "x" * 100
-        result = generate_persona_status(long_msg, "", _print_prompt=lambda **kw: "")
-        assert len(result) == 80
+        with pytest.raises(ClaudeError):
+            generate_persona_status("at the vet", "persona", _print_prompt=failing)
 
     def test_empty_persona(self) -> None:
         result = generate_persona_status("test", "", _print_prompt=lambda **kw: "woof")
@@ -56,18 +45,12 @@ class TestGeneratePersonaEmoji:
         )
         assert result == ":wrench:"
 
-    def test_empty_response_falls_back_to_dog(self) -> None:
-        result = generate_persona_emoji(
-            "test", "persona", _print_prompt_json=lambda **kw: ""
-        )
-        assert result == ":dog:"
-
-    def test_claude_error_falls_back_to_dog(self) -> None:
+    def test_claude_error_propagates(self) -> None:
         def failing(**kw):
             raise ClaudeError("fail")
 
-        result = generate_persona_emoji("test", "persona", _print_prompt_json=failing)
-        assert result == ":dog:"
+        with pytest.raises(ClaudeError):
+            generate_persona_emoji("test", "persona", _print_prompt_json=failing)
 
     def test_empty_persona(self) -> None:
         result = generate_persona_emoji(
@@ -92,6 +75,21 @@ class TestSetGhStatus:
         mock_gh.set_user_status.assert_called_once_with(
             "sniffing around", ":dog2:", busy=True
         )
+
+    def test_claude_error_skips_status_update(self, tmp_path) -> None:
+        mock_gh = MagicMock()
+
+        def failing(msg: str, persona: str) -> str:
+            raise ClaudeError("fail")
+
+        set_gh_status(
+            "diagnosing issue",
+            persona_path=tmp_path / "persona.md",
+            _generate_persona_status=failing,
+            _generate_persona_emoji=lambda txt, p: ":dog:",
+            _get_github=lambda: mock_gh,
+        )
+        mock_gh.set_user_status.assert_not_called()
 
     def test_missing_persona_file(self, tmp_path) -> None:
         mock_gh = MagicMock()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -504,6 +504,18 @@ class TestReorderTasks:
         reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: "")
         assert list_tasks(tmp_path) == result_before
 
+    def test_skips_on_claude_error(self, tmp_path: Path) -> None:
+        from kennel.claude import ClaudeError
+
+        self._add(tmp_path, "Task A")
+        result_before = list_tasks(tmp_path)
+
+        def failing(*a, **k):
+            raise ClaudeError("fail")
+
+        reorder_tasks(tmp_path, "", _print_prompt=failing)
+        assert list_tasks(tmp_path) == result_before
+
     def test_skips_on_unparseable_response(self, tmp_path: Path) -> None:
         self._add(tmp_path, "Task A")
         result_before = list_tasks(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -381,25 +381,38 @@ class TestWorker:
         )
         gh.set_user_status.assert_called_once_with("napping", "😴", busy=False)
 
-    def test_set_status_uses_what_as_fallback_when_claude_returns_empty(
+    def test_set_status_uses_what_as_fallback_when_claude_fails(
         self, tmp_path: Path
     ) -> None:
+        from kennel.claude import ClaudeError
+
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(tmp_path, gh).set_status(
-            "idle", **self._ss(tmp_path, text="", session_id="")
+            "idle",
+            **{
+                **self._ss(tmp_path),
+                "_generate_status_with_session": MagicMock(
+                    side_effect=ClaudeError("fail")
+                ),
+            },
         )
         gh.set_user_status.assert_called_once()
         call_args = gh.set_user_status.call_args[0]
         assert call_args[0] == "idle"
 
-    def test_set_status_emoji_fallback_when_empty(self, tmp_path: Path) -> None:
-        # generate_status_emoji returns empty → :dog: fallback
+    def test_set_status_emoji_fallback_when_claude_fails(self, tmp_path: Path) -> None:
+        # generate_status_emoji raises → :dog: fallback
+        from kennel.claude import ClaudeError
+
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(tmp_path, gh).set_status(
             "idle",
-            **self._ss(tmp_path, text="Sniffing out endpoints", emoji=""),
+            **{
+                **self._ss(tmp_path, text="Sniffing out endpoints"),
+                "_generate_status_emoji": MagicMock(side_effect=ClaudeError("fail")),
+            },
         )
         gh.set_user_status.assert_called_once_with(
             "Sniffing out endpoints", ":dog:", busy=True
@@ -414,6 +427,27 @@ class TestWorker:
             "something",
             **self._ss(tmp_path, text=long_text, resume_side_effect=[""]),
         )
+        called_text = gh.set_user_status.call_args[0][0]
+        assert len(called_text) == 80
+
+    def test_set_status_resumes_status_breaks_on_claude_error(
+        self, tmp_path: Path
+    ) -> None:
+        # _resume_status raises ClaudeError → retry loop stops, text truncated
+        from kennel.claude import ClaudeError
+
+        gh = self._make_gh()
+        long_text = "x" * 100
+        (tmp_path / "persona.md").write_text("I am Fido.")
+        mock_resume = MagicMock(side_effect=ClaudeError("fail"))
+        Worker(tmp_path, gh).set_status(
+            "something",
+            **{
+                **self._ss(tmp_path, text=long_text, session_id="sess-1"),
+                "_resume_status": mock_resume,
+            },
+        )
+        mock_resume.assert_called_once()
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
 
@@ -481,16 +515,24 @@ class TestWorker:
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
 
-    def test_set_status_logs_warning_on_empty_response(
+    def test_set_status_logs_warning_on_claude_failure(
         self, tmp_path: Path, caplog
     ) -> None:
         import logging
+
+        from kennel.claude import ClaudeError
 
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.WARNING, logger="kennel"):
             Worker(tmp_path, gh).set_status(
-                "idle", **self._ss(tmp_path, text="", session_id="")
+                "idle",
+                **{
+                    **self._ss(tmp_path),
+                    "_generate_status_with_session": MagicMock(
+                        side_effect=ClaudeError("fail")
+                    ),
+                },
             )
         assert "fallback" in caplog.text
 
@@ -1267,6 +1309,24 @@ class TestWorkerPostPickupComment:
         with (
             patch("kennel.worker._sub_dir", return_value=tmp_path),
             patch("kennel.worker.claude.generate_reply", return_value=""),
+        ):
+            (tmp_path / "persona.md").write_text("I am Fido.")
+            worker.post_pickup_comment("owner/repo", 5, "A task", "fido-bot")
+        gh.comment_issue.assert_called_once_with(
+            "owner/repo", 5, "Picking up issue: A task"
+        )
+
+    def test_falls_back_to_plain_text_when_claude_fails(self, tmp_path: Path) -> None:
+        from kennel.claude import ClaudeError
+
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_issue_comments.return_value = []
+        with (
+            patch("kennel.worker._sub_dir", return_value=tmp_path),
+            patch(
+                "kennel.worker.claude.generate_reply",
+                side_effect=ClaudeError("fail"),
+            ),
         ):
             (tmp_path / "persona.md").write_text("I am Fido.")
             worker.post_pickup_comment("owner/repo", 5, "A task", "fido-bot")
@@ -2845,6 +2905,37 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert "42" in caplog.text
+
+    def test_no_pr_branch_name_falls_back_on_claude_error(self, tmp_path: Path) -> None:
+        """generate_branch_name raises ClaudeError → slug derived from issue title."""
+        from kennel.claude import ClaudeError
+
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = None
+        gh.create_pr.return_value = "https://github.com/owner/proj/pull/99"
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "_git"),
+            patch(
+                "kennel.worker.claude.generate_branch_name",
+                side_effect=ClaudeError("fail"),
+            ),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_start", return_value=""),
+            patch("kennel.worker._write_pr_description"),
+            patch(
+                "kennel.worker.tasks.list_tasks",
+                return_value=[{"title": "t", "status": "pending"}],
+            ),
+        ):
+            result = worker.find_or_create_pr(
+                fido_dir, self._make_repo_ctx(), 5, "Fix the bug"
+            )
+        assert result is not None
+        _, slug = result
+        # slug derived from "Fix the bug" via _sanitize_slug
+        assert slug  # non-empty
+        assert slug == slug.lower()
 
 
 class TestSeedTasksFromPrBody:


### PR DESCRIPTION
The current body is just `Fixes #376.` — so there's no existing descriptive summary beyond that. Based on the updated task list, here's the replacement description:

Fixes #376.

When Claude subprocess calls fail, kennel currently swallows the error and falls back to a synthetic ACT/DO response, which creates nonsensical tasks. This PR makes Claude failures raise exceptions instead of returning empty strings and removes the synthetic fallback from triage, letting failures surface through the normal reply flow.

---

Want me to update the PR body directly?

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Raise on Claude subprocess failure instead of returning empty string <!-- type:spec -->
- [x] Remove synthetic ACT/DO fallback from triage and surface failure in reply flows <!-- type:spec -->
- [x] PR comment: remove try/except ClaudeError in gh_status.generate_persona_status <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->