### PR TITLE
Handle already-merged PRs gracefully and log crashes to kennel.log

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -453,9 +453,18 @@ class GH:
     def pr_merge(
         self, repo: str, pr: int | str, squash: bool = True, auto: bool = False
     ) -> None:
-        """Merge a PR."""
+        """Merge a PR.
+
+        If the PR is already merged, logs and returns success rather than
+        raising.  This handles the race where kennel self-restarts after a
+        PR merge and the worker resumes with stale state thinking the PR
+        still needs merging.
+        """
+        pr_data = self._get(f"/repos/{repo}/pulls/{pr}")
+        if pr_data.get("merged"):
+            log.info("PR %s/#%s already merged — skipping", repo, pr)
+            return
         if auto:
-            pr_data = self._get(f"/repos/{repo}/pulls/{pr}")
             node_id = pr_data["node_id"]
             merge_method = "SQUASH" if squash else "MERGE"
             query = (
@@ -467,10 +476,25 @@ class GH:
             self._graphql(query, prId=node_id, mergeMethod=merge_method)
         else:
             merge_method = "squash" if squash else "merge"
-            self._put(
-                f"/repos/{repo}/pulls/{pr}/merge",
-                merge_method=merge_method,
-            )
+            try:
+                self._put(
+                    f"/repos/{repo}/pulls/{pr}/merge",
+                    merge_method=merge_method,
+                )
+            except _requests.HTTPError as e:
+                # Re-check: if the PR was merged between our initial get_pr and
+                # the merge call (race with webhook-triggered self-restart on
+                # another process), treat 405 as success.
+                if e.response is not None and e.response.status_code == 405:
+                    recheck = self._get(f"/repos/{repo}/pulls/{pr}")
+                    if recheck.get("merged"):
+                        log.info(
+                            "PR %s/#%s merged concurrently — treating 405 as success",
+                            repo,
+                            pr,
+                        )
+                        return
+                raise
 
     def get_pr(self, repo: str, pr: int | str) -> dict[str, Any]:
         """Return PR data (reviews, isDraft, mergeStateStatus, body, commits)."""

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -510,6 +510,23 @@ def run(
         handlers=handlers,
     )
 
+    # Route uncaught exceptions through the logger so tracebacks land in
+    # kennel.log, not just ~/log/kennel-crash.log (where start-kennel.sh
+    # redirects stderr).  Before this, RCA on crashes required reading two
+    # different log files.
+    def _log_uncaught(exc_type, exc_value, exc_tb):
+        log.critical("uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
+
+    def _log_thread_exception(args):
+        log.critical(
+            "uncaught exception in thread %s",
+            args.thread.name if args.thread else "?",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    sys.excepthook = _log_uncaught
+    threading.excepthook = _log_thread_exception
+
     _startup_pull()
 
     _populate_memberships(config)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -322,9 +322,12 @@ class TestGitHubClass:
 
     def test_pr_merge_delegates(self) -> None:
         gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.put.return_value = mock_resp
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        mock_s.get.return_value = get_resp
+        put_resp = MagicMock()
+        put_resp.json.return_value = {}
+        mock_s.put.return_value = put_resp
         gh.pr_merge("o/r", 10)
         assert mock_s.put.call_args.kwargs["json"]["merge_method"] == "squash"
 
@@ -1424,9 +1427,12 @@ class TestGHClass:
 
     def test_pr_merge_squash(self) -> None:
         gh, mock_s = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.put.return_value = mock_resp
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        mock_s.get.return_value = get_resp
+        put_resp = MagicMock()
+        put_resp.json.return_value = {}
+        mock_s.put.return_value = put_resp
         gh.pr_merge("o/r", 10)
         url = mock_s.put.call_args.args[0]
         assert "repos/o/r/pulls/10/merge" in url
@@ -1434,16 +1440,19 @@ class TestGHClass:
 
     def test_pr_merge_no_squash(self) -> None:
         gh, mock_s = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.put.return_value = mock_resp
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        mock_s.get.return_value = get_resp
+        put_resp = MagicMock()
+        put_resp.json.return_value = {}
+        mock_s.put.return_value = put_resp
         gh.pr_merge("o/r", 10, squash=False)
         assert mock_s.put.call_args.kwargs["json"]["merge_method"] == "merge"
 
     def test_pr_merge_auto(self) -> None:
         gh, mock_s = self._gh()
         pr_resp = MagicMock()
-        pr_resp.json.return_value = {"node_id": "PR_abc"}
+        pr_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
         graphql_resp = MagicMock()
         graphql_resp.json.return_value = {"data": {}}
         mock_s.get.return_value = pr_resp
@@ -1453,6 +1462,89 @@ class TestGHClass:
         assert "enablePullRequestAutoMerge" in body["query"]
         assert body["variables"]["mergeMethod"] == "SQUASH"
         assert body["variables"]["prId"] == "PR_abc"
+
+    def test_pr_merge_already_merged_returns_early(self) -> None:
+        """If the PR is already merged, skip the merge call silently."""
+        gh, mock_s = self._gh()
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": True, "node_id": "PR_abc"}
+        mock_s.get.return_value = get_resp
+        gh.pr_merge("o/r", 10)
+        mock_s.put.assert_not_called()
+        mock_s.post.assert_not_called()
+
+    def test_pr_merge_already_merged_auto_returns_early(self) -> None:
+        gh, mock_s = self._gh()
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": True, "node_id": "PR_abc"}
+        mock_s.get.return_value = get_resp
+        gh.pr_merge("o/r", 10, auto=True)
+        mock_s.post.assert_not_called()
+
+    def test_pr_merge_405_after_concurrent_merge_treated_as_success(self) -> None:
+        """Race: get_pr returns not-merged, but PR merges between our check and
+        the merge call.  405 response + recheck showing merged = treat as success."""
+        import requests as _requests
+
+        gh, mock_s = self._gh()
+        get_responses = [
+            MagicMock(
+                json=MagicMock(return_value={"merged": False, "node_id": "PR_x"})
+            ),
+            MagicMock(json=MagicMock(return_value={"merged": True, "node_id": "PR_x"})),
+        ]
+        mock_s.get.side_effect = get_responses
+        err = _requests.HTTPError("405 Method Not Allowed")
+        err.response = MagicMock(status_code=405)
+        put_resp = MagicMock()
+        put_resp.raise_for_status.side_effect = err
+        mock_s.put.return_value = put_resp
+        # Should not raise — 405 + recheck shows merged.
+        gh.pr_merge("o/r", 10)
+        assert mock_s.get.call_count == 2
+
+    def test_pr_merge_405_but_still_not_merged_reraises(self) -> None:
+        """405 with recheck showing not-merged means something else is wrong;
+        re-raise so the caller sees it."""
+        import requests as _requests
+
+        gh, mock_s = self._gh()
+        get_responses = [
+            MagicMock(
+                json=MagicMock(return_value={"merged": False, "node_id": "PR_x"})
+            ),
+            MagicMock(
+                json=MagicMock(return_value={"merged": False, "node_id": "PR_x"})
+            ),
+        ]
+        mock_s.get.side_effect = get_responses
+        err = _requests.HTTPError("405 Method Not Allowed")
+        err.response = MagicMock(status_code=405)
+        put_resp = MagicMock()
+        put_resp.raise_for_status.side_effect = err
+        mock_s.put.return_value = put_resp
+        import pytest as _pytest
+
+        with _pytest.raises(_requests.HTTPError):
+            gh.pr_merge("o/r", 10)
+
+    def test_pr_merge_non_405_error_reraises(self) -> None:
+        """Non-405 errors (e.g. 500) should not be swallowed."""
+        import requests as _requests
+
+        gh, mock_s = self._gh()
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"merged": False, "node_id": "PR_x"}
+        mock_s.get.return_value = get_resp
+        err = _requests.HTTPError("500 Internal Server Error")
+        err.response = MagicMock(status_code=500)
+        put_resp = MagicMock()
+        put_resp.raise_for_status.side_effect = err
+        mock_s.put.return_value = put_resp
+        import pytest as _pytest
+
+        with _pytest.raises(_requests.HTTPError):
+            gh.pr_merge("o/r", 10)
 
     def test_get_pr_returns_dict(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import urllib.error
 import urllib.request
 from http.server import HTTPServer
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1075,6 +1075,66 @@ class TestRun:
 
         mock_watchdog_cls.assert_called_once_with(mock_registry, fake_cfg.repos)
         mock_watchdog_cls.return_value.start_thread.assert_called_once()
+
+    def test_run_installs_excepthooks(self, tmp_path: Path) -> None:
+        """Uncaught exceptions (main thread and worker threads) should route
+        through the logger so tracebacks land in kennel.log, not just stderr."""
+        import sys as _sys
+        import threading as _threading
+
+        from kennel.server import run
+
+        fake_cfg = self._fake_cfg(tmp_path)
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+
+        saved_sys = _sys.excepthook
+        saved_thr = _threading.excepthook
+        try:
+            run(
+                _from_args=lambda: fake_cfg,
+                _HTTPServer=lambda *a, **kw: mock_server,
+                _make_registry=MagicMock(),
+                _path_home=lambda: tmp_path,
+                _basic_config=MagicMock(),
+                _populate_memberships=MagicMock(),
+                _startup_pull=MagicMock(),
+                _Watchdog=MagicMock(),
+            )
+            assert _sys.excepthook is not saved_sys
+            assert _threading.excepthook is not saved_thr
+
+            # Call the hooks to confirm they don't raise and they go through logging.
+            import kennel.server as srv_mod
+
+            with patch.object(srv_mod, "log") as mock_log:
+                try:
+                    raise ValueError("boom")
+                except ValueError:
+                    _sys.excepthook(*_sys.exc_info())
+                mock_log.critical.assert_called_once()
+
+            with patch.object(srv_mod, "log") as mock_log:
+                fake_args = MagicMock()
+                fake_args.thread = MagicMock(name="tname")
+                fake_args.exc_type = ValueError
+                fake_args.exc_value = ValueError("boom")
+                fake_args.exc_traceback = None
+                _threading.excepthook(fake_args)
+                mock_log.critical.assert_called_once()
+
+            # Also cover the branch where thread is None.
+            with patch.object(srv_mod, "log") as mock_log:
+                fake_args = MagicMock()
+                fake_args.thread = None
+                fake_args.exc_type = ValueError
+                fake_args.exc_value = ValueError("boom")
+                fake_args.exc_traceback = None
+                _threading.excepthook(fake_args)
+                mock_log.critical.assert_called_once()
+        finally:
+            _sys.excepthook = saved_sys
+            _threading.excepthook = saved_thr
 
 
 def _self_restart_cfg(tmp_path: Path) -> Config:


### PR DESCRIPTION
## Summary

Three fixes for the crash that took kennel down:

1. **`pr_merge()` handles already-merged PRs** — checks `pr_data.merged` first and returns early. If we hit a 405 from the merge endpoint (race with concurrent merge), re-check and treat as success if merged. Otherwise re-raise.

2. **Crash tracebacks now land in `kennel.log`** — installed `sys.excepthook` and `threading.excepthook` in `run()` to route uncaught exceptions through the logger. Before this, the crash traceback only made it to `~/log/kennel-crash.log` (stderr redirect from `start-kennel.sh`), which made RCA way harder than it needed to be.

Fixes #409

## Test plan

- [x] 1556 tests pass, 100% coverage
- [x] `test_pr_merge_already_merged_returns_early` — merged PR skips PUT
- [x] `test_pr_merge_405_after_concurrent_merge_treated_as_success` — race path
- [x] `test_pr_merge_405_but_still_not_merged_reraises` — genuine 405 bubbles up
- [x] `test_pr_merge_non_405_error_reraises` — other HTTP errors don't get swallowed
- [x] `test_run_installs_excepthooks` — main thread + worker thread + nil-thread branches

*no more silent crashes*