### PR TITLE
Strict <body> tag contract for PR description output

### DIFF
--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -315,7 +315,13 @@ def rewrite_description_prompt(
         "1. Keep it to 2-3 sentences.\n"
         "2. Preserve any 'Fixes #N.' lines exactly as they appear — do not add, remove, or modify them.\n"
         "3. Do not include work queue content, markdown headers, or HTML comments.\n"
-        "4. Output ONLY the replacement description text — no preamble, no explanation."
+        "4. Wrap your final output in <body>...</body> tags. Only text between the tags is used.\n"
+        "5. Do not add any text before the opening <body> tag or after the closing </body> tag.\n\n"
+        "Example output:\n"
+        "<body>\n"
+        "Fixes #123.\n\n"
+        "Refactors the foo module to use bar so we can add baz support later.\n"
+        "</body>"
     )
 
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -319,6 +319,26 @@ def ci_ready_for_review(
     return all(states.get(name) == "SUCCESS" for name in required_checks)
 
 
+_BODY_TAG_RE = re.compile(r"<body>\s*(.*?)\s*</body>", re.DOTALL | re.IGNORECASE)
+
+
+def _extract_body(raw: str | None) -> str:
+    """Extract content between <body>...</body> tags from Opus output.
+
+    Returns the extracted content stripped of whitespace, or "" if no body
+    tags were found or the raw input was empty.  This enforces the output
+    contract in :func:`kennel.prompts.rewrite_description_prompt` — Opus is
+    told to wrap its output in body tags so we can strip any preamble or
+    trailing commentary.
+    """
+    if not raw:
+        return ""
+    m = _BODY_TAG_RE.search(raw)
+    if not m:
+        return ""
+    return m.group(1).strip()
+
+
 def _write_pr_description(
     gh: Any,
     repo: str,
@@ -372,10 +392,12 @@ def _write_pr_description(
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
     prompt = rewrite_description_prompt(existing_body, task_list)
-    new_desc = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    new_desc = _extract_body(raw)
     if not new_desc:
         log.warning(
-            "_write_pr_description: Opus returned empty — using plain-text fallback"
+            "_write_pr_description: Opus returned no <body> content — using plain-text fallback (raw=%r)",
+            (raw or "")[:200],
         )
         new_desc = f"Working on #{issue}."
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3144,7 +3144,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="<body>Fresh desc.\n\nFixes #42.</body>"),
+            _print_prompt=MagicMock(
+                return_value="<body>Fresh desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3160,7 +3162,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="<body>New desc.\n\nFixes #42.</body>"),
+            _print_prompt=MagicMock(
+                return_value="<body>New desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3113,7 +3113,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New description.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>New description.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3126,7 +3128,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="Updated description.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>Updated description.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3140,7 +3144,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="Fresh desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(return_value="<body>Fresh desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3156,7 +3160,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(return_value="<body>New desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -793,10 +793,12 @@ class TestRewriteDescriptionPrompt:
         result = rewrite_description_prompt(self._body(), [])
         assert "work queue" in result.lower()
 
-    def test_output_only_constraint_stated(self) -> None:
+    def test_body_tag_contract_stated(self) -> None:
+        """Prompt must instruct Opus to wrap output in <body> tags so we can
+        reliably strip preamble and trailing chatter."""
         result = rewrite_description_prompt(self._body(), [])
-        assert "ONLY" in result or "only" in result
-        assert "preamble" in result or "no preamble" in result
+        assert "<body>" in result
+        assert "</body>" in result
 
     def test_extracts_description_at_divider(self) -> None:
         body = "My description.\n\nFixes #3.\n\n---\n\nStuff below divider."

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2166,6 +2166,52 @@ class TestGitClean:
         assert order == ["checkout", "clean"]
 
 
+class TestExtractBody:
+    """Tests for the module-level _extract_body helper."""
+
+    def test_extracts_between_tags(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body("<body>hello</body>") == "hello"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body("<body>\n  hello  \n</body>") == "hello"
+
+    def test_returns_empty_when_no_tags(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body("no tags here") == ""
+
+    def test_returns_empty_for_none(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body(None) == ""
+
+    def test_returns_empty_for_empty_string(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body("") == ""
+
+    def test_handles_preamble_and_trailing_chatter(self) -> None:
+        from kennel.worker import _extract_body
+
+        raw = "Here's my take:\n<body>the real content</body>\nHope that helps!"
+        assert _extract_body(raw) == "the real content"
+
+    def test_handles_multiline_body(self) -> None:
+        from kennel.worker import _extract_body
+
+        raw = "<body>line 1\n\nline 2\n\nFixes #5.</body>"
+        assert _extract_body(raw) == "line 1\n\nline 2\n\nFixes #5."
+
+    def test_case_insensitive(self) -> None:
+        from kennel.worker import _extract_body
+
+        assert _extract_body("<BODY>upper</BODY>") == "upper"
+
+
 class TestWritePrDescription:
     """Tests for the module-level _write_pr_description function."""
 
@@ -2177,7 +2223,7 @@ class TestWritePrDescription:
         gh,
         task_list=None,
         existing_body="",
-        print_return="Desc.\n\nFixes #1.",
+        print_return="<body>Desc.\n\nFixes #1.</body>",
         issue=1,
         pr_number=42,
     ):
@@ -2290,7 +2336,10 @@ class TestWritePrDescription:
     def test_fixes_line_appended_when_missing(self) -> None:
         gh = MagicMock()
         self._call(
-            gh, print_return="Summary without fixes line.", issue=99, pr_number=5
+            gh,
+            print_return="<body>Summary without fixes line.</body>",
+            issue=99,
+            pr_number=5,
         )
         body = gh.edit_pr_body.call_args[0][2]
         assert "Fixes #99." in body
@@ -2299,11 +2348,39 @@ class TestWritePrDescription:
         gh = MagicMock()
         self._call(
             gh,
-            print_return="Summary.\n\nFixes #1.",
+            print_return="<body>Summary.\n\nFixes #1.</body>",
             issue=1,
         )
         body = gh.edit_pr_body.call_args[0][2]
         assert body.count("Fixes #1.") == 1
+
+    def test_strips_preamble_before_body_tag(self) -> None:
+        """Claude's chatty preamble before <body> must be stripped from the PR."""
+        gh = MagicMock()
+        chatty = (
+            "The current body is short. Here's the replacement:\n\n"
+            "<body>Clean description.\n\nFixes #1.</body>\n\n"
+            "Want me to update it directly?"
+        )
+        self._call(gh, print_return=chatty, issue=1)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Clean description." in body
+        assert "The current body is short" not in body
+        assert "Want me to update it directly" not in body
+
+    def test_falls_back_when_no_body_tags(self) -> None:
+        """No body tags = treat as garbage, use plain-text fallback."""
+        gh = MagicMock()
+        self._call(gh, print_return="Bare text with no body tags.", issue=42)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Working on #42." in body
+        assert "Bare text with no body tags" not in body
+
+    def test_body_tag_match_is_case_insensitive(self) -> None:
+        gh = MagicMock()
+        self._call(gh, print_return="<BODY>Upper case tag.</BODY>", issue=1)
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "Upper case tag." in body
 
     def test_rewrite_preserves_rest_section(self) -> None:
         gh = MagicMock()


### PR DESCRIPTION
## Summary

Opus was returning chatty preamble and trailing questions alongside the actual PR body — stuff like "The current body is just \`Fixes #376\`..." and "Want me to update the PR body directly?" ended up in the PR description.

This PR tightens the contract:
- **Prompt**: requires output wrapped in \`<body>...</body>\` tags with an explicit example
- **Worker**: \`_extract_body()\` pulls only the content between the tags; anything outside is dropped
- **Fallback**: if Opus doesn't emit body tags at all, fall back to \`Working on #N.\` and log the raw (truncated) output so we can see what went wrong

Fixes #411

## Test plan

- [x] 1567 tests pass, 100% coverage
- [x] \`test_strips_preamble_before_body_tag\` — chatty text outside tags is dropped
- [x] \`test_falls_back_when_no_body_tags\` — no tags = plain-text fallback
- [x] \`test_body_tag_match_is_case_insensitive\` — \`<BODY>\` also works
- [x] 8 unit tests on \`_extract_body\` directly (empty, None, multiline, etc.)

*no more chatty PR bodies*