### PR TITLE
Surface PR-body sync and rewrite failures (closes #378)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -826,8 +826,9 @@ def _rewrite_pr_description(
     PR creation and post-rescope rewrites share one code path.
 
     Silently skips when there is no active issue or no open PR for it.
-    Skips (and logs) when the PR body fetch fails or when the shared writer
-    skips (no ``---`` divider, or Opus returned empty).
+    Skips without error when the shared writer returns False (no ``---``
+    divider, or Opus returned empty).  All GitHub fetch and write errors
+    propagate so the caller's thread excepthook can surface them.
 
     Retries up to *_max_retries* times when the task list changes while Opus
     is generating the description, so the written description always reflects
@@ -849,12 +850,8 @@ def _rewrite_pr_description(
         log.info("_rewrite_pr_description: no active issue in state — skipping")
         return
 
-    try:
-        repo = gh.get_repo_info(cwd=work_dir)
-        user = gh.get_user()
-    except Exception:
-        log.exception("_rewrite_pr_description: failed to get repo info")
-        return
+    repo = gh.get_repo_info(cwd=work_dir)
+    user = gh.get_user()
 
     pr_data = gh.find_pr(repo, issue, user)
     if pr_data is None or pr_data.get("state") != "OPEN":
@@ -867,19 +864,10 @@ def _rewrite_pr_description(
         task_list = _tasks.list()
         snapshot_before = _task_snapshot(task_list)
 
-        try:
-            body = gh.get_pr_body(repo, pr_number)
-        except Exception:
-            log.exception("_rewrite_pr_description: failed to get PR body")
-            return
-
-        try:
-            written = _write_pr_description(
-                gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
-            )
-        except Exception:
-            log.exception("_rewrite_pr_description: failed to update PR body")
-            return
+        body = gh.get_pr_body(repo, pr_number)
+        written = _write_pr_description(
+            gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
+        )
 
         if not written:
             return

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -264,12 +264,8 @@ def _auto_complete_ask_tasks(
     if not ask_tasks:
         return
 
-    try:
-        owner, repo_name = repo.split("/", 1)
-        nodes = gh.get_review_threads(owner, repo_name, pr_number)
-    except Exception:
-        log.exception("sync_tasks: failed to fetch review threads for ASK resolution")
-        return
+    owner, repo_name = repo.split("/", 1)
+    nodes = gh.get_review_threads(owner, repo_name, pr_number)
 
     resolved_ids: set[int] = set()
     for node in nodes:
@@ -325,12 +321,8 @@ def sync_tasks(
             log.info("sync_tasks: no current issue — nothing to sync")
             return
 
-        try:
-            repo = gh.get_repo_info(cwd=work_dir)
-            user = gh.get_user()
-        except Exception:
-            log.exception("sync_tasks: failed to get repo info or user")
-            return
+        repo = gh.get_repo_info(cwd=work_dir)
+        user = gh.get_user()
 
         pr_data = gh.find_pr(repo, issue, user)
         if pr_data is None or pr_data.get("state") != "OPEN":
@@ -348,11 +340,7 @@ def sync_tasks(
         queue = _format_work_queue(task_list)
         log.info("sync_tasks: syncing task list → PR #%s", pr_number)
 
-        try:
-            body = gh.get_pr_body(repo, pr_number)
-        except Exception:
-            log.exception("sync_tasks: failed to get PR body")
-            return
+        body = gh.get_pr_body(repo, pr_number)
 
         if "WORK_QUEUE_START" not in body:
             log.info(
@@ -362,11 +350,8 @@ def sync_tasks(
             return
 
         new_body = _apply_queue_to_body(body, queue)
-        try:
-            gh.edit_pr_body(repo, pr_number, new_body)
-            log.info("sync_tasks: PR #%s work queue synced", pr_number)
-        except Exception:
-            log.exception("sync_tasks: failed to update PR body")
+        gh.edit_pr_body(repo, pr_number, new_body)
+        log.info("sync_tasks: PR #%s work queue synced", pr_number)
     finally:
         sync_lock_fd.close()
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+
 from kennel.config import Config, RepoConfig
 from kennel.events import (
     Action,
@@ -1602,6 +1604,7 @@ class TestCreateTask:
                 thread=new_thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -1738,6 +1741,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_called_once_with("owner/repo")
         # ABORT_KEEP: current task stays in tasks.json
@@ -1767,6 +1771,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_called_once_with("owner/repo")
         # task should still be in tasks.json (ABORT_KEEP)
@@ -1795,6 +1800,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -3035,15 +3041,16 @@ class TestRewritePrDescription:
         )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_skips_on_get_repo_exception(self, tmp_path: Path) -> None:
+    def test_raises_on_get_repo_exception(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
         mock_gh.get_repo_info.side_effect = RuntimeError("network error")
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(),
-            _state=self._mock_state(),
-        )
+        with pytest.raises(RuntimeError, match="network error"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(),
+                _state=self._mock_state(),
+            )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_no_open_pr(self, tmp_path: Path) -> None:
@@ -3068,16 +3075,17 @@ class TestRewritePrDescription:
         )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_skips_on_get_pr_body_exception(self, tmp_path: Path) -> None:
+    def test_raises_on_get_pr_body_exception(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
         mock_gh.get_pr_body.side_effect = RuntimeError("API error")
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(),
-            _state=self._mock_state(),
-            _tasks=self._mock_tasks(),
-        )
+        with pytest.raises(RuntimeError, match="API error"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(),
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
+            )
         mock_gh.edit_pr_body.assert_not_called()
 
     def test_skips_when_no_divider_in_body(self, tmp_path: Path) -> None:
@@ -3155,19 +3163,19 @@ class TestRewritePrDescription:
         assert "Fresh desc." in new_body
         assert "## Work queue" in new_body
 
-    def test_handles_edit_pr_body_exception(self, tmp_path: Path) -> None:
+    def test_raises_on_edit_pr_body_exception(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
         mock_gh.edit_pr_body.side_effect = RuntimeError("write failed")
-        # Should not propagate the exception
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New desc.\n\nFixes #42.</body>"
-            ),
-            _state=self._mock_state(),
-            _tasks=self._mock_tasks(),
-        )
+        with pytest.raises(RuntimeError, match="write failed"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(
+                    return_value="<body>New desc.\n\nFixes #42.</body>"
+                ),
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
+            )
 
     def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7707,19 +7707,20 @@ class TestAutoCompleteAskTasks:
         )
         mock_complete.assert_not_called()
 
-    def test_get_review_threads_exception_logged(self, tmp_path: Path) -> None:
+    def test_get_review_threads_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = self._ask_task(1)
         gh.get_review_threads.side_effect = RuntimeError("api fail")
         mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
+        with pytest.raises(RuntimeError, match="api fail"):
+            _auto_complete_ask_tasks(
+                tmp_path,
+                gh,
+                "owner/repo",
+                1,
+                _list_tasks=MagicMock(return_value=[task]),
+                _complete_by_id=mock_complete,
+            )
         mock_complete.assert_not_called()
 
     def test_non_ask_tasks_ignored(self, tmp_path: Path) -> None:
@@ -7905,15 +7906,16 @@ class TestSyncTasks:
         sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
         gh.edit_pr_body.assert_not_called()
 
-    def test_get_repo_info_exception_logged(self, tmp_path: Path) -> None:
+    def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)
         self._state_with_issue(fido_dir)
         gh.get_repo_info.side_effect = RuntimeError("no remote")
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
+        with pytest.raises(RuntimeError, match="no remote"):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.find_pr.assert_not_called()
 
-    def test_get_pr_body_exception_breaks_loop(self, tmp_path: Path) -> None:
+    def test_get_pr_body_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)
         self._state_with_issue(fido_dir)
@@ -7922,10 +7924,11 @@ class TestSyncTasks:
         gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
         gh.get_pr_body.side_effect = RuntimeError("api down")
         task = {"title": "Do it", "status": "pending"}
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with pytest.raises(RuntimeError, match="api down"):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
         gh.edit_pr_body.assert_not_called()
 
-    def test_edit_pr_body_exception_breaks_loop(self, tmp_path: Path) -> None:
+    def test_edit_pr_body_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)
         self._state_with_issue(fido_dir)
@@ -7936,9 +7939,8 @@ class TestSyncTasks:
         gh.get_pr_body.return_value = body
         gh.edit_pr_body.side_effect = RuntimeError("api down")
         task = {"title": "Do it", "status": "pending"}
-        sync_tasks(
-            tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task])
-        )  # should not raise
+        with pytest.raises(RuntimeError, match="api down"):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
 
 
 class TestSyncTasksBackground:


### PR DESCRIPTION
Harden the task-sync and PR description update paths so GitHub fetch and update failures surface loudly instead of being silently swallowed.

Fixes #378.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Fail sync_tasks loudly on GitHub fetch/update errors <!-- type:spec -->
- [x] Fail _rewrite_pr_description loudly on GitHub fetch/update errors <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->