### PR TITLE
Make reply flows fail closed around human-visible side effects (closes #379)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -555,7 +555,10 @@ def reply_to_issue_comment(
     _print_prompt=None,
     _gh=None,
 ) -> tuple[str, list[str]]:
-    """Triage and reply to a top-level PR comment (issue_comment event)."""
+    """Triage and reply to a top-level PR comment (issue_comment event).
+
+    Raises on reply-post failure so callers fail closed.
+    """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     comment = action.comment_body or ""
@@ -617,11 +620,8 @@ def reply_to_issue_comment(
         body = "On it!" if category in ("ACT", "DO") else "Noted."
 
     log.info("posting issue comment reply on PR #%s: %s", number, body[:80])
-    try:
-        gh.comment_issue(repo_full, number, body)
-        log.info("reply posted")
-    except Exception:
-        log.exception("failed to post issue comment reply")
+    gh.comment_issue(repo_full, number, body)
+    log.info("reply posted")
 
     # Get comment_id from the dispatch payload (stored in context)
     _cid = (action.context or {}).get("comment_id")

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -826,9 +826,8 @@ def _rewrite_pr_description(
     PR creation and post-rescope rewrites share one code path.
 
     Silently skips when there is no active issue or no open PR for it.
-    Skips without error when the shared writer returns False (no ``---``
-    divider, or Opus returned empty).  All GitHub fetch and write errors
-    propagate so the caller's thread excepthook can surface them.
+    All other errors (missing ``---`` divider, empty Opus output, GitHub API
+    failures) propagate so the caller's thread excepthook can surface them.
 
     Retries up to *_max_retries* times when the task list changes while Opus
     is generating the description, so the written description always reflects
@@ -865,12 +864,9 @@ def _rewrite_pr_description(
         snapshot_before = _task_snapshot(task_list)
 
         body = gh.get_pr_body(repo, pr_number)
-        written = _write_pr_description(
+        _write_pr_description(
             gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
         )
-
-        if not written:
-            return
 
         snapshot_after = _task_snapshot(_tasks.list())
         if snapshot_after == snapshot_before:

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -269,20 +269,20 @@ def reply_to_comment(
     *,
     _print_prompt=None,
     _gh=None,
-) -> tuple[bool, str, list[str]]:
+) -> tuple[str, list[str]]:
     """Triage a comment via Opus, generate a reply via Opus, post it.
 
-    Returns (posted, triage_category, task_titles).
-    posted is True only when the reply was successfully sent to GitHub.
+    Returns (triage_category, task_titles).
     task_titles is a list: one entry for non-task categories (used as reply
     context), or one or more entries for ACT/DO (each becomes a task).
     Uses a per-comment lockfile to prevent concurrent replies.
+    Raises on reply-post failure so callers fail closed.
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     info = action.reply_to
     if not info or not action.comment_body:
-        return (False, "ACT", [action.comment_body or action.prompt])
+        return ("ACT", [action.comment_body or action.prompt])
 
     # Per-comment lock — prevents concurrent replies
     cid = info.get("comment_id")
@@ -294,7 +294,7 @@ def reply_to_comment(
         except OSError:
             log.info("comment %s locked by another process — skipping", cid)
             lock_fd.close()
-            return (False, "ACT", [action.comment_body[:80]])
+            return ("ACT", [action.comment_body[:80]])
     else:
         lock_fd = None
 
@@ -364,13 +364,8 @@ def reply_to_comment(
         )
 
     log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
-    posted = False
-    try:
-        gh.reply_to_review_comment(info["repo"], info["pr"], body, info["comment_id"])
-        posted = True
-        log.info("reply posted")
-    except Exception:
-        log.exception("failed to post reply")
+    gh.reply_to_review_comment(info["repo"], info["pr"], body, info["comment_id"])
+    log.info("reply posted")
 
     # Maybe react
     maybe_react(
@@ -391,7 +386,7 @@ def reply_to_comment(
     if lock_fd:
         lock_fd.close()
 
-    return (posted, category, titles)
+    return (category, titles)
 
 
 def _try_resolve_thread(info: dict[str, Any], config: Config) -> None:
@@ -444,7 +439,7 @@ def reply_to_review(
         return
     log.info("replying to %d review comments", len(todo))
     for cid, body in todo:
-        posted, *_ = reply_to_comment(
+        reply_to_comment(
             Action(
                 prompt=action.prompt,
                 reply_to={
@@ -459,7 +454,7 @@ def reply_to_review(
             _print_prompt=_print_prompt,
             _gh=gh,
         )
-        if posted and already_replied is not None:
+        if already_replied is not None:
             already_replied.add(cid)
 
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -206,21 +206,16 @@ def _load_persona(config: Config) -> str:
         return ""
 
 
-def _open_defer_issue(
-    gh: Any, repo: str, pr_url: str, title: str, comment: str
-) -> str | None:
+def _open_defer_issue(gh: Any, repo: str, pr_url: str, title: str, comment: str) -> str:
     """Create a tracking issue for a DEFER triage result.
 
-    Returns the new issue URL, or None if creation failed.
+    Returns the new issue URL.  Raises on any creation failure so the caller
+    fails closed rather than crafting a reply that references a missing issue.
     """
     issue_body = f"Deferred from {pr_url}\n\n> {comment}" if pr_url else comment
-    try:
-        url = gh.create_issue(repo, title, issue_body)
-        log.info("opened tracking issue for DEFER: %s", url)
-        return url
-    except Exception:
-        log.exception("failed to open tracking issue for DEFER")
-        return None
+    url = gh.create_issue(repo, title, issue_body)
+    log.info("opened tracking issue for DEFER: %s", url)
+    return url
 
 
 def _comment_lock(work_dir: Path, comment_id: int) -> Path:
@@ -336,7 +331,8 @@ def reply_to_comment(
     )
     log.info("triage: %s — %s", category, titles)
 
-    # Step 2: For DEFER, open a tracking issue before crafting the reply
+    # Step 2: For DEFER, open a tracking issue before crafting the reply.
+    # Raises on failure so we don't craft a reply referencing a missing issue.
     issue_url: str | None = None
     if category == "DEFER" and info.get("repo"):
         pr_url = f"https://github.com/{info['repo']}/pull/{info['pr']}"
@@ -604,7 +600,8 @@ def reply_to_issue_comment(
     )
     log.info("issue comment triage: %s — %s", category, titles)
 
-    # For DEFER, open a tracking issue before crafting the reply
+    # For DEFER, open a tracking issue before crafting the reply.
+    # Raises on failure so we don't craft a reply referencing a missing issue.
     issue_url: str | None = None
     if category == "DEFER":
         pr_url = f"https://github.com/{repo_full}/pull/{number}" if number else ""

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -439,21 +439,25 @@ def reply_to_review(
         return
     log.info("replying to %d review comments", len(todo))
     for cid, body in todo:
-        reply_to_comment(
-            Action(
-                prompt=action.prompt,
-                reply_to={
-                    "repo": info["repo"],
-                    "pr": info["pr"],
-                    "comment_id": cid,
-                },
-                comment_body=body,
-            ),
-            config,
-            repo_cfg,
-            _print_prompt=_print_prompt,
-            _gh=gh,
-        )
+        try:
+            reply_to_comment(
+                Action(
+                    prompt=action.prompt,
+                    reply_to={
+                        "repo": info["repo"],
+                        "pr": info["pr"],
+                        "comment_id": cid,
+                    },
+                    comment_body=body,
+                ),
+                config,
+                repo_cfg,
+                _print_prompt=_print_prompt,
+                _gh=gh,
+            )
+        except Exception:
+            log.exception("failed to reply to review comment %s — skipping", cid)
+            continue
         if already_replied is not None:
             already_replied.add(cid)
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -287,10 +287,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     handled = True
                     category, titles = None, []
                 else:
-                    posted, category, titles = type(self)._fn_reply_to_comment(
+                    category, titles = type(self)._fn_reply_to_comment(
                         action, self.config, repo_cfg
                     )
-                    if cid and posted:
+                    if cid:
                         _replied_comments.add(cid)
                     handled = True
                 # Create task based on triage result.

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -348,7 +348,7 @@ def _write_pr_description(
     existing_body: str = "",
     *,
     _print_prompt=None,
-) -> bool:
+) -> None:
     """Write or rewrite the PR description.
 
     Handles both initial PR creation (``existing_body=""``; builds work-queue
@@ -357,9 +357,9 @@ def _write_pr_description(
     divider).
 
     Generates the description via Opus and writes it back via
-    ``gh.edit_pr_body``.  Returns ``True`` if the body was written,
-    ``False`` when skipped (no divider in an existing body).  When Opus
-    returns empty, falls back to a plain-text ``"Working on #N."`` line.
+    ``gh.edit_pr_body``.  Raises ``ValueError`` when the existing body has no
+    ``---`` divider (rewrite precondition) or when Opus returns no
+    ``<body>``-tagged content.
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
@@ -370,10 +370,9 @@ def _write_pr_description(
     # where the description section ends.  For initial write (empty body)
     # skip this guard and build the rest section fresh.
     if existing_body and divider not in existing_body:
-        log.info(
-            "_write_pr_description: no --- divider in PR #%s body — skipping", pr_number
+        raise ValueError(
+            f"_write_pr_description: no --- divider in PR #{pr_number} body"
         )
-        return False
 
     # Preserve the existing rest section or build the work-queue from scratch.
     if divider in existing_body:
@@ -395,11 +394,10 @@ def _write_pr_description(
     raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
     new_desc = _extract_body(raw)
     if not new_desc:
-        log.warning(
-            "_write_pr_description: Opus returned no <body> content — using plain-text fallback (raw=%r)",
-            (raw or "")[:200],
+        raise ValueError(
+            f"_write_pr_description: Opus returned no <body> content for PR #{pr_number}"
+            f" (raw={str(raw or '')[:200]!r})"
         )
-        new_desc = f"Working on #{issue}."
 
     # Ensure "Fixes #N" is always present (Opus preserves it for rewrites via
     # prompt rules; for initial writes we append it here).
@@ -409,7 +407,6 @@ def _write_pr_description(
     new_body = f"{new_desc.strip()}{divider}{rest}"
     gh.edit_pr_body(repo, pr_number, new_body)
     log.info("_write_pr_description: PR #%s description written", pr_number)
-    return True
 
 
 class Worker:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1250,15 +1250,14 @@ class TestReplyToIssueComment:
         )
         assert cat == "ACT"
 
-    def test_post_exception_does_not_raise(self, tmp_path: Path) -> None:
-        """comment_issue failure is caught and does not propagate."""
+    def test_post_exception_propagates(self, tmp_path: Path) -> None:
+        """comment_issue failure propagates so callers fail closed."""
         cfg = self._cfg(tmp_path)
-        # Use action without comment_id so react block is skipped
         action = Action(
             prompt="PR top-level comment on #7 by owner:\n\nplease fix",
             comment_body="please fix",
             is_bot=False,
-            context={"pr_title": "My PR"},  # no comment_id → react block skipped
+            context={"pr_title": "My PR"},
         )
 
         def fake_pp(prompt, model, **kwargs):
@@ -1268,14 +1267,14 @@ class TestReplyToIssueComment:
 
         mock_gh = MagicMock()
         mock_gh.comment_issue.side_effect = Exception("gh fail")
-        cat, titles = reply_to_issue_comment(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            _print_prompt=fake_pp,
-            _gh=mock_gh,
-        )
-        assert cat == "ACT"
+        with pytest.raises(Exception, match="gh fail"):
+            reply_to_issue_comment(
+                action,
+                cfg,
+                self._repo_cfg(tmp_path),
+                _print_prompt=fake_pp,
+                _gh=mock_gh,
+            )
 
     def test_no_comment_id_skips_react(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3088,33 +3088,31 @@ class TestRewritePrDescription:
             )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_skips_when_no_divider_in_body(self, tmp_path: Path) -> None:
+    def test_raises_when_no_divider_in_body(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh(
             body="No divider here. <!-- WORK_QUEUE_START -->x<!-- WORK_QUEUE_END -->"
         )
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(),
-            _state=self._mock_state(),
-            _tasks=self._mock_tasks(),
-        )
+        with pytest.raises(ValueError, match="no --- divider"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(),
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
+            )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_uses_plain_text_fallback_when_opus_returns_empty(
-        self, tmp_path: Path
-    ) -> None:
+    def test_raises_when_opus_returns_empty(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(return_value=""),
-            _state=self._mock_state(),
-            _tasks=self._mock_tasks(),
-        )
-        mock_gh.edit_pr_body.assert_called_once()
-        body = mock_gh.edit_pr_body.call_args[0][2]
-        assert "Working on #42." in body
+        with pytest.raises(ValueError, match="no <body> content"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(return_value=""),
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
+            )
+        mock_gh.edit_pr_body.assert_not_called()
 
     def test_updates_pr_body_with_new_description(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
@@ -3179,7 +3177,10 @@ class TestRewritePrDescription:
 
     def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
-        with patch("kennel.claude.print_prompt", return_value="") as mock_pp:
+        with patch(
+            "kennel.claude.print_prompt",
+            return_value="<body>Desc.\n\nFixes #42.</body>",
+        ) as mock_pp:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
@@ -3210,7 +3211,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>New desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=tasks,
         )
@@ -3232,7 +3235,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>New desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=tasks,
         )
@@ -3253,32 +3258,29 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>New desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=tasks,
             _max_retries=3,
         )
         assert mock_gh.edit_pr_body.call_count == 3
 
-    def test_no_retry_when_write_skipped(self, tmp_path: Path) -> None:
-        """When _write_pr_description returns False (e.g. no divider), no retry."""
-        task_before = {"id": "t1", "status": "pending", "title": "Before"}
-        task_after = {"id": "t2", "status": "pending", "title": "After"}
-        tasks = MagicMock()
-        tasks.list.side_effect = [
-            [task_before],  # snapshot before
-            [task_after],  # snapshot after (would differ — but write was skipped)
-        ]
+    def test_no_divider_raises_before_retry(self, tmp_path: Path) -> None:
+        """When the PR body has no --- divider, ValueError propagates immediately."""
         mock_gh = self._mock_gh(body="No divider here. Nothing.")
-        _rewrite_pr_description(
-            tmp_path,
-            mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
-            _state=self._mock_state(),
-            _tasks=tasks,
-        )
+        with pytest.raises(ValueError, match="no --- divider"):
+            _rewrite_pr_description(
+                tmp_path,
+                mock_gh,
+                _print_prompt=MagicMock(
+                    return_value="<body>New desc.\n\nFixes #42.</body>"
+                ),
+                _state=self._mock_state(),
+                _tasks=self._mock_tasks(),
+            )
         mock_gh.edit_pr_body.assert_not_called()
-        assert tasks.list.call_count == 1  # no after-snapshot read
 
     def test_refetches_pr_body_on_retry(self, tmp_path: Path) -> None:
         """PR body is re-fetched on each attempt so work-queue stays current."""
@@ -3295,7 +3297,9 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(return_value="New desc.\n\nFixes #42."),
+            _print_prompt=MagicMock(
+                return_value="<body>New desc.\n\nFixes #42.</body>"
+            ),
             _state=self._mock_state(),
             _tasks=tasks,
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -650,8 +650,7 @@ class TestReplyToComment:
     def test_no_reply_to_returns_act(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="do stuff")
-        posted, cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
-        assert not posted
+        cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
         assert cat == "ACT"
 
     def test_no_comment_body_returns_act(self, tmp_path: Path) -> None:
@@ -660,8 +659,7 @@ class TestReplyToComment:
             prompt="something",
             reply_to={"repo": "a/b", "pr": 1, "comment_id": 5},
         )
-        posted, cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
-        assert not posted
+        cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
         assert cat == "ACT"
 
     def test_full_flow_act(self, tmp_path: Path) -> None:
@@ -686,14 +684,13 @@ class TestReplyToComment:
                 return "ACT: add logging"
             return "I will add logging."
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ACT"
         assert "logging" in titles[0].lower()
 
@@ -713,14 +710,13 @@ class TestReplyToComment:
                 return "ASK: need more info"
             return "What specifically?"
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ASK"
 
     def test_full_flow_answer(self, tmp_path: Path) -> None:
@@ -739,14 +735,13 @@ class TestReplyToComment:
                 return "ANSWER: explain choice"
             return "I did this because..."
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ANSWER"
 
     def test_full_flow_do(self, tmp_path: Path) -> None:
@@ -766,14 +761,13 @@ class TestReplyToComment:
             return "On it!"
 
         mock_gh = MagicMock()
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=mock_gh,
         )
-        assert posted
         assert cat == "DO"
         assert titles == ["add result caching"]
         mock_gh.create_issue.assert_not_called()
@@ -796,14 +790,13 @@ class TestReplyToComment:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.return_value = "https://github.com/owner/repo/issues/99"
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=mock_gh,
         )
-        assert posted
         assert cat == "DEFER"
         mock_gh.create_issue.assert_called_once_with(
             "owner/repo",
@@ -827,14 +820,13 @@ class TestReplyToComment:
                 return "DUMP: not applicable"
             return "Not applicable here."
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "DUMP"
 
     def test_full_flow_defer_issue_creation_failure_propagates(
@@ -884,14 +876,13 @@ class TestReplyToComment:
                 return "ACT: do it"
             return ""  # empty reply triggers fallback
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ACT"  # still succeeds with fallback body
 
     def test_claude_timeout_uses_fallback(self, tmp_path: Path) -> None:
@@ -910,14 +901,13 @@ class TestReplyToComment:
                 return "ACT: do it"
             return ""  # simulates timeout — print_prompt returns "" on failure
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ACT"
 
     def test_lock_race_returns_act(self, tmp_path: Path) -> None:
@@ -937,10 +927,7 @@ class TestReplyToComment:
                 comment_body="competing update",
                 is_bot=False,
             )
-            posted, cat, titles = reply_to_comment(
-                action, cfg, self._repo_cfg(tmp_path)
-            )
-            assert not posted  # locked — no reply sent
+            cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
             assert cat == "ACT"  # returns without posting
         finally:
             lock_fd.close()
@@ -962,14 +949,13 @@ class TestReplyToComment:
                 return "ACT: do it"
             return "ok"
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ACT"
 
     def test_multiple_tasks_from_one_comment(self, tmp_path: Path) -> None:
@@ -989,14 +975,13 @@ class TestReplyToComment:
                 return "ACT: add unit tests\nACT: update documentation"
             return "On it!"
 
-        posted, cat, titles = reply_to_comment(
+        cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             _print_prompt=fake_pp,
             _gh=MagicMock(),
         )
-        assert posted
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
 
@@ -2745,18 +2730,17 @@ class TestReplyToCommentElseBranch:
             patch("kennel.events._triage", return_value=("UNKNOWN_CAT", ["do it"])),
             patch("kennel.events.needs_more_context", return_value=False),
         ):
-            posted, cat, titles = reply_to_comment(
+            cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
                 _print_prompt=MagicMock(return_value="I'll look into this."),
                 _gh=MagicMock(),
             )
-        assert posted
         assert cat == "UNKNOWN_CAT"
 
-    def test_gh_post_exception_caught(self, tmp_path: Path) -> None:
-        """Exception in reply_to_review_comment is caught."""
+    def test_gh_post_exception_propagates(self, tmp_path: Path) -> None:
+        """Exception in reply_to_review_comment propagates so callers fail closed."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -2774,15 +2758,14 @@ class TestReplyToCommentElseBranch:
 
         mock_gh = MagicMock()
         mock_gh.reply_to_review_comment.side_effect = RuntimeError("network down")
-        posted, cat, titles = reply_to_comment(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            _print_prompt=fake_pp,
-            _gh=mock_gh,
-        )  # must not raise
-        assert not posted  # post failed
-        assert cat == "ACT"
+        with pytest.raises(RuntimeError, match="network down"):
+            reply_to_comment(
+                action,
+                cfg,
+                self._repo_cfg(tmp_path),
+                _print_prompt=fake_pp,
+                _gh=mock_gh,
+            )
 
 
 class TestReplyToReviewAlreadyRepliedTracking:
@@ -2830,7 +2813,7 @@ class TestReplyToReviewAlreadyRepliedTracking:
     def test_does_not_add_to_already_replied_on_post_failure(
         self, tmp_path: Path
     ) -> None:
-        """Dedup set is NOT updated when the GitHub post fails."""
+        """Dedup set is NOT updated when the GitHub post fails (exception propagates)."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="review",
@@ -2848,14 +2831,15 @@ class TestReplyToReviewAlreadyRepliedTracking:
         mock_gh = MagicMock()
         mock_gh.get_review_comments.return_value = [(501, "please fix")]
         mock_gh.reply_to_review_comment.side_effect = RuntimeError("network down")
-        reply_to_review(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            already_replied=already,
-            _print_prompt=fake_pp,
-            _gh=mock_gh,
-        )
+        with pytest.raises(RuntimeError, match="network down"):
+            reply_to_review(
+                action,
+                cfg,
+                self._repo_cfg(tmp_path),
+                already_replied=already,
+                _print_prompt=fake_pp,
+                _gh=mock_gh,
+            )
         assert 501 not in already  # post failed — should not be marked as replied
 
 
@@ -2962,7 +2946,7 @@ class TestReplyToCommentTerseEnrichment:
             return "On it."
 
         with patch("kennel.events.needs_more_context", return_value=True):
-            posted, cat, titles = reply_to_comment(
+            cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
@@ -2970,7 +2954,6 @@ class TestReplyToCommentTerseEnrichment:
                 _gh=mock_gh,
             )
 
-        assert posted
         assert cat == "ACT"
 
     def test_terse_no_siblings_leaves_context_clean(self, tmp_path: Path) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2812,7 +2812,7 @@ class TestReplyToReviewAlreadyRepliedTracking:
     def test_does_not_add_to_already_replied_on_post_failure(
         self, tmp_path: Path
     ) -> None:
-        """Dedup set is NOT updated when the GitHub post fails (exception propagates)."""
+        """Failed comment is not added to already_replied; loop continues for others."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="review",
@@ -2828,18 +2828,25 @@ class TestReplyToReviewAlreadyRepliedTracking:
             return "Will fix."
 
         mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = [(501, "please fix")]
-        mock_gh.reply_to_review_comment.side_effect = RuntimeError("network down")
-        with pytest.raises(RuntimeError, match="network down"):
-            reply_to_review(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                already_replied=already,
-                _print_prompt=fake_pp,
-                _gh=mock_gh,
-            )
+        mock_gh.get_review_comments.return_value = [
+            (501, "please fix"),
+            (502, "also fix this"),
+        ]
+        # First comment fails, second succeeds
+        mock_gh.reply_to_review_comment.side_effect = [
+            RuntimeError("network down"),
+            None,
+        ]
+        reply_to_review(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            already_replied=already,
+            _print_prompt=fake_pp,
+            _gh=mock_gh,
+        )
         assert 501 not in already  # post failed — should not be marked as replied
+        assert 502 in already  # second comment still processed
 
 
 class TestReplyToCommentTerseEnrichment:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -837,8 +837,10 @@ class TestReplyToComment:
         assert posted
         assert cat == "DUMP"
 
-    def test_full_flow_defer_issue_creation_failure(self, tmp_path: Path) -> None:
-        """DEFER still posts a reply even when create_issue raises."""
+    def test_full_flow_defer_issue_creation_failure_propagates(
+        self, tmp_path: Path
+    ) -> None:
+        """DEFER issue creation failure propagates — no reply posted with missing issue."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -856,15 +858,15 @@ class TestReplyToComment:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.side_effect = RuntimeError("network fail")
-        posted, cat, titles = reply_to_comment(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            _print_prompt=fake_pp,
-            _gh=mock_gh,
-        )
-        assert posted
-        assert cat == "DEFER"
+        with pytest.raises(RuntimeError, match="network fail"):
+            reply_to_comment(
+                action,
+                cfg,
+                self._repo_cfg(tmp_path),
+                _print_prompt=fake_pp,
+                _gh=mock_gh,
+            )
+        mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_empty_body_uses_fallback(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1205,8 +1207,10 @@ class TestReplyToIssueComment:
             "Deferred from https://github.com/owner/repo/pull/7\n\n> big refactor",
         )
 
-    def test_defer_reply_issue_creation_failure(self, tmp_path: Path) -> None:
-        """DEFER still posts a reply even when create_issue raises."""
+    def test_defer_reply_issue_creation_failure_propagates(
+        self, tmp_path: Path
+    ) -> None:
+        """DEFER issue creation failure propagates — no reply posted with missing issue."""
         cfg = self._cfg(tmp_path)
 
         def fake_pp(prompt, model, **kwargs):
@@ -1217,14 +1221,15 @@ class TestReplyToIssueComment:
         mock_gh = MagicMock()
         mock_gh.get_repo_info.return_value = "owner/repo"
         mock_gh.create_issue.side_effect = RuntimeError("network fail")
-        cat, titles = reply_to_issue_comment(
-            self._action("big refactor"),
-            cfg,
-            self._repo_cfg(tmp_path),
-            _print_prompt=fake_pp,
-            _gh=mock_gh,
-        )
-        assert cat == "DEFER"
+        with pytest.raises(RuntimeError, match="network fail"):
+            reply_to_issue_comment(
+                self._action("big refactor"),
+                cfg,
+                self._repo_cfg(tmp_path),
+                _print_prompt=fake_pp,
+                _gh=mock_gh,
+            )
+        mock_gh.comment_issue.assert_not_called()
 
     def test_empty_body_fallback(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -357,6 +357,35 @@ class TestProcessAction:
         time.sleep(0.2)
         mock_task.assert_not_called()
 
+    def test_reply_to_comment_failure_skips_task(self, server: tuple) -> None:
+        """If reply posting raises, no task is created (fail closed)."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 205,
+                "body": "please add logging",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "foo.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 5, "title": "My PR", "body": ""},
+        }
+        mock_task = MagicMock()
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=RuntimeError("network down")
+        )
+        WebhookHandler._fn_create_task = mock_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=MagicMock())
+        status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        assert status == 200
+        time.sleep(0.2)
+        mock_task.assert_not_called()
+
     def test_reply_to_comment_do_creates_task(self, server: tuple) -> None:
         """DO adds to tasks.json."""
         url, cfg = server
@@ -504,6 +533,32 @@ class TestProcessAction:
         assert status == 200
         time.sleep(0.2)
         mock_ic.assert_called()
+        mock_task.assert_not_called()
+
+    def test_reply_to_issue_comment_failure_skips_task(self, server: tuple) -> None:
+        """If issue comment reply raises, no task is created (fail closed)."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {"id": 302, "body": "please fix", "user": {"login": "owner"}},
+            "issue": {
+                "number": 13,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        mock_task = MagicMock()
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            side_effect=RuntimeError("network down")
+        )
+        WebhookHandler._fn_create_task = mock_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=MagicMock())
+        status = _post_webhook(url, cfg, "issue_comment", payload)
+        assert status == 200
+        time.sleep(0.2)
         mock_task.assert_not_called()
 
     def test_exception_in_process_action_does_not_crash(self, server: tuple) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -291,7 +291,7 @@ class TestProcessAction:
             },
             "pull_request": {"number": 3, "title": "My PR", "body": "desc"},
         }
-        mock_reply = MagicMock(return_value=(True, "ACT", ["add logging"]))
+        mock_reply = MagicMock(return_value=("ACT", ["add logging"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = mock_task
@@ -318,7 +318,7 @@ class TestProcessAction:
             },
             "pull_request": {"number": 4, "title": "My PR", "body": ""},
         }
-        mock_reply = MagicMock(return_value=(True, "DUMP", ["nope"]))
+        mock_reply = MagicMock(return_value=("DUMP", ["nope"]))
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = mock_task
@@ -348,7 +348,7 @@ class TestProcessAction:
         }
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = MagicMock(
-            return_value=(True, "DEFER", ["big refactor"])
+            return_value=("DEFER", ["big refactor"])
         )
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -380,7 +380,7 @@ class TestProcessAction:
             task_titles.append(title)
 
         WebhookHandler._fn_reply_to_comment = MagicMock(
-            return_value=(True, "DO", ["add result caching"])
+            return_value=("DO", ["add result caching"])
         )
         WebhookHandler._fn_create_task = capture_task
         WebhookHandler._fn_launch_worker = MagicMock()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2246,23 +2246,16 @@ class TestWritePrDescription:
         self._call(gh)
         gh.edit_pr_body.assert_called_once()
 
-    def test_returns_true_when_written(self) -> None:
+    def test_raises_when_opus_returns_empty(self) -> None:
         gh = MagicMock()
-        result, _ = self._call(gh)
-        assert result is True
+        with pytest.raises(ValueError, match="no <body> content"):
+            self._call(gh, print_return="", issue=7)
+        gh.edit_pr_body.assert_not_called()
 
-    def test_uses_plain_text_fallback_when_opus_empty(self) -> None:
+    def test_raises_when_no_divider_in_existing_body(self) -> None:
         gh = MagicMock()
-        result, _ = self._call(gh, print_return="", issue=7)
-        assert result is True
-        gh.edit_pr_body.assert_called_once()
-        body = gh.edit_pr_body.call_args[0][2]
-        assert "Working on #7." in body
-
-    def test_returns_false_when_no_divider_in_existing_body(self) -> None:
-        gh = MagicMock()
-        result, _ = self._call(gh, existing_body="no divider here")
-        assert result is False
+        with pytest.raises(ValueError, match="no --- divider"):
+            self._call(gh, existing_body="no divider here")
         gh.edit_pr_body.assert_not_called()
 
     def test_initial_write_contains_work_queue_start_marker(self) -> None:
@@ -2368,13 +2361,12 @@ class TestWritePrDescription:
         assert "The current body is short" not in body
         assert "Want me to update it directly" not in body
 
-    def test_falls_back_when_no_body_tags(self) -> None:
-        """No body tags = treat as garbage, use plain-text fallback."""
+    def test_raises_when_opus_returns_no_body_tags(self) -> None:
+        """No body tags = garbage output; raise instead of silently falling back."""
         gh = MagicMock()
-        self._call(gh, print_return="Bare text with no body tags.", issue=42)
-        body = gh.edit_pr_body.call_args[0][2]
-        assert "Working on #42." in body
-        assert "Bare text with no body tags" not in body
+        with pytest.raises(ValueError, match="no <body> content"):
+            self._call(gh, print_return="Bare text with no body tags.", issue=42)
+        gh.edit_pr_body.assert_not_called()
 
     def test_body_tag_match_is_case_insensitive(self) -> None:
         gh = MagicMock()
@@ -2395,15 +2387,18 @@ class TestWritePrDescription:
         assert "<!-- WORK_QUEUE_START -->" in body
         assert "Old description." not in body
 
-    def test_rewrite_skips_when_no_divider(self) -> None:
+    def test_rewrite_raises_when_no_divider(self) -> None:
         gh = MagicMock()
-        result, _ = self._call(gh, existing_body="no divider here")
-        assert result is False
+        with pytest.raises(ValueError, match="no --- divider"):
+            self._call(gh, existing_body="no divider here")
         gh.edit_pr_body.assert_not_called()
 
     def test_defaults_to_claude_print_prompt(self) -> None:
         gh = MagicMock()
-        with patch("kennel.claude.print_prompt", return_value="") as mock_pp:
+        with patch(
+            "kennel.claude.print_prompt",
+            return_value="<body>Desc.\n\nFixes #1.</body>",
+        ) as mock_pp:
             _write_pr_description(gh, "owner/repo", 1, 1, [])
         mock_pp.assert_called_once()
 


### PR DESCRIPTION
Tightens error handling across the reply and PR-description paths so failures surface instead of being silently swallowed. Makes `_rewrite_pr_description` and `_open_defer_issue` fail closed, propagates reply-post exceptions from `reply_to_comment` and `reply_to_issue_comment`, and gates downstream task creation in `_process_action` and `reply_to_review` on whether the reply actually posted.

Fixes #379.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [raise on empty or divider-less Opus output in _rewrite_pr_description](https://github.com/FidoCanCode/home/pull/414#discussion_r3076493292) <!-- type:thread -->
- [x] Make _open_defer_issue fail closed: raise on issue creation failure <!-- type:spec -->
- [x] reply_to_comment: let reply-post exceptions propagate so callers fail closed <!-- type:spec -->
- [x] reply_to_issue_comment: return posted flag and propagate post failures <!-- type:spec -->
- [x] server._process_action: gate downstream task creation on reply posted flag <!-- type:spec -->
- [x] reply_to_review: skip task creation for comments whose reply failed to post <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->