### PR TITLE
Audit core subprocess calls for explicit exit-code handling (closes #380)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -294,8 +294,12 @@ def print_prompt_from_file(
 ) -> str:
     """Run claude --print reading system prompt and user prompt from files.
 
-    Returns stdout on success, empty string on failure.  Kills the process
-    if no output is produced for *idle_timeout* seconds (default 30 min).
+    Returns the full stdout on success.  Kills the process if no output
+    is produced for *idle_timeout* seconds (default 30 min).
+
+    Raises ``ClaudeStreamError`` on nonzero exit or idle timeout.
+    ``FileNotFoundError`` propagates if the claude CLI is not installed.
+    Both are authoritative failures — callers should not silently ignore them.
     """
     cmd = [
         "claude",
@@ -309,12 +313,7 @@ def print_prompt_from_file(
         str(system_file),
         "--print",
     ]
-    try:
-        return "".join(
-            streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
-        ).strip()
-    except ClaudeStreamError, FileNotFoundError:
-        return ""
+    return "".join(streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)).strip()
 
 
 def resume_session(
@@ -328,8 +327,12 @@ def resume_session(
 ) -> str:
     """Continue an existing claude session by ID, feeding prompt_file on stdin.
 
-    Returns stdout on success, empty string on failure.  Kills the process
-    if no output is produced for *idle_timeout* seconds (default 30 min).
+    Returns the full stdout on success.  Kills the process if no output
+    is produced for *idle_timeout* seconds (default 30 min).
+
+    Raises ``ClaudeStreamError`` on nonzero exit or idle timeout.
+    ``FileNotFoundError`` propagates if the claude CLI is not installed.
+    Both are authoritative failures — callers should not silently ignore them.
     """
     cmd = [
         "claude",
@@ -343,12 +346,7 @@ def resume_session(
         session_id,
         "--print",
     ]
-    try:
-        return "".join(
-            streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
-        ).strip()
-    except ClaudeStreamError, FileNotFoundError:
-        return ""
+    return "".join(streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)).strip()
 
 
 # ── Specialised wrappers used by events.py ───────────────────────────────────

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -152,9 +152,12 @@ def print_prompt(
 ) -> str:
     """Run claude --print with a prompt, return stdout (empty string on failure).
 
-    Uses -p to pass the prompt as a positional argument (no tool access).
-    Retries up to ``_EMPTY_RETRY_COUNT`` times (with a short delay) when
-    Claude exits 0 but produces no output, to handle transient empty responses.
+    Best-effort enrichment: nonzero exit, timeout, and missing CLI all return
+    ``""`` — callers must treat an empty result as "unavailable" rather than
+    as an error.  Uses -p to pass the prompt as a positional argument (no tool
+    access).  Retries up to ``_EMPTY_RETRY_COUNT`` times (with a short delay)
+    when Claude exits 0 but produces no output, to handle transient empty
+    responses.
     """
     args: list[str] = ["--model", model, "--print"]
     if system_prompt is not None:
@@ -193,11 +196,11 @@ def print_prompt_json(
 ) -> str:
     """Run claude --print, parse JSON from output, return the string at *key*.
 
+    Best-effort enrichment: returns ``""`` on any subprocess failure or JSON
+    parse error — callers must treat an empty result as "unavailable".
     Appends a JSON-format instruction to *system_prompt* so Claude outputs
     {"key": "..."}.  Scans the raw response for a JSON object, so preamble
     or trailing text from Opus does not corrupt the result.
-
-    Returns the string value at *key*, or empty string on failure.
     """
     json_instruction = (
         f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
@@ -359,7 +362,8 @@ def triage_comment(
 ) -> str:
     """Ask claude to triage a PR comment. Returns the raw first line of output.
 
-    Returns empty string on timeout or if the CLI is not found.
+    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
+    CLI — callers must treat an empty result as "unable to triage".
     """
     try:
         result = _claude(
@@ -378,7 +382,11 @@ def generate_reply(
     timeout: int = 30,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> str:
-    """Ask claude to generate a short reply. Returns stripped output or empty string."""
+    """Ask claude to generate a short reply. Returns stripped output or empty string.
+
+    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
+    CLI — callers must treat an empty result as "no reply generated".
+    """
     try:
         result = _claude(
             "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
@@ -394,7 +402,11 @@ def generate_branch_name(
     timeout: int = 15,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> str:
-    """Ask claude to generate a git branch name slug. Returns first line of output."""
+    """Ask claude to generate a git branch name slug. Returns first line of output.
+
+    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
+    CLI — callers must treat an empty result as "use a fallback branch name".
+    """
     try:
         result = _claude(
             "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
@@ -413,7 +425,11 @@ def generate_status(
     timeout: int = 15,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> str:
-    """Ask claude to generate a GitHub status (two lines: emoji + text)."""
+    """Ask claude to generate a GitHub status (two lines: emoji + text).
+
+    Best-effort enrichment: returns ``""`` on any failure — callers must treat
+    an empty result as "status unavailable".
+    """
     return print_prompt(
         prompt=prompt,
         model=model,
@@ -432,7 +448,8 @@ def generate_status_emoji(
 ) -> str:
     """Ask claude to choose a single emoji for a GitHub status.
 
-    Returns the stripped response, or an empty string on failure.
+    Best-effort enrichment: returns ``""`` on any failure — callers must treat
+    an empty result as "emoji unavailable".
     """
     return print_prompt(
         prompt=prompt,
@@ -453,9 +470,10 @@ def generate_status_with_session(
 ) -> tuple[str, str]:
     """Generate a GitHub status, returning (status_text, session_id).
 
-    Uses stream-json output format to capture the session_id alongside the
-    response text, enabling follow-up calls (e.g., ``resume_status`` to
-    shorten a long response).  Returns ``("", "")`` on failure.
+    Best-effort enrichment: returns ``("", "")`` on any failure — callers must
+    treat an all-empty tuple as "status unavailable".  Uses stream-json output
+    format to capture the session_id alongside the response text, enabling
+    follow-up calls (e.g., ``resume_status`` to shorten a long response).
     Retries up to ``_EMPTY_RETRY_COUNT`` times when Claude exits 0 but
     produces no output.
     """
@@ -512,9 +530,9 @@ def resume_status(
 ) -> str:
     """Resume an existing claude session to refine a status response.
 
+    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
+    CLI — callers must treat an empty result as "refinement unavailable".
     Passes *prompt* as a positional argument (``-p``), so no file is needed.
-    Returns the response text extracted from stream-json output, or an empty
-    string on failure.
     """
     try:
         result = _claude(

--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -18,9 +18,6 @@ class Cmd:
     """CLI command handler with injectable dependencies for testability."""
 
     def __init__(self, *, github: GitHub | None = None) -> None:
-        if github is None:
-            github = GitHub()
-
         self._github = github
 
     def _resolve_thread_if_ours(self, thread: dict) -> None:
@@ -31,9 +28,10 @@ class Cmd:
         if not (repo and pr and comment_id):
             return
 
+        github = self._github if self._github is not None else GitHub()
         try:
-            us = self._github.get_user()
-            comments = self._github.get_pull_comments(repo, pr)
+            us = github.get_user()
+            comments = github.get_pull_comments(repo, pr)
             thread_comments = sorted(
                 [
                     c
@@ -51,13 +49,13 @@ class Cmd:
                 return
 
             owner, repo_name = repo.split("/", 1)
-            threads = self._github.get_review_threads(owner, repo_name, pr)
+            threads = github.get_review_threads(owner, repo_name, pr)
             for t in threads:
                 if t["isResolved"]:
                     continue
                 nodes = t["comments"]["nodes"]
                 if nodes and nodes[0].get("databaseId") == comment_id:
-                    self._github.resolve_thread(t["id"])
+                    github.resolve_thread(t["id"])
                     log.info("thread resolved: %s", t["id"])
                     return
         except Exception as exc:  # noqa: BLE001

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -695,9 +695,10 @@ def _maybe_abort_for_new_task(
 def _get_commit_summary(work_dir: Path) -> str:
     """Return a short ``git log --oneline`` summary of recent commits.
 
-    Used to give Opus context about what has already been implemented when
-    it reorders the pending task list.  Returns an empty string on any error
-    (e.g. not a git repository, git not found, timeout).
+    Best-effort enrichment: used to give Opus context about what has already
+    been implemented when it reorders the pending task list.  Returns an empty
+    string on nonzero exit, subprocess error, or missing git binary — callers
+    must not treat the result as authoritative.
     """
     try:
         result = subprocess.run(
@@ -707,8 +708,10 @@ def _get_commit_summary(work_dir: Path) -> str:
             text=True,
             timeout=10,
         )
+        if result.returncode != 0:
+            return ""
         return result.stdout.strip()
-    except Exception:
+    except subprocess.SubprocessError, OSError:
         return ""
 
 

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -31,7 +31,12 @@ def _gh_token(
     runner: Any = subprocess.run,
     environ: Any = os.environ,
 ) -> str:
-    """Return a GitHub token from env or the gh CLI."""
+    """Return a GitHub token from env or the gh CLI.
+
+    Raises ``RuntimeError`` on nonzero exit (e.g. not logged in).
+    ``FileNotFoundError`` propagates if the gh CLI is not installed.
+    ``subprocess.TimeoutExpired`` propagates if the CLI hangs.
+    """
     token = environ.get("GITHUB_TOKEN", "")
     if not token:
         result = runner(
@@ -40,6 +45,10 @@ def _gh_token(
             text=True,
             timeout=10,
         )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"gh auth token failed (exit {result.returncode}) — run `gh auth login`"
+            )
         token = result.stdout.strip()
     return token
 

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -330,13 +330,20 @@ class GH:
         cwd: Path | str | None = None,
         runner: Any = subprocess.run,
     ) -> str:
-        """Return 'owner/repo' for the repo at cwd, parsed from the git remote."""
+        """Return 'owner/repo' for the repo at cwd, parsed from the git remote.
+
+        Raises ``subprocess.CalledProcessError`` on nonzero exit (e.g. not a
+        git repo or no ``origin`` remote).  ``FileNotFoundError`` propagates
+        if git is not installed.  Raises ``ValueError`` if the remote URL is
+        not a recognised GitHub format.
+        """
         result = runner(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
             text=True,
             timeout=10,
             cwd=cwd,
+            check=True,
         )
         url = result.stdout.strip().removesuffix(".git")
         if url.startswith("https://github.com/"):

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -69,7 +69,13 @@ def _fido_running(lock_path: Path) -> bool:
 
 
 def _pgrep(pattern: str, *, _run: Callable[..., Any] = subprocess.run) -> list[int]:
-    """Return PIDs whose command line matches pattern via pgrep -f."""
+    """Return PIDs whose command line matches pattern via pgrep -f.
+
+    Best-effort enrichment for status display.  A nonzero exit code (e.g.
+    pgrep exits 1 when no processes match) is not treated as an error —
+    the PID list is built from stdout alone.  Returns [] on OSError
+    (e.g. pgrep not installed).
+    """
     try:
         result = _run(
             ["pgrep", "-f", pattern],
@@ -92,7 +98,12 @@ def _pgrep(pattern: str, *, _run: Callable[..., Any] = subprocess.run) -> list[i
 def _process_uptime_seconds(
     pid: int, *, _run: Callable[..., Any] = subprocess.run
 ) -> int | None:
-    """Return elapsed seconds since the process started, or None if unavailable."""
+    """Return elapsed seconds since the process started, or None if unavailable.
+
+    Best-effort enrichment for status display.  A nonzero exit code (e.g.
+    ps exits non-zero for an unknown PID) is not treated as an error —
+    callers receive None whenever the value cannot be determined.
+    """
     try:
         result = _run(
             ["ps", "-p", str(pid), "-o", "etimes="],
@@ -179,7 +190,11 @@ def _claude_pid(fido_dir: Path) -> int | None:
 def _git_dir(
     work_dir: Path, *, _run: Callable[..., Any] = subprocess.run
 ) -> Path | None:
-    """Return the absolute git directory for work_dir, or None if unavailable."""
+    """Return the absolute git directory for work_dir, or None if unavailable.
+
+    Best-effort enrichment for status display.  Returns None on nonzero
+    exit (not a git repo) or if git is not installed.
+    """
     try:
         result = _run(
             ["git", "rev-parse", "--absolute-git-dir"],
@@ -189,7 +204,7 @@ def _git_dir(
             check=True,
         )
         return Path(result.stdout.strip())
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError, FileNotFoundError:
         return None
 
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -198,7 +198,10 @@ def claude_start(
 ) -> str:
     """Start a new sub-Claude session from fido_dir/system and fido_dir/prompt.
 
-    Returns the session_id string (empty string on failure).
+    Returns the session_id extracted from stream-json output, or an empty
+    string if the session_id is absent from the output.  Raises
+    ``ClaudeStreamError`` or ``FileNotFoundError`` on subprocess failure —
+    these propagate to the worker's crash handler.
     """
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
@@ -222,7 +225,9 @@ def claude_run(
     *fido_dir/system* and *fido_dir/prompt*.
 
     Returns ``(session_id, raw_output)`` where *raw_output* is the full
-    stream-json text produced by the claude CLI.
+    stream-json text produced by the claude CLI.  Raises
+    ``ClaudeStreamError`` or ``FileNotFoundError`` on subprocess failure —
+    these propagate to the worker's crash handler.
     """
     prompt_file = fido_dir / "prompt"
     if session_id:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -5,6 +5,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from kennel.claude import (
     ClaudeStreamError,
     _claude,
@@ -392,29 +394,29 @@ class TestPrintPromptFromFile:
         )
         assert result == "session output"
 
-    def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
-    def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(side_effect=FileNotFoundError)
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(FileNotFoundError):
+            print_prompt_from_file(
+                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
+            )
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
@@ -452,32 +454,41 @@ class TestResumeSession:
         )
         assert result == "continued"
 
-    def test_returns_empty_on_nonzero(self, tmp_path: Path) -> None:
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
-    def test_returns_empty_on_idle_timeout(self, tmp_path: Path) -> None:
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(ClaudeStreamError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
         mock_stream = MagicMock(side_effect=FileNotFoundError)
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == ""
+        with pytest.raises(FileNotFoundError):
+            resume_session(
+                "sess-123",
+                prompt_file,
+                "claude-sonnet-4-6",
+                streaming_runner=mock_stream,
+            )
 
     def test_passes_correct_cmd(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1431,7 +1431,14 @@ class TestCreateTask:
         thread = {"repo": "a/b", "pr": 1, "comment_id": 5}
         mock_tasks = self._mock_tasks()
         with patch("kennel.events.launch_sync"):
-            create_task("do something", cfg, repo_cfg, thread=thread, _tasks=mock_tasks)
+            create_task(
+                "do something",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
+            )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
         )
@@ -1481,7 +1488,12 @@ class TestCreateTask:
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
             create_task(
-                "Comment task", cfg, repo_cfg, thread=thread, _tasks=mock_tasks
+                "Comment task",
+                cfg,
+                repo_cfg,
+                thread=thread,
+                _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )  # no registry
         registry.abort_task.assert_not_called()
 
@@ -1549,6 +1561,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -1619,6 +1632,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -1648,6 +1662,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -1677,6 +1692,7 @@ class TestCreateTask:
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
             )
         registry.abort_task.assert_not_called()
 
@@ -2043,6 +2059,7 @@ class TestReorderTasksBackground:
             "some commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2058,6 +2075,7 @@ class TestReorderTasksBackground:
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2073,6 +2091,7 @@ class TestReorderTasksBackground:
             "feat: add parser",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2130,6 +2149,7 @@ class TestReorderTasksBackground:
             repo_cfg=repo_cfg,
             registry=registry,
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2148,6 +2168,7 @@ class TestReorderTasksBackground:
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2167,6 +2188,7 @@ class TestReorderTasksBackground:
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
@@ -2192,6 +2214,7 @@ class TestReorderTasksBackground:
             "commits",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _rewrite_fn=mock_rewrite,
             _print_prompt=fake_pp,
             _reorder_fn=mock_reorder,
@@ -2214,6 +2237,7 @@ class TestReorderTasksBackground:
             "cs1",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2226,6 +2250,7 @@ class TestReorderTasksBackground:
             "cs2",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2244,6 +2269,7 @@ class TestReorderTasksBackground:
             "cs1",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2253,6 +2279,7 @@ class TestReorderTasksBackground:
             "cs2",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2276,6 +2303,7 @@ class TestReorderTasksBackground:
                 cs,
                 self._cfg(tmp_path),
                 _start=lambda t: started.append(t),
+                _gh=MagicMock(),
                 _reorder_fn=mock_reorder,
                 _coalesce_state=state,
             )
@@ -2298,6 +2326,7 @@ class TestReorderTasksBackground:
             "cs",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2317,6 +2346,7 @@ class TestReorderTasksBackground:
             "cs1",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2327,6 +2357,7 @@ class TestReorderTasksBackground:
             "cs2",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2345,6 +2376,7 @@ class TestReorderTasksBackground:
             "cs",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2353,6 +2385,7 @@ class TestReorderTasksBackground:
             "cs",
             self._cfg(tmp_path),
             _start=lambda t: started.append(t),
+            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1982,13 +1982,31 @@ class TestGetCommitSummary:
             result = _get_commit_summary(tmp_path)
         assert result == ""
 
-    def test_returns_empty_stdout_when_git_fails(self, tmp_path: Path) -> None:
+    def test_returns_empty_on_nonzero_exit(self, tmp_path: Path) -> None:
         import subprocess as sp
 
         fake_result = sp.CompletedProcess(
             args=[], returncode=128, stdout="", stderr="not a git repo"
         )
         with patch("kennel.events.subprocess.run", return_value=fake_result):
+            result = _get_commit_summary(tmp_path)
+        assert result == ""
+
+    def test_nonzero_exit_ignored_even_with_stdout(self, tmp_path: Path) -> None:
+        import subprocess as sp
+
+        # Explicit guard: returncode wins over any stdout content.
+        fake_result = sp.CompletedProcess(
+            args=[], returncode=1, stdout="abc123 orphan output\n", stderr=""
+        )
+        with patch("kennel.events.subprocess.run", return_value=fake_result):
+            result = _get_commit_summary(tmp_path)
+        assert result == ""
+
+    def test_returns_empty_on_oserror(self, tmp_path: Path) -> None:
+        with patch(
+            "kennel.events.subprocess.run", side_effect=OSError("permission denied")
+        ):
             result = _get_commit_summary(tmp_path)
         assert result == ""
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -41,6 +41,16 @@ class TestGhToken:
         mock_run = MagicMock(return_value=_completed("  tok  \n"))
         assert _gh_token(runner=mock_run, environ={}) == "tok"
 
+    def test_raises_on_nonzero_exit(self) -> None:
+        mock_run = MagicMock(return_value=_completed("", returncode=1))
+        with pytest.raises(RuntimeError, match="gh auth token failed"):
+            _gh_token(runner=mock_run, environ={})
+
+    def test_error_message_includes_exit_code(self) -> None:
+        mock_run = MagicMock(return_value=_completed("", returncode=4))
+        with pytest.raises(RuntimeError, match=r"exit 4"):
+            _gh_token(runner=mock_run, environ={})
+
 
 class TestGetGh:
     def test_creates_instance_lazily(self) -> None:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1180,6 +1180,18 @@ class TestGHClass:
         with pytest.raises(ValueError, match="Cannot parse"):
             gh.get_repo_info(runner=mock_run)
 
+    def test_get_repo_info_raises_on_git_failure(self) -> None:
+        gh = GH("test-token")
+        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, "git"))
+        with pytest.raises(subprocess.CalledProcessError):
+            gh.get_repo_info(runner=mock_run)
+
+    def test_get_repo_info_raises_on_file_not_found(self) -> None:
+        gh = GH("test-token")
+        mock_run = MagicMock(side_effect=FileNotFoundError("git not found"))
+        with pytest.raises(FileNotFoundError):
+            gh.get_repo_info(runner=mock_run)
+
     def test_get_default_branch(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -374,8 +374,12 @@ class TestGitDir:
         mock_run = MagicMock(return_value=MagicMock(stdout="  /a/b/.git  \n"))
         assert _git_dir(tmp_path, _run=mock_run) == Path("/a/b/.git")
 
-    def test_returns_none_on_error(self, tmp_path: Path) -> None:
+    def test_returns_none_on_called_process_error(self, tmp_path: Path) -> None:
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, "git"))
+        assert _git_dir(tmp_path, _run=mock_run) is None
+
+    def test_returns_none_when_git_not_found(self, tmp_path: Path) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError("git not found"))
         assert _git_dir(tmp_path, _run=mock_run) is None
 
 


### PR DESCRIPTION
Audits the remaining best-effort subprocess call sites, narrowing broad excepts and documenting which helpers are purely enrichment so silent failures stay intentional. Hardens the authoritative paths — `_gh_token`, `GH.get_repo_info`, and streaming fido runs — to validate return codes and surface failures instead of swallowing them.

Fixes #380.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] events.py: narrow _get_commit_summary exceptions and mark best-effort <!-- type:spec -->
- [x] status.py: document _pgrep, _process_uptime_seconds, _git_dir as enrichment-only <!-- type:spec -->
- [x] claude.py: document enrichment-only CLI wrappers as best-effort <!-- type:spec -->
- [x] github.py: validate returncode in _gh_token and raise on failure <!-- type:spec -->
- [x] github.py: use check=True in GH.get_repo_info and cover failure path <!-- type:spec -->
- [x] claude.py: surface streaming failures from authoritative fido runs <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->