### PR TITLE
Bound external I/O and detect stuck workers (closes #382)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -15,6 +15,8 @@ import requests as _requests
 
 log = logging.getLogger(__name__)
 
+_HTTP_TIMEOUT: int = 30  # seconds for all outbound GitHub HTTP requests
+
 
 class GraphQLError(Exception):
     """Raised when a GitHub GraphQL response contains an errors field."""
@@ -69,26 +71,26 @@ class GH:
         )
 
     def _get(self, path: str) -> Any:
-        resp = self._s.get(f"{self.BASE}{path}")
+        resp = self._s.get(f"{self.BASE}{path}", timeout=_HTTP_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
     def _post(self, path: str, **payload: Any) -> None:
-        resp = self._s.post(f"{self.BASE}{path}", json=payload)
+        resp = self._s.post(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
         resp.raise_for_status()
 
     def _post_json(self, path: str, **payload: Any) -> Any:
-        resp = self._s.post(f"{self.BASE}{path}", json=payload)
+        resp = self._s.post(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
     def _patch(self, path: str, **payload: Any) -> Any:
-        resp = self._s.patch(f"{self.BASE}{path}", json=payload)
+        resp = self._s.patch(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
     def _put(self, path: str, **payload: Any) -> Any:
-        resp = self._s.put(f"{self.BASE}{path}", json=payload)
+        resp = self._s.put(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
         resp.raise_for_status()
         return resp.json()
 
@@ -97,6 +99,7 @@ class GH:
         resp = self._s.post(
             f"{self.BASE}/graphql",
             json={"query": query, "variables": variables},
+            timeout=_HTTP_TIMEOUT,
         )
         resp.raise_for_status()
         data = resp.json()
@@ -197,7 +200,7 @@ class GH:
         """Yield each item from all pages of a paginated GitHub API endpoint."""
         current: str | None = url
         while current:
-            resp = self._s.get(current)
+            resp = self._s.get(current, timeout=_HTTP_TIMEOUT)
             resp.raise_for_status()
             yield from resp.json()
             link = resp.headers.get("Link", "")
@@ -622,7 +625,8 @@ class GH:
             if job.get("conclusion") not in ("failure", "timed_out"):
                 continue
             resp = self._s.get(
-                f"{self.BASE}/repos/{repo}/actions/jobs/{job['id']}/logs"
+                f"{self.BASE}/repos/{repo}/actions/jobs/{job['id']}/logs",
+                timeout=_HTTP_TIMEOUT,
             )
             resp.raise_for_status()
             parts.append(resp.text)

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -18,6 +18,16 @@ log = logging.getLogger(__name__)
 _HTTP_TIMEOUT: int = 30  # seconds for all outbound GitHub HTTP requests
 
 
+class _TimeoutSession(_requests.Session):
+    """requests.Session that applies _HTTP_TIMEOUT to every request by default."""
+
+    def request(
+        self, method: str | bytes, url: str | bytes, **kwargs: Any
+    ) -> _requests.Response:  # type: ignore[override]
+        kwargs.setdefault("timeout", _HTTP_TIMEOUT)
+        return super().request(method, url, **kwargs)
+
+
 class GraphQLError(Exception):
     """Raised when a GitHub GraphQL response contains an errors field."""
 
@@ -61,7 +71,7 @@ class GH:
     BASE = "https://api.github.com"
 
     def __init__(self, token: str, session: _requests.Session | None = None) -> None:
-        self._s = session if session is not None else _requests.Session()
+        self._s = session if session is not None else _TimeoutSession()
         self._s.headers.update(
             {
                 "Authorization": f"Bearer {token}",
@@ -71,26 +81,26 @@ class GH:
         )
 
     def _get(self, path: str) -> Any:
-        resp = self._s.get(f"{self.BASE}{path}", timeout=_HTTP_TIMEOUT)
+        resp = self._s.get(f"{self.BASE}{path}")
         resp.raise_for_status()
         return resp.json()
 
     def _post(self, path: str, **payload: Any) -> None:
-        resp = self._s.post(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
+        resp = self._s.post(f"{self.BASE}{path}", json=payload)
         resp.raise_for_status()
 
     def _post_json(self, path: str, **payload: Any) -> Any:
-        resp = self._s.post(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
+        resp = self._s.post(f"{self.BASE}{path}", json=payload)
         resp.raise_for_status()
         return resp.json()
 
     def _patch(self, path: str, **payload: Any) -> Any:
-        resp = self._s.patch(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
+        resp = self._s.patch(f"{self.BASE}{path}", json=payload)
         resp.raise_for_status()
         return resp.json()
 
     def _put(self, path: str, **payload: Any) -> Any:
-        resp = self._s.put(f"{self.BASE}{path}", json=payload, timeout=_HTTP_TIMEOUT)
+        resp = self._s.put(f"{self.BASE}{path}", json=payload)
         resp.raise_for_status()
         return resp.json()
 
@@ -99,7 +109,6 @@ class GH:
         resp = self._s.post(
             f"{self.BASE}/graphql",
             json={"query": query, "variables": variables},
-            timeout=_HTTP_TIMEOUT,
         )
         resp.raise_for_status()
         data = resp.json()
@@ -200,7 +209,7 @@ class GH:
         """Yield each item from all pages of a paginated GitHub API endpoint."""
         current: str | None = url
         while current:
-            resp = self._s.get(current, timeout=_HTTP_TIMEOUT)
+            resp = self._s.get(current)
             resp.raise_for_status()
             yield from resp.json()
             link = resp.headers.get("Link", "")
@@ -625,8 +634,7 @@ class GH:
             if job.get("conclusion") not in ("failure", "timed_out"):
                 continue
             resp = self._s.get(
-                f"{self.BASE}/repos/{repo}/actions/jobs/{job['id']}/logs",
-                timeout=_HTTP_TIMEOUT,
+                f"{self.BASE}/repos/{repo}/actions/jobs/{job['id']}/logs"
             )
             resp.raise_for_status()
             parts.append(resp.text)

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -7,13 +7,18 @@ import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 from kennel.config import RepoConfig
 from kennel.github import GitHub
 from kennel.worker import WorkerThread
 
 log = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime."""
+    return datetime.now(tz=timezone.utc)
 
 
 @dataclass
@@ -23,6 +28,7 @@ class WorkerActivity:
     repo_name: str
     what: str
     busy: bool
+    last_progress_at: datetime
 
 
 @dataclass
@@ -82,12 +88,38 @@ class WorkerRegistry:
         if thread:
             thread.abort_task()
 
-    def report_activity(self, repo_name: str, what: str, busy: bool) -> None:
+    def report_activity(
+        self,
+        repo_name: str,
+        what: str,
+        busy: bool,
+        *,
+        _now: Callable[[], datetime] = _utcnow,
+    ) -> None:
         """Record what *repo_name*'s worker is currently doing."""
         with self._activity_lock:
             self._activities[repo_name] = WorkerActivity(
-                repo_name=repo_name, what=what, busy=busy
+                repo_name=repo_name, what=what, busy=busy, last_progress_at=_now()
             )
+
+    def is_stale(
+        self,
+        repo_name: str,
+        threshold: float,
+        *,
+        _now: Callable[[], datetime] = _utcnow,
+    ) -> bool:
+        """Return True if *repo_name*'s last progress is older than *threshold* seconds.
+
+        Returns False when no activity has been recorded for the repo (e.g. it
+        has never reported in) — the caller can treat that as a fresh start
+        rather than a stall.
+        """
+        with self._activity_lock:
+            activity = self._activities.get(repo_name)
+        if activity is None:
+            return False
+        return (_now() - activity.last_progress_at).total_seconds() > threshold
 
     def get_all_activities(self) -> list[WorkerActivity]:
         """Return a snapshot of all registered workers' current activities."""

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -28,7 +28,7 @@ from kennel.events import (
 )
 from kennel.github import GitHub
 from kennel.registry import WorkerRegistry, make_registry
-from kennel.watchdog import Watchdog
+from kennel.watchdog import _STALE_THRESHOLD, Watchdog  # noqa: PLC2701
 from kennel.worker import RepoContextFilter, RepoNameFilter
 
 log = logging.getLogger(__name__)
@@ -395,6 +395,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         "busy": a.busy,
                         "crash_count": crash.death_count if crash else 0,
                         "last_crash_error": crash.last_error if crash else None,
+                        "is_stuck": self.registry.is_stale(
+                            a.repo_name, _STALE_THRESHOLD
+                        ),
                     }
                 )
             body = json.dumps(activities).encode()

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -278,6 +278,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _process_action(self, action, repo_cfg: RepoConfig) -> None:
         try:
+            self.registry.report_activity(
+                repo_cfg.name, "handling webhook action", busy=True
+            )
             handled = False
 
             if action.reply_to:

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -27,6 +27,7 @@ class RepoStatus:
     worker_what: str | None  # activity text from the live registry
     crash_count: int  # number of unexpected worker deaths since kennel started
     last_crash_error: str | None  # error from the most recent crash, if any
+    worker_stuck: bool  # True if the worker is alive but making no progress
 
 
 @dataclass
@@ -164,7 +165,7 @@ def _port_from_pid(pid: int) -> int | None:
 def _fetch_activities(
     port: int, *, _urlopen: Callable[..., Any] = urllib.request.urlopen
 ) -> dict[str, dict[str, Any]]:
-    """Query GET /status, returning {repo_name: {what, crash_count, last_crash_error}}."""
+    """Query GET /status, returning {repo_name: {what, crash_count, last_crash_error, is_stuck}}."""
     try:
         with _urlopen(f"http://localhost:{port}/status", timeout=2) as resp:
             data = json.loads(resp.read())
@@ -173,6 +174,7 @@ def _fetch_activities(
                 "what": item["what"],
                 "crash_count": item["crash_count"],
                 "last_crash_error": item["last_crash_error"],
+                "is_stuck": item.get("is_stuck", False),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -251,6 +253,7 @@ def repo_status(
     worker_what: str | None = None,
     crash_count: int = 0,
     last_crash_error: str | None = None,
+    worker_stuck: bool = False,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     git_dir = _git_dir(repo_config.work_dir)
@@ -267,6 +270,7 @@ def repo_status(
             worker_what=worker_what,
             crash_count=crash_count,
             last_crash_error=last_crash_error,
+            worker_stuck=worker_stuck,
         )
 
     fido_dir = git_dir / "fido"
@@ -298,6 +302,7 @@ def repo_status(
         worker_what=worker_what,
         crash_count=crash_count,
         last_crash_error=last_crash_error,
+        worker_stuck=worker_stuck,
     )
 
 
@@ -322,6 +327,7 @@ def collect() -> KennelStatus:
                 worker_what=info["what"] if info else None,
                 crash_count=info["crash_count"] if info else 0,
                 last_crash_error=info["last_crash_error"] if info else None,
+                worker_stuck=info["is_stuck"] if info else False,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
@@ -371,6 +377,9 @@ def format_status(status: KennelStatus) -> str:
             if repo.claude_uptime is not None:
                 claude_str += f" (running {_format_uptime(repo.claude_uptime)})"
             parts.append(claude_str)
+
+        if repo.worker_stuck:
+            parts.append("STUCK")
 
         if repo.crash_count > 0:
             crash_str = f"crashed {repo.crash_count}x"

--- a/kennel/watchdog.py
+++ b/kennel/watchdog.py
@@ -1,4 +1,4 @@
-"""Watchdog — check WorkerThread health and restart dead threads."""
+"""Watchdog — check WorkerThread health and restart dead or stuck threads."""
 
 from __future__ import annotations
 
@@ -12,22 +12,40 @@ from kennel.registry import WorkerRegistry
 log = logging.getLogger(__name__)
 
 _WATCHDOG_INTERVAL: float = 30.0
+_STALE_THRESHOLD: float = (
+    600.0  # seconds of no progress before a worker is considered stuck
+)
+_MAX_STALE_COUNT: int = 2  # consecutive stale detections before forcing a restart
 
 
 class Watchdog:
-    """Check whether each WorkerThread is alive and restart any that have died.
+    """Check WorkerThread health and restart dead or stuck threads.
 
     Accepts *registry* and *repos* via the constructor so tests can inject
     mock objects without patching module-level names.
+
+    Dead threads (is_alive returns False) are restarted immediately.
+
+    Stale threads (alive but no progress for *_stale_threshold* seconds) are
+    counted across consecutive checks.  Once the count reaches
+    *_max_stale_count* the thread is stopped, joined, and restarted.  The
+    count resets whenever a healthy check is observed so transient slowness
+    (a single long Opus call) does not accumulate toward a forced restart.
     """
 
     def __init__(
         self,
         registry: WorkerRegistry,
         repos: dict[str, RepoConfig],
+        *,
+        _stale_threshold: float = _STALE_THRESHOLD,
+        _max_stale_count: int = _MAX_STALE_COUNT,
     ) -> None:
         self.registry = registry
         self.repos = repos
+        self._stale_threshold = _stale_threshold
+        self._max_stale_count = _max_stale_count
+        self._stale_counts: dict[str, int] = {}
 
     def run(self) -> int:
         """Run one watchdog iteration. Returns 0."""
@@ -37,7 +55,32 @@ class Watchdog:
                 if error is not None:
                     self.registry.record_crash(repo_name, error)
                 log.info("thread for %s is not alive — restarting", repo_name)
+                self._stale_counts.pop(repo_name, None)
                 self.registry.start(repo_cfg)
+            elif self.registry.is_stale(repo_name, self._stale_threshold):
+                count = self._stale_counts.get(repo_name, 0) + 1
+                self._stale_counts[repo_name] = count
+                log.warning(
+                    "thread for %s is alive but stale (%d/%d)",
+                    repo_name,
+                    count,
+                    self._max_stale_count,
+                )
+                if count >= self._max_stale_count:
+                    log.error(
+                        "thread for %s stuck after %d stale checks — forcing restart",
+                        repo_name,
+                        count,
+                    )
+                    self.registry.record_crash(
+                        repo_name,
+                        f"stuck: no progress for {self._stale_threshold:.0f}s",
+                    )
+                    self._stale_counts.pop(repo_name, None)
+                    self.registry.stop_and_join(repo_name)
+                    self.registry.start(repo_cfg)
+            else:
+                self._stale_counts.pop(repo_name, None)
         return 0
 
     def start_thread(

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1593,6 +1593,8 @@ class WorkerThread(threading.Thread):
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
         try:
             while not self._stop:
+                if self._registry is not None:
+                    self._registry.report_activity(self._repo_name, "idle", busy=False)
                 result = Worker(
                     self.work_dir,
                     self._gh,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from kennel.github import (
+    _HTTP_TIMEOUT,  # noqa: PLC2701
     GH,
     GitHub,
     GraphQLError,
@@ -449,7 +450,9 @@ class TestGHClass:
         mock_resp.json.return_value = [{"id": 1}]
         mock_s.get.return_value = mock_resp
         result = gh._get("/repos/o/r/issues")
-        mock_s.get.assert_called_once_with("https://api.github.com/repos/o/r/issues")
+        mock_s.get.assert_called_once_with(
+            "https://api.github.com/repos/o/r/issues", timeout=_HTTP_TIMEOUT
+        )
         assert result == [{"id": 1}]
 
     def test_get_raises_on_error(self) -> None:
@@ -471,6 +474,7 @@ class TestGHClass:
         mock_s.post.assert_called_once_with(
             "https://api.github.com/repos/o/r/issues/1/comments",
             json={"body": "hi"},
+            timeout=_HTTP_TIMEOUT,
         )
 
     def test_post_raises_on_error(self) -> None:
@@ -504,6 +508,7 @@ class TestGHClass:
         mock_s.patch.assert_called_once_with(
             "https://api.github.com/repos/o/r/issues/1",
             json={"state": "closed"},
+            timeout=_HTTP_TIMEOUT,
         )
 
     def test_patch_raises_on_error(self) -> None:
@@ -526,6 +531,7 @@ class TestGHClass:
         mock_s.put.assert_called_once_with(
             "https://api.github.com/repos/o/r/pulls/1/merge",
             json={"merge_method": "squash"},
+            timeout=_HTTP_TIMEOUT,
         )
 
     def test_put_raises_on_error(self) -> None:
@@ -538,6 +544,60 @@ class TestGHClass:
             assert False, "should have raised"
         except Exception as e:
             assert "405" in str(e)
+
+    def test_get_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        mock_s.get.return_value = MagicMock()
+        gh._get("/anything")
+        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_post_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        mock_s.post.return_value = MagicMock()
+        gh._post("/anything")
+        assert mock_s.post.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_patch_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        mock_s.patch.return_value = mock_resp
+        gh._patch("/anything")
+        assert mock_s.patch.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_put_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {}
+        mock_s.put.return_value = mock_resp
+        gh._put("/anything")
+        assert mock_s.put.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_graphql_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        mock_s.post.return_value = MagicMock()
+        mock_s.post.return_value.json.return_value = {"data": {}}
+        gh._graphql("query {}")
+        assert mock_s.post.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_paginate_passes_timeout(self) -> None:
+        gh, mock_s = self._gh()
+        resp = MagicMock()
+        resp.json.return_value = []
+        resp.headers = {}
+        mock_s.get.return_value = resp
+        list(gh._paginate("https://api.github.com/repos/o/r/items"))
+        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
+
+    def test_get_run_log_passes_timeout_for_log_download(self) -> None:
+        gh, mock_s = self._gh()
+        jobs_resp = MagicMock()
+        jobs_resp.json.return_value = {"jobs": [{"id": 9, "conclusion": "failure"}]}
+        log_resp = MagicMock()
+        log_resp.text = "err\n"
+        mock_s.get.side_effect = [jobs_resp, log_resp]
+        gh.get_run_log("o/r", 1)
+        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
 
     def test_graphql_posts_to_graphql_endpoint(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -13,6 +13,7 @@ from kennel.github import (
     GraphQLError,
     _get_gh,
     _gh_token,
+    _TimeoutSession,  # noqa: PLC2701
     get_github,
 )
 
@@ -431,6 +432,30 @@ class TestGitHubClass:
         assert gh.get_run_log("o/r", 1) == "log\n"
 
 
+class TestTimeoutSession:
+    def test_injects_default_timeout(self) -> None:
+        from unittest.mock import patch
+
+        with patch("requests.Session.request") as mock_req:
+            mock_req.return_value = MagicMock()
+            s = _TimeoutSession()
+            s.request("GET", "https://example.com")
+        assert mock_req.call_args.kwargs.get("timeout") == _HTTP_TIMEOUT
+
+    def test_does_not_override_caller_timeout(self) -> None:
+        from unittest.mock import patch
+
+        with patch("requests.Session.request") as mock_req:
+            mock_req.return_value = MagicMock()
+            s = _TimeoutSession()
+            s.request("GET", "https://example.com", timeout=5)
+        assert mock_req.call_args.kwargs.get("timeout") == 5
+
+    def test_gh_uses_timeout_session_when_no_session_injected(self) -> None:
+        gh = GH("tok")
+        assert isinstance(gh._s, _TimeoutSession)
+
+
 class TestGHClass:
     def _gh(self) -> tuple[GH, MagicMock]:
         mock_s = MagicMock()
@@ -450,9 +475,7 @@ class TestGHClass:
         mock_resp.json.return_value = [{"id": 1}]
         mock_s.get.return_value = mock_resp
         result = gh._get("/repos/o/r/issues")
-        mock_s.get.assert_called_once_with(
-            "https://api.github.com/repos/o/r/issues", timeout=_HTTP_TIMEOUT
-        )
+        mock_s.get.assert_called_once_with("https://api.github.com/repos/o/r/issues")
         assert result == [{"id": 1}]
 
     def test_get_raises_on_error(self) -> None:
@@ -474,7 +497,6 @@ class TestGHClass:
         mock_s.post.assert_called_once_with(
             "https://api.github.com/repos/o/r/issues/1/comments",
             json={"body": "hi"},
-            timeout=_HTTP_TIMEOUT,
         )
 
     def test_post_raises_on_error(self) -> None:
@@ -508,7 +530,6 @@ class TestGHClass:
         mock_s.patch.assert_called_once_with(
             "https://api.github.com/repos/o/r/issues/1",
             json={"state": "closed"},
-            timeout=_HTTP_TIMEOUT,
         )
 
     def test_patch_raises_on_error(self) -> None:
@@ -531,7 +552,6 @@ class TestGHClass:
         mock_s.put.assert_called_once_with(
             "https://api.github.com/repos/o/r/pulls/1/merge",
             json={"merge_method": "squash"},
-            timeout=_HTTP_TIMEOUT,
         )
 
     def test_put_raises_on_error(self) -> None:
@@ -544,60 +564,6 @@ class TestGHClass:
             assert False, "should have raised"
         except Exception as e:
             assert "405" in str(e)
-
-    def test_get_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        mock_s.get.return_value = MagicMock()
-        gh._get("/anything")
-        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_post_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        mock_s.post.return_value = MagicMock()
-        gh._post("/anything")
-        assert mock_s.post.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_patch_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.patch.return_value = mock_resp
-        gh._patch("/anything")
-        assert mock_s.patch.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_put_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.put.return_value = mock_resp
-        gh._put("/anything")
-        assert mock_s.put.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_graphql_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        mock_s.post.return_value = MagicMock()
-        mock_s.post.return_value.json.return_value = {"data": {}}
-        gh._graphql("query {}")
-        assert mock_s.post.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_paginate_passes_timeout(self) -> None:
-        gh, mock_s = self._gh()
-        resp = MagicMock()
-        resp.json.return_value = []
-        resp.headers = {}
-        mock_s.get.return_value = resp
-        list(gh._paginate("https://api.github.com/repos/o/r/items"))
-        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
-
-    def test_get_run_log_passes_timeout_for_log_download(self) -> None:
-        gh, mock_s = self._gh()
-        jobs_resp = MagicMock()
-        jobs_resp.json.return_value = {"jobs": [{"id": 9, "conclusion": "failure"}]}
-        log_resp = MagicMock()
-        log_resp.text = "err\n"
-        mock_s.get.side_effect = [jobs_resp, log_resp]
-        gh.get_run_log("o/r", 1)
-        assert mock_s.get.call_args.kwargs["timeout"] == _HTTP_TIMEOUT
 
     def test_graphql_posts_to_graphql_endpoint(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 
 from kennel.config import RepoConfig
 from kennel.registry import (
-    WorkerActivity,
     WorkerCrash,
     WorkerRegistry,
     _make_thread,
@@ -161,23 +160,28 @@ class TestWorkerRegistry:
         reg, _ = self._make_registry()
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         activities = reg.get_all_activities()
-        assert activities == [WorkerActivity("foo/bar", "Working on: #1", busy=True)]
+        assert len(activities) == 1
+        assert activities[0].repo_name == "foo/bar"
+        assert activities[0].what == "Working on: #1"
+        assert activities[0].busy is True
 
     def test_report_activity_overwrites_previous(self) -> None:
         reg, _ = self._make_registry()
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/bar", "Napping", busy=False)
         activities = reg.get_all_activities()
-        assert activities == [WorkerActivity("foo/bar", "Napping", busy=False)]
+        assert len(activities) == 1
+        assert activities[0].what == "Napping"
+        assert activities[0].busy is False
 
     def test_get_all_activities_returns_all_repos(self) -> None:
         reg, _ = self._make_registry()
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/baz", "Napping", busy=False)
-        activities = reg.get_all_activities()
-        assert sorted(activities, key=lambda a: a.repo_name) == [
-            WorkerActivity("foo/bar", "Working on: #1", busy=True),
-            WorkerActivity("foo/baz", "Napping", busy=False),
+        activities = sorted(reg.get_all_activities(), key=lambda a: a.repo_name)
+        assert [(a.repo_name, a.what, a.busy) for a in activities] == [
+            ("foo/bar", "Working on: #1", True),
+            ("foo/baz", "Napping", False),
         ]
 
     def test_get_all_activities_empty_initially(self) -> None:
@@ -190,7 +194,69 @@ class TestWorkerRegistry:
         snapshot = reg.get_all_activities()
         reg.report_activity("foo/bar", "Napping", busy=False)
         # snapshot must not reflect the later update
-        assert snapshot == [WorkerActivity("foo/bar", "Working on: #1", busy=True)]
+        assert snapshot[0].what == "Working on: #1"
+
+    def test_report_activity_records_last_progress_at(self) -> None:
+        import datetime as dt
+
+        fixed = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: fixed)
+        activities = reg.get_all_activities()
+        assert activities[0].last_progress_at == fixed
+
+    def test_report_activity_updates_last_progress_at(self) -> None:
+        import datetime as dt
+
+        t1 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        t2 = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.timezone.utc)
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "first", busy=True, _now=lambda: t1)
+        reg.report_activity("foo/bar", "second", busy=True, _now=lambda: t2)
+        activities = reg.get_all_activities()
+        assert activities[0].last_progress_at == t2
+
+    def test_is_stale_false_when_no_activity(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.is_stale("foo/bar", threshold=60.0) is False
+
+    def test_is_stale_false_when_recent(self) -> None:
+        import datetime as dt
+
+        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        t_now = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.timezone.utc)  # 30s later
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
+        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
+
+    def test_is_stale_true_when_old(self) -> None:
+        import datetime as dt
+
+        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)  # 10m later
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
+        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
+
+    def test_is_stale_exactly_at_threshold_is_not_stale(self) -> None:
+        import datetime as dt
+
+        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        t_now = dt.datetime(2026, 1, 1, 12, 1, 0, tzinfo=dt.timezone.utc)  # exactly 60s
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
+        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
+
+    def test_is_stale_per_repo(self) -> None:
+        import datetime as dt
+
+        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)
+        reg, _ = self._make_registry()
+        reg.report_activity("foo/bar", "old", busy=True, _now=lambda: t0)
+        reg.report_activity("foo/baz", "fresh", busy=True, _now=lambda: t_now)
+        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
+        assert reg.is_stale("foo/baz", threshold=60.0, _now=lambda: t_now) is False
 
     def test_concurrent_report_and_read_are_safe(self) -> None:
         """report_activity and get_all_activities are safe under concurrent load.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -139,11 +139,18 @@ class TestGetEndpoint:
         assert b"kennel is running" in resp.read()
 
     def test_status_endpoint_returns_activities(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
         from kennel.registry import WorkerActivity
 
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(repo_name="owner/repo", what="Working on: #1", busy=True),
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
         ]
         WebhookHandler.registry.get_crash_info.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
@@ -160,13 +167,18 @@ class TestGetEndpoint:
         ]
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         from kennel.registry import WorkerActivity, WorkerCrash
 
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(repo_name="owner/repo", what="Napping", busy=False),
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Napping",
+                busy=False,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
         ]
         WebhookHandler.registry.get_crash_info.return_value = WorkerCrash(
             death_count=3,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -153,6 +153,7 @@ class TestGetEndpoint:
             ),
         ]
         WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
@@ -163,6 +164,7 @@ class TestGetEndpoint:
                 "busy": True,
                 "crash_count": 0,
                 "last_crash_error": None,
+                "is_stuck": False,
             }
         ]
 
@@ -185,6 +187,7 @@ class TestGetEndpoint:
             last_error="RuntimeError: boom",
             last_crash_time=datetime(2026, 1, 1),
         )
+        WebhookHandler.registry.is_stale.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -202,6 +205,26 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_all_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.headers.get("Content-Type") == "application/json"
+
+    def test_status_endpoint_is_stuck_true_when_stale(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = True
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["is_stuck"] is True
 
 
 class TestEmptyBody:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -573,6 +573,22 @@ class TestProcessAction:
         time.sleep(0.2)
         mock_task.assert_not_called()
 
+    def test_process_action_emits_heartbeat(self, server: tuple) -> None:
+        """_process_action calls registry.report_activity at the start."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "closed",
+            "pull_request": {"number": 14, "merged": True},
+        }
+        WebhookHandler._fn_launch_worker = MagicMock()
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        time.sleep(0.2)
+        WebhookHandler.registry.report_activity.assert_called_with(
+            "owner/repo", "handling webhook action", busy=True
+        )
+
     def test_exception_in_process_action_does_not_crash(self, server: tuple) -> None:
         url, cfg = server
         payload = {

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -284,6 +284,7 @@ class TestFetchActivities:
                     "busy": True,
                     "crash_count": 0,
                     "last_crash_error": None,
+                    "is_stuck": False,
                 }
             ]
         ).encode()
@@ -293,6 +294,7 @@ class TestFetchActivities:
                 "what": "Working on: #1",
                 "crash_count": 0,
                 "last_crash_error": None,
+                "is_stuck": False,
             }
         }
 
@@ -305,6 +307,7 @@ class TestFetchActivities:
                     "busy": False,
                     "crash_count": 0,
                     "last_crash_error": None,
+                    "is_stuck": False,
                 },
                 {
                     "repo_name": "c/d",
@@ -312,16 +315,23 @@ class TestFetchActivities:
                     "busy": True,
                     "crash_count": 2,
                     "last_crash_error": "RuntimeError: boom",
+                    "is_stuck": True,
                 },
             ]
         ).encode()
         result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
         assert result == {
-            "a/b": {"what": "Napping", "crash_count": 0, "last_crash_error": None},
+            "a/b": {
+                "what": "Napping",
+                "crash_count": 0,
+                "last_crash_error": None,
+                "is_stuck": False,
+            },
             "c/d": {
                 "what": "Fixing CI",
                 "crash_count": 2,
                 "last_crash_error": "RuntimeError: boom",
+                "is_stuck": True,
             },
         }
 
@@ -338,6 +348,22 @@ class TestFetchActivities:
         data = json.dumps([{"repo_name": "a/b", "busy": True}]).encode()
         result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
         assert result == {}
+
+    def test_is_stuck_defaults_to_false_when_absent(self) -> None:
+        data = json.dumps(
+            [
+                {
+                    "repo_name": "owner/repo",
+                    "what": "Napping",
+                    "busy": False,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                    # no "is_stuck" key — older server version
+                }
+            ]
+        ).encode()
+        result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
+        assert result["owner/repo"]["is_stuck"] is False
 
     def test_calls_correct_url(self) -> None:
         mock_urlopen = self._make_urlopen(b"[]")
@@ -579,6 +605,32 @@ class TestRepoStatus:
         assert result.claude_pid is None
         assert result.claude_uptime is None
 
+    def test_worker_stuck_defaults_to_false(self, tmp_path: Path) -> None:
+        cfg = self._make_config(tmp_path)
+        with patch("kennel.status._git_dir", return_value=None):
+            result = repo_status(cfg)
+        assert result.worker_stuck is False
+
+    def test_worker_stuck_passed_through_no_git_dir(self, tmp_path: Path) -> None:
+        cfg = self._make_config(tmp_path)
+        with patch("kennel.status._git_dir", return_value=None):
+            result = repo_status(cfg, worker_stuck=True)
+        assert result.worker_stuck is True
+
+    def test_worker_stuck_passed_through_with_git_dir(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        fido_dir = git_dir / "fido"
+        fido_dir.mkdir(parents=True)
+        cfg = self._make_config(tmp_path)
+        with (
+            patch("kennel.status._git_dir", return_value=git_dir),
+            patch("kennel.status._fido_running", return_value=False),
+            patch("kennel.status._claude_pid", return_value=None),
+            patch("kennel.status._process_uptime_seconds", return_value=None),
+        ):
+            result = repo_status(cfg, worker_stuck=True)
+        assert result.worker_stuck is True
+
 
 class TestCollect:
     def _fake_repo_status(self, name: str = "owner/repo") -> RepoStatus:
@@ -594,6 +646,7 @@ class TestCollect:
             worker_what=None,
             crash_count=0,
             last_crash_error=None,
+            worker_stuck=False,
         )
 
     def test_kennel_up_with_uptime(self, tmp_path: Path) -> None:
@@ -633,11 +686,13 @@ class TestCollect:
         what: str = "Working on: #1",
         crash_count: int = 0,
         last_crash_error: str | None = None,
+        is_stuck: bool = False,
     ) -> dict:
         return {
             "what": what,
             "crash_count": crash_count,
             "last_crash_error": last_crash_error,
+            "is_stuck": is_stuck,
         }
 
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:
@@ -686,7 +741,11 @@ class TestCollect:
         ):
             collect()
         mock_rs.assert_called_once_with(
-            rc, worker_what="Fixing CI: tests", crash_count=0, last_crash_error=None
+            rc,
+            worker_what="Fixing CI: tests",
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -714,6 +773,7 @@ class TestCollect:
             worker_what="Napping",
             crash_count=3,
             last_crash_error="ValueError: oops",
+            worker_stuck=False,
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -730,7 +790,35 @@ class TestCollect:
         ):
             collect()
         mock_rs.assert_called_once_with(
-            rc, worker_what=None, crash_count=0, last_crash_error=None
+            rc,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+
+    def test_passes_is_stuck_to_repo_status(self, tmp_path: Path) -> None:
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch(
+                "kennel.status._fetch_activities",
+                return_value={"owner/repo": self._activity_info(is_stuck=True)},
+            ),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_rs,
+        ):
+            collect()
+        mock_rs.assert_called_once_with(
+            rc,
+            worker_what="Working on: #1",
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=True,
         )
 
 
@@ -748,6 +836,7 @@ class TestFormatStatus:
             worker_what=None,
             crash_count=0,
             last_crash_error=None,
+            worker_stuck=False,
         )
         defaults.update(kwargs)
         return RepoStatus(**defaults)
@@ -883,3 +972,21 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "claude pid 9999 (running 1m) — crashed 2x: OSError: disk full" in output
+
+    def test_worker_stuck_false_not_shown(self) -> None:
+        repo = self._repo(worker_stuck=False)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "STUCK" not in output
+
+    def test_worker_stuck_true_shown(self) -> None:
+        repo = self._repo(worker_stuck=True)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "STUCK" in output
+
+    def test_stuck_appears_before_crash_info(self) -> None:
+        repo = self._repo(worker_stuck=True, crash_count=1, last_crash_error="err")
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "STUCK — crashed 1x: err" in output

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from kennel.config import RepoConfig
-from kennel.watchdog import Watchdog, run
+from kennel.watchdog import (
+    _MAX_STALE_COUNT,  # noqa: PLC2701
+    _STALE_THRESHOLD,  # noqa: PLC2701
+    Watchdog,
+    run,
+)
 
 
 def _repo(name: str = "owner/repo") -> RepoConfig:
@@ -18,6 +23,7 @@ def _make(repos: dict[str, RepoConfig] | None = None) -> tuple[Watchdog, MagicMo
     if repos is None:
         repos = {"owner/repo": _repo()}
     registry = MagicMock()
+    registry.is_stale.return_value = False
     return Watchdog(registry, repos), registry
 
 
@@ -115,7 +121,201 @@ class TestWatchdogRun:
         registry.start.assert_not_called()
 
 
+# ── Watchdog stale detection ───────────────────────────────────────────────────
+
+
+class TestWatchdogStale:
+    def _stale_make(self, max_stale: int = 2) -> tuple[Watchdog, MagicMock]:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=max_stale,
+        )
+        return w, registry
+
+    def test_warns_on_first_stale_detection(self) -> None:
+        w, _ = self._stale_make()
+        from unittest.mock import patch
+
+        with patch("kennel.watchdog.log") as mock_log:
+            w.run()
+        mock_log.warning.assert_called_once()
+        args = mock_log.warning.call_args.args
+        assert "owner/repo" in args[1]
+
+    def test_does_not_restart_on_first_stale_detection(self) -> None:
+        w, registry = self._stale_make(max_stale=2)
+        w.run()
+        registry.start.assert_not_called()
+        registry.stop_and_join.assert_not_called()
+
+    def test_increments_stale_count_each_detection(self) -> None:
+        w, _ = self._stale_make(max_stale=5)
+        w.run()
+        assert w._stale_counts["owner/repo"] == 1
+        w.run()
+        assert w._stale_counts["owner/repo"] == 2
+
+    def test_forces_restart_at_max_stale_count(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=2,
+        )
+        w.run()  # count → 1, no restart
+        registry.start.assert_not_called()
+        w.run()  # count → 2 == max, restart
+        registry.stop_and_join.assert_called_once_with("owner/repo")
+        registry.start.assert_called_once_with(repo_cfg)
+
+    def test_stop_and_join_called_before_start_on_stale_restart(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        call_order: list[str] = []
+        registry.stop_and_join.side_effect = lambda *_: call_order.append(
+            "stop_and_join"
+        )
+        registry.start.side_effect = lambda *_: call_order.append("start")
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=1,
+        )
+        w.run()
+        assert call_order == ["stop_and_join", "start"]
+
+    def test_records_crash_before_stale_restart(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        call_order: list[str] = []
+        registry.record_crash.side_effect = lambda *_: call_order.append("record_crash")
+        registry.stop_and_join.side_effect = lambda *_: call_order.append(
+            "stop_and_join"
+        )
+        registry.start.side_effect = lambda *_: call_order.append("start")
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=1,
+        )
+        w.run()
+        assert call_order == ["record_crash", "stop_and_join", "start"]
+
+    def test_stale_restart_records_crash_with_stuck_message(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=1,
+        )
+        w.run()
+        registry.record_crash.assert_called_once()
+        _, error = registry.record_crash.call_args.args
+        assert "stuck" in error
+
+    def test_stale_count_resets_after_forced_restart(self) -> None:
+        w, _ = self._stale_make(max_stale=1)
+        w.run()  # triggers restart, resets count
+        assert "owner/repo" not in w._stale_counts
+
+    def test_stale_count_resets_on_healthy_check(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = True
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=5,
+        )
+        registry.is_stale.return_value = True
+        w.run()
+        w.run()
+        assert w._stale_counts.get("owner/repo", 0) == 2
+        registry.is_stale.return_value = False
+        w.run()  # healthy — resets
+        assert "owner/repo" not in w._stale_counts
+
+    def test_stale_count_resets_on_dead_thread_restart(self) -> None:
+        repo_cfg = _repo()
+        registry = MagicMock()
+        w = Watchdog(
+            registry,
+            {"owner/repo": repo_cfg},
+            _stale_threshold=300.0,
+            _max_stale_count=5,
+        )
+        # Build up a stale count
+        registry.is_alive.return_value = True
+        registry.is_stale.return_value = True
+        w.run()
+        assert w._stale_counts.get("owner/repo", 0) == 1
+        # Thread dies next iteration
+        registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = None
+        w.run()
+        assert "owner/repo" not in w._stale_counts
+
+    def test_default_stale_threshold_constant(self) -> None:
+        assert _STALE_THRESHOLD == 600.0
+
+    def test_default_max_stale_count_constant(self) -> None:
+        assert _MAX_STALE_COUNT == 2
+
+    def test_watchdog_accepts_stale_threshold_kwarg(self) -> None:
+        w = Watchdog(MagicMock(), {}, _stale_threshold=120.0)
+        assert w._stale_threshold == 120.0
+
+    def test_watchdog_accepts_max_stale_count_kwarg(self) -> None:
+        w = Watchdog(MagicMock(), {}, _max_stale_count=3)
+        assert w._max_stale_count == 3
+
+    def test_is_stale_called_with_threshold(self) -> None:
+        w, registry = self._stale_make()
+        registry.is_stale.return_value = False
+        w.run()
+        registry.is_stale.assert_called_once_with("owner/repo", 300.0)
+
+    def test_stale_check_skipped_when_thread_dead(self) -> None:
+        """is_stale must not be called for a dead thread."""
+        repo_cfg = _repo()
+        registry = MagicMock()
+        registry.is_alive.return_value = False
+        registry.get_thread_crash_error.return_value = None
+        w = Watchdog(registry, {"owner/repo": repo_cfg})
+        w.run()
+        registry.is_stale.assert_not_called()
+
+
 # ── module-level run() ─────────────────────────────────────────────────────────
+
+
+def _registry(*, alive: bool = True, stale: bool = False) -> MagicMock:
+    """Return a mock registry with is_alive and is_stale pre-configured."""
+    reg = MagicMock()
+    reg.is_alive.return_value = alive
+    reg.is_stale.return_value = stale
+    return reg
 
 
 class TestStartThread:
@@ -123,50 +323,39 @@ class TestStartThread:
         return {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
 
     def test_returns_daemon_thread(self, tmp_path: Path) -> None:
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        t = Watchdog(_registry(), self._repos(tmp_path)).start_thread(_interval=60.0)
         assert t.daemon
 
     def test_thread_name_is_watchdog(self, tmp_path: Path) -> None:
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        t = Watchdog(_registry(), self._repos(tmp_path)).start_thread(_interval=60.0)
         assert t.name == "watchdog"
 
     def test_thread_is_alive(self, tmp_path: Path) -> None:
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        t = Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=60.0)
+        t = Watchdog(_registry(), self._repos(tmp_path)).start_thread(_interval=60.0)
         assert t.is_alive()
 
     def test_calls_run_periodically(self, tmp_path: Path) -> None:
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        Watchdog(registry, self._repos(tmp_path)).start_thread(_interval=0.01)
+        reg = _registry()
+        Watchdog(reg, self._repos(tmp_path)).start_thread(_interval=0.01)
         time.sleep(0.1)
-        registry.is_alive.assert_called()
+        reg.is_alive.assert_called()
 
     def test_restarts_dead_worker(self, tmp_path: Path) -> None:
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
-        registry = MagicMock()
-        registry.is_alive.return_value = False
-        Watchdog(registry, {"owner/repo": repo_cfg}).start_thread(_interval=0.01)
+        reg = _registry(alive=False)
+        Watchdog(reg, {"owner/repo": repo_cfg}).start_thread(_interval=0.01)
         time.sleep(0.1)
-        registry.start.assert_called_with(repo_cfg)
+        reg.start.assert_called_with(repo_cfg)
 
 
 class TestModuleLevelRun:
     def test_delegates_to_watchdog(self) -> None:
         repo_cfg = _repo()
         repos = {"owner/repo": repo_cfg}
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        result = run(registry, repos)
+        reg = _registry()
+        result = run(reg, repos)
         assert result == 0
-        registry.is_alive.assert_called_once_with("owner/repo")
+        reg.is_alive.assert_called_once_with("owner/repo")
 
     def test_returns_zero(self) -> None:
-        registry = MagicMock()
-        registry.is_alive.return_value = True
-        assert run(registry, {"owner/repo": _repo()}) == 0
+        assert run(_registry(), {"owner/repo": _repo()}) == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8203,3 +8203,38 @@ class TestWorkerThread:
 
         assert len(captured) == 1
         assert captured[0] is wt._abort_task
+
+    def test_heartbeat_emitted_each_iteration(self, tmp_path: Path) -> None:
+        """report_activity is called at the top of each loop iteration."""
+        mock_registry = MagicMock()
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), registry=mock_registry)
+        wt._wake = MagicMock()
+        call_count = 0
+
+        def fake_worker_run(self_ignored=None) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                wt._stop = True
+            return 0
+
+        with patch.object(Worker, "run", fake_worker_run):
+            self._run_thread(wt)
+
+        assert call_count == 2
+        assert mock_registry.report_activity.call_count == 2
+        for call in mock_registry.report_activity.call_args_list:
+            assert call.args[0] == "owner/repo"
+            assert call.kwargs.get("busy") is False or call.args[2] is False
+
+    def test_heartbeat_not_emitted_when_no_registry(self, tmp_path: Path) -> None:
+        """WorkerThread without a registry must not crash on the heartbeat path."""
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), registry=None)
+        wt._wake = MagicMock()
+
+        def fake_worker_run(self_ignored=None) -> int:
+            wt._stop = True
+            return 0
+
+        with patch.object(Worker, "run", fake_worker_run):
+            self._run_thread(wt)  # must not raise


### PR DESCRIPTION
Adds defense-in-depth against stuck workers: a shared request helper with bounded HTTP timeouts in the GitHub client, progress heartbeats from worker and webhook action threads tracked in WorkerRegistry, and a watchdog that detects stale-but-alive workers and escalates to restart. Surfaces the resulting stuck-worker state through the /status endpoint and kennel status output.

Fixes #382.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] [deduplicate timeout argument into shared request helper](https://github.com/FidoCanCode/home/pull/426#discussion_r3076691619) <!-- type:thread -->
- [x] Emit heartbeats from WorkerThread loop and webhook background action threads <!-- type:spec -->
- [x] Extend Watchdog to detect stale-but-alive workers and escalate to restart <!-- type:spec -->
- [x] Surface stuck-worker state in /status endpoint and kennel status output <!-- type:spec -->
- [x] Add explicit bounded timeouts to GitHub HTTP requests in kennel/github.py <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->