### PR TITLE
Make runner failures fail fast and surface worker death explicitly (closes #197)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import os
-import re
 import shutil
 import signal
 import subprocess
@@ -16,6 +15,7 @@ import time
 from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from urllib.parse import urlparse
 
 from kennel.claude import kill_active_children
 from kennel.config import Config, RepoConfig, RepoMembership
@@ -51,8 +51,18 @@ def _runner_dir() -> Path:
 
 def _parse_repo_from_url(url: str) -> str | None:
     """Extract 'owner/repo' from an SSH or HTTPS git remote URL, or return None."""
-    m = re.search(r"[:/]([^:/]+/[^/]+?)(?:\.git)?$", url)
-    return m.group(1) if m else None
+    parsed = urlparse(url)
+    if parsed.scheme:
+        # Standard URL (https, ssh, git, etc.): path is /owner/repo[.git]
+        path = parsed.path
+    elif ":" in url:
+        # SCP-style SSH: git@github.com:owner/repo[.git]
+        _, path = url.split(":", 1)
+    else:
+        return None
+    path = path.lstrip("/").removesuffix(".git")
+    parts = path.split("/")
+    return path if len(parts) == 2 and all(parts) else None
 
 
 def _get_self_repo(

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -48,6 +48,12 @@ def _runner_dir() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _parse_repo_from_url(url: str) -> str | None:
+    """Extract 'owner/repo' from an SSH or HTTPS git remote URL, or return None."""
+    m = re.search(r"[:/]([^:/]+/[^/]+?)(?:\.git)?$", url)
+    return m.group(1) if m else None
+
+
 def _get_self_repo(
     runner_dir: Path,
     *,
@@ -70,11 +76,51 @@ def _get_self_repo(
         log.error("self-restart: failed to read origin remote: %s", e)
         return None
     url = result.stdout.strip()
-    m = re.search(r"[:/]([^:/]+/[^/]+?)(?:\.git)?$", url)
-    if not m:
+    parsed = _parse_repo_from_url(url)
+    if not parsed:
         log.error("self-restart: could not parse owner/repo from remote url: %r", url)
         return None
-    return m.group(1)
+    return parsed
+
+
+def preflight_repo_identity(
+    repos: dict[str, RepoConfig],
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """Verify each configured work_dir is a git repo whose origin matches its name.
+
+    Raises :exc:`SystemExit` if any repo's origin remote can't be read, can't
+    be parsed, or doesn't match the configured ``owner/repo`` name.  This runs
+    once at startup so misconfigured repo mappings fail immediately rather than
+    surfacing as silent divergence deep inside webhook or worker paths.
+    """
+    for name, repo_cfg in repos.items():
+        try:
+            result = _run(
+                ["git", "remote", "get-url", "origin"],
+                cwd=str(repo_cfg.work_dir),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise SystemExit(
+                f"preflight: {name}: git remote get-url failed: {e}"
+            ) from e
+        except FileNotFoundError as e:
+            raise SystemExit(f"preflight: {name}: git not found: {e}") from e
+        url = result.stdout.strip()
+        actual = _parse_repo_from_url(url)
+        if actual is None:
+            raise SystemExit(
+                f"preflight: {name}: could not parse owner/repo from origin remote: {url!r}"
+            )
+        if actual != name:
+            raise SystemExit(
+                f"preflight: {name}: origin remote is {actual!r} — expected {name!r}"
+            )
+        log.info("preflight: %s: work_dir identity confirmed", name)
 
 
 def _get_head(
@@ -488,6 +534,7 @@ def run(
     _kill_active_children=kill_active_children,
     _startup_pull=_startup_pull,
     _Watchdog=Watchdog,
+    _preflight_repo_identity=preflight_repo_identity,
 ) -> None:
     config = _from_args()
 
@@ -534,6 +581,7 @@ def run(
     threading.excepthook = _log_thread_exception
 
     _startup_pull()
+    _preflight_repo_identity(config.repos)
 
     _populate_memberships(config)
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -143,6 +143,24 @@ def preflight_tools(
     log.info("preflight: all required tools found: %s", ", ".join(_REQUIRED_TOOLS))
 
 
+def preflight_gh_auth(
+    *,
+    _gh_factory: Callable[[], GitHub] = GitHub,
+) -> None:
+    """Verify gh auth works by fetching the authenticated bot user.
+
+    Raises :exc:`SystemExit` if the GitHub client cannot be constructed or
+    ``get_user()`` fails for any reason (bad token, network error, etc.).
+    Runs once at startup so auth failures surface immediately rather than
+    deep inside a webhook or worker path.
+    """
+    try:
+        bot_user = _gh_factory().get_user()
+    except Exception as e:
+        raise SystemExit(f"preflight: gh auth check failed: {e}") from e
+    log.info("preflight: gh auth confirmed — bot user is %r", bot_user)
+
+
 def _get_head(
     runner_dir: Path,
     *,
@@ -556,6 +574,7 @@ def run(
     _Watchdog=Watchdog,
     _preflight_repo_identity=preflight_repo_identity,
     _preflight_tools=preflight_tools,
+    _preflight_gh_auth=preflight_gh_auth,
 ) -> None:
     config = _from_args()
 
@@ -603,6 +622,7 @@ def run(
 
     _startup_pull()
     _preflight_tools()
+    _preflight_gh_auth()
     _preflight_repo_identity(config.repos)
 
     _populate_memberships(config)

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -143,6 +143,25 @@ def preflight_tools(
     log.info("preflight: all required tools found: %s", ", ".join(_REQUIRED_TOOLS))
 
 
+def preflight_sub_dir(
+    config: Config,
+    *,
+    _is_dir: Callable[[Path], bool] = Path.is_dir,
+) -> None:
+    """Verify that the skill-files directory exists.
+
+    Raises :exc:`SystemExit` if ``config.sub_dir`` is not an existing directory.
+    Workers read ``persona.md`` and sub-skill files from here on every task
+    run — a missing directory causes every worker invocation to fail with an
+    obscure I/O error rather than a clear startup message.
+    """
+    if not _is_dir(config.sub_dir):
+        raise SystemExit(
+            f"preflight: skill-files directory not found: {config.sub_dir}"
+        )
+    log.info("preflight: skill-files directory confirmed: %s", config.sub_dir)
+
+
 def preflight_gh_auth(
     *,
     _gh_factory: Callable[[], GitHub] = GitHub,
@@ -574,6 +593,7 @@ def run(
     _Watchdog=Watchdog,
     _preflight_repo_identity=preflight_repo_identity,
     _preflight_tools=preflight_tools,
+    _preflight_sub_dir=preflight_sub_dir,
     _preflight_gh_auth=preflight_gh_auth,
 ) -> None:
     config = _from_args()
@@ -622,6 +642,7 @@ def run(
 
     _startup_pull()
     _preflight_tools()
+    _preflight_sub_dir(config)
     _preflight_gh_auth()
     _preflight_repo_identity(config.repos)
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -121,6 +122,25 @@ def preflight_repo_identity(
                 f"preflight: {name}: origin remote is {actual!r} — expected {name!r}"
             )
         log.info("preflight: %s: work_dir identity confirmed", name)
+
+
+_REQUIRED_TOOLS = ("git", "gh", "claude")
+
+
+def preflight_tools(
+    *,
+    _which: Callable[[str], str | None] = shutil.which,
+) -> None:
+    """Verify that all required CLI tools are on PATH.
+
+    Raises :exc:`SystemExit` naming the first missing tool.  Runs once at
+    startup so a missing binary is caught immediately rather than discovered
+    inside a worker or webhook handler hours later.
+    """
+    for tool in _REQUIRED_TOOLS:
+        if _which(tool) is None:
+            raise SystemExit(f"preflight: required tool not found on PATH: {tool!r}")
+    log.info("preflight: all required tools found: %s", ", ".join(_REQUIRED_TOOLS))
 
 
 def _get_head(
@@ -535,6 +555,7 @@ def run(
     _startup_pull=_startup_pull,
     _Watchdog=Watchdog,
     _preflight_repo_identity=preflight_repo_identity,
+    _preflight_tools=preflight_tools,
 ) -> None:
     config = _from_args()
 
@@ -581,6 +602,7 @@ def run(
     threading.excepthook = _log_thread_exception
 
     _startup_pull()
+    _preflight_tools()
     _preflight_repo_identity(config.repos)
 
     _populate_memberships(config)

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -44,6 +44,14 @@ _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
 
 
+class PreflightError(RuntimeError):
+    """Raised by preflight checks when a startup precondition is not met.
+
+    Caught by :func:`run` and converted to :exc:`SystemExit` so individual
+    preflight functions remain testable without triggering process exit.
+    """
+
+
 def _runner_dir() -> Path:
     """Return the runner clone directory — where the running kennel code lives."""
     return Path(__file__).resolve().parents[1]
@@ -101,10 +109,8 @@ def preflight_repo_identity(
 ) -> None:
     """Verify each configured work_dir is a git repo whose origin matches its name.
 
-    Raises :exc:`SystemExit` if any repo's origin remote can't be read, can't
-    be parsed, or doesn't match the configured ``owner/repo`` name.  This runs
-    once at startup so misconfigured repo mappings fail immediately rather than
-    surfacing as silent divergence deep inside webhook or worker paths.
+    Raises :exc:`PreflightError` if any repo's origin remote can't be read,
+    can't be parsed, or doesn't match the configured ``owner/repo`` name.
     """
     for name, repo_cfg in repos.items():
         try:
@@ -116,19 +122,19 @@ def preflight_repo_identity(
                 check=True,
             )
         except subprocess.CalledProcessError as e:
-            raise SystemExit(
+            raise PreflightError(
                 f"preflight: {name}: git remote get-url failed: {e}"
             ) from e
         except FileNotFoundError as e:
-            raise SystemExit(f"preflight: {name}: git not found: {e}") from e
+            raise PreflightError(f"preflight: {name}: git not found: {e}") from e
         url = result.stdout.strip()
         actual = _parse_repo_from_url(url)
         if actual is None:
-            raise SystemExit(
+            raise PreflightError(
                 f"preflight: {name}: could not parse owner/repo from origin remote: {url!r}"
             )
         if actual != name:
-            raise SystemExit(
+            raise PreflightError(
                 f"preflight: {name}: origin remote is {actual!r} — expected {name!r}"
             )
         log.info("preflight: %s: work_dir identity confirmed", name)
@@ -143,13 +149,13 @@ def preflight_tools(
 ) -> None:
     """Verify that all required CLI tools are on PATH.
 
-    Raises :exc:`SystemExit` naming the first missing tool.  Runs once at
-    startup so a missing binary is caught immediately rather than discovered
-    inside a worker or webhook handler hours later.
+    Raises :exc:`PreflightError` naming the first missing tool.
     """
     for tool in _REQUIRED_TOOLS:
         if _which(tool) is None:
-            raise SystemExit(f"preflight: required tool not found on PATH: {tool!r}")
+            raise PreflightError(
+                f"preflight: required tool not found on PATH: {tool!r}"
+            )
     log.info("preflight: all required tools found: %s", ", ".join(_REQUIRED_TOOLS))
 
 
@@ -160,13 +166,13 @@ def preflight_sub_dir(
 ) -> None:
     """Verify that the skill-files directory exists.
 
-    Raises :exc:`SystemExit` if ``config.sub_dir`` is not an existing directory.
-    Workers read ``persona.md`` and sub-skill files from here on every task
-    run — a missing directory causes every worker invocation to fail with an
-    obscure I/O error rather than a clear startup message.
+    Raises :exc:`PreflightError` if ``config.sub_dir`` is not an existing
+    directory.  Workers read ``persona.md`` and sub-skill files from here on
+    every task run — a missing directory causes every worker invocation to fail
+    with an obscure I/O error rather than a clear startup message.
     """
     if not _is_dir(config.sub_dir):
-        raise SystemExit(
+        raise PreflightError(
             f"preflight: skill-files directory not found: {config.sub_dir}"
         )
     log.info("preflight: skill-files directory confirmed: %s", config.sub_dir)
@@ -178,15 +184,13 @@ def preflight_gh_auth(
 ) -> None:
     """Verify gh auth works by fetching the authenticated bot user.
 
-    Raises :exc:`SystemExit` if the GitHub client cannot be constructed or
+    Raises :exc:`PreflightError` if the GitHub client cannot be constructed or
     ``get_user()`` fails for any reason (bad token, network error, etc.).
-    Runs once at startup so auth failures surface immediately rather than
-    deep inside a webhook or worker path.
     """
     try:
         bot_user = _gh_factory().get_user()
     except Exception as e:
-        raise SystemExit(f"preflight: gh auth check failed: {e}") from e
+        raise PreflightError(f"preflight: gh auth check failed: {e}") from e
     log.info("preflight: gh auth confirmed — bot user is %r", bot_user)
 
 
@@ -651,10 +655,13 @@ def run(
     threading.excepthook = _log_thread_exception
 
     _startup_pull()
-    _preflight_tools()
-    _preflight_sub_dir(config)
-    _preflight_gh_auth()
-    _preflight_repo_identity(config.repos)
+    try:
+        _preflight_tools()
+        _preflight_sub_dir(config)
+        _preflight_gh_auth()
+        _preflight_repo_identity(config.repos)
+    except PreflightError as e:
+        raise SystemExit(str(e)) from e
 
     _populate_memberships(config)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -904,6 +904,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -928,6 +929,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
@@ -957,6 +959,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
@@ -986,6 +989,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=mock_kill,
@@ -1025,6 +1029,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1054,6 +1059,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1081,6 +1087,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1120,6 +1127,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1172,6 +1180,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1205,6 +1214,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
             _Watchdog=mock_watchdog_cls,
         )
@@ -1237,6 +1247,7 @@ class TestRun:
                 _startup_pull=MagicMock(),
                 _preflight_repo_identity=MagicMock(),
                 _preflight_tools=MagicMock(),
+                _preflight_sub_dir=MagicMock(),
                 _preflight_gh_auth=MagicMock(),
                 _Watchdog=MagicMock(),
             )
@@ -1429,6 +1440,9 @@ class TestPreflightRepoIdentity:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=mock_preflight,
+            _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         mock_preflight.assert_called_once_with(fake_cfg.repos)
@@ -1458,6 +1472,7 @@ class TestPreflightRepoIdentity:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=mock_preflight,
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
         )
 
@@ -1488,10 +1503,42 @@ class TestPreflightRepoIdentity:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=mock_preflight,
         )
 
         mock_preflight.assert_called_once_with()
+
+    def test_run_calls_preflight_sub_dir(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = Config(
+            port=0,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_preflight = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=MagicMock(),
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
+            _preflight_sub_dir=mock_preflight,
+            _preflight_gh_auth=MagicMock(),
+        )
+
+        mock_preflight.assert_called_once_with(fake_cfg)
 
 
 class TestPreflightTools:
@@ -1525,6 +1572,50 @@ class TestPreflightTools:
         from kennel.server import _REQUIRED_TOOLS
 
         assert set(_REQUIRED_TOOLS) == {"git", "gh", "claude"}
+
+
+class TestPreflightSubDir:
+    def test_succeeds_when_sub_dir_exists(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_sub_dir
+
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="INFO",
+            sub_dir=tmp_path / "sub",
+        )
+        preflight_sub_dir(cfg, _is_dir=lambda _: True)  # no exception
+
+    def test_raises_when_sub_dir_missing(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_sub_dir
+
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="INFO",
+            sub_dir=tmp_path / "sub",
+        )
+        with pytest.raises(SystemExit, match="skill-files directory not found"):
+            preflight_sub_dir(cfg, _is_dir=lambda _: False)
+
+    def test_error_message_includes_path(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_sub_dir
+
+        sub = tmp_path / "my-sub"
+        cfg = Config(
+            port=0,
+            secret=b"s",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="INFO",
+            sub_dir=sub,
+        )
+        with pytest.raises(SystemExit, match=str(sub)):
+            preflight_sub_dir(cfg, _is_dir=lambda _: False)
 
 
 class TestPreflightGhAuth:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -903,6 +903,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -925,6 +926,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
         )
@@ -952,6 +954,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
         )
@@ -979,6 +982,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=mock_kill,
         )
@@ -1016,6 +1020,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         assert len(captured_kwargs) == 1
@@ -1043,6 +1048,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         assert len(captured_handlers) >= 1
@@ -1068,6 +1074,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -1105,6 +1112,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -1155,6 +1163,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
         )
 
         repo_handler = next(
@@ -1186,6 +1195,7 @@ class TestRun:
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
             _Watchdog=mock_watchdog_cls,
         )
 
@@ -1216,6 +1226,7 @@ class TestRun:
                 _populate_memberships=MagicMock(),
                 _startup_pull=MagicMock(),
                 _preflight_repo_identity=MagicMock(),
+                _preflight_tools=MagicMock(),
                 _Watchdog=MagicMock(),
             )
             assert _sys.excepthook is not saved_sys
@@ -1410,6 +1421,68 @@ class TestPreflightRepoIdentity:
         )
 
         mock_preflight.assert_called_once_with(fake_cfg.repos)
+
+    def test_run_calls_preflight_tools(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = Config(
+            port=0,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_preflight = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=MagicMock(),
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
+            _preflight_tools=mock_preflight,
+        )
+
+        mock_preflight.assert_called_once_with()
+
+
+class TestPreflightTools:
+    def test_succeeds_when_all_tools_found(self) -> None:
+        from kennel.server import preflight_tools
+
+        preflight_tools(_which=lambda _: "/usr/bin/git")  # no exception
+
+    def test_raises_when_git_missing(self) -> None:
+        from kennel.server import preflight_tools
+
+        missing = "git"
+        with pytest.raises(SystemExit, match=repr(missing)):
+            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+
+    def test_raises_when_gh_missing(self) -> None:
+        from kennel.server import preflight_tools
+
+        missing = "gh"
+        with pytest.raises(SystemExit, match=repr(missing)):
+            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+
+    def test_raises_when_claude_missing(self) -> None:
+        from kennel.server import preflight_tools
+
+        missing = "claude"
+        with pytest.raises(SystemExit, match=repr(missing)):
+            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+
+    def test_required_tools_constant(self) -> None:
+        from kennel.server import _REQUIRED_TOOLS
+
+        assert set(_REQUIRED_TOOLS) == {"git", "gh", "claude"}
 
 
 class TestGetSelfRepo:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -904,6 +904,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -927,6 +928,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
         )
@@ -955,6 +957,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
         )
@@ -983,6 +986,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=mock_kill,
         )
@@ -1021,6 +1025,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         assert len(captured_kwargs) == 1
@@ -1049,6 +1054,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         assert len(captured_handlers) >= 1
@@ -1075,6 +1081,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -1113,6 +1120,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -1164,6 +1172,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
         )
 
         repo_handler = next(
@@ -1196,6 +1205,7 @@ class TestRun:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
             _Watchdog=mock_watchdog_cls,
         )
 
@@ -1227,6 +1237,7 @@ class TestRun:
                 _startup_pull=MagicMock(),
                 _preflight_repo_identity=MagicMock(),
                 _preflight_tools=MagicMock(),
+                _preflight_gh_auth=MagicMock(),
                 _Watchdog=MagicMock(),
             )
             assert _sys.excepthook is not saved_sys
@@ -1447,6 +1458,37 @@ class TestPreflightRepoIdentity:
             _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=mock_preflight,
+            _preflight_gh_auth=MagicMock(),
+        )
+
+        mock_preflight.assert_called_once_with()
+
+    def test_run_calls_preflight_gh_auth(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = Config(
+            port=0,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_preflight = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=MagicMock(),
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
+            _preflight_gh_auth=mock_preflight,
         )
 
         mock_preflight.assert_called_once_with()
@@ -1483,6 +1525,38 @@ class TestPreflightTools:
         from kennel.server import _REQUIRED_TOOLS
 
         assert set(_REQUIRED_TOOLS) == {"git", "gh", "claude"}
+
+
+class TestPreflightGhAuth:
+    def test_succeeds_when_get_user_works(self) -> None:
+        from kennel.server import preflight_gh_auth
+
+        mock_gh = MagicMock()
+        mock_gh.return_value.get_user.return_value = "fido-bot"
+        preflight_gh_auth(_gh_factory=mock_gh)  # no exception
+
+    def test_raises_when_get_user_raises_runtime_error(self) -> None:
+        from kennel.server import preflight_gh_auth
+
+        mock_gh = MagicMock()
+        mock_gh.return_value.get_user.side_effect = RuntimeError("not logged in")
+        with pytest.raises(SystemExit, match="not logged in"):
+            preflight_gh_auth(_gh_factory=mock_gh)
+
+    def test_raises_when_gh_factory_raises(self) -> None:
+        from kennel.server import preflight_gh_auth
+
+        mock_gh = MagicMock(side_effect=RuntimeError("gh auth token failed"))
+        with pytest.raises(SystemExit, match="gh auth token failed"):
+            preflight_gh_auth(_gh_factory=mock_gh)
+
+    def test_raises_when_get_user_raises_any_exception(self) -> None:
+        from kennel.server import preflight_gh_auth
+
+        mock_gh = MagicMock()
+        mock_gh.return_value.get_user.side_effect = Exception("network error")
+        with pytest.raises(SystemExit, match="network error"):
+            preflight_gh_auth(_gh_factory=mock_gh)
 
 
 class TestGetSelfRepo:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -902,6 +902,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -923,6 +924,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
         )
@@ -949,6 +951,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
         )
@@ -975,6 +978,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
             _signal=fake_signal,
             _kill_active_children=mock_kill,
         )
@@ -1011,6 +1015,7 @@ class TestRun:
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         assert len(captured_kwargs) == 1
@@ -1037,6 +1042,7 @@ class TestRun:
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         assert len(captured_handlers) >= 1
@@ -1061,6 +1067,7 @@ class TestRun:
             _stderr=mock_stderr,
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -1097,6 +1104,7 @@ class TestRun:
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -1146,6 +1154,7 @@ class TestRun:
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
         )
 
         repo_handler = next(
@@ -1176,6 +1185,7 @@ class TestRun:
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
             _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
             _Watchdog=mock_watchdog_cls,
         )
 
@@ -1205,6 +1215,7 @@ class TestRun:
                 _basic_config=MagicMock(),
                 _populate_memberships=MagicMock(),
                 _startup_pull=MagicMock(),
+                _preflight_repo_identity=MagicMock(),
                 _Watchdog=MagicMock(),
             )
             assert _sys.excepthook is not saved_sys
@@ -1272,6 +1283,133 @@ _PUSH_PAYLOAD = {
     },
     "ref": "refs/heads/main",
 }
+
+
+class TestParseRepoFromUrl:
+    def test_parses_ssh_url(self) -> None:
+        from kennel.server import _parse_repo_from_url
+
+        assert _parse_repo_from_url("git@github.com:owner/repo.git") == "owner/repo"
+
+    def test_parses_https_url(self) -> None:
+        from kennel.server import _parse_repo_from_url
+
+        assert _parse_repo_from_url("https://github.com/owner/repo.git") == "owner/repo"
+
+    def test_parses_url_without_git_suffix(self) -> None:
+        from kennel.server import _parse_repo_from_url
+
+        assert _parse_repo_from_url("https://github.com/owner/repo") == "owner/repo"
+
+    def test_returns_none_for_garbage(self) -> None:
+        from kennel.server import _parse_repo_from_url
+
+        assert _parse_repo_from_url("garbage") is None
+
+
+class TestPreflightRepoIdentity:
+    def test_succeeds_when_remote_matches(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_run = MagicMock(
+            return_value=MagicMock(stdout="git@github.com:owner/repo.git\n")
+        )
+        preflight_repo_identity(repos, _run=mock_run)  # no exception
+
+    def test_raises_on_remote_mismatch(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_run = MagicMock(
+            return_value=MagicMock(stdout="git@github.com:other/thing.git\n")
+        )
+        with pytest.raises(SystemExit, match="other/thing"):
+            preflight_repo_identity(repos, _run=mock_run)
+
+    def test_raises_on_subprocess_error(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
+        with pytest.raises(SystemExit):
+            preflight_repo_identity(repos, _run=mock_run)
+
+    def test_raises_when_git_not_found(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_run = MagicMock(side_effect=FileNotFoundError())
+        with pytest.raises(SystemExit):
+            preflight_repo_identity(repos, _run=mock_run)
+
+    def test_raises_on_unparseable_url(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n"))
+        with pytest.raises(SystemExit):
+            preflight_repo_identity(repos, _run=mock_run)
+
+    def test_checks_all_repos(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {
+            "owner/repo1": RepoConfig(name="owner/repo1", work_dir=tmp_path),
+            "owner/repo2": RepoConfig(name="owner/repo2", work_dir=tmp_path),
+        }
+        mock_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="git@github.com:owner/repo1.git\n"),
+                MagicMock(stdout="git@github.com:owner/repo2.git\n"),
+            ]
+        )
+        preflight_repo_identity(repos, _run=mock_run)  # no exception
+        assert mock_run.call_count == 2
+
+    def test_raises_on_second_repo_mismatch(self, tmp_path: Path) -> None:
+        from kennel.server import preflight_repo_identity
+
+        repos = {
+            "owner/repo1": RepoConfig(name="owner/repo1", work_dir=tmp_path),
+            "owner/repo2": RepoConfig(name="owner/repo2", work_dir=tmp_path),
+        }
+        mock_run = MagicMock(
+            side_effect=[
+                MagicMock(stdout="git@github.com:owner/repo1.git\n"),
+                MagicMock(stdout="git@github.com:other/thing.git\n"),
+            ]
+        )
+        with pytest.raises(SystemExit, match="other/thing"):
+            preflight_repo_identity(repos, _run=mock_run)
+
+    def test_run_calls_preflight_repo_identity(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = Config(
+            port=0,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_preflight = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=MagicMock(),
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _preflight_repo_identity=mock_preflight,
+        )
+
+        mock_preflight.assert_called_once_with(fake_cfg.repos)
 
 
 class TestGetSelfRepo:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kennel.config import Config, RepoConfig
-from kennel.server import WebhookHandler
+from kennel.server import PreflightError, WebhookHandler
 
 
 def _config(tmp_path: Path) -> Config:
@@ -1357,7 +1357,7 @@ class TestPreflightRepoIdentity:
         mock_run = MagicMock(
             return_value=MagicMock(stdout="git@github.com:other/thing.git\n")
         )
-        with pytest.raises(SystemExit, match="other/thing"):
+        with pytest.raises(PreflightError, match="other/thing"):
             preflight_repo_identity(repos, _run=mock_run)
 
     def test_raises_on_subprocess_error(self, tmp_path: Path) -> None:
@@ -1365,7 +1365,7 @@ class TestPreflightRepoIdentity:
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
-        with pytest.raises(SystemExit):
+        with pytest.raises(PreflightError):
             preflight_repo_identity(repos, _run=mock_run)
 
     def test_raises_when_git_not_found(self, tmp_path: Path) -> None:
@@ -1373,7 +1373,7 @@ class TestPreflightRepoIdentity:
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_run = MagicMock(side_effect=FileNotFoundError())
-        with pytest.raises(SystemExit):
+        with pytest.raises(PreflightError):
             preflight_repo_identity(repos, _run=mock_run)
 
     def test_raises_on_unparseable_url(self, tmp_path: Path) -> None:
@@ -1381,7 +1381,7 @@ class TestPreflightRepoIdentity:
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n"))
-        with pytest.raises(SystemExit):
+        with pytest.raises(PreflightError):
             preflight_repo_identity(repos, _run=mock_run)
 
     def test_checks_all_repos(self, tmp_path: Path) -> None:
@@ -1413,7 +1413,7 @@ class TestPreflightRepoIdentity:
                 MagicMock(stdout="git@github.com:other/thing.git\n"),
             ]
         )
-        with pytest.raises(SystemExit, match="other/thing"):
+        with pytest.raises(PreflightError, match="other/thing"):
             preflight_repo_identity(repos, _run=mock_run)
 
     def test_run_calls_preflight_repo_identity(self, tmp_path: Path) -> None:
@@ -1540,6 +1540,36 @@ class TestPreflightRepoIdentity:
 
         mock_preflight.assert_called_once_with(fake_cfg)
 
+    def test_run_converts_preflight_error_to_system_exit(self, tmp_path: Path) -> None:
+        from kennel.server import run
+
+        fake_cfg = Config(
+            port=0,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        mock_server = MagicMock()
+
+        with pytest.raises(SystemExit, match="something went wrong"):
+            run(
+                _from_args=lambda: fake_cfg,
+                _HTTPServer=lambda *a, **kw: mock_server,
+                _make_registry=MagicMock(),
+                _path_home=lambda: tmp_path,
+                _basic_config=MagicMock(),
+                _populate_memberships=MagicMock(),
+                _startup_pull=MagicMock(),
+                _preflight_tools=MagicMock(
+                    side_effect=PreflightError("something went wrong")
+                ),
+                _preflight_sub_dir=MagicMock(),
+                _preflight_gh_auth=MagicMock(),
+                _preflight_repo_identity=MagicMock(),
+            )
+
 
 class TestPreflightTools:
     def test_succeeds_when_all_tools_found(self) -> None:
@@ -1551,21 +1581,21 @@ class TestPreflightTools:
         from kennel.server import preflight_tools
 
         missing = "git"
-        with pytest.raises(SystemExit, match=repr(missing)):
+        with pytest.raises(PreflightError, match=repr(missing)):
             preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
 
     def test_raises_when_gh_missing(self) -> None:
         from kennel.server import preflight_tools
 
         missing = "gh"
-        with pytest.raises(SystemExit, match=repr(missing)):
+        with pytest.raises(PreflightError, match=repr(missing)):
             preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
 
     def test_raises_when_claude_missing(self) -> None:
         from kennel.server import preflight_tools
 
         missing = "claude"
-        with pytest.raises(SystemExit, match=repr(missing)):
+        with pytest.raises(PreflightError, match=repr(missing)):
             preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
 
     def test_required_tools_constant(self) -> None:
@@ -1599,7 +1629,7 @@ class TestPreflightSubDir:
             log_level="INFO",
             sub_dir=tmp_path / "sub",
         )
-        with pytest.raises(SystemExit, match="skill-files directory not found"):
+        with pytest.raises(PreflightError, match="skill-files directory not found"):
             preflight_sub_dir(cfg, _is_dir=lambda _: False)
 
     def test_error_message_includes_path(self, tmp_path: Path) -> None:
@@ -1614,7 +1644,7 @@ class TestPreflightSubDir:
             log_level="INFO",
             sub_dir=sub,
         )
-        with pytest.raises(SystemExit, match=str(sub)):
+        with pytest.raises(PreflightError, match=str(sub)):
             preflight_sub_dir(cfg, _is_dir=lambda _: False)
 
 
@@ -1631,14 +1661,14 @@ class TestPreflightGhAuth:
 
         mock_gh = MagicMock()
         mock_gh.return_value.get_user.side_effect = RuntimeError("not logged in")
-        with pytest.raises(SystemExit, match="not logged in"):
+        with pytest.raises(PreflightError, match="not logged in"):
             preflight_gh_auth(_gh_factory=mock_gh)
 
     def test_raises_when_gh_factory_raises(self) -> None:
         from kennel.server import preflight_gh_auth
 
         mock_gh = MagicMock(side_effect=RuntimeError("gh auth token failed"))
-        with pytest.raises(SystemExit, match="gh auth token failed"):
+        with pytest.raises(PreflightError, match="gh auth token failed"):
             preflight_gh_auth(_gh_factory=mock_gh)
 
     def test_raises_when_get_user_raises_any_exception(self) -> None:
@@ -1646,7 +1676,7 @@ class TestPreflightGhAuth:
 
         mock_gh = MagicMock()
         mock_gh.return_value.get_user.side_effect = Exception("network error")
-        with pytest.raises(SystemExit, match="network error"):
+        with pytest.raises(PreflightError, match="network error"):
             preflight_gh_auth(_gh_factory=mock_gh)
 
 


### PR DESCRIPTION
Adds startup preflight checks so kennel fails closed before workers and webhooks start.

- Verifies each `work_dir` is a git repo for its configured `owner/repo`
- Confirms required CLI tools (`git`, `gh`, `claude`) are on PATH
- Checks that `gh` auth works by fetching the bot user
- Checks that the skill-files directory (`sub/`) exists

Fixes #383.

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] [replace regex URL parsing with urlparse in _parse_repo_from_url](https://github.com/FidoCanCode/home/pull/434#discussion_r3076902821) <!-- type:thread -->
- [x] Add preflight: verify required CLI tools (git, gh, claude) are on PATH <!-- type:spec -->
- [x] Add preflight: verify gh auth works by fetching the bot user <!-- type:spec -->
- [x] [Expand preflight to cover all remaining checks from issue #383 (beyond repo/CLI/gh-auth)](https://github.com/FidoCanCode/home/pull/434#issuecomment-4240952720) <!-- type:thread -->
- [x] Wire preflight into run() to fail closed before workers and webhooks start <!-- type:spec -->
- [x] PR comment: replace SystemExit with PreflightError in preflight_repo_identity <!-- type:thread -->
- [x] [replace SystemExit with custom PreflightError exception in preflight functions](https://github.com/FidoCanCode/home/pull/434#discussion_r3076934429) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->