### PR TITLE
Collapse GitHub integration into one injectable public client and remove hidden factories (closes #311)

### DIFF
--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -131,10 +131,10 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None, *, _GitHub=GitHub) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
-    cmd = Cmd(github=GitHub())
+    cmd = Cmd(github=_GitHub())
 
     match args.command:
         case "add":

--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class Cmd:
     """CLI command handler with injectable dependencies for testability."""
 
-    def __init__(self, *, github: GitHub | None = None) -> None:
+    def __init__(self, *, github: GitHub) -> None:
         self._github = github
 
     def _resolve_thread_if_ours(self, thread: dict) -> None:
@@ -28,7 +28,7 @@ class Cmd:
         if not (repo and pr and comment_id):
             return
 
-        github = self._github if self._github is not None else GitHub()
+        github = self._github
         try:
             us = github.get_user()
             comments = github.get_pull_comments(repo, pr)
@@ -134,7 +134,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
-    cmd = Cmd()
+    cmd = Cmd(github=GitHub())
 
     match args.command:
         case "add":

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from kennel import claude
 from kennel.config import Config, RepoConfig
-from kennel.github import get_github
+from kennel.github import GitHub
 from kennel.prompts import (
     Prompts,
     issue_reply_instruction,
@@ -254,7 +254,7 @@ def maybe_react(
         log.debug("fido chose not to react (got: %s)", reaction)
         return
 
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     log.info("fido reacts with %s to comment %s", reaction, comment_id)
     try:
         gh.add_reaction(repo, comment_type, comment_id, reaction)
@@ -298,7 +298,7 @@ def reply_to_comment(
     else:
         lock_fd = None
 
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     prompts = Prompts(_load_persona(config))
     comment = action.comment_body
 
@@ -411,7 +411,7 @@ def reply_to_review(
     if not info:
         return
 
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     log.info(
         "fetching review comments for PR #%s review %s", info["pr"], info["review_id"]
     )
@@ -571,7 +571,7 @@ def reply_to_issue_comment(
     m = re.search(r"#(\d+)", action.prompt)
     number = m.group(1) if m else ""
 
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     repo_full = gh.get_repo_info(cwd=repo_cfg.work_dir)
 
     # Fetch full conversation history for context
@@ -734,7 +734,7 @@ def _notify_thread_change(
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
 
     task = change["task"]
     thread = task.get("thread") or {}
@@ -955,7 +955,7 @@ def _reorder_tasks_background(
     from kennel.tasks import reorder_tasks as _reorder_tasks
 
     reorder = _reorder_fn if _reorder_fn is not None else _reorder_tasks
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
     state = _coalesce_state if _coalesce_state is not None else _reorder_coalesce
 
@@ -1042,7 +1042,7 @@ def launch_sync(config: Config, repo_cfg: RepoConfig, *, _gh=None) -> None:
     """Sync tasks.json → PR body in a background thread."""
     from kennel.tasks import sync_tasks_background
 
-    gh = _gh if _gh is not None else get_github()
+    gh = _gh if _gh is not None else GitHub()
     sync_tasks_background(repo_cfg.work_dir, gh)
     log.info("sync-tasks launched")
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -231,9 +231,9 @@ def maybe_react(
     comment_type: str,
     repo: str,
     config: Config,
+    gh: GitHub,
     *,
     _print_prompt=None,
-    _gh=None,
 ) -> None:
     """Let Fido decide whether to react to a comment with an emoji.
 
@@ -254,7 +254,6 @@ def maybe_react(
         log.debug("fido chose not to react (got: %s)", reaction)
         return
 
-    gh = _gh if _gh is not None else GitHub()
     log.info("fido reacts with %s to comment %s", reaction, comment_id)
     try:
         gh.add_reaction(repo, comment_type, comment_id, reaction)
@@ -266,9 +265,9 @@ def reply_to_comment(
     action: Action,
     config: Config,
     repo_cfg: RepoConfig,
+    gh: GitHub,
     *,
     _print_prompt=None,
-    _gh=None,
 ) -> tuple[str, list[str]]:
     """Triage a comment via Opus, generate a reply via Opus, post it.
 
@@ -298,7 +297,6 @@ def reply_to_comment(
     else:
         lock_fd = None
 
-    gh = _gh if _gh is not None else GitHub()
     prompts = Prompts(_load_persona(config))
     comment = action.comment_body
 
@@ -374,8 +372,8 @@ def reply_to_comment(
         "pulls",
         info.get("repo", ""),
         config,
+        gh,
         _print_prompt=_print_prompt,
-        _gh=gh,
     )
 
     # For DUMP: also resolve the thread
@@ -399,10 +397,10 @@ def reply_to_review(
     action: Action,
     config: Config,
     repo_cfg: RepoConfig,
+    gh: GitHub,
     already_replied: set[int] | None = None,
     *,
     _print_prompt=None,
-    _gh=None,
 ) -> None:
     """Fetch inline comments from a review and reply to each."""
     if _print_prompt is None:
@@ -411,7 +409,6 @@ def reply_to_review(
     if not info:
         return
 
-    gh = _gh if _gh is not None else GitHub()
     log.info(
         "fetching review comments for PR #%s review %s", info["pr"], info["review_id"]
     )
@@ -452,8 +449,8 @@ def reply_to_review(
                 ),
                 config,
                 repo_cfg,
+                gh,
                 _print_prompt=_print_prompt,
-                _gh=gh,
             )
         except Exception:
             log.exception("failed to reply to review comment %s — skipping", cid)
@@ -555,9 +552,9 @@ def reply_to_issue_comment(
     action: Action,
     config: Config,
     repo_cfg: RepoConfig,
+    gh: GitHub,
     *,
     _print_prompt=None,
-    _gh=None,
 ) -> tuple[str, list[str]]:
     """Triage and reply to a top-level PR comment (issue_comment event).
 
@@ -571,7 +568,6 @@ def reply_to_issue_comment(
     m = re.search(r"#(\d+)", action.prompt)
     number = m.group(1) if m else ""
 
-    gh = _gh if _gh is not None else GitHub()
     repo_full = gh.get_repo_info(cwd=repo_cfg.work_dir)
 
     # Fetch full conversation history for context
@@ -636,8 +632,8 @@ def reply_to_issue_comment(
             "issues",
             repo_full,
             config,
+            gh,
             _print_prompt=_print_prompt,
-            _gh=gh,
         )
 
     return (category, titles)
@@ -718,9 +714,9 @@ def _get_commit_summary(work_dir: Path) -> str:
 def _notify_thread_change(
     change: dict[str, Any],
     config: Config,
+    gh: GitHub,
     *,
     _print_prompt=None,
-    _gh=None,
 ) -> None:
     """Post a brief comment notifying a commenter that their task was rescoped.
 
@@ -734,7 +730,6 @@ def _notify_thread_change(
     """
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
-    gh = _gh if _gh is not None else GitHub()
 
     task = change["task"]
     thread = task.get("thread") or {}
@@ -898,7 +893,7 @@ def _make_reorder_kwargs(
 
     def on_changes(changes: list[dict[str, Any]]) -> None:
         for change in changes:
-            _notify_thread_change(change, config, _gh=gh)
+            _notify_thread_change(change, config, gh)
 
     def on_done() -> None:
         rewrite_fn(work_dir, gh, _print_prompt=print_prompt)
@@ -921,11 +916,11 @@ def _reorder_tasks_background(
     work_dir: Path,
     commit_summary: str,
     config: Config,
+    gh: GitHub,
     repo_cfg: RepoConfig | None = None,
     registry: WorkerRegistry | None = None,
     *,
     _start=threading.Thread.start,
-    _gh=None,
     _print_prompt=None,
     _rewrite_fn=None,
     _reorder_fn=None,
@@ -955,7 +950,6 @@ def _reorder_tasks_background(
     from kennel.tasks import reorder_tasks as _reorder_tasks
 
     reorder = _reorder_fn if _reorder_fn is not None else _reorder_tasks
-    gh = _gh if _gh is not None else GitHub()
     rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
     state = _coalesce_state if _coalesce_state is not None else _reorder_coalesce
 
@@ -998,6 +992,7 @@ def create_task(
     prompt: str,
     config: Config,
     repo_cfg: RepoConfig,
+    gh: GitHub,
     thread: dict[str, Any] | None = None,
     registry: WorkerRegistry | None = None,
     *,
@@ -1027,22 +1022,21 @@ def create_task(
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
-    launch_sync(config, repo_cfg)
+    launch_sync(config, repo_cfg, gh)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
         _reorder_background_fn(
-            repo_cfg.work_dir, commit_summary, config, repo_cfg, registry
+            repo_cfg.work_dir, commit_summary, config, gh, repo_cfg, registry
         )
     if registry is not None:
         _maybe_abort_for_new_task(repo_cfg, new_task, registry)
     return new_task
 
 
-def launch_sync(config: Config, repo_cfg: RepoConfig, *, _gh=None) -> None:
+def launch_sync(config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
     """Sync tasks.json → PR body in a background thread."""
     from kennel.tasks import sync_tasks_background
 
-    gh = _gh if _gh is not None else GitHub()
     sync_tasks_background(repo_cfg.work_dir, gh)
     log.info("sync-tasks launched")
 

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from kennel import claude
-from kennel.github import GitHub, get_github
+from kennel.github import GitHub
 
 _SUB_DIR = Path(__file__).resolve().parent.parent / "sub"
 _PERSONA_PATH = _SUB_DIR / "persona.md"
@@ -63,7 +63,7 @@ def set_gh_status(
     persona_path: Path = _PERSONA_PATH,
     _generate_persona_status: Callable[..., str] = generate_persona_status,
     _generate_persona_emoji: Callable[..., str] = generate_persona_emoji,
-    _get_github: Callable[..., GitHub] = get_github,
+    _get_github: Callable[..., GitHub] = GitHub,
 ) -> None:
     try:
         persona = persona_path.read_text()

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -63,7 +63,7 @@ def set_gh_status(
     persona_path: Path = _PERSONA_PATH,
     _generate_persona_status: Callable[..., str] = generate_persona_status,
     _generate_persona_emoji: Callable[..., str] = generate_persona_emoji,
-    _get_github: Callable[..., GitHub] = GitHub,
+    _gh: GitHub,
 ) -> None:
     try:
         persona = persona_path.read_text()
@@ -71,12 +71,11 @@ def set_gh_status(
         persona = ""
     text = _generate_persona_status(message, persona)
     emoji = _generate_persona_emoji(text, persona)
-    gh = _get_github()
-    gh.set_user_status(text, emoji, busy=True)
+    _gh.set_user_status(text, emoji, busy=True)
 
 
 def main(argv: list[str]) -> None:
     if len(argv) < 2 or argv[0] != "set":
         print("Usage: kennel gh-status set <message>", file=sys.stderr)
         raise SystemExit(1)
-    set_gh_status(" ".join(argv[1:]))
+    set_gh_status(" ".join(argv[1:]), _gh=GitHub())

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -74,8 +74,8 @@ def set_gh_status(
     _gh.set_user_status(text, emoji, busy=True)
 
 
-def main(argv: list[str]) -> None:
+def main(argv: list[str], *, _GitHub=GitHub) -> None:
     if len(argv) < 2 or argv[0] != "set":
         print("Usage: kennel gh-status set <message>", file=sys.stderr)
         raise SystemExit(1)
-    set_gh_status(" ".join(argv[1:]), _gh=GitHub())
+    set_gh_status(" ".join(argv[1:]), _gh=_GitHub())

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import logging
 import os
 import re
@@ -643,9 +642,3 @@ class GitHub:
             resp.raise_for_status()
             parts.append(resp.text)
         return "".join(parts)
-
-
-@functools.cache
-def get_github(token: str | None = None) -> GitHub:
-    """Return the shared GitHub instance, creating it on first call."""
-    return GitHub(token)

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -36,9 +36,6 @@ class GraphQLError(Exception):
         self.errors = errors
 
 
-# ── Requests-based GitHub API client ─────────────────────────────────────────
-
-
 def _gh_token(
     runner: Any = subprocess.run,
     environ: Any = os.environ,
@@ -65,16 +62,18 @@ def _gh_token(
     return token
 
 
-class GH:
+class GitHub:
     """GitHub client: requests-based REST and GraphQL API calls."""
 
     BASE = "https://api.github.com"
 
-    def __init__(self, token: str, session: _requests.Session | None = None) -> None:
+    def __init__(
+        self, token: str | None = None, session: _requests.Session | None = None
+    ) -> None:
         self._s = session if session is not None else _TimeoutSession()
         self._s.headers.update(
             {
-                "Authorization": f"Bearer {token}",
+                "Authorization": f"Bearer {token if token is not None else _gh_token()}",
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28",
             }
@@ -364,8 +363,13 @@ class GH:
             return url[len("git@github.com:") :]
         raise ValueError(f"Cannot parse GitHub remote URL: {url!r}")
 
-    def get_default_branch(self, repo: str) -> str:
-        """Return the default branch name for the given repo."""
+    def get_default_branch(
+        self,
+        cwd: Path | str | None = None,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Return the default branch for the repo at cwd."""
+        repo = self.get_repo_info(cwd=cwd, runner=runner)
         data = self._get(f"/repos/{repo}")
         return data["default_branch"]
 
@@ -642,191 +646,6 @@ class GH:
 
 
 @functools.cache
-def _get_gh(token: str | None = None) -> GH:
-    """Return the shared GH instance, creating it on first call."""
-    return GH(token if token is not None else _gh_token())
-
-
-class GitHub:
-    """Facade that stores a single GH client as self._gh and exposes named methods."""
-
-    def __init__(
-        self,
-        token: str | None = None,
-        session: _requests.Session | None = None,
-    ) -> None:
-        self._gh = GH(token if token is not None else _gh_token(), session=session)
-
-    # ── Repo / user context ───────────────────────────────────────────────────
-
-    def get_repo_info(
-        self, cwd: Path | str | None = None, runner: Any = subprocess.run
-    ) -> str:
-        """Return 'owner/repo' for the repo at cwd."""
-        return self._gh.get_repo_info(cwd=cwd, runner=runner)
-
-    def get_user(self) -> str:
-        """Return the authenticated GitHub username."""
-        return self._gh.get_user()
-
-    def get_collaborators(self, repo: str) -> list[str]:
-        """Return logins of collaborators with write+ permission on *repo*."""
-        return self._gh.get_collaborators(repo)
-
-    def get_default_branch(
-        self, cwd: Path | str | None = None, runner: Any = subprocess.run
-    ) -> str:
-        """Return the default branch name for the repo at cwd."""
-        repo = self._gh.get_repo_info(cwd=cwd, runner=runner)
-        return self._gh.get_default_branch(repo)
-
-    def set_user_status(self, msg: str, emoji: str, busy: bool = True) -> None:
-        """Set the authenticated user's GitHub status."""
-        self._gh.set_user_status(msg, emoji, busy)
-
-    # ── Issues ────────────────────────────────────────────────────────────────
-
-    def find_issues(self, owner: str, repo: str, login: str) -> list[dict[str, Any]]:
-        """Return open issues assigned to login (oldest first) with sub-issue states."""
-        return self._gh.find_issues(owner, repo, login)
-
-    def view_issue(self, repo: str, number: int | str) -> dict[str, Any]:
-        """Return issue data (state, title, body)."""
-        return self._gh.view_issue(repo, number)
-
-    def comment_issue(self, repo: str, number: int | str, body: str) -> None:
-        """Post a comment on an issue."""
-        self._gh.comment_issue(repo, number, body)
-
-    def get_issue_comments(self, repo: str, number: int | str) -> list[dict[str, Any]]:
-        """Return all comments on an issue."""
-        return self._gh.get_issue_comments(repo, number)
-
-    def get_issue_events(self, repo: str, number: int | str) -> list[dict[str, Any]]:
-        """Return all events on an issue."""
-        return self._gh.get_issue_events(repo, number)
-
-    def create_issue(self, repo: str, title: str, body: str) -> str:
-        """Create an issue and return its HTML URL."""
-        return self._gh.create_issue(repo, title, body)
-
-    # ── Pull requests ─────────────────────────────────────────────────────────
-
-    def get_pull_comments(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
-        """Return all inline review comments on a pull request."""
-        return self._gh.get_pull_comments(repo, pr)
-
-    def fetch_sibling_threads(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
-        """Return all review-comment threads for a PR as a structured list."""
-        return self._gh.fetch_sibling_threads(repo, pr)
-
-    def fetch_comment_thread(
-        self, repo: str, pr: int | str, comment_id: int
-    ) -> list[dict[str, Any]]:
-        """Return all comments in the review thread containing comment_id."""
-        return self._gh.fetch_comment_thread(repo, pr, comment_id)
-
-    def find_pr(
-        self, repo: str, issue_number: int | str, user: str
-    ) -> dict[str, Any] | None:
-        """Find the most recent PR linked to issue_number authored by user, or None."""
-        return self._gh.find_pr(repo, issue_number, user)
-
-    def create_pr(
-        self,
-        repo: str,
-        title: str,
-        body: str,
-        base: str,
-        head: str,
-    ) -> str:
-        """Create a draft PR and return its URL."""
-        return self._gh.create_pr(repo, title, body, base, head)
-
-    def edit_pr_body(self, repo: str, pr: int | str, body: str) -> None:
-        """Edit a PR's body."""
-        self._gh.edit_pr_body(repo, pr, body)
-
-    def get_pr_body(self, repo: str, pr: int | str) -> str:
-        """Return just the PR body text."""
-        return self._gh.get_pr_body(repo, pr)
-
-    def add_pr_reviewers(self, repo: str, pr: int | str, reviewers: list[str]) -> None:
-        """Request review from one or more users on a PR."""
-        self._gh.add_pr_reviewers(repo, pr, reviewers)
-
-    def pr_checks(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
-        """Return check statuses for a PR."""
-        return self._gh.pr_checks(repo, pr)
-
-    def pr_ready(self, repo: str, pr: int | str) -> None:
-        """Mark a PR ready for review."""
-        self._gh.pr_ready(repo, pr)
-
-    def pr_merge(
-        self, repo: str, pr: int | str, squash: bool = True, auto: bool = False
-    ) -> None:
-        """Merge a PR."""
-        self._gh.pr_merge(repo, pr, squash=squash, auto=auto)
-
-    def get_pr(self, repo: str, pr: int | str) -> dict[str, Any]:
-        """Return PR data (reviews, isDraft, mergeStateStatus, body, commits)."""
-        return self._gh.get_pr(repo, pr)
-
-    def get_reviews(self, repo: str, pr: int | str) -> dict[str, Any]:
-        """Return reviews and isDraft for a PR."""
-        return self._gh.get_reviews(repo, pr)
-
-    def get_review_comments(
-        self, repo: str, pr: int | str, review_id: int | str
-    ) -> list[tuple[int, str]]:
-        """Return list of (comment_id, body) pairs from a review."""
-        return self._gh.get_review_comments(repo, pr, review_id)
-
-    def reply_to_review_comment(
-        self,
-        repo: str,
-        pr: int | str,
-        body: str,
-        in_reply_to: int | str,
-    ) -> None:
-        """Post a reply to an inline review comment."""
-        self._gh.reply_to_review_comment(repo, pr, body, in_reply_to)
-
-    def add_reaction(
-        self,
-        repo: str,
-        comment_type: str,
-        comment_id: int | str,
-        content: str,
-    ) -> None:
-        """Add a reaction to a comment. comment_type: 'pulls' or 'issues'."""
-        self._gh.add_reaction(repo, comment_type, comment_id, content)
-
-    # ── Review threads ────────────────────────────────────────────────────────
-
-    def get_review_threads(
-        self, owner: str, repo: str, pr: int | str
-    ) -> list[dict[str, Any]]:
-        """Return review-thread nodes for a PR."""
-        return self._gh.get_review_threads(owner, repo, pr)
-
-    def resolve_thread(self, thread_id: str) -> None:
-        """Resolve a review thread via GraphQL mutation."""
-        self._gh.resolve_thread(thread_id)
-
-    # ── CI runs ───────────────────────────────────────────────────────────────
-
-    def get_required_checks(self, repo: str, branch: str) -> list[str]:
-        """Return required status check names for branch, or [] if unprotected."""
-        return self._gh.get_required_checks(repo, branch)
-
-    def get_run_log(self, repo: str, run_id: str | int) -> str:
-        """Return the failed log output for a CI run."""
-        return self._gh.get_run_log(repo, run_id)
-
-
-@functools.cache
 def get_github(token: str | None = None) -> GitHub:
-    """Return the shared GitHub facade instance, creating it on first call."""
+    """Return the shared GitHub instance, creating it on first call."""
     return GitHub(token)

--- a/kennel/main.py
+++ b/kennel/main.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import sys
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(
+    argv: list[str] | None = None,
+    *,
+    _GitHub=None,
+) -> None:
     args = sys.argv[1:] if argv is None else argv
 
     # TODO: remove this compat shim once shell scripts are fully removed
@@ -13,7 +17,7 @@ def main(argv: list[str] | None = None) -> None:
         from kennel.cli import main as task_main
         from kennel.github import GitHub
 
-        task_main(args[1:], _GitHub=GitHub)
+        task_main(args[1:], _GitHub=_GitHub or GitHub)
     elif args and args[0] == "status":
         from kennel.status import collect, format_status
 
@@ -33,7 +37,7 @@ def main(argv: list[str] | None = None) -> None:
         from kennel.tasks import sync_tasks
 
         work_dir = Path(args[1]) if len(args) > 1 else Path.cwd()
-        sync_tasks(work_dir, GitHub())
+        sync_tasks(work_dir, (_GitHub or GitHub)())
     else:
         from kennel.server import run as server_run
 

--- a/kennel/main.py
+++ b/kennel/main.py
@@ -11,8 +11,9 @@ def main(argv: list[str] | None = None) -> None:
     # TODO: remove this compat shim once shell scripts are fully removed
     if args and args[0] == "task":
         from kennel.cli import main as task_main
+        from kennel.github import GitHub
 
-        task_main(args[1:])
+        task_main(args[1:], _GitHub=GitHub)
     elif args and args[0] == "status":
         from kennel.status import collect, format_status
 

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -253,14 +253,14 @@ def _make_thread(
     repo_cfg: RepoConfig,
     registry: WorkerRegistry,
     *,
-    _GitHub=GitHub,
+    gh: GitHub,
     _WorkerThread=WorkerThread,
 ) -> WorkerThread:
-    """Default factory: create a WorkerThread with a live GitHub client."""
+    """Default factory: create a WorkerThread with the provided GitHub client."""
     return _WorkerThread(
         repo_cfg.work_dir,
         repo_cfg.name,
-        _GitHub(),
+        gh,
         registry,
         repo_cfg.membership,
     )
@@ -268,18 +268,19 @@ def _make_thread(
 
 def make_registry(
     repos: dict[str, RepoConfig],
+    gh: GitHub,
     *,
     _thread_factory=_make_thread,
 ) -> WorkerRegistry:
     """Create a :class:`WorkerRegistry` and start threads for all repos.
 
-    Uses :func:`_make_thread` as the factory so each thread gets its own
-    live :class:`~kennel.github.GitHub` client.  Pass a custom registry
-    directly (with a mock factory) in tests instead of calling this.
+    Uses :func:`_make_thread` as the factory; all threads share the provided
+    :class:`~kennel.github.GitHub` client.  Pass a custom registry directly
+    (with a mock factory) in tests instead of calling this.
     """
 
     def factory(cfg: RepoConfig) -> WorkerThread:
-        return _thread_factory(cfg, registry)
+        return _thread_factory(cfg, registry, gh=gh)
 
     registry = WorkerRegistry(factory)
     for repo_cfg in repos.values():

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -288,9 +288,9 @@ def _pull_with_backoff(
 class WebhookHandler(BaseHTTPRequestHandler):
     config: Config
     registry: WorkerRegistry
-    # Injectable callables — set as class attributes so HTTP-driven tests can
-    # replace them without patching module-level names.
-    _fn_get_github = GitHub
+    # Injectable collaborators — set as class attributes so HTTP-driven tests
+    # can replace them without patching module-level names.
+    gh = GitHub()
     _fn_dispatch = dispatch
     _fn_reply_to_comment = reply_to_comment
     _fn_reply_to_review = reply_to_review
@@ -398,7 +398,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.registry.report_activity(
                 repo_cfg.name, "handling webhook action", busy=True
             )
-            gh = type(self)._fn_get_github()
+            gh = self.gh
             handled = False
 
             if action.reply_to:
@@ -473,8 +473,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         comment_id = thread.get("comment_id")
         comment_type = thread.get("comment_type", "issues")
         try:
-            gh = type(self)._fn_get_github()
-            gh.add_reaction(repo, comment_type, comment_id, "confused")
+            self.gh.add_reaction(repo, comment_type, comment_id, "confused")
         except Exception:
             log.exception("failed to post error reaction on comment %s", comment_id)
 
@@ -669,6 +668,7 @@ def run(
     _populate_memberships(config)
 
     WebhookHandler.config = config
+    WebhookHandler.gh = GitHub()
     registry = _make_registry(config.repos)
     WebhookHandler.registry = registry
     _Watchdog(registry, config.repos).start_thread()

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -291,7 +291,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     registry: WorkerRegistry
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
-    gh = GitHub()
+    gh: GitHub | None = None
     _fn_dispatch = dispatch
     _fn_reply_to_comment = reply_to_comment
     _fn_reply_to_review = reply_to_review
@@ -702,7 +702,7 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = GitHub()
-    registry = _make_registry(config.repos)
+    registry = _make_registry(config.repos, WebhookHandler.gh)
     WebhookHandler.registry = registry
     _Watchdog(registry, config.repos).start_thread()
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -398,6 +398,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.registry.report_activity(
                 repo_cfg.name, "handling webhook action", busy=True
             )
+            gh = type(self)._fn_get_github()
             handled = False
 
             if action.reply_to:
@@ -408,7 +409,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     category, titles = None, []
                 else:
                     category, titles = type(self)._fn_reply_to_comment(
-                        action, self.config, repo_cfg
+                        action, self.config, repo_cfg, gh
                     )
                     if cid:
                         _replied_comments.add(cid)
@@ -422,20 +423,21 @@ class WebhookHandler(BaseHTTPRequestHandler):
                             title,
                             self.config,
                             repo_cfg,
+                            gh,
                             thread=action.reply_to,
                             registry=self.registry,
                         )
 
             if action.review_comments:
                 type(self)._fn_reply_to_review(
-                    action, self.config, repo_cfg, already_replied=_replied_comments
+                    action, self.config, repo_cfg, gh, already_replied=_replied_comments
                 )
                 handled = True  # inline comments handled individually
 
             # Top-level PR comments (issue_comment) — no reply_to, but has comment_body
             if not handled and action.comment_body:
                 category, titles = type(self)._fn_reply_to_issue_comment(
-                    action, self.config, repo_cfg
+                    action, self.config, repo_cfg, gh
                 )
                 handled = True
                 # DEFER files a GitHub issue — no tasks.json entry.
@@ -445,6 +447,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                             title,
                             self.config,
                             repo_cfg,
+                            gh,
                             thread=action.thread,
                             registry=self.registry,
                         )

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -179,17 +179,14 @@ def preflight_sub_dir(
     log.info("preflight: skill-files directory confirmed: %s", config.sub_dir)
 
 
-def preflight_gh_auth(
-    *,
-    _gh_factory: Callable[[], GitHub] = GitHub,
-) -> None:
+def preflight_gh_auth(gh: GitHub) -> None:
     """Verify gh auth works by fetching the authenticated bot user.
 
-    Raises :exc:`PreflightError` if the GitHub client cannot be constructed or
-    ``get_user()`` fails for any reason (bad token, network error, etc.).
+    Raises :exc:`PreflightError` if ``get_user()`` fails for any reason
+    (bad token, network error, etc.).
     """
     try:
-        bot_user = _gh_factory().get_user()
+        bot_user = gh.get_user()
     except Exception as e:
         raise PreflightError(f"preflight: gh auth check failed: {e}") from e
     log.info("preflight: gh auth confirmed — bot user is %r", bot_user)
@@ -580,17 +577,14 @@ class WebhookHandler(BaseHTTPRequestHandler):
         pass
 
 
-def populate_memberships(
-    config: Config, *, _gh_factory: Callable[[], GitHub] = GitHub
-) -> None:
+def populate_memberships(config: Config, gh: GitHub) -> None:
     """Fetch collaborators for each repo once at startup and store on RepoConfig.
 
     Mutates ``config.repos`` in place — each :class:`RepoConfig` is replaced
     with a new instance carrying a populated :class:`RepoMembership`.  Uses
-    one GitHub client instance for all repos.  Bot account (gh_user) is
-    excluded from every collaborator set.
+    the provided GitHub client instance for all repos.  Bot account (gh_user)
+    is excluded from every collaborator set.
     """
-    gh = _gh_factory()
     bot_user = gh.get_user()
     for name, repo_cfg in list(config.repos.items()):
         collabs = frozenset(c for c in gh.get_collaborators(name) if c != bot_user)
@@ -644,6 +638,7 @@ def run(
     _preflight_tools=preflight_tools,
     _preflight_sub_dir=preflight_sub_dir,
     _preflight_gh_auth=preflight_gh_auth,
+    _GitHub=GitHub,
 ) -> None:
     config = _from_args()
 
@@ -689,20 +684,21 @@ def run(
     sys.excepthook = _log_uncaught
     threading.excepthook = _log_thread_exception
 
+    gh = _GitHub()
     _startup_pull()
     try:
         _preflight_tools()
         _preflight_sub_dir(config)
-        _preflight_gh_auth()
+        _preflight_gh_auth(gh)
         _preflight_repo_identity(config.repos)
     except PreflightError as e:
         raise SystemExit(str(e)) from e
 
-    _populate_memberships(config)
+    _populate_memberships(config, gh)
 
     WebhookHandler.config = config
-    WebhookHandler.gh = GitHub()
-    registry = _make_registry(config.repos, WebhookHandler.gh)
+    WebhookHandler.gh = gh
+    registry = _make_registry(config.repos, gh)
     WebhookHandler.registry = registry
     _Watchdog(registry, config.repos).start_thread()
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1828,11 +1828,11 @@ class WorkerThread(threading.Thread):
             raise
 
 
-def run(work_dir: Path) -> int:
+def run(work_dir: Path, *, _GitHub: type[GitHub] = GitHub) -> int:
     """Run one iteration of the worker loop.
 
     Creates a :class:`Worker` with a live :class:`~kennel.github.GitHub` client
-    and delegates to :meth:`Worker.run`.  For testing, construct ``Worker``
-    directly with a mock ``gh`` instead of patching module-level names.
+    and delegates to :meth:`Worker.run`.  Pass ``_GitHub=MockClass`` in tests
+    instead of patching the module-level name.
     """
-    return Worker(work_dir, GitHub()).run()
+    return Worker(work_dir, _GitHub()).run()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -384,7 +384,7 @@ class TestCmdList:
 class TestMain:
     def test_add_via_main(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        main([str(tmp_path), "add", "spec", "task title"])
+        main([str(tmp_path), "add", "spec", "task title"], _GitHub=MagicMock)
         capsys.readouterr()
         from kennel.tasks import list_tasks
 
@@ -405,7 +405,8 @@ class TestMain:
                 "r/r",
                 "--pr",
                 "3",
-            ]
+            ],
+            _GitHub=MagicMock,
         )
         capsys.readouterr()
         from kennel.tasks import list_tasks
@@ -415,19 +416,19 @@ class TestMain:
 
     def test_complete_via_main(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        main([str(tmp_path), "add", "spec", "finish me"])
+        main([str(tmp_path), "add", "spec", "finish me"], _GitHub=MagicMock)
         out = capsys.readouterr().out
         task_id = json.loads(out)["id"]
-        main([str(tmp_path), "complete", task_id])
+        main([str(tmp_path), "complete", task_id], _GitHub=MagicMock)
         from kennel.tasks import list_tasks
 
         assert list_tasks(tmp_path)[0]["status"] == "completed"
 
     def test_list_via_main(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        main([str(tmp_path), "add", "spec", "one"])
+        main([str(tmp_path), "add", "spec", "one"], _GitHub=MagicMock)
         capsys.readouterr()
-        main([str(tmp_path), "list"])
+        main([str(tmp_path), "list"], _GitHub=MagicMock)
         out = capsys.readouterr().out
         data = json.loads(out)
         assert data[0]["title"] == "one"
@@ -449,4 +450,4 @@ class TestMain:
 
         monkeypatch.setattr(cli_mod, "build_parser", lambda: fake_parser)
         with pytest.raises(AssertionError, match="unreachable"):
-            main([])
+            main([], _GitHub=MagicMock)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,7 +90,9 @@ class TestBuildParser:
 class TestCmdAdd:
     def test_adds_task(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        Cmd().add(tmp_path, TaskType.SPEC, "my task", "some description")
+        Cmd(github=MagicMock()).add(
+            tmp_path, TaskType.SPEC, "my task", "some description"
+        )
         capsys.readouterr()  # consume add output
         from kennel.tasks import list_tasks
 
@@ -102,7 +104,7 @@ class TestCmdAdd:
 
     def test_adds_task_no_description(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        Cmd().add(tmp_path, TaskType.CI, "bare task", "")
+        Cmd(github=MagicMock()).add(tmp_path, TaskType.CI, "bare task", "")
         capsys.readouterr()
         from kennel.tasks import list_tasks
 
@@ -114,7 +116,7 @@ class TestCmdAdd:
         self, tmp_path: Path, capsys
     ) -> None:
         _task_file(tmp_path)
-        Cmd().add(
+        Cmd(github=MagicMock()).add(
             tmp_path, TaskType.THREAD, "threaded", "", comment_id=42, repo="a/b", pr=7
         )
         capsys.readouterr()
@@ -126,7 +128,9 @@ class TestCmdAdd:
     def test_adds_task_comment_id_only(self, tmp_path: Path, capsys) -> None:
         """comment_id without repo/pr still sets a thread for dedup purposes."""
         _task_file(tmp_path)
-        Cmd().add(tmp_path, TaskType.THREAD, "threaded", "", comment_id=99)
+        Cmd(github=MagicMock()).add(
+            tmp_path, TaskType.THREAD, "threaded", "", comment_id=99
+        )
         capsys.readouterr()
         from kennel.tasks import list_tasks
 
@@ -135,7 +139,7 @@ class TestCmdAdd:
 
     def test_add_deduplicates_by_comment_id(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        Cmd().add(
+        Cmd(github=MagicMock()).add(
             tmp_path,
             TaskType.THREAD,
             "first title",
@@ -145,7 +149,7 @@ class TestCmdAdd:
             pr=7,
         )
         capsys.readouterr()
-        Cmd().add(
+        Cmd(github=MagicMock()).add(
             tmp_path,
             TaskType.THREAD,
             "different title",
@@ -163,7 +167,7 @@ class TestCmdAdd:
 
     def test_add_prints_task_json(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        Cmd().add(tmp_path, TaskType.SPEC, "my task", "")
+        Cmd(github=MagicMock()).add(tmp_path, TaskType.SPEC, "my task", "")
         out = capsys.readouterr().out
         data = json.loads(out)
         assert data["title"] == "my task"
@@ -176,7 +180,7 @@ class TestCmdAdd:
 class TestCmdComplete:
     def test_completes_task_no_thread(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        cmd = Cmd()
+        cmd = Cmd(github=MagicMock())
         task = cmd.add(tmp_path, TaskType.SPEC, "task to finish", "")
         capsys.readouterr()
         cmd.complete(tmp_path, task["id"])
@@ -346,7 +350,7 @@ class TestCmdComplete:
     def test_complete_nonexistent_id_no_error(self, tmp_path: Path) -> None:
         """Completing a non-existent task ID should not raise."""
         _task_file(tmp_path)
-        Cmd().complete(tmp_path, "nonexistent-id")
+        Cmd(github=MagicMock()).complete(tmp_path, "nonexistent-id")
 
 
 # ── Cmd.list ──────────────────────────────────────────────────────────────────
@@ -355,7 +359,7 @@ class TestCmdComplete:
 class TestCmdList:
     def test_prints_json(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        cmd = Cmd()
+        cmd = Cmd(github=MagicMock())
         cmd.add(tmp_path, TaskType.SPEC, "alpha", "")
         capsys.readouterr()
         cmd.add(tmp_path, TaskType.SPEC, "beta", "desc")
@@ -369,7 +373,7 @@ class TestCmdList:
 
     def test_empty_list(self, tmp_path: Path, capsys) -> None:
         _task_file(tmp_path)
-        Cmd().list(tmp_path)
+        Cmd(github=MagicMock()).list(tmp_path)
         out = capsys.readouterr().out
         assert json.loads(out) == []
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2533,11 +2533,11 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, _print_prompt=fake_pp, _gh=MagicMock())
         assert "alice" in captured_prompt[0]
 
-    def test_gh_none_uses_get_github(self, tmp_path: Path) -> None:
+    def test_gh_none_uses_github_constructor(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
-        with patch("kennel.events.get_github", return_value=mock_gh):
+        with patch("kennel.events.GitHub", return_value=mock_gh):
             _notify_thread_change(
                 change, cfg, _print_prompt=MagicMock(return_value="ok")
             )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -556,8 +556,8 @@ class TestMaybeReact:
             "pulls",
             "owner/repo",
             cfg,
+            mock_gh,
             _print_prompt=MagicMock(return_value="heart"),
-            _gh=mock_gh,
         )
         mock_gh.add_reaction.assert_called_once_with("owner/repo", "pulls", 99, "heart")
 
@@ -570,8 +570,8 @@ class TestMaybeReact:
             "pulls",
             "owner/repo",
             cfg,
+            mock_gh,
             _print_prompt=MagicMock(return_value="NONE"),
-            _gh=mock_gh,
         )
         mock_gh.add_reaction.assert_not_called()
 
@@ -583,6 +583,7 @@ class TestMaybeReact:
             "pulls",
             "owner/repo",
             cfg,
+            MagicMock(),
             _print_prompt=MagicMock(return_value=""),
         )
 
@@ -594,6 +595,7 @@ class TestMaybeReact:
             "pulls",
             "owner/repo",
             cfg,
+            MagicMock(),
             _print_prompt=MagicMock(return_value=""),
         )
 
@@ -621,15 +623,15 @@ class TestMaybeReact:
             "pulls",
             "owner/repo",
             cfg,
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert "you are fido" in captured.get("prompt", "")
 
     def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         with patch("kennel.claude.print_prompt", return_value="NONE") as mock_pp:
-            maybe_react("hi", 1, "pulls", "owner/repo", cfg)
+            maybe_react("hi", 1, "pulls", "owner/repo", cfg, MagicMock())
         mock_pp.assert_called_once()
 
 
@@ -650,7 +652,9 @@ class TestReplyToComment:
     def test_no_reply_to_returns_act(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="do stuff")
-        cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+        cat, titles = reply_to_comment(
+            action, cfg, self._repo_cfg(tmp_path), MagicMock()
+        )
         assert cat == "ACT"
 
     def test_no_comment_body_returns_act(self, tmp_path: Path) -> None:
@@ -659,7 +663,9 @@ class TestReplyToComment:
             prompt="something",
             reply_to={"repo": "a/b", "pr": 1, "comment_id": 5},
         )
-        cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+        cat, titles = reply_to_comment(
+            action, cfg, self._repo_cfg(tmp_path), MagicMock()
+        )
         assert cat == "ACT"
 
     def test_full_flow_act(self, tmp_path: Path) -> None:
@@ -688,8 +694,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
         assert "logging" in titles[0].lower()
@@ -714,8 +720,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ASK"
 
@@ -739,8 +745,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ANSWER"
 
@@ -765,8 +771,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert cat == "DO"
         assert titles == ["add result caching"]
@@ -794,8 +800,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert cat == "DEFER"
         mock_gh.create_issue.assert_called_once_with(
@@ -824,8 +830,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "DUMP"
 
@@ -855,8 +861,8 @@ class TestReplyToComment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
         mock_gh.reply_to_review_comment.assert_not_called()
 
@@ -880,8 +886,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"  # still succeeds with fallback body
 
@@ -905,8 +911,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -927,7 +933,9 @@ class TestReplyToComment:
                 comment_body="competing update",
                 is_bot=False,
             )
-            cat, titles = reply_to_comment(action, cfg, self._repo_cfg(tmp_path))
+            cat, titles = reply_to_comment(
+                action, cfg, self._repo_cfg(tmp_path), MagicMock()
+            )
             assert cat == "ACT"  # returns without posting
         finally:
             lock_fd.close()
@@ -953,8 +961,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -979,8 +987,8 @@ class TestReplyToComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
@@ -1004,7 +1012,7 @@ class TestReplyToReview:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="review", review_comments=None)
         # should return without error
-        reply_to_review(action, cfg, self._repo_cfg(tmp_path))
+        reply_to_review(action, cfg, self._repo_cfg(tmp_path), MagicMock())
 
     def test_fetches_and_replies(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1023,7 +1031,7 @@ class TestReplyToReview:
         mock_gh = MagicMock()
         mock_gh.get_review_comments.return_value = [(100, "fix this"), (200, "nit")]
         reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), _print_prompt=fake_pp, _gh=mock_gh
+            action, cfg, self._repo_cfg(tmp_path), mock_gh, _print_prompt=fake_pp
         )
 
     def test_skips_already_replied(self, tmp_path: Path) -> None:
@@ -1045,9 +1053,9 @@ class TestReplyToReview:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             already_replied=already,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         # no claude calls since all comments already replied
         assert not calls
@@ -1061,7 +1069,7 @@ class TestReplyToReview:
         mock_gh = MagicMock()
         mock_gh.get_review_comments.side_effect = Exception("network fail")
         reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), _gh=mock_gh
+            action, cfg, self._repo_cfg(tmp_path), mock_gh
         )  # should not raise
 
     def test_no_inline_comments(self, tmp_path: Path) -> None:
@@ -1073,7 +1081,7 @@ class TestReplyToReview:
         mock_gh = MagicMock()
         mock_gh.get_review_comments.return_value = []
         reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), _gh=mock_gh
+            action, cfg, self._repo_cfg(tmp_path), mock_gh
         )  # empty → no replies
 
 
@@ -1111,8 +1119,8 @@ class TestReplyToIssueComment:
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -1128,8 +1136,8 @@ class TestReplyToIssueComment:
             self._action("unclear"),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ASK"
 
@@ -1145,8 +1153,8 @@ class TestReplyToIssueComment:
             self._action("why?"),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ANSWER"
 
@@ -1162,8 +1170,8 @@ class TestReplyToIssueComment:
             self._action("do it differently"),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "DUMP"
 
@@ -1182,8 +1190,8 @@ class TestReplyToIssueComment:
             self._action("big refactor"),
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert cat == "DEFER"
         mock_gh.create_issue.assert_called_once_with(
@@ -1211,8 +1219,8 @@ class TestReplyToIssueComment:
                 self._action("big refactor"),
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
         mock_gh.comment_issue.assert_not_called()
 
@@ -1228,8 +1236,8 @@ class TestReplyToIssueComment:
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -1245,8 +1253,8 @@ class TestReplyToIssueComment:
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -1272,8 +1280,8 @@ class TestReplyToIssueComment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
 
     def test_no_comment_id_skips_react(self, tmp_path: Path) -> None:
@@ -1294,8 +1302,8 @@ class TestReplyToIssueComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
 
@@ -1310,7 +1318,7 @@ class TestReplyToIssueComment:
 
         with patch("kennel.claude.print_prompt", side_effect=fake_pp) as mock_pp:
             cat, titles = reply_to_issue_comment(
-                action, cfg, self._repo_cfg(tmp_path), _gh=MagicMock()
+                action, cfg, self._repo_cfg(tmp_path), MagicMock()
             )
         assert mock_pp.called
         assert cat == "ACT"
@@ -1337,8 +1345,8 @@ class TestReplyToIssueComment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
         assert cat == "ACT"
         mock_gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
@@ -1363,8 +1371,8 @@ class TestReplyToIssueComment:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert cat == "ACT"
 
@@ -1381,8 +1389,8 @@ class TestReplyToIssueComment:
             self._action("add tests and update docs"),
             cfg,
             self._repo_cfg(tmp_path),
+            MagicMock(),
             _print_prompt=fake_pp,
-            _gh=MagicMock(),
         )
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
@@ -1417,13 +1425,14 @@ class TestCreateTask:
     def test_calls_add_task_and_launch_sync(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        mock_gh = MagicMock()
         mock_tasks = self._mock_tasks()
         with patch("kennel.events.launch_sync") as mock_sync:
-            create_task("do something", cfg, repo_cfg, _tasks=mock_tasks)
+            create_task("do something", cfg, repo_cfg, mock_gh, _tasks=mock_tasks)
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=None
         )
-        mock_sync.assert_called_once_with(cfg, repo_cfg)
+        mock_sync.assert_called_once_with(cfg, repo_cfg, mock_gh)
 
     def test_passes_thread(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1435,6 +1444,7 @@ class TestCreateTask:
                 "do something",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
@@ -1454,7 +1464,9 @@ class TestCreateTask:
         }
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
-            result = create_task("do something", cfg, repo_cfg, _tasks=mock_tasks)
+            result = create_task(
+                "do something", cfg, repo_cfg, MagicMock(), _tasks=mock_tasks
+            )
         assert result == fake_task
 
     def test_no_abort_without_registry(self, tmp_path: Path) -> None:
@@ -1491,6 +1503,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
@@ -1529,6 +1542,7 @@ class TestCreateTask:
                 "Another plain task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 registry=registry,
                 _tasks=mock_tasks,
             )  # no thread
@@ -1558,6 +1572,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1603,6 +1618,7 @@ class TestCreateTask:
                 "New thread task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=new_thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1629,6 +1645,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1659,6 +1676,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1689,6 +1707,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1743,6 +1762,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1773,6 +1793,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1802,6 +1823,7 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 registry=registry,
                 _tasks=mock_tasks,
@@ -1818,7 +1840,14 @@ class TestCreateTask:
         fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
-            create_task("CI fix", cfg, repo_cfg, registry=registry, _tasks=mock_tasks)
+            create_task(
+                "CI fix",
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_called_once_with("owner/repo")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -1832,7 +1861,14 @@ class TestCreateTask:
         fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
-            create_task("CI fix", cfg, repo_cfg, registry=registry, _tasks=mock_tasks)
+            create_task(
+                "CI fix",
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                registry=registry,
+                _tasks=mock_tasks,
+            )
         registry.abort_task.assert_called_once_with("owner/repo")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -1851,7 +1887,12 @@ class TestCreateTask:
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
             create_task(
-                "New spec task", cfg, repo_cfg, registry=registry, _tasks=mock_tasks
+                "New spec task",
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                registry=registry,
+                _tasks=mock_tasks,
             )
         registry.abort_task.assert_not_called()
 
@@ -1866,6 +1907,7 @@ class TestCreateTask:
             "type": "thread",
             "thread": thread,
         }
+        mock_gh = MagicMock()
         reorder_called: list[tuple] = []
         mock_tasks = self._mock_tasks(fake_task)
         with patch("kennel.events.launch_sync"):
@@ -1873,10 +1915,11 @@ class TestCreateTask:
                 "Comment task",
                 cfg,
                 repo_cfg,
+                mock_gh,
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "abc1234 add thing",
-                _reorder_background_fn=lambda wd, cs, cfg, rc, reg: (
-                    reorder_called.append((wd, cs, cfg, rc, reg))
+                _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: (
+                    reorder_called.append((wd, cs, cfg, gh, rc, reg))
                 ),
                 _tasks=mock_tasks,
             )
@@ -1884,8 +1927,9 @@ class TestCreateTask:
         assert reorder_called[0][0] == tmp_path
         assert reorder_called[0][1] == "abc1234 add thing"
         assert reorder_called[0][2] is cfg
-        assert reorder_called[0][3] is repo_cfg
-        assert reorder_called[0][4] is None  # no registry passed
+        assert reorder_called[0][3] is mock_gh
+        assert reorder_called[0][4] is repo_cfg
+        assert reorder_called[0][5] is None  # no registry passed
 
     def test_spec_task_does_not_trigger_reorder(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -1903,6 +1947,7 @@ class TestCreateTask:
                 "Spec task",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 _reorder_background_fn=lambda *a: reorder_called.append(a),
                 _tasks=mock_tasks,
             )
@@ -1919,7 +1964,9 @@ class TestCreateTask:
             patch("kennel.events.launch_sync"),
             patch("kennel.events._rewrite_pr_description") as mock_rewrite,
         ):
-            create_task("Spec task", cfg, repo_cfg, _tasks=mock_tasks)  # thread=None
+            create_task(
+                "Spec task", cfg, repo_cfg, MagicMock(), _tasks=mock_tasks
+            )  # thread=None
         mock_rewrite.assert_not_called()
 
     def test_commit_summary_comes_from_get_commit_summary_fn(
@@ -1942,10 +1989,11 @@ class TestCreateTask:
                 "t",
                 cfg,
                 repo_cfg,
+                MagicMock(),
                 thread=thread,
                 _get_commit_summary_fn=lambda wd: "custom summary",
-                _reorder_background_fn=lambda wd, cs, cfg, rc, reg: summaries.append(
-                    cs
+                _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: (
+                    summaries.append(cs)
                 ),
                 _tasks=mock_tasks,
             )
@@ -1956,7 +2004,7 @@ class TestCreateTask:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         with patch("kennel.events.launch_sync"):
-            result = create_task("do a thing", cfg, repo_cfg)
+            result = create_task("do a thing", cfg, repo_cfg, MagicMock())
         assert result["title"] == "do a thing"
         from kennel.tasks import list_tasks
 
@@ -2058,8 +2106,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "some commits",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2074,8 +2122,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2090,8 +2138,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "feat: add parser",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2108,8 +2156,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            mock_gh,
             _start=lambda t: started.append(t),
-            _gh=mock_gh,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2133,7 +2181,7 @@ class TestReorderTasksBackground:
         }
         with patch("kennel.events._notify_thread_change") as mock_notify:
             on_changes([change])
-        mock_notify.assert_called_once_with(change, self._cfg(tmp_path), _gh=mock_gh)
+        mock_notify.assert_called_once_with(change, self._cfg(tmp_path), mock_gh)
 
     def test_on_inprogress_affected_aborts_worker_via_registry(
         self, tmp_path: Path
@@ -2146,10 +2194,10 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            MagicMock(),
             repo_cfg=repo_cfg,
             registry=registry,
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2167,8 +2215,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
@@ -2187,8 +2235,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
@@ -2213,8 +2261,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "commits",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _rewrite_fn=mock_rewrite,
             _print_prompt=fake_pp,
             _reorder_fn=mock_reorder,
@@ -2236,8 +2284,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2249,8 +2297,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs2",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2268,8 +2316,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2278,8 +2326,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs2",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2302,8 +2350,8 @@ class TestReorderTasksBackground:
                 tmp_path,
                 cs,
                 self._cfg(tmp_path),
+                MagicMock(),
                 _start=lambda t: started.append(t),
-                _gh=MagicMock(),
                 _reorder_fn=mock_reorder,
                 _coalesce_state=state,
             )
@@ -2325,8 +2373,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2345,8 +2393,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2356,8 +2404,8 @@ class TestReorderTasksBackground:
             tmp_path,
             "cs2",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2375,8 +2423,8 @@ class TestReorderTasksBackground:
             dir_a,
             "cs",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2384,8 +2432,8 @@ class TestReorderTasksBackground:
             dir_b,
             "cs",
             self._cfg(tmp_path),
+            MagicMock(),
             _start=lambda t: started.append(t),
-            _gh=MagicMock(),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
         )
@@ -2426,7 +2474,7 @@ class TestNotifyThreadChange:
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value="Noted!"), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Noted!")
         )
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Noted!")
 
@@ -2440,7 +2488,7 @@ class TestNotifyThreadChange:
             "new_description": "",
         }
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value="Updated!"), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Updated!")
         )
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Updated!")
 
@@ -2450,7 +2498,7 @@ class TestNotifyThreadChange:
         task = self._task()
         task["thread"] = {}
         change = {"task": task, "kind": "completed"}
-        _notify_thread_change(change, cfg, _print_prompt=MagicMock(), _gh=mock_gh)
+        _notify_thread_change(change, cfg, mock_gh, _print_prompt=MagicMock())
         mock_gh.comment_issue.assert_not_called()
 
     def test_empty_opus_uses_fallback_for_completed(self, tmp_path: Path) -> None:
@@ -2458,7 +2506,7 @@ class TestNotifyThreadChange:
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="")
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "Fix the thing" in body
@@ -2474,7 +2522,7 @@ class TestNotifyThreadChange:
             "new_description": "",
         }
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value=""), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="")
         )
         body = mock_gh.comment_issue.call_args[0][2]
         assert "New title" in body
@@ -2489,8 +2537,8 @@ class TestNotifyThreadChange:
         _notify_thread_change(
             change,
             cfg,
+            mock_gh,
             _print_prompt=MagicMock(return_value="In-thread reply"),
-            _gh=mock_gh,
         )
         mock_gh.reply_to_review_comment.assert_called_once_with(
             "owner/repo", 42, "In-thread reply", 999
@@ -2506,7 +2554,7 @@ class TestNotifyThreadChange:
         change = {"task": task, "kind": "completed"}
         # Should not raise
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="ok")
         )
 
     def test_no_comment_type_defaults_to_issue_comment(self, tmp_path: Path) -> None:
@@ -2516,7 +2564,7 @@ class TestNotifyThreadChange:
         del task["thread"]["comment_type"]
         change = {"task": task, "kind": "completed"}
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value="Fallback"), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Fallback")
         )
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Fallback")
         mock_gh.reply_to_review_comment.assert_not_called()
@@ -2530,18 +2578,8 @@ class TestNotifyThreadChange:
             return "ok"
 
         change = {"task": self._task(), "kind": "completed"}
-        _notify_thread_change(change, cfg, _print_prompt=fake_pp, _gh=MagicMock())
+        _notify_thread_change(change, cfg, MagicMock(), _print_prompt=fake_pp)
         assert "alice" in captured_prompt[0]
-
-    def test_gh_none_uses_github_constructor(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "completed"}
-        with patch("kennel.events.GitHub", return_value=mock_gh):
-            _notify_thread_change(
-                change, cfg, _print_prompt=MagicMock(return_value="ok")
-            )
-        mock_gh.comment_issue.assert_called_once()
 
     def test_comment_issue_exception_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2550,7 +2588,7 @@ class TestNotifyThreadChange:
         change = {"task": self._task(), "kind": "completed"}
         # Should not raise
         _notify_thread_change(
-            change, cfg, _print_prompt=MagicMock(return_value="ok"), _gh=mock_gh
+            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="ok")
         )
 
     def test_default_print_prompt_uses_claude(self, tmp_path: Path) -> None:
@@ -2558,7 +2596,7 @@ class TestNotifyThreadChange:
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
         with patch("kennel.events.claude.print_prompt", return_value="Auto reply"):
-            _notify_thread_change(change, cfg, _gh=mock_gh)
+            _notify_thread_change(change, cfg, mock_gh)
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Auto reply")
 
 
@@ -2580,15 +2618,13 @@ class TestLaunchSync:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         with patch("kennel.tasks.sync_tasks_background") as mock_sync:
-            launch_sync(cfg, self._repo_cfg(tmp_path), _gh=mock_gh)
+            launch_sync(cfg, self._repo_cfg(tmp_path), mock_gh)
         mock_sync.assert_called_once_with(tmp_path, mock_gh)
 
     def test_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         with patch("kennel.tasks.sync_tasks_background"):
-            launch_sync(
-                cfg, self._repo_cfg(tmp_path), _gh=MagicMock()
-            )  # should not raise
+            launch_sync(cfg, self._repo_cfg(tmp_path), MagicMock())  # should not raise
 
 
 class TestLaunchWorker:
@@ -2743,8 +2779,8 @@ class TestMaybeReactGhException:
             "pulls",
             "owner/repo",
             cfg,
+            mock_gh,
             _print_prompt=MagicMock(return_value="heart"),
-            _gh=mock_gh,
         )  # must not raise
 
 
@@ -2784,8 +2820,8 @@ class TestReplyToCommentElseBranch:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                MagicMock(),
                 _print_prompt=MagicMock(return_value="I'll look into this."),
-                _gh=MagicMock(),
             )
         assert cat == "UNKNOWN_CAT"
 
@@ -2813,8 +2849,8 @@ class TestReplyToCommentElseBranch:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
 
 
@@ -2854,9 +2890,9 @@ class TestReplyToReviewAlreadyRepliedTracking:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             already_replied=already,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert 500 in already
 
@@ -2892,9 +2928,9 @@ class TestReplyToReviewAlreadyRepliedTracking:
             action,
             cfg,
             self._repo_cfg(tmp_path),
+            mock_gh,
             already_replied=already,
             _print_prompt=fake_pp,
-            _gh=mock_gh,
         )
         assert 501 not in already  # post failed — should not be marked as replied
         assert 502 in already  # second comment still processed
@@ -2950,8 +2986,8 @@ class TestReplyToCommentTerseEnrichment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=MagicMock(return_value="On it!"),
-                _gh=mock_gh,
             )
 
         mock_gh.fetch_sibling_threads.assert_called_once_with("owner/repo", 5)
@@ -2979,8 +3015,8 @@ class TestReplyToCommentTerseEnrichment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
 
         mock_gh.fetch_sibling_threads.assert_not_called()
@@ -3007,8 +3043,8 @@ class TestReplyToCommentTerseEnrichment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=fake_pp,
-                _gh=mock_gh,
             )
 
         assert cat == "ACT"
@@ -3041,8 +3077,8 @@ class TestReplyToCommentTerseEnrichment:
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
+                mock_gh,
                 _print_prompt=MagicMock(return_value="On it!"),
-                _gh=mock_gh,
             )
 
         assert "sibling_threads" not in captured_context

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -109,7 +109,7 @@ class TestMain:
         orig = kennel.gh_status.set_gh_status
         kennel.gh_status.set_gh_status = fake_set
         try:
-            main(["set", "hello", "world"])
+            main(["set", "hello", "world"], _GitHub=MagicMock)
         finally:
             kennel.gh_status.set_gh_status = orig
         assert calls == ["hello world"]

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -72,7 +72,7 @@ class TestSetGhStatus:
             persona_path=persona_file,
             _generate_persona_status=lambda msg, p: "sniffing around",
             _generate_persona_emoji=lambda txt, p: ":dog2:",
-            _get_github=lambda: mock_gh,
+            _gh=mock_gh,
         )
         mock_gh.set_user_status.assert_called_once_with(
             "sniffing around", ":dog2:", busy=True
@@ -91,7 +91,7 @@ class TestSetGhStatus:
             persona_path=tmp_path / "nonexistent.md",
             _generate_persona_status=track_status,
             _generate_persona_emoji=lambda txt, p: ":dog:",
-            _get_github=lambda: mock_gh,
+            _gh=mock_gh,
         )
         assert calls == [""]
         mock_gh.set_user_status.assert_called_once()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -12,7 +12,6 @@ from kennel.github import (
     GraphQLError,
     _gh_token,
     _TimeoutSession,  # noqa: PLC2701
-    get_github,
 )
 
 
@@ -20,12 +19,6 @@ def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedPro
     return subprocess.CompletedProcess(
         args=[], returncode=returncode, stdout=stdout, stderr=""
     )
-
-
-@pytest.fixture(autouse=True)
-def _reset_gh_cache() -> None:
-    """Reset cache before each test for isolation."""
-    get_github.cache_clear()
 
 
 class TestGhToken:
@@ -49,17 +42,6 @@ class TestGhToken:
         mock_run = MagicMock(return_value=_completed("", returncode=4))
         with pytest.raises(RuntimeError, match=r"exit 4"):
             _gh_token(runner=mock_run, environ={})
-
-
-class TestGetGithub:
-    def test_creates_instance_lazily(self) -> None:
-        result = get_github(token="tok")
-        assert isinstance(result, GitHub)
-
-    def test_returns_cached_instance(self) -> None:
-        first = get_github(token="tok")
-        second = get_github(token="tok")
-        assert first is second
 
 
 class TestTimeoutSession:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -8,10 +8,8 @@ import pytest
 
 from kennel.github import (
     _HTTP_TIMEOUT,  # noqa: PLC2701
-    GH,
     GitHub,
     GraphQLError,
-    _get_gh,
     _gh_token,
     _TimeoutSession,  # noqa: PLC2701
     get_github,
@@ -26,8 +24,7 @@ def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedPro
 
 @pytest.fixture(autouse=True)
 def _reset_gh_cache() -> None:
-    """Reset caches before each test for isolation."""
-    _get_gh.cache_clear()
+    """Reset cache before each test for isolation."""
     get_github.cache_clear()
 
 
@@ -54,18 +51,6 @@ class TestGhToken:
             _gh_token(runner=mock_run, environ={})
 
 
-class TestGetGh:
-    def test_creates_instance_lazily(self) -> None:
-        result = _get_gh(token="tok")
-        assert isinstance(result, GH)
-        assert result._s.headers["Authorization"] == "Bearer tok"
-
-    def test_returns_cached_instance(self) -> None:
-        first = _get_gh(token="tok")
-        second = _get_gh(token="tok")
-        assert first is second
-
-
 class TestGetGithub:
     def test_creates_instance_lazily(self) -> None:
         result = get_github(token="tok")
@@ -75,361 +60,6 @@ class TestGetGithub:
         first = get_github(token="tok")
         second = get_github(token="tok")
         assert first is second
-
-
-class TestGitHubClass:
-    def _github(self) -> tuple[GitHub, MagicMock]:
-        mock_s = MagicMock()
-        return GitHub("test-token", session=mock_s), mock_s
-
-    def test_stores_gh_as_attribute(self) -> None:
-        gh = GitHub("test-token")
-        assert isinstance(gh._gh, GH)
-
-    def test_uses_provided_token(self) -> None:
-        gh = GitHub("my-token")
-        assert gh._gh._s.headers["Authorization"] == "Bearer my-token"
-
-    def test_get_repo_info_delegates(self) -> None:
-        gh, _ = self._github()
-        mock_run = MagicMock(return_value=_completed("https://github.com/o/r.git\n"))
-        assert gh.get_repo_info(runner=mock_run) == "o/r"
-
-    def test_get_user_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"login": "fido"}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_user() == "fido"
-
-    def test_get_collaborators_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = [
-            {"login": "alice", "role_name": "admin"},
-            {"login": "bob", "role_name": "write"},
-            {"login": "carol", "role_name": "read"},
-        ]
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_collaborators("owner/repo") == ["alice", "bob"]
-
-    def test_get_default_branch_delegates(self) -> None:
-        gh, mock_s = self._github()
-        remote_resp = _completed("https://github.com/o/r.git\n")
-        repo_resp = MagicMock()
-        repo_resp.json.return_value = {"default_branch": "main"}
-        mock_run = MagicMock(return_value=remote_resp)
-        mock_s.get.return_value = repo_resp
-        assert gh.get_default_branch(runner=mock_run) == "main"
-
-    def test_get_default_branch_passes_cwd(self) -> None:
-        gh, mock_s = self._github()
-        remote_resp = _completed("https://github.com/o/r.git\n")
-        repo_resp = MagicMock()
-        repo_resp.json.return_value = {"default_branch": "main"}
-        mock_run = MagicMock(return_value=remote_resp)
-        mock_s.get.return_value = repo_resp
-        gh.get_default_branch(cwd=Path("/repo"), runner=mock_run)
-        assert mock_run.call_args.kwargs["cwd"] == Path("/repo")
-
-    def test_set_user_status_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.post.return_value = mock_resp
-        gh.set_user_status("working", "🐕", busy=True)
-        body = mock_s.post.call_args.kwargs["json"]
-        assert body["variables"]["busy"] is True
-
-    def test_find_issues_delegates(self) -> None:
-        gh, mock_s = self._github()
-        nodes = [{"number": 1, "title": "t"}]
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "data": {"repository": {"issues": {"nodes": nodes}}}
-        }
-        mock_s.post.return_value = mock_resp
-        assert gh.find_issues("o", "r", "fido") == nodes
-
-    def test_view_issue_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "state": "open",
-            "title": "T",
-            "body": "b",
-            "created_at": "2024-01-01T00:00:00Z",
-        }
-        mock_s.get.return_value = mock_resp
-        result = gh.view_issue("o/r", 1)
-        assert result["state"] == "OPEN"
-        assert result["created_at"] == "2024-01-01T00:00:00Z"
-
-    def test_comment_issue_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_s.post.return_value = mock_resp
-        gh.comment_issue("o/r", 7, "hi")
-        assert "repos/o/r/issues/7/comments" in mock_s.post.call_args.args[0]
-
-    def test_get_issue_comments_delegates(self) -> None:
-        gh, mock_s = self._github()
-        comments = [{"id": 1}]
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = comments
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_issue_comments("o/r", 9) == comments
-
-    def test_get_issue_events_delegates(self) -> None:
-        gh, mock_s = self._github()
-        events = [{"event": "reopened", "created_at": "2024-06-01T00:00:00Z"}]
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = events
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_issue_events("o/r", 3) == events
-
-    def test_create_issue_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"html_url": "https://github.com/o/r/issues/10"}
-        mock_s.post.return_value = mock_resp
-        url = gh.create_issue("o/r", "My suggestion", "some body")
-        assert url == "https://github.com/o/r/issues/10"
-        assert "repos/o/r/issues" in mock_s.post.call_args.args[0]
-
-    def test_get_pull_comments_delegates(self) -> None:
-        gh, mock_s = self._github()
-        comments = [{"id": 42}]
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = comments
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_pull_comments("o/r", 7) == comments
-
-    def test_fetch_sibling_threads_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = []
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        result = gh.fetch_sibling_threads("o/r", 7)
-        assert result == []
-
-    def test_fetch_comment_thread_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = [
-            {
-                "id": 10,
-                "in_reply_to_id": None,
-                "user": {"login": "alice"},
-                "body": "root",
-            }
-        ]
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        result = gh.fetch_comment_thread("o/r", 7, 10)
-        assert result == [{"author": "alice", "body": "root"}]
-
-    def test_find_pr_delegates(self) -> None:
-        gh, mock_s = self._github()
-        pr = {
-            "__typename": "PullRequest",
-            "number": 1,
-            "headRefName": "feat",
-            "state": "OPEN",
-            "author": {"login": "fido"},
-            "body": "closes #5",
-        }
-        mock_s.post.return_value.json.return_value = {
-            "data": {
-                "repository": {
-                    "issue": {
-                        "timelineItems": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": None},
-                            "nodes": [
-                                {"__typename": "CrossReferencedEvent", "source": pr}
-                            ],
-                        }
-                    }
-                }
-            }
-        }
-        result = gh.find_pr("o/r", 5, "fido")
-        assert result is not None
-        assert result["number"] == 1
-
-    def test_create_pr_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"html_url": "https://github.com/o/r/pull/1"}
-        mock_s.post.return_value = mock_resp
-        result = gh.create_pr("o/r", "t", "b", "main", "feat")
-        assert result == "https://github.com/o/r/pull/1"
-
-    def test_edit_pr_body_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {}
-        mock_s.patch.return_value = mock_resp
-        gh.edit_pr_body("o/r", 10, "new")
-        assert mock_s.patch.call_args.kwargs["json"]["body"] == "new"
-
-    def test_get_pr_body_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"body": "some body"}
-        mock_s.get.return_value = mock_resp
-        result = gh.get_pr_body("o/r", 10)
-        assert result == "some body"
-
-    def test_add_pr_reviewers_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_s.post.return_value = mock_resp
-        gh.add_pr_reviewers("o/r", 10, ["alice", "bob"])
-        assert mock_s.post.call_args.kwargs["json"]["reviewers"] == ["alice", "bob"]
-
-    def test_add_pr_reviewers_empty_is_noop(self) -> None:
-        gh, mock_s = self._github()
-        gh.add_pr_reviewers("o/r", 10, [])
-        mock_s.post.assert_not_called()
-
-    def test_pr_checks_delegates(self) -> None:
-        gh, mock_s = self._github()
-        pr_resp = MagicMock()
-        pr_resp.json.return_value = {"head": {"sha": "abc"}}
-        checks_resp = MagicMock()
-        checks_resp.json.return_value = {"check_runs": []}
-        mock_s.get.side_effect = [pr_resp, checks_resp]
-        assert gh.pr_checks("o/r", 10) == []
-
-    def test_get_required_checks_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "required_status_checks": {
-                "checks": [{"context": "ci / test", "app_id": 1}]
-            }
-        }
-        mock_s.get.return_value = mock_resp
-        result = gh.get_required_checks("o/r", "main")
-        assert result == ["ci / test"]
-
-    def test_pr_ready_delegates(self) -> None:
-        gh, mock_s = self._github()
-        pr_resp = MagicMock()
-        pr_resp.json.return_value = {"node_id": "PR_xyz"}
-        graphql_resp = MagicMock()
-        graphql_resp.json.return_value = {"data": {}}
-        mock_s.get.return_value = pr_resp
-        mock_s.post.return_value = graphql_resp
-        gh.pr_ready("o/r", 10)
-        body = mock_s.post.call_args.kwargs["json"]
-        assert "markPullRequestReadyForReview" in body["query"]
-        assert body["variables"]["prId"] == "PR_xyz"
-
-    def test_pr_merge_delegates(self) -> None:
-        gh, mock_s = self._github()
-        get_resp = MagicMock()
-        get_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
-        mock_s.get.return_value = get_resp
-        put_resp = MagicMock()
-        put_resp.json.return_value = {}
-        mock_s.put.return_value = put_resp
-        gh.pr_merge("o/r", 10)
-        assert mock_s.put.call_args.kwargs["json"]["merge_method"] == "squash"
-
-    def test_get_pr_delegates(self) -> None:
-        gh, mock_s = self._github()
-        pr_resp = MagicMock()
-        pr_resp.json.return_value = {
-            "draft": False,
-            "mergeable_state": "clean",
-            "body": "b",
-        }
-        reviews_resp = MagicMock()
-        reviews_resp.json.return_value = []
-        reviews_resp.headers = {}
-        commits_resp = MagicMock()
-        commits_resp.json.return_value = []
-        commits_resp.headers = {}
-        mock_s.get.side_effect = [pr_resp, reviews_resp, commits_resp]
-        result = gh.get_pr("o/r", 10)
-        assert result["isDraft"] is False
-
-    def test_get_reviews_delegates(self) -> None:
-        gh, mock_s = self._github()
-        pr_resp = MagicMock()
-        pr_resp.json.return_value = {"draft": True}
-        reviews_resp = MagicMock()
-        reviews_resp.json.return_value = []
-        reviews_resp.headers = {}
-        commits_resp = MagicMock()
-        commits_resp.json.return_value = []
-        commits_resp.headers = {}
-        mock_s.get.side_effect = [pr_resp, reviews_resp, commits_resp]
-        result = gh.get_reviews("o/r", 10)
-        assert result["isDraft"] is True
-
-    def test_get_review_comments_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = [
-            {"id": 1, "body": "fix this"},
-            {"id": 2, "body": "nit"},
-        ]
-        mock_resp.headers = {}
-        mock_s.get.return_value = mock_resp
-        assert gh.get_review_comments("o/r", 10, 99) == [
-            (1, "fix this"),
-            (2, "nit"),
-        ]
-
-    def test_reply_to_review_comment_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_s.post.return_value = mock_resp
-        gh.reply_to_review_comment("o/r", 10, "lgtm", 55)
-        assert mock_s.post.call_args.kwargs["json"]["body"] == "lgtm"
-
-    def test_add_reaction_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_s.post.return_value = mock_resp
-        gh.add_reaction("o/r", "pulls", 42, "rocket")
-        assert mock_s.post.call_args.kwargs["json"]["content"] == "rocket"
-
-    def test_get_review_threads_delegates(self) -> None:
-        gh, mock_s = self._github()
-        nodes = [{"id": "T_1", "isResolved": False}]
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
-        }
-        mock_s.post.return_value = mock_resp
-        result = gh.get_review_threads("o", "r", 10)
-        assert result == nodes
-
-    def test_resolve_thread_delegates(self) -> None:
-        gh, mock_s = self._github()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"data": {}}
-        mock_s.post.return_value = mock_resp
-        gh.resolve_thread("T_abc")
-        assert "resolveReviewThread" in mock_s.post.call_args.kwargs["json"]["query"]
-
-    def test_get_run_log_delegates(self) -> None:
-        gh, mock_s = self._github()
-        jobs_resp = MagicMock()
-        jobs_resp.json.return_value = {"jobs": [{"id": 1, "conclusion": "failure"}]}
-        log_resp = MagicMock()
-        log_resp.text = "log\n"
-        mock_s.get.side_effect = [jobs_resp, log_resp]
-        assert gh.get_run_log("o/r", 1) == "log\n"
 
 
 class TestTimeoutSession:
@@ -451,22 +81,22 @@ class TestTimeoutSession:
             s.request("GET", "https://example.com", timeout=5)
         assert mock_req.call_args.kwargs.get("timeout") == 5
 
-    def test_gh_uses_timeout_session_when_no_session_injected(self) -> None:
-        gh = GH("tok")
+    def test_uses_timeout_session_when_no_session_injected(self) -> None:
+        gh = GitHub("tok")
         assert isinstance(gh._s, _TimeoutSession)
 
 
-class TestGHClass:
-    def _gh(self) -> tuple[GH, MagicMock]:
+class TestGitHubClass:
+    def _gh(self) -> tuple[GitHub, MagicMock]:
         mock_s = MagicMock()
-        return GH("test-token", session=mock_s), mock_s
+        return GitHub("test-token", session=mock_s), mock_s
 
     def test_sets_auth_header(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         assert gh._s.headers["Authorization"] == "Bearer test-token"
 
     def test_sets_accept_header(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         assert gh._s.headers["Accept"] == "application/vnd.github+json"
 
     def test_get_calls_session(self) -> None:
@@ -1183,50 +813,59 @@ class TestGHClass:
         assert gh.get_collaborators("o/r") == ["bob"]
 
     def test_get_repo_info_https(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(
             return_value=_completed("https://github.com/owner/repo.git\n")
         )
         assert gh.get_repo_info(runner=mock_run) == "owner/repo"
 
     def test_get_repo_info_ssh(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(return_value=_completed("git@github.com:owner/repo.git\n"))
         assert gh.get_repo_info(runner=mock_run) == "owner/repo"
 
     def test_get_repo_info_passes_cwd(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(return_value=_completed("https://github.com/o/r.git"))
         gh.get_repo_info(cwd="/tmp/repo", runner=mock_run)
         assert mock_run.call_args.kwargs["cwd"] == "/tmp/repo"
 
     def test_get_repo_info_raises_unknown(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(return_value=_completed("https://example.com/repo.git"))
         with pytest.raises(ValueError, match="Cannot parse"):
             gh.get_repo_info(runner=mock_run)
 
     def test_get_repo_info_raises_on_git_failure(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, "git"))
         with pytest.raises(subprocess.CalledProcessError):
             gh.get_repo_info(runner=mock_run)
 
     def test_get_repo_info_raises_on_file_not_found(self) -> None:
-        gh = GH("test-token")
+        gh = GitHub("test-token")
         mock_run = MagicMock(side_effect=FileNotFoundError("git not found"))
         with pytest.raises(FileNotFoundError):
             gh.get_repo_info(runner=mock_run)
 
     def test_get_default_branch(self) -> None:
         gh, mock_s = self._gh()
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"default_branch": "main", "name": "repo"}
-        mock_s.get.return_value = mock_resp
-        result = gh.get_default_branch("o/r")
-        url = mock_s.get.call_args.args[0]
-        assert "repos/o/r" in url
-        assert result == "main"
+        remote_resp = _completed("https://github.com/o/r.git\n")
+        repo_resp = MagicMock()
+        repo_resp.json.return_value = {"default_branch": "main"}
+        mock_run = MagicMock(return_value=remote_resp)
+        mock_s.get.return_value = repo_resp
+        assert gh.get_default_branch(runner=mock_run) == "main"
+
+    def test_get_default_branch_passes_cwd(self) -> None:
+        gh, mock_s = self._gh()
+        remote_resp = _completed("https://github.com/o/r.git\n")
+        repo_resp = MagicMock()
+        repo_resp.json.return_value = {"default_branch": "main"}
+        mock_run = MagicMock(return_value=remote_resp)
+        mock_s.get.return_value = repo_resp
+        gh.get_default_branch(cwd=Path("/repo"), runner=mock_run)
+        assert mock_run.call_args.kwargs["cwd"] == Path("/repo")
 
     def test_set_user_status_graphql(self) -> None:
         gh, mock_s = self._gh()
@@ -1663,6 +1302,29 @@ class TestGHClass:
         result = gh.get_pr("o/r", 10)
         assert result["body"] == ""
         assert result["mergeStateStatus"] == ""
+
+    def test_get_review_threads(self) -> None:
+        gh, mock_s = self._gh()
+        nodes = [{"id": "T_1", "isResolved": False, "comments": {"nodes": []}}]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
+        mock_s.post.return_value = mock_resp
+        result = gh.get_review_threads("o", "r", 10)
+        assert result == nodes
+        body = mock_s.post.call_args.kwargs["json"]
+        assert body["variables"] == {"owner": "o", "repo": "r", "pr": 10}
+
+    def test_resolve_thread(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": {}}
+        mock_s.post.return_value = mock_resp
+        gh.resolve_thread("T_abc")
+        body = mock_s.post.call_args.kwargs["json"]
+        assert "resolveReviewThread" in body["query"]
+        assert body["variables"] == {"id": "T_abc"}
 
     def test_get_reviews_returns_dict(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from kennel.main import main
 
@@ -19,11 +19,8 @@ class TestMain:
             "type": "spec",
             "status": "pending",
         }
-        with (
-            patch("kennel.tasks.add_task", return_value=fake_task) as mock_add,
-            patch("kennel.github.GitHub"),
-        ):
-            main(["task", str(tmp_path), "add", "spec", "my task"])
+        with patch("kennel.tasks.add_task", return_value=fake_task) as mock_add:
+            main(["task", str(tmp_path), "add", "spec", "my task"], _GitHub=MagicMock())
 
         mock_add.assert_called_once()
 
@@ -59,27 +56,20 @@ class TestMain:
         with (
             patch("sys.argv", ["kennel", "task", str(tmp_path), "list"]),
             patch("kennel.tasks.list_tasks", return_value=[]),
-            patch("kennel.github.GitHub"),
         ):
-            main()  # should not raise
+            main(_GitHub=MagicMock())  # should not raise
 
     def test_sync_tasks_subcommand_dispatches(self, tmp_path) -> None:
         """'kennel sync-tasks <path>' should invoke sync_tasks."""
-        with (
-            patch("kennel.tasks.sync_tasks") as mock_sync,
-            patch("kennel.github.GitHub"),
-        ):
-            main(["sync-tasks", str(tmp_path)])
+        with patch("kennel.tasks.sync_tasks") as mock_sync:
+            main(["sync-tasks", str(tmp_path)], _GitHub=MagicMock())
         mock_sync.assert_called_once()
         assert mock_sync.call_args[0][0] == tmp_path
 
     def test_sync_tasks_subcommand_defaults_to_cwd(self) -> None:
         """'kennel sync-tasks' without path uses cwd."""
-        with (
-            patch("kennel.tasks.sync_tasks") as mock_sync,
-            patch("kennel.github.GitHub"),
-        ):
-            main(["sync-tasks"])
+        with patch("kennel.tasks.sync_tasks") as mock_sync:
+            main(["sync-tasks"], _GitHub=MagicMock())
         mock_sync.assert_called_once()
         from pathlib import Path
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,10 @@ class TestMain:
             "type": "spec",
             "status": "pending",
         }
-        with patch("kennel.tasks.add_task", return_value=fake_task) as mock_add:
+        with (
+            patch("kennel.tasks.add_task", return_value=fake_task) as mock_add,
+            patch("kennel.github.GitHub"),
+        ):
             main(["task", str(tmp_path), "add", "spec", "my task"])
 
         mock_add.assert_called_once()
@@ -56,6 +59,7 @@ class TestMain:
         with (
             patch("sys.argv", ["kennel", "task", str(tmp_path), "list"]),
             patch("kennel.tasks.list_tasks", return_value=[]),
+            patch("kennel.github.GitHub"),
         ):
             main()  # should not raise
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -430,17 +430,15 @@ class TestMakeThread:
     ) -> None:
         cfg = _repo("foo/bar", tmp_path)
         mock_registry = MagicMock()
-        mock_gh_cls = MagicMock()
+        mock_gh = MagicMock()
         mock_wt_cls = MagicMock()
-        result = _make_thread(
-            cfg, mock_registry, _GitHub=mock_gh_cls, _WorkerThread=mock_wt_cls
-        )
+        result = _make_thread(cfg, mock_registry, gh=mock_gh, _WorkerThread=mock_wt_cls)
         from kennel.config import RepoMembership
 
         mock_wt_cls.assert_called_once_with(
             tmp_path,
             "foo/bar",
-            mock_gh_cls.return_value,
+            mock_gh,
             mock_registry,
             RepoMembership(),
         )
@@ -451,7 +449,7 @@ class TestMakeThread:
         work_dir.mkdir()
         cfg = _repo("foo/bar", work_dir)
         mock_wt_cls = MagicMock()
-        _make_thread(cfg, MagicMock(), _GitHub=MagicMock(), _WorkerThread=mock_wt_cls)
+        _make_thread(cfg, MagicMock(), gh=MagicMock(), _WorkerThread=mock_wt_cls)
         assert mock_wt_cls.call_args[0][0] == work_dir
 
 
@@ -460,7 +458,9 @@ class TestMakeRegistry:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
         result = make_registry(
-            {"foo/bar": cfg}, _thread_factory=MagicMock(return_value=mock_thread)
+            {"foo/bar": cfg},
+            MagicMock(),
+            _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert isinstance(result, WorkerRegistry)
 
@@ -469,12 +469,16 @@ class TestMakeRegistry:
         cfg2 = _repo("foo/baz", tmp_path)
         mock_thread = MagicMock()
         mock_factory = MagicMock(return_value=mock_thread)
-        make_registry({"foo/bar": cfg1, "foo/baz": cfg2}, _thread_factory=mock_factory)
+        make_registry(
+            {"foo/bar": cfg1, "foo/baz": cfg2},
+            MagicMock(),
+            _thread_factory=mock_factory,
+        )
         assert mock_factory.call_count == 2
         assert mock_thread.start.call_count == 2
 
     def test_empty_repos_returns_empty_registry(self) -> None:
-        result = make_registry({})
+        result = make_registry({}, MagicMock())
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
 
@@ -483,7 +487,9 @@ class TestMakeRegistry:
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = True
         reg = make_registry(
-            {"foo/bar": cfg}, _thread_factory=MagicMock(return_value=mock_thread)
+            {"foo/bar": cfg},
+            MagicMock(),
+            _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert reg.is_alive("foo/bar") is True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,7 +44,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 @pytest.fixture(autouse=True)
 def _restore_handler_fns():
     saved = {
-        "_fn_get_github": WebhookHandler._fn_get_github,
+        "gh": WebhookHandler.gh,
         "_fn_dispatch": WebhookHandler._fn_dispatch,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
@@ -415,7 +415,7 @@ class TestProcessAction:
         )
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=MagicMock())
+        WebhookHandler.gh = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
         time.sleep(0.2)
@@ -525,7 +525,7 @@ class TestProcessAction:
         mock_gh = MagicMock()
         mock_ic = MagicMock(return_value=("ACT", ["do it"]))
         mock_task = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_reply_to_issue_comment = mock_ic
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -593,7 +593,7 @@ class TestProcessAction:
         )
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=MagicMock())
+        WebhookHandler.gh = MagicMock()
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
         time.sleep(0.2)
@@ -622,7 +622,7 @@ class TestProcessAction:
             "action": "closed",
             "pull_request": {"number": 13, "merged": True},
         }
-        WebhookHandler._fn_get_github = MagicMock()
+        WebhookHandler.gh = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=Exception("explode"))
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
@@ -647,7 +647,7 @@ class TestProcessAction:
             "pull_request": {"number": 20, "title": "T", "body": ""},
         }
         mock_gh = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_reply_to_comment = MagicMock(
             side_effect=RuntimeError("boom")
         )
@@ -678,7 +678,7 @@ class TestProcessAction:
             },
         }
         mock_gh = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             side_effect=RuntimeError("boom")
         )
@@ -700,7 +700,7 @@ class TestProcessAction:
             "pull_request": {"number": 22, "merged": True},
         }
         mock_gh = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=RuntimeError("boom"))
         _post_webhook(url, cfg, "pull_request", payload)
         time.sleep(0.2)
@@ -723,7 +723,7 @@ class TestProcessAction:
             "pull_request": {"number": 24},
         }
         mock_gh = MagicMock()
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_reply_to_review = MagicMock(side_effect=RuntimeError("boom"))
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "pull_request_review", payload)
@@ -751,7 +751,7 @@ class TestProcessAction:
         }
         mock_gh = MagicMock()
         mock_gh.add_reaction.side_effect = RuntimeError("reaction failed")
-        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
+        WebhookHandler.gh = mock_gh
         WebhookHandler._fn_reply_to_comment = MagicMock(
             side_effect=RuntimeError("process boom")
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -832,7 +832,7 @@ class TestPopulateMemberships:
         mock_gh = MagicMock()
         mock_gh.get_user.return_value = "fido-bot"
         mock_gh.get_collaborators.return_value = ["alice", "bob"]
-        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        populate_memberships(cfg, mock_gh)
         assert cfg.repos["owner/repo"].membership == RepoMembership(
             collaborators=frozenset({"alice", "bob"})
         )
@@ -853,7 +853,7 @@ class TestPopulateMemberships:
         mock_gh = MagicMock()
         mock_gh.get_user.return_value = "fido-bot"
         mock_gh.get_collaborators.return_value = ["alice", "fido-bot", "bob"]
-        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        populate_memberships(cfg, mock_gh)
         result = cfg.repos["owner/repo"].membership.collaborators
         assert result == frozenset({"alice", "bob"})
         assert "fido-bot" not in result
@@ -878,7 +878,7 @@ class TestPopulateMemberships:
             "o/r1": ["alice"],
             "o/r2": ["bob", "carol"],
         }[name]
-        populate_memberships(cfg, _gh_factory=lambda: mock_gh)
+        populate_memberships(cfg, mock_gh)
         assert cfg.repos["o/r1"].membership.collaborators == frozenset({"alice"})
         assert cfg.repos["o/r2"].membership.collaborators == frozenset({"bob", "carol"})
 
@@ -915,6 +915,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -940,6 +941,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
             _signal=MagicMock(),
             _kill_active_children=mock_kill,
         )
@@ -970,6 +972,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
             _signal=fake_signal,
             _kill_active_children=MagicMock(),
         )
@@ -1000,6 +1003,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
             _signal=fake_signal,
             _kill_active_children=mock_kill,
         )
@@ -1040,6 +1044,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         assert len(captured_kwargs) == 1
@@ -1070,6 +1075,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         assert len(captured_handlers) >= 1
@@ -1098,6 +1104,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         mock_server.serve_forever.assert_called_once()
@@ -1138,6 +1145,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         # Two shared handlers (file + no tty stderr) + two per-repo handlers
@@ -1191,6 +1199,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         repo_handler = next(
@@ -1225,6 +1234,7 @@ class TestRun:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
             _Watchdog=mock_watchdog_cls,
         )
 
@@ -1258,6 +1268,7 @@ class TestRun:
                 _preflight_tools=MagicMock(),
                 _preflight_sub_dir=MagicMock(),
                 _preflight_gh_auth=MagicMock(),
+                _GitHub=MagicMock,
                 _Watchdog=MagicMock(),
             )
             assert _sys.excepthook is not saved_sys
@@ -1452,6 +1463,7 @@ class TestPreflightRepoIdentity:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         mock_preflight.assert_called_once_with(fake_cfg.repos)
@@ -1483,6 +1495,7 @@ class TestPreflightRepoIdentity:
             _preflight_tools=mock_preflight,
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         mock_preflight.assert_called_once_with()
@@ -1514,9 +1527,10 @@ class TestPreflightRepoIdentity:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
             _preflight_gh_auth=mock_preflight,
+            _GitHub=MagicMock,
         )
 
-        mock_preflight.assert_called_once_with()
+        mock_preflight.assert_called_once()
 
     def test_run_calls_preflight_sub_dir(self, tmp_path: Path) -> None:
         from kennel.server import run
@@ -1545,6 +1559,7 @@ class TestPreflightRepoIdentity:
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=mock_preflight,
             _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
         )
 
         mock_preflight.assert_called_once_with(fake_cfg)
@@ -1576,6 +1591,7 @@ class TestPreflightRepoIdentity:
                 ),
                 _preflight_sub_dir=MagicMock(),
                 _preflight_gh_auth=MagicMock(),
+                _GitHub=MagicMock,
                 _preflight_repo_identity=MagicMock(),
             )
 
@@ -1662,31 +1678,24 @@ class TestPreflightGhAuth:
         from kennel.server import preflight_gh_auth
 
         mock_gh = MagicMock()
-        mock_gh.return_value.get_user.return_value = "fido-bot"
-        preflight_gh_auth(_gh_factory=mock_gh)  # no exception
+        mock_gh.get_user.return_value = "fido-bot"
+        preflight_gh_auth(mock_gh)  # no exception
 
     def test_raises_when_get_user_raises_runtime_error(self) -> None:
         from kennel.server import preflight_gh_auth
 
         mock_gh = MagicMock()
-        mock_gh.return_value.get_user.side_effect = RuntimeError("not logged in")
+        mock_gh.get_user.side_effect = RuntimeError("not logged in")
         with pytest.raises(PreflightError, match="not logged in"):
-            preflight_gh_auth(_gh_factory=mock_gh)
-
-    def test_raises_when_gh_factory_raises(self) -> None:
-        from kennel.server import preflight_gh_auth
-
-        mock_gh = MagicMock(side_effect=RuntimeError("gh auth token failed"))
-        with pytest.raises(PreflightError, match="gh auth token failed"):
-            preflight_gh_auth(_gh_factory=mock_gh)
+            preflight_gh_auth(mock_gh)
 
     def test_raises_when_get_user_raises_any_exception(self) -> None:
         from kennel.server import preflight_gh_auth
 
         mock_gh = MagicMock()
-        mock_gh.return_value.get_user.side_effect = Exception("network error")
+        mock_gh.get_user.side_effect = Exception("network error")
         with pytest.raises(PreflightError, match="network error"):
-            preflight_gh_auth(_gh_factory=mock_gh)
+            preflight_gh_auth(mock_gh)
 
 
 class TestGetSelfRepo:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -522,8 +522,10 @@ class TestProcessAction:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
+        mock_gh = MagicMock()
         mock_ic = MagicMock(return_value=("ACT", ["do it"]))
         mock_task = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
         WebhookHandler._fn_reply_to_issue_comment = mock_ic
         WebhookHandler._fn_create_task = mock_task
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -535,6 +537,7 @@ class TestProcessAction:
             "do it",
             cfg,
             cfg.repos["owner/repo"],
+            mock_gh,
             thread={
                 "repo": "owner/repo",
                 "pr": 11,
@@ -696,12 +699,12 @@ class TestProcessAction:
             "action": "closed",
             "pull_request": {"number": 22, "merged": True},
         }
-        mock_gh_factory = MagicMock()
-        WebhookHandler._fn_get_github = mock_gh_factory
+        mock_gh = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=RuntimeError("boom"))
         _post_webhook(url, cfg, "pull_request", payload)
         time.sleep(0.2)
-        mock_gh_factory.assert_not_called()
+        mock_gh.add_reaction.assert_not_called()
 
     def test_process_action_error_no_reaction_when_comment_id_missing(
         self, server: tuple
@@ -719,13 +722,13 @@ class TestProcessAction:
             },
             "pull_request": {"number": 24},
         }
-        mock_gh_factory = MagicMock()
-        WebhookHandler._fn_get_github = mock_gh_factory
+        mock_gh = MagicMock()
+        WebhookHandler._fn_get_github = MagicMock(return_value=mock_gh)
         WebhookHandler._fn_reply_to_review = MagicMock(side_effect=RuntimeError("boom"))
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "pull_request_review", payload)
         time.sleep(0.2)
-        mock_gh_factory.assert_not_called()
+        mock_gh.add_reaction.assert_not_called()
 
     def test_process_action_error_reaction_failure_doesnt_crash(
         self, server: tuple

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1701,11 +1701,9 @@ class TestRun:
     def test_creates_worker_and_calls_run(self, tmp_path: Path) -> None:
         mock_worker = MagicMock()
         mock_worker.run.return_value = 0
-        with (
-            patch("kennel.worker.GitHub") as mock_gh_cls,
-            patch("kennel.worker.Worker", return_value=mock_worker) as mock_worker_cls,
-        ):
-            result = run(tmp_path)
+        mock_gh_cls = MagicMock()
+        with patch("kennel.worker.Worker", return_value=mock_worker) as mock_worker_cls:
+            result = run(tmp_path, _GitHub=mock_gh_cls)
         mock_worker_cls.assert_called_once_with(tmp_path, mock_gh_cls.return_value)
         mock_worker.run.assert_called_once()
         assert result == 0
@@ -1713,11 +1711,8 @@ class TestRun:
     def test_returns_worker_run_result(self, tmp_path: Path) -> None:
         mock_worker = MagicMock()
         mock_worker.run.return_value = 2
-        with (
-            patch("kennel.worker.GitHub"),
-            patch("kennel.worker.Worker", return_value=mock_worker),
-        ):
-            assert run(tmp_path) == 2
+        with patch("kennel.worker.Worker", return_value=mock_worker):
+            assert run(tmp_path, _GitHub=MagicMock()) == 2
 
 
 class TestCreateCompactScript:


### PR DESCRIPTION
Collapses the parallel GH and GitHub clients into a single injectable GitHub collaborator, removing cached factories and hidden defaults across events, the webhook handler, the registry, and CLI entry points. Tests now construct fakes directly instead of patching module globals.

Fixes #311.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Collapse GH and GitHub into a single injectable GitHub client <!-- type:spec -->
- [x] Remove _get_gh and get_github cached factories, require explicit construction <!-- type:spec -->
- [x] Inject GitHub collaborator into events.py functions, drop _gh keyword fallback <!-- type:spec -->
- [x] Replace WebhookHandler._fn_get_github with an injected GitHub instance <!-- type:spec -->
- [x] Drop hidden GitHub defaults from registry, cli, gh_status, and main entry points <!-- type:spec -->
- [x] Update tests to fake GitHub by construction instead of patching module globals <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->