### PR TITLE
Show claude pid for resumed sessions

### DIFF
--- a/kennel/status.py
+++ b/kennel/status.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from kennel.config import RepoConfig
+from kennel.state import State
 
 
 @dataclass
@@ -184,8 +185,20 @@ def _fetch_activities(
 
 
 def _claude_pid(fido_dir: Path) -> int | None:
-    """Return the PID of the claude process using fido_dir/system, or None."""
+    """Return the PID of the claude process for this fido_dir, or None.
+
+    Matches both initial sessions (command line includes the system-prompt
+    file under fido_dir/system) and resumed sessions (command line includes
+    ``--resume <session_id>`` from state.json, which doesn't mention the
+    system file).
+    """
     pids = _pgrep(str(fido_dir / "system"))
+    if pids:
+        return pids[0]
+    session_id = State(fido_dir).load().get("setup_session_id")
+    if not session_id:
+        return None
+    pids = _pgrep(session_id)
     return pids[0] if pids else None
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -378,17 +378,66 @@ class TestClaudePid:
             result = _claude_pid(fido_dir)
         assert result == 999
 
-    def test_returns_none_when_no_match(self, tmp_path: Path) -> None:
+    def test_returns_none_when_no_match_and_no_state(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
         with patch("kennel.status._pgrep", return_value=[]):
             result = _claude_pid(fido_dir)
         assert result is None
 
-    def test_searches_for_system_file(self, tmp_path: Path) -> None:
+    def test_searches_for_system_file_first(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
         with patch("kennel.status._pgrep", return_value=[]) as mock:
             _claude_pid(fido_dir)
-        mock.assert_called_once_with(str(fido_dir / "system"))
+        mock.assert_any_call(str(fido_dir / "system"))
+
+    def test_falls_back_to_resumed_session_id(self, tmp_path: Path) -> None:
+        """Resumed sessions run with --resume <id> and don't reference the
+        system file — fall back to matching the session id from state.json."""
+        from kennel.state import State
+
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        State(fido_dir).save({"setup_session_id": "abc-123", "issue": 7})
+
+        def fake_pgrep(pattern: str) -> list[int]:
+            return [42] if pattern == "abc-123" else []
+
+        with patch("kennel.status._pgrep", side_effect=fake_pgrep):
+            result = _claude_pid(fido_dir)
+        assert result == 42
+
+    def test_resumed_fallback_returns_none_when_no_process(
+        self, tmp_path: Path
+    ) -> None:
+        from kennel.state import State
+
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        State(fido_dir).save({"setup_session_id": "abc-123"})
+        with patch("kennel.status._pgrep", return_value=[]):
+            result = _claude_pid(fido_dir)
+        assert result is None
+
+    def test_resumed_fallback_skipped_when_no_session_id(self, tmp_path: Path) -> None:
+        from kennel.state import State
+
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        State(fido_dir).save({"issue": 7})
+        with patch("kennel.status._pgrep", return_value=[]) as mock:
+            result = _claude_pid(fido_dir)
+        assert result is None
+        # Only the system-file pgrep fires when there's no session id.
+        assert mock.call_count == 1
+
+    def test_resumed_fallback_skipped_when_state_absent(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        with patch("kennel.status._pgrep", return_value=[]):
+            result = _claude_pid(fido_dir)
+        assert result is None
 
 
 class TestGitDir:


### PR DESCRIPTION
## Summary

\`kennel status\` showed no claude pid for workers running a resumed session, even when a claude subprocess was clearly alive. Made healthy workers look stuck.

\`_claude_pid\` matched only claude subprocesses whose command line included the \`fido/system\` file path — which covers initial sessions but not resumed ones (those run with \`--resume <session_id>\` and don't reference the system file).

Now falls back to matching the \`setup_session_id\` from \`state.json\` against pgrep when the system-file match misses. Reads through \`State(fido_dir).load()\` so flock discipline is honored — no raw \`state.json\` access.

Fixes #445

## Test plan

- [x] 1648 tests pass, 100% coverage
- [x] Initial session match still works (system-file path)
- [x] Resumed session match via session id from state.json
- [x] Graceful None when no process, no session id, or no state at all

*no more phantom-stuck workers*