### PR TITLE
Redesign kennel status: multi-line layout with worker stats and webhook visibility

### DIFF
--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -40,6 +40,21 @@ class WorkerCrash:
     last_crash_time: datetime
 
 
+@dataclass
+class WebhookActivity:
+    """One in-flight webhook handler running alongside the worker.
+
+    Created when ``_process_action`` starts handling a webhook action; removed
+    when that handler returns (success or failure).  Surfaced in ``kennel
+    status`` as a sub-bullet under the repo so we can see what's being
+    handled beyond the worker's own task.
+    """
+
+    handle_id: int
+    description: str
+    started_at: datetime
+
+
 class WorkerRegistry:
     """Owns and manages one :class:`~kennel.worker.WorkerThread` per repo.
 
@@ -62,13 +77,24 @@ class WorkerRegistry:
         self._status_lock = threading.Lock()
         self._crashes: dict[str, WorkerCrash] = {}
         self._crash_lock = threading.Lock()
+        self._started_at: dict[str, datetime] = {}
+        self._started_at_lock = threading.Lock()
+        self._webhook_activities: dict[str, list[WebhookActivity]] = {}
+        self._webhook_lock = threading.Lock()
 
     def start(self, repo_cfg: RepoConfig) -> None:
         """Create and start a WorkerThread for *repo_cfg*."""
         thread = self._factory(repo_cfg)
         self._threads[repo_cfg.name] = thread
+        with self._started_at_lock:
+            self._started_at[repo_cfg.name] = _utcnow()
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)
+
+    def thread_started_at(self, repo_name: str) -> datetime | None:
+        """Return when the worker thread for *repo_name* was started, or None."""
+        with self._started_at_lock:
+            return self._started_at.get(repo_name)
 
     def wake(self, repo_name: str) -> None:
         """Wake the thread for *repo_name* so it checks for work immediately.
@@ -144,6 +170,46 @@ class WorkerRegistry:
         """Return crash history for *repo_name*, or None if it has never crashed."""
         with self._crash_lock:
             return self._crashes.get(repo_name)
+
+    @contextmanager
+    def webhook_activity(
+        self,
+        repo_name: str,
+        description: str,
+        *,
+        _now: Callable[[], datetime] = _utcnow,
+    ) -> Generator[None, None, None]:
+        """Register an in-flight webhook handler for the duration of the block.
+
+        Usage::
+
+            with registry.webhook_activity("owner/repo", "triaging comment"):
+                ...do the work...
+
+        Appears in ``kennel status`` as a sub-bullet under the repo.  Entries
+        self-unregister on block exit (both success and exception paths).
+        """
+        activity = WebhookActivity(
+            handle_id=id(object()),  # cheap unique id per call
+            description=description,
+            started_at=_now(),
+        )
+        with self._webhook_lock:
+            self._webhook_activities.setdefault(repo_name, []).append(activity)
+        try:
+            yield
+        finally:
+            with self._webhook_lock:
+                items = self._webhook_activities.get(repo_name)
+                if items is not None:
+                    self._webhook_activities[repo_name] = [
+                        a for a in items if a.handle_id != activity.handle_id
+                    ]
+
+    def get_webhook_activities(self, repo_name: str) -> list[WebhookActivity]:
+        """Return a snapshot of in-flight webhook activities for *repo_name*."""
+        with self._webhook_lock:
+            return list(self._webhook_activities.get(repo_name, []))
 
     @contextmanager
     def status_update(self) -> Generator[None, None, None]:

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from urllib.parse import urlparse
@@ -394,6 +395,22 @@ class WebhookHandler(BaseHTTPRequestHandler):
             ).start()
 
     def _process_action(self, action, repo_cfg: RepoConfig) -> None:
+        description = self._describe_action(action)
+        with self.registry.webhook_activity(repo_cfg.name, description):
+            self._process_action_inner(action, repo_cfg)
+
+    def _describe_action(self, action) -> str:
+        """Short label for status display — what this webhook handler is doing."""
+        if action.reply_to:
+            cid = action.reply_to.get("comment_id")
+            return f"replying to review comment {cid}" if cid else "replying to review"
+        if action.review_comments:
+            return "replying to review thread"
+        if action.comment_body:
+            return "triaging PR comment"
+        return "handling webhook action"
+
+    def _process_action_inner(self, action, repo_cfg: RepoConfig) -> None:
         try:
             self.registry.report_activity(
                 repo_cfg.name, "handling webhook action", busy=True
@@ -502,9 +519,23 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/status":
+            now = datetime.now(tz=timezone.utc)
             activities = []
             for a in self.registry.get_all_activities():
                 crash = self.registry.get_crash_info(a.repo_name)
+                started_at = self.registry.thread_started_at(a.repo_name)
+                worker_uptime = (
+                    (now - started_at).total_seconds()
+                    if started_at is not None
+                    else None
+                )
+                webhooks = [
+                    {
+                        "description": w.description,
+                        "elapsed_seconds": (now - w.started_at).total_seconds(),
+                    }
+                    for w in self.registry.get_webhook_activities(a.repo_name)
+                ]
                 activities.append(
                     {
                         "repo_name": a.repo_name,
@@ -515,6 +546,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         "is_stuck": self.registry.is_stale(
                             a.repo_name, _STALE_THRESHOLD
                         ),
+                        "worker_uptime_seconds": worker_uptime,
+                        "webhook_activities": webhooks,
                     }
                 )
             body = json.dumps(activities).encode()

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -7,12 +7,21 @@ import json
 import subprocess
 import urllib.request
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from kennel.config import RepoConfig
 from kennel.state import State
+
+
+@dataclass
+class WebhookActivityInfo:
+    """Lightweight in-flight webhook handler, used purely for display."""
+
+    description: str
+    elapsed_seconds: int
 
 
 @dataclass
@@ -29,6 +38,15 @@ class RepoStatus:
     crash_count: int  # number of unexpected worker deaths since kennel started
     last_crash_error: str | None  # error from the most recent crash, if any
     worker_stuck: bool  # True if the worker is alive but making no progress
+    # Newer fields default so callers (tests) can omit them safely.
+    issue_title: str | None = None
+    issue_elapsed_seconds: int | None = None
+    pr_number: int | None = None
+    pr_title: str | None = None
+    task_number: int | None = None
+    task_total: int | None = None
+    worker_uptime: int | None = None
+    webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -176,6 +194,8 @@ def _fetch_activities(
                 "crash_count": item["crash_count"],
                 "last_crash_error": item["last_crash_error"],
                 "is_stuck": item.get("is_stuck", False),
+                "worker_uptime_seconds": item.get("worker_uptime_seconds"),
+                "webhook_activities": item.get("webhook_activities", []),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -261,42 +281,86 @@ def _current_task(task_list: list[dict[str, Any]]) -> str | None:
     return None
 
 
+def _task_position(task_list: list[dict[str, Any]]) -> tuple[int | None, int | None]:
+    """Return (task_number, total_non_completed) for display.
+
+    task_number is the 1-indexed position of the first in_progress or
+    pending task among all non-completed tasks; total is the count of
+    non-completed tasks.  Returns (None, None) when there are none.
+    """
+    non_completed = [t for t in task_list if t["status"] != "completed"]
+    if not non_completed:
+        return (None, None)
+    for idx, t in enumerate(non_completed, start=1):
+        if t["status"] == "in_progress":
+            return (idx, len(non_completed))
+    return (1, len(non_completed))
+
+
+def _elapsed_since_iso(iso: str | None, *, _now=None) -> int | None:
+    """Return integer seconds since *iso* (an ISO-8601 timestamp), or None."""
+    if not iso:
+        return None
+    try:
+        started = datetime.fromisoformat(iso)
+    except TypeError, ValueError:
+        return None
+    now = _now() if _now is not None else datetime.now(tz=timezone.utc)
+    return max(0, int((now - started).total_seconds()))
+
+
 def repo_status(
     repo_config: RepoConfig,
     worker_what: str | None = None,
     crash_count: int = 0,
     last_crash_error: str | None = None,
     worker_stuck: bool = False,
+    worker_uptime: int | None = None,
+    webhook_activities: list[WebhookActivityInfo] | None = None,
 ) -> RepoStatus:
     """Collect status for a single repo."""
+    webhook_activities = list(webhook_activities or [])
     git_dir = _git_dir(repo_config.work_dir)
     if git_dir is None:
         return RepoStatus(
             name=repo_config.name,
             fido_running=False,
             issue=None,
+            issue_title=None,
+            issue_elapsed_seconds=None,
+            pr_number=None,
+            pr_title=None,
             pending=0,
             completed=0,
             current_task=None,
+            task_number=None,
+            task_total=None,
             claude_pid=None,
             claude_uptime=None,
+            worker_uptime=worker_uptime,
             worker_what=worker_what,
             crash_count=crash_count,
             last_crash_error=last_crash_error,
             worker_stuck=worker_stuck,
+            webhook_activities=webhook_activities,
         )
 
     fido_dir = git_dir / "fido"
     running = _fido_running(fido_dir / "lock")
 
-    state = _read_state(fido_dir)
+    state = State(fido_dir).load()
     issue = state.get("issue")
+    issue_title = state.get("issue_title")
+    issue_elapsed = _elapsed_since_iso(state.get("issue_started_at"))
+    pr_number = state.get("pr_number")
+    pr_title = state.get("pr_title")
 
     task_list = _read_tasks(fido_dir)
     pending = sum(1 for t in task_list if t["status"] == "pending")
     completed = sum(1 for t in task_list if t["status"] == "completed")
 
     current = _current_task(task_list)
+    task_number, task_total = _task_position(task_list)
 
     claude_pid = _claude_pid(fido_dir)
     claude_uptime = (
@@ -307,15 +371,23 @@ def repo_status(
         name=repo_config.name,
         fido_running=running,
         issue=issue,
+        issue_title=issue_title,
+        issue_elapsed_seconds=issue_elapsed,
+        pr_number=pr_number,
+        pr_title=pr_title,
         pending=pending,
         completed=completed,
         current_task=current,
+        task_number=task_number,
+        task_total=task_total,
         claude_pid=claude_pid,
         claude_uptime=claude_uptime,
+        worker_uptime=worker_uptime,
         worker_what=worker_what,
         crash_count=crash_count,
         last_crash_error=last_crash_error,
         worker_stuck=worker_stuck,
+        webhook_activities=webhook_activities,
     )
 
 
@@ -334,6 +406,18 @@ def collect() -> KennelStatus:
     repos = []
     for rc in repo_configs:
         info = activities.get(rc.name)
+        webhook_list = []
+        worker_uptime_val: int | None = None
+        if info:
+            for w in info.get("webhook_activities") or []:
+                webhook_list.append(
+                    WebhookActivityInfo(
+                        description=w["description"],
+                        elapsed_seconds=int(w["elapsed_seconds"]),
+                    )
+                )
+            wu = info.get("worker_uptime_seconds")
+            worker_uptime_val = int(wu) if wu is not None else None
         repos.append(
             repo_status(
                 rc,
@@ -341,16 +425,94 @@ def collect() -> KennelStatus:
                 crash_count=info["crash_count"] if info else 0,
                 last_crash_error=info["last_crash_error"] if info else None,
                 worker_stuck=info["is_stuck"] if info else False,
+                worker_uptime=worker_uptime_val,
+                webhook_activities=webhook_list,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
 
 
+_SILENT_DISPLAY_THRESHOLD: int = 300  # seconds of claude silence before we note it
+
+
+def _format_repo_header(repo: RepoStatus) -> str:
+    """Top line: `<name>: fido <state> — <compact stats>`.
+
+    Stats are comma-separated and only shown when they matter right now:
+    `crashes N` (skipped when 0), `up X` (worker thread uptime, always
+    shown when known), `BUSY Xm` (no activity for ≥5m; since #444 this is
+    informational only, not a restart signal).
+    """
+    state = "fido running" if repo.fido_running else "fido idle"
+    stats: list[str] = []
+    if repo.crash_count > 0:
+        stats.append(f"crashes {repo.crash_count}")
+    if repo.worker_uptime is not None:
+        stats.append(f"up {_format_uptime(repo.worker_uptime)}")
+    if repo.worker_stuck:
+        # worker_uptime includes time on the current task; there isn't a
+        # separate "silent" counter yet, so we just flag BUSY.
+        stats.append("BUSY")
+    if repo.crash_count > 0 and repo.last_crash_error:
+        stats.append(f"last crash: {repo.last_crash_error}")
+
+    header = f"{repo.name}: {state}"
+    if stats:
+        header += " — " + ", ".join(stats)
+    return header
+
+
+def _format_repo_body(repo: RepoStatus) -> list[str]:
+    """Indented sub-lines: Issue / PR / Task / claude / webhooks."""
+    body: list[str] = []
+
+    if repo.issue is None:
+        body.append("  no assigned issues")
+        return body
+
+    issue_line = f"  Issue:  #{repo.issue}"
+    if repo.issue_title:
+        issue_line += f" — {repo.issue_title}"
+    if repo.issue_elapsed_seconds is not None:
+        issue_line += f"  (elapsed {_format_uptime(repo.issue_elapsed_seconds)})"
+    body.append(issue_line)
+
+    if repo.pr_number is not None:
+        pr_line = f"  PR:     #{repo.pr_number}"
+        if repo.pr_title:
+            pr_line += f" — {repo.pr_title}"
+        body.append(pr_line)
+
+    if repo.task_number is not None and repo.task_total is not None:
+        task_line = f"  Task:   {repo.task_number}/{repo.task_total}"
+        if repo.current_task:
+            task_line += f" — {repo.current_task}"
+        body.append(task_line)
+    elif repo.current_task:
+        body.append(f"  Task:   {repo.current_task}")
+
+    if repo.worker_what and not (repo.current_task or repo.pr_number):
+        # Only show the live activity when nothing more specific fits.
+        body.append(f"  Doing:  {repo.worker_what}")
+
+    if repo.claude_pid is not None:
+        claude_str = f"  └─ claude pid {repo.claude_pid}"
+        if repo.claude_uptime is not None:
+            claude_str += f" (running {_format_uptime(repo.claude_uptime)})"
+        body.append(claude_str)
+
+    for w in repo.webhook_activities:
+        body.append(
+            f"  └─ webhook: {w.description} ({_format_uptime(w.elapsed_seconds)})"
+        )
+
+    return body
+
+
 def format_status(status: KennelStatus) -> str:
     """Format a KennelStatus as a human-readable string."""
-    lines = []
+    lines: list[str] = []
 
-    # Kennel server line
     if status.kennel_pid is not None:
         uptime_str = (
             f", uptime {_format_uptime(status.kennel_uptime)}"
@@ -361,45 +523,8 @@ def format_status(status: KennelStatus) -> str:
     else:
         lines.append("kennel: DOWN")
 
-    # Per-repo lines
     for repo in status.repos:
-        parts = []
-
-        if repo.fido_running:
-            parts.append("fido running")
-        else:
-            parts.append("fido idle")
-
-        if repo.worker_what:
-            parts.append(repo.worker_what)
-
-        if repo.issue is not None:
-            total = repo.pending + repo.completed
-            issue_str = f"issue #{repo.issue}"
-            if repo.current_task:
-                done = repo.completed
-                issue_str += f', task {done + 1}/{total} "{repo.current_task}"'
-            elif total > 0:
-                issue_str += f", {repo.pending} pending"
-            parts.append(issue_str)
-        else:
-            parts.append("no assigned issues")
-
-        if repo.claude_pid is not None:
-            claude_str = f"claude pid {repo.claude_pid}"
-            if repo.claude_uptime is not None:
-                claude_str += f" (running {_format_uptime(repo.claude_uptime)})"
-            parts.append(claude_str)
-
-        if repo.worker_stuck:
-            parts.append("BUSY")
-
-        if repo.crash_count > 0:
-            crash_str = f"crashed {repo.crash_count}x"
-            if repo.last_crash_error:
-                crash_str += f": {repo.last_crash_error}"
-            parts.append(crash_str)
-
-        lines.append(f"{repo.name}: {' — '.join(parts)}")
+        lines.append(_format_repo_header(repo))
+        lines.extend(_format_repo_body(repo))
 
     return "\n".join(lines)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -10,6 +10,7 @@ import subprocess
 import threading
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Protocol
 
@@ -619,7 +620,13 @@ class Worker:
                 number = issue["number"]
                 title = issue["title"]
                 log.info("starting issue #%s: %s", number, title)
-                State(fido_dir).save({"issue": number})
+                State(fido_dir).save(
+                    {
+                        "issue": number,
+                        "issue_title": title,
+                        "issue_started_at": datetime.now(tz=timezone.utc).isoformat(),
+                    }
+                )
                 self.set_status(f"Picking up issue #{number}: {title}")
                 return number
 
@@ -687,6 +694,10 @@ class Worker:
         if existing is not None:
             pr_number = existing["number"]
             slug = existing["headRefName"]
+            pr_title = existing.get("title") or request
+            with State(fido_dir).modify() as state:
+                state["pr_number"] = pr_number
+                state["pr_title"] = pr_title
             # Open PR — resume
             log.info("resuming PR #%s on branch %s", pr_number, slug)
             self._git(["fetch", remote])
@@ -774,6 +785,9 @@ class Worker:
             slug,
         )
         pr_number = int(url.rstrip("/").split("/")[-1])
+        with State(fido_dir).modify() as state:
+            state["pr_number"] = pr_number
+            state["pr_title"] = request
         _write_pr_description(
             self.gh, repo_ctx.repo, pr_number, issue, self._tasks.list()
         )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -486,3 +486,58 @@ class TestMakeRegistry:
             {"foo/bar": cfg}, _thread_factory=MagicMock(return_value=mock_thread)
         )
         assert reg.is_alive("foo/bar") is True
+
+
+class TestThreadStartedAt:
+    def test_records_on_start(self, tmp_path: Path) -> None:
+        reg = WorkerRegistry(MagicMock())
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        assert reg.thread_started_at("foo/bar") is not None
+
+    def test_returns_none_for_unknown(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        assert reg.thread_started_at("nope/none") is None
+
+
+class TestWebhookActivity:
+    def test_registers_and_unregisters(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        assert reg.get_webhook_activities("foo/bar") == []
+        with reg.webhook_activity("foo/bar", "triaging"):
+            activities = reg.get_webhook_activities("foo/bar")
+            assert len(activities) == 1
+            assert activities[0].description == "triaging"
+        assert reg.get_webhook_activities("foo/bar") == []
+
+    def test_unregisters_on_exception(self) -> None:
+        import pytest as _pytest
+
+        reg = WorkerRegistry(MagicMock())
+        with _pytest.raises(RuntimeError):
+            with reg.webhook_activity("foo/bar", "oops"):
+                raise RuntimeError("boom")
+        assert reg.get_webhook_activities("foo/bar") == []
+
+    def test_multiple_concurrent_activities(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        with reg.webhook_activity("foo/bar", "first"):
+            with reg.webhook_activity("foo/bar", "second"):
+                descs = sorted(
+                    a.description for a in reg.get_webhook_activities("foo/bar")
+                )
+                assert descs == ["first", "second"]
+        assert reg.get_webhook_activities("foo/bar") == []
+
+    def test_activities_isolated_per_repo(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        with reg.webhook_activity("a/b", "work-ab"):
+            with reg.webhook_activity("c/d", "work-cd"):
+                a = reg.get_webhook_activities("a/b")
+                c = reg.get_webhook_activities("c/d")
+                assert [x.description for x in a] == ["work-ab"]
+                assert [x.description for x in c] == ["work-cd"]
+
+    def test_unknown_repo_returns_empty_list(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        assert reg.get_webhook_activities("ghost/repo") == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -154,19 +154,21 @@ class TestGetEndpoint:
         ]
         WebhookHandler.registry.get_crash_info.return_value = None
         WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
-        assert data == [
-            {
-                "repo_name": "owner/repo",
-                "what": "Working on: #1",
-                "busy": True,
-                "crash_count": 0,
-                "last_crash_error": None,
-                "is_stuck": False,
-            }
-        ]
+        assert len(data) == 1
+        entry = data[0]
+        assert entry["repo_name"] == "owner/repo"
+        assert entry["what"] == "Working on: #1"
+        assert entry["busy"] is True
+        assert entry["crash_count"] == 0
+        assert entry["last_crash_error"] is None
+        assert entry["is_stuck"] is False
+        assert entry["worker_uptime_seconds"] is None
+        assert entry["webhook_activities"] == []
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
         from datetime import datetime, timezone
@@ -188,6 +190,8 @@ class TestGetEndpoint:
             last_crash_time=datetime(2026, 1, 1),
         )
         WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -222,6 +226,8 @@ class TestGetEndpoint:
         ]
         WebhookHandler.registry.get_crash_info.return_value = None
         WebhookHandler.registry.is_stale.return_value = True
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -12,6 +12,7 @@ from kennel.config import RepoConfig
 from kennel.status import (
     KennelStatus,
     RepoStatus,
+    WebhookActivityInfo,
     _claude_pid,
     _current_task,
     _fetch_activities,
@@ -267,6 +268,117 @@ class TestPortFromPid:
         assert paths_read == [Path("/proc/1234/cmdline")]
 
 
+class TestTaskPosition:
+    def test_task_in_progress_takes_precedence(self) -> None:
+        from kennel.status import _task_position
+
+        tasks = [
+            {"status": "pending"},
+            {"status": "in_progress"},
+            {"status": "pending"},
+        ]
+        assert _task_position(tasks) == (2, 3)
+
+    def test_first_pending_when_none_in_progress(self) -> None:
+        from kennel.status import _task_position
+
+        tasks = [{"status": "pending"}, {"status": "pending"}]
+        assert _task_position(tasks) == (1, 2)
+
+    def test_empty_when_all_completed(self) -> None:
+        from kennel.status import _task_position
+
+        tasks = [{"status": "completed"}, {"status": "completed"}]
+        assert _task_position(tasks) == (None, None)
+
+
+class TestElapsedSinceIso:
+    def test_none_on_empty(self) -> None:
+        from kennel.status import _elapsed_since_iso
+
+        assert _elapsed_since_iso(None) is None
+        assert _elapsed_since_iso("") is None
+
+    def test_none_on_bad_format(self) -> None:
+        from kennel.status import _elapsed_since_iso
+
+        assert _elapsed_since_iso("not a date") is None
+
+    def test_none_on_wrong_type(self) -> None:
+        from kennel.status import _elapsed_since_iso
+
+        # datetime.fromisoformat raises TypeError for non-str input.
+        assert _elapsed_since_iso(12345) is None  # type: ignore[arg-type]
+
+    def test_returns_seconds_since(self) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from kennel.status import _elapsed_since_iso
+
+        ref = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        iso = (ref - timedelta(minutes=5)).isoformat()
+        assert _elapsed_since_iso(iso, _now=lambda: ref) == 300
+
+    def test_floors_at_zero_for_future_timestamps(self) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from kennel.status import _elapsed_since_iso
+
+        ref = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        future = (ref + timedelta(minutes=1)).isoformat()
+        assert _elapsed_since_iso(future, _now=lambda: ref) == 0
+
+
+class TestCollectWebhookPropagation:
+    """collect() forwards worker_uptime + webhook_activities into repo_status."""
+
+    def test_worker_uptime_and_webhooks_forwarded(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        activity = {
+            "what": "Working on: #1",
+            "crash_count": 0,
+            "last_crash_error": None,
+            "is_stuck": False,
+            "worker_uptime_seconds": 120,
+            "webhook_activities": [
+                {"description": "triaging", "elapsed_seconds": 5.0},
+            ],
+        }
+        fake_status = RepoStatus(
+            name="owner/repo",
+            fido_running=False,
+            issue=None,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch(
+                "kennel.status._fetch_activities",
+                return_value={"owner/repo": activity},
+            ),
+            patch("kennel.status.repo_status", return_value=fake_status) as mock_rs,
+        ):
+            collect()
+        kwargs = mock_rs.call_args.kwargs
+        assert kwargs["worker_uptime"] == 120
+        assert len(kwargs["webhook_activities"]) == 1
+        assert kwargs["webhook_activities"][0].description == "triaging"
+        assert kwargs["webhook_activities"][0].elapsed_seconds == 5
+
+
 class TestFetchActivities:
     def _make_urlopen(self, data: bytes) -> MagicMock:
         mock_resp = MagicMock()
@@ -295,6 +407,8 @@ class TestFetchActivities:
                 "crash_count": 0,
                 "last_crash_error": None,
                 "is_stuck": False,
+                "worker_uptime_seconds": None,
+                "webhook_activities": [],
             }
         }
 
@@ -326,12 +440,16 @@ class TestFetchActivities:
                 "crash_count": 0,
                 "last_crash_error": None,
                 "is_stuck": False,
+                "worker_uptime_seconds": None,
+                "webhook_activities": [],
             },
             "c/d": {
                 "what": "Fixing CI",
                 "crash_count": 2,
                 "last_crash_error": "RuntimeError: boom",
                 "is_stuck": True,
+                "worker_uptime_seconds": None,
+                "webhook_activities": [],
             },
         }
 
@@ -736,12 +854,16 @@ class TestCollect:
         crash_count: int = 0,
         last_crash_error: str | None = None,
         is_stuck: bool = False,
+        worker_uptime_seconds: int | None = None,
+        webhook_activities: list | None = None,
     ) -> dict:
         return {
             "what": what,
             "crash_count": crash_count,
             "last_crash_error": last_crash_error,
             "is_stuck": is_stuck,
+            "worker_uptime_seconds": worker_uptime_seconds,
+            "webhook_activities": webhook_activities or [],
         }
 
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:
@@ -795,6 +917,8 @@ class TestCollect:
             crash_count=0,
             last_crash_error=None,
             worker_stuck=False,
+            worker_uptime=None,
+            webhook_activities=[],
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -823,6 +947,8 @@ class TestCollect:
             crash_count=3,
             last_crash_error="ValueError: oops",
             worker_stuck=False,
+            worker_uptime=None,
+            webhook_activities=[],
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -844,6 +970,8 @@ class TestCollect:
             crash_count=0,
             last_crash_error=None,
             worker_stuck=False,
+            worker_uptime=None,
+            webhook_activities=[],
         )
 
     def test_passes_is_stuck_to_repo_status(self, tmp_path: Path) -> None:
@@ -868,6 +996,8 @@ class TestCollect:
             crash_count=0,
             last_crash_error=None,
             worker_stuck=True,
+            worker_uptime=None,
+            webhook_activities=[],
         )
 
 
@@ -912,7 +1042,8 @@ class TestFormatStatus:
             repos=[self._repo(name="owner/myrepo")],
         )
         output = format_status(status)
-        assert "owner/myrepo: fido idle — no assigned issues" in output
+        assert "owner/myrepo: fido idle" in output
+        assert "no assigned issues" in output
 
     def test_repo_fido_running_no_issue(self) -> None:
         status = KennelStatus(
@@ -931,96 +1062,152 @@ class TestFormatStatus:
             pending=1,
             completed=2,
             current_task="Do the thing",
+            task_number=3,
+            task_total=3,
+            issue_title="Add widget",
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert 'issue #42, task 3/3 "Do the thing"' in output
+        assert "Issue:  #42 — Add widget" in output
+        assert "Task:   3/3 — Do the thing" in output
 
-    def test_repo_issue_no_current_task_but_has_tasks(self) -> None:
-        repo = self._repo(issue=5, pending=2, completed=0)
+    def test_repo_issue_without_title(self) -> None:
+        repo = self._repo(issue=5, pending=2, completed=0, task_number=1, task_total=2)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "issue #5, 2 pending" in output
+        assert "Issue:  #5" in output
+        assert "Task:   1/2" in output
 
     def test_repo_issue_no_tasks(self) -> None:
         repo = self._repo(issue=3)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "issue #3" in output
-        assert "pending" not in output
+        assert "Issue:  #3" in output
+        assert "Task:" not in output
 
     def test_claude_pid_with_uptime(self) -> None:
-        repo = self._repo(claude_pid=9999, claude_uptime=185)
+        repo = self._repo(issue=1, claude_pid=9999, claude_uptime=185)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "claude pid 9999 (running 3m)" in output
+        assert "└─ claude pid 9999 (running 3m)" in output
 
     def test_claude_pid_no_uptime(self) -> None:
-        repo = self._repo(claude_pid=9999, claude_uptime=None)
+        repo = self._repo(issue=1, claude_pid=9999, claude_uptime=None)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "claude pid 9999" in output
+        assert "└─ claude pid 9999" in output
         assert "running" not in output
 
     def test_multiple_repos(self) -> None:
+        # Each repo emits a header + "no assigned issues" body line.
         repos = [
             self._repo(name="a/b"),
             self._repo(name="c/d"),
         ]
         status = KennelStatus(kennel_pid=1, kennel_uptime=60, repos=repos)
         lines = format_status(status).splitlines()
-        assert len(lines) == 3
         assert lines[0].startswith("kennel:")
-        assert lines[1].startswith("a/b:")
-        assert lines[2].startswith("c/d:")
+        assert any(line.startswith("a/b:") for line in lines)
+        assert any(line.startswith("c/d:") for line in lines)
 
-    def test_worker_what_included_in_output(self) -> None:
-        repo = self._repo(fido_running=True, worker_what="Working on: #3 add widget")
+    def test_worker_what_included_when_no_task_or_pr(self) -> None:
+        """worker_what shows up in body when nothing more specific applies."""
+        repo = self._repo(
+            fido_running=True, issue=1, worker_what="Working on: #3 add widget"
+        )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Working on: #3 add widget" in output
 
-    def test_worker_what_none_not_included(self) -> None:
-        repo = self._repo(fido_running=True, worker_what=None)
+    def test_worker_what_hidden_when_task_present(self) -> None:
+        """worker_what is redundant when there's a specific Task line."""
+        repo = self._repo(
+            fido_running=True,
+            issue=1,
+            current_task="Do thing",
+            task_number=1,
+            task_total=1,
+            worker_what="Working on something",
+        )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "Working on:" not in output
-
-    def test_worker_what_appears_after_fido_status(self) -> None:
-        repo = self._repo(fido_running=True, worker_what="Napping — waiting for work")
-        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
-        output = format_status(status)
-        assert "fido running — Napping — waiting for work" in output
+        assert "Working on something" not in output
 
     def test_crash_count_zero_not_shown(self) -> None:
         repo = self._repo(crash_count=0, last_crash_error=None)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "crashed" not in output
+        assert "crashes" not in output
+        assert "crash" not in output.lower()
 
     def test_crash_count_nonzero_shown_with_error(self) -> None:
         repo = self._repo(crash_count=3, last_crash_error="RuntimeError: boom")
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "crashed 3x: RuntimeError: boom" in output
+        assert "crashes 3" in output
+        assert "RuntimeError: boom" in output
 
     def test_crash_count_without_error(self) -> None:
         repo = self._repo(crash_count=1, last_crash_error=None)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "crashed 1x" in output
-        assert "crashed 1x:" not in output
+        assert "crashes 1" in output
+        assert "last crash" not in output
 
-    def test_crash_info_appears_after_claude_info(self) -> None:
+    def test_worker_uptime_shown_in_header(self) -> None:
+        repo = self._repo(fido_running=True, worker_uptime=7320)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        # 7320s = 2h02m
+        assert "up 2h2m" in output
+
+    def test_issue_elapsed_shown_in_body(self) -> None:
+        repo = self._repo(issue=1, issue_elapsed_seconds=3900)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        # 3900s = 1h05m
+        assert "elapsed 1h5m" in output
+
+    def test_pr_line_rendered_when_pr_number_set(self) -> None:
         repo = self._repo(
-            claude_pid=9999,
-            claude_uptime=60,
-            crash_count=2,
-            last_crash_error="OSError: disk full",
+            issue=1,
+            pr_number=42,
+            pr_title="Refactor widget",
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "claude pid 9999 (running 1m) — crashed 2x: OSError: disk full" in output
+        assert "PR:     #42 — Refactor widget" in output
+
+    def test_pr_line_without_title(self) -> None:
+        repo = self._repo(issue=1, pr_number=7, pr_title=None)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "PR:     #7" in output
+
+    def test_current_task_line_without_numbering(self) -> None:
+        repo = self._repo(
+            issue=1, current_task="Freeform task", task_number=None, task_total=None
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "Task:   Freeform task" in output
+
+    def test_webhook_activities_rendered_as_sub_bullets(self) -> None:
+        repo = self._repo(
+            issue=1,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description="triaging comment on PR #9", elapsed_seconds=12
+                ),
+                WebhookActivityInfo(
+                    description="replying to review", elapsed_seconds=3
+                ),
+            ],
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "└─ webhook: triaging comment on PR #9 (12s)" in output
+        assert "└─ webhook: replying to review (3s)" in output
 
     def test_worker_busy_false_not_shown(self) -> None:
         repo = self._repo(worker_stuck=False)
@@ -1034,8 +1221,11 @@ class TestFormatStatus:
         output = format_status(status)
         assert "BUSY" in output
 
-    def test_busy_appears_before_crash_info(self) -> None:
+    def test_busy_appears_in_header_with_crash(self) -> None:
         repo = self._repo(worker_stuck=True, crash_count=1, last_crash_error="err")
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "BUSY — crashed 1x: err" in output
+        # Both appear in the comma-separated top-line stats.
+        assert "crashes 1" in output
+        assert "BUSY" in output
+        assert "last crash: err" in output

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1132,7 +1132,10 @@ class TestWorkerFindNextIssue:
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
             worker.find_next_issue(fido_dir, self._make_repo_ctx())
-        assert load_state(fido_dir) == {"issue": 7}
+        state = load_state(fido_dir)
+        assert state["issue"] == 7
+        assert state["issue_title"] == "Fetch!"
+        assert "issue_started_at" in state
 
     def test_does_not_save_state_when_no_issue(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)


### PR DESCRIPTION
## Summary

One PR landing both #427 (cramped single-line display) and #447 (no visibility into webhook handlers).

### Before
\`\`\`
FidoCanCode/home: fido running — Working on: Extend WorkerThread aliveness check to cover stuck task iterations — issue #382, task 2/2 \"Extend WorkerThread aliveness check to cover stuck task iterations\"
\`\`\`

### After
\`\`\`
rhencke/confusio: fido running — crashes 2, up 1h03m, BUSY
  Issue:  #31 — Implement GitHub REST API for Secret Scanning  (elapsed 2h30m)
  PR:     #105 — Implement GitHub REST API for Secret Scanning
  Task:   3/25 — Bitbucket: secret scanning endpoints and tests
  └─ claude pid 1862353 (running 4m)
  └─ webhook: triaging comment on PR #105 (3s)
\`\`\`

Top line keeps health at-a-glance (crashes, up, BUSY — skipped when normal).
Sub-bullets give the specifics: Issue / PR / Task with elapsed time, plus \`└─\` lines for the live claude subprocess and any in-flight webhook handler (#447).

## Under the hood

- **State**: persist \`issue_title\`, \`issue_started_at\`, \`pr_number\`, \`pr_title\` on pickup/resume so status renders real titles without extra GitHub API calls.
- **Registry**: \`thread_started_at\` for worker uptime; \`webhook_activity\` context manager + \`get_webhook_activities\` for in-flight handlers.
- **Server**: \`/status\` JSON gains \`worker_uptime_seconds\` and \`webhook_activities\`. \`_process_action\` wraps work in \`registry.webhook_activity\` so it shows up live.
- **Status**: \`RepoStatus\` gets new fields (defaulted for test stability). \`format_status\` splits into \`_format_repo_header\` + \`_format_repo_body\`.

Fixes #427
Fixes #447

## Test plan

- [x] 1668 tests pass, 100% coverage
- [x] New \`TestWebhookActivity\` suite covers registration, exception cleanup, concurrent activities, per-repo isolation
- [x] New \`TestTaskPosition\` / \`TestElapsedSinceIso\` / \`TestCollectWebhookPropagation\` suites
- [x] Existing format_status tests rewritten for the new layout

*BUSY but organized now*