### PR TITLE
Nudge claude on no-commit retries, reset session when it keeps spinning

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -458,6 +458,49 @@ def _has_pending_asks(task_list: list[dict[str, Any]]) -> bool:
 
 _DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 
+# Number of session-resume attempts with escalating nudges before we
+# abandon the stale session and start a fresh one.  Resuming the same
+# session forever can get stuck in a rut where claude keeps replying
+# with the same "nothing to do" no matter how hard we nudge; rebuilding
+# the context from scratch usually unsticks it.  See #452.
+_NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION: int = 5
+
+
+def _no_commit_nudge(attempt: int, task_title: str, pr_number: int | None) -> str:
+    """Build an escalating nudge prompt for the no-commit resume loop.
+
+    Each attempt demands a concrete action — commit, mark complete, or
+    post a blocked-status comment on the PR.  "Explain what's blocking
+    you" without posting it is intentionally not an option; an
+    explanation that never leaves claude's head isn't actionable.
+    """
+    pr_hint = (
+        f"`gh pr comment {pr_number} --body ...`"
+        if pr_number is not None
+        else "`gh pr comment <pr> --body ...`"
+    )
+    if attempt <= 2:
+        return (
+            f"You're working on: {task_title}\n\n"
+            "I don't see any commits yet.  Continue the task.  If you "
+            "already have changes, commit them now.  If the task is "
+            "already fully complete, mark it done."
+        )
+    return (
+        f"You're working on: {task_title}\n\n"
+        f"This is attempt {attempt} and there are still no commits on "
+        "the branch.  Take exactly one of these actions:\n"
+        "1. Commit the changes you have (`git add -A && git commit`)\n"
+        "2. Mark the task complete via `kennel task complete <id>` "
+        "if it was already done in a previous commit.\n"
+        "3. If something outside your control is blocking you, post a "
+        f"comment on the PR ({pr_hint}) that starts with `BLOCKED:` "
+        "and explains what's blocking you and why — so a human can "
+        "unblock you.  Do not just describe the situation internally; "
+        "post the comment.\n\n"
+        "Do not respond with a plan — just act."
+    )
+
 
 def latest_decisive_review(
     owner_reviews: list[dict[str, Any]],
@@ -1401,9 +1444,20 @@ class Worker:
                 )
                 break
             attempt += 1
+            # After _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION nudges fail, drop
+            # the stale session and start a fresh one.  Do not give up on
+            # the task — just reset context and keep going.
+            if session_id and attempt > _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION:
+                log.warning(
+                    "task produced no commits after %d nudges — starting fresh session",
+                    _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION,
+                )
+                session_id = ""
+            nudge = _no_commit_nudge(attempt, task_title, pr_number)
+            (fido_dir / "prompt").write_text(nudge)
             if session_id:
                 log.info(
-                    "task produced no commits — resuming session (attempt %d)",
+                    "task produced no commits — nudging session (attempt %d)",
                     attempt,
                 )
                 session_id, output = claude_run(
@@ -1411,10 +1465,9 @@ class Worker:
                 )
             else:
                 log.info(
-                    "task produced no commits — starting fresh session (attempt %d)",
+                    "task produced no commits — fresh session with nudge (attempt %d)",
                     attempt,
                 )
-                build_prompt(fido_dir, "task", context)
                 session_id, output = claude_run(fido_dir, cwd=self.work_dir)
             log.info("task resume done (session=%s)", session_id)
             head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5762,9 +5762,7 @@ class TestExecuteTask:
 
         def git_side(args, **kw):
             if args == ["rev-parse", "HEAD"]:
-                return MagicMock(
-                    returncode=0, stdout=next(head_iter, "bbb"), stderr=""
-                )
+                return MagicMock(returncode=0, stdout=next(head_iter, "bbb"), stderr="")
             return MagicMock(returncode=0, stdout="", stderr="")
 
         # Initial + n nudged resumes on sess-1, then the fresh start returns sess-2.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1307,6 +1307,35 @@ def _issue(
     return node
 
 
+class TestNoCommitNudge:
+    def test_early_attempt_is_gentle(self) -> None:
+        from kennel.worker import _no_commit_nudge
+
+        msg = _no_commit_nudge(1, "Fix widget", 42)
+        assert "Fix widget" in msg
+        assert "commit" in msg.lower()
+        # Early nudges don't threaten or list numbered actions.
+        assert "attempt 1" not in msg.lower()
+        assert "blocked" not in msg.lower()
+
+    def test_late_attempt_offers_blocked_comment_with_pr(self) -> None:
+        from kennel.worker import _no_commit_nudge
+
+        msg = _no_commit_nudge(3, "Fix widget", 42)
+        assert "attempt 3" in msg.lower()
+        assert "blocked:" in msg.lower()
+        assert "gh pr comment 42" in msg
+        # Two of the three actions are commit / mark complete.
+        assert "git add" in msg.lower()
+        assert "kennel task complete" in msg.lower()
+
+    def test_late_attempt_without_pr_uses_placeholder(self) -> None:
+        from kennel.worker import _no_commit_nudge
+
+        msg = _no_commit_nudge(3, "Fix widget", None)
+        assert "gh pr comment <pr>" in msg
+
+
 class TestPickNextIssue:
     """Direct unit tests for _pick_next_issue / _walk_to_root / _descend_issue."""
 
@@ -5648,7 +5677,8 @@ class TestExecuteTask:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
-        # No session_id on first run, retry starts fresh, second run produces commits
+        # No session_id on first run, retry writes nudge to prompt_file (no
+        # build_prompt), second run produces commits
         shas = iter(["aaa", "aaa", "bbb"])
         git_mock = MagicMock(
             side_effect=lambda args, **kw: MagicMock(
@@ -5671,9 +5701,12 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        # build_prompt called twice: initial + fresh restart
-        assert mock_bp.call_count == 2
+        # build_prompt only called for initial setup now — retries nudge
+        # in place via prompt_file directly.
+        assert mock_bp.call_count == 1
         assert mock_run.call_count == 2
+        # prompt_file should contain the first nudge after the retry.
+        assert "commit" in (fido_dir / "prompt").read_text().lower()
 
     def test_keeps_retrying_across_multiple_resumes(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -5709,6 +5742,49 @@ class TestExecuteTask:
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert mock_run.call_count == 4
         mock_complete.assert_called_once()
+
+    def test_drops_stale_session_after_nudge_limit(self, tmp_path: Path) -> None:
+        """After _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION nudges, the next retry
+        drops the session id so claude starts from scratch.  We don't give
+        up on the task — just reset context."""
+        from kennel.worker import _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION
+
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Stubborn task")
+
+        n = _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION
+        # head_before=aaa, then n+1 resumes return aaa (no commits), then
+        # the fresh session lands commits at bbb so loop exits.  Every
+        # iteration rev-parses HEAD once.
+        head_seq = ["aaa"] * (1 + (n + 1)) + ["bbb"]
+        head_iter = iter(head_seq)
+
+        def git_side(args, **kw):
+            if args == ["rev-parse", "HEAD"]:
+                return MagicMock(
+                    returncode=0, stdout=next(head_iter, "bbb"), stderr=""
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        # Initial + n nudged resumes on sess-1, then the fresh start returns sess-2.
+        runs = [("sess-1", "o")] * (n + 1) + [("sess-2", "fresh")]
+
+        with (
+            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", side_effect=runs) as mock_run,
+            patch.object(worker, "_git", side_effect=git_side),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
+
+        # Call index (n+1) is the fresh start — session_id kwarg missing/empty.
+        fresh_call = mock_run.call_args_list[n + 1]
+        assert fresh_call.kwargs.get("session_id", "") == ""
 
     def test_breaks_retry_loop_when_task_externally_completed(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

When claude finishes a task without producing commits, the worker was resuming the same session with the same prompt file forever — same prompt, same \"nothing to do\" response, spinning until something else killed it.  Saw 60+ attempts in the field before manual intervention.

Each retry now writes an escalating nudge into \`prompt_file\` before resuming:

- **attempts 1-2**: gentle \"commit the changes you have, or mark the task done\"
- **attempt 3+**: numbered demands — commit, mark complete, or post a \`BLOCKED:\` comment on the PR explaining what's blocking (so a human can unblock).  Explanations-without-action are intentionally not an option.

After \`_NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION\` (5) nudges fail, the worker drops the stale session id and starts fresh on the same task.  Don't give up; just reset context — which usually unsticks claude when it's fallen into a rut.

Fixes #452

## Test plan

- [x] 1692 tests pass, 100% coverage
- [x] \`TestNoCommitNudge\` — early/late content, PR number in the blocked-comment hint
- [x] \`TestExecuteTask.test_drops_stale_session_after_nudge_limit\` — after N nudges, next claude_run called with session_id=\"\"
- [x] Existing retry tests updated (build_prompt only called once, prompt_file now receives the nudge)

*no more silent 60-attempt spin loops*