### PR TITLE
Bake task id and PR number into nudge prompts

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -473,7 +473,7 @@ def _no_commit_nudge(
     work_dir: Path | str,
     pr_number: int | None,
 ) -> str:
-    """Build an escalating nudge prompt for the no-commit resume loop.
+    r"""Build an escalating nudge prompt for the no-commit resume loop.
 
     Each attempt demands a concrete action — commit, mark complete, or
     post a blocked-status comment on the PR.  "Explain what's blocking

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -466,38 +466,48 @@ _DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION: int = 5
 
 
-def _no_commit_nudge(attempt: int, task_title: str, pr_number: int | None) -> str:
+def _no_commit_nudge(
+    attempt: int,
+    task_title: str,
+    task_id: str,
+    work_dir: Path | str,
+    pr_number: int | None,
+) -> str:
     """Build an escalating nudge prompt for the no-commit resume loop.
 
     Each attempt demands a concrete action — commit, mark complete, or
     post a blocked-status comment on the PR.  "Explain what's blocking
     you" without posting it is intentionally not an option; an
     explanation that never leaves claude's head isn't actionable.
+
+    The exact \`kennel task complete\` and \`gh pr comment\` invocations
+    are pre-baked with the actual task ID, work_dir, and PR number so
+    claude doesn't have to guess.
     """
-    pr_hint = (
-        f"`gh pr comment {pr_number} --body ...`"
+    complete_cmd = f"kennel task complete {work_dir} {task_id}"
+    pr_comment_cmd = (
+        f"gh pr comment {pr_number} --body 'BLOCKED: ...'"
         if pr_number is not None
-        else "`gh pr comment <pr> --body ...`"
+        else "gh pr comment <pr> --body 'BLOCKED: ...'"
     )
     if attempt <= 2:
         return (
             f"You're working on: {task_title}\n\n"
             "I don't see any commits yet.  Continue the task.  If you "
             "already have changes, commit them now.  If the task is "
-            "already fully complete, mark it done."
+            f"already fully complete in a previous commit, run:\n"
+            f"  {complete_cmd}\n"
         )
     return (
         f"You're working on: {task_title}\n\n"
         f"This is attempt {attempt} and there are still no commits on "
         "the branch.  Take exactly one of these actions:\n"
         "1. Commit the changes you have (`git add -A && git commit`)\n"
-        "2. Mark the task complete via `kennel task complete <id>` "
-        "if it was already done in a previous commit.\n"
-        "3. If something outside your control is blocking you, post a "
-        f"comment on the PR ({pr_hint}) that starts with `BLOCKED:` "
-        "and explains what's blocking you and why — so a human can "
-        "unblock you.  Do not just describe the situation internally; "
-        "post the comment.\n\n"
+        f"2. Mark this task complete: `{complete_cmd}`\n"
+        f"3. If something outside your control is blocking you, run "
+        f"`{pr_comment_cmd}` with a real explanation of what's "
+        "blocking you and why — so a human can unblock you.  Do not "
+        "just describe the situation internally; post the comment.\n\n"
         "Do not respond with a plan — just act."
     )
 
@@ -1453,7 +1463,9 @@ class Worker:
                     _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION,
                 )
                 session_id = ""
-            nudge = _no_commit_nudge(attempt, task_title, pr_number)
+            nudge = _no_commit_nudge(
+                attempt, task_title, task["id"], self.work_dir, pr_number
+            )
             (fido_dir / "prompt").write_text(nudge)
             if session_id:
                 log.info(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1308,31 +1308,33 @@ def _issue(
 
 
 class TestNoCommitNudge:
-    def test_early_attempt_is_gentle(self) -> None:
+    def test_early_attempt_is_gentle_and_includes_complete_command(self) -> None:
         from kennel.worker import _no_commit_nudge
 
-        msg = _no_commit_nudge(1, "Fix widget", 42)
+        msg = _no_commit_nudge(1, "Fix widget", "task-7", "/repo/work", 42)
         assert "Fix widget" in msg
         assert "commit" in msg.lower()
+        # Even early nudges include the exact mark-complete command so
+        # claude can use it without guessing the task id.
+        assert "kennel task complete /repo/work task-7" in msg
         # Early nudges don't threaten or list numbered actions.
         assert "attempt 1" not in msg.lower()
         assert "blocked" not in msg.lower()
 
-    def test_late_attempt_offers_blocked_comment_with_pr(self) -> None:
+    def test_late_attempt_offers_three_concrete_actions(self) -> None:
         from kennel.worker import _no_commit_nudge
 
-        msg = _no_commit_nudge(3, "Fix widget", 42)
+        msg = _no_commit_nudge(3, "Fix widget", "task-7", "/repo/work", 42)
         assert "attempt 3" in msg.lower()
-        assert "blocked:" in msg.lower()
-        assert "gh pr comment 42" in msg
-        # Two of the three actions are commit / mark complete.
+        # All three actions are concrete commands with real arguments.
         assert "git add" in msg.lower()
-        assert "kennel task complete" in msg.lower()
+        assert "kennel task complete /repo/work task-7" in msg
+        assert "gh pr comment 42 --body 'BLOCKED:" in msg
 
     def test_late_attempt_without_pr_uses_placeholder(self) -> None:
         from kennel.worker import _no_commit_nudge
 
-        msg = _no_commit_nudge(3, "Fix widget", None)
+        msg = _no_commit_nudge(3, "Fix widget", "task-7", "/repo/work", None)
         assert "gh pr comment <pr>" in msg
 
 


### PR DESCRIPTION
## Summary

Direct follow-up to #453.  The nudge told claude to run \`kennel task complete <id>\` but never said *what id*.  Claude couldn't comply, so it kept replying \"work already done\" and we kept resuming.  Saw it in the wild on rhencke/confusio#122 — claude posted a perfect [BLOCKED: comment](https://github.com/rhencke/confusio/pull/122#issuecomment-4241673285) explaining the situation, but couldn't unblock itself because it didn't know its own task id.

Now the nudge bakes in the literal commands:

\`\`\`
kennel task complete /home/rhencke/workspace/confusio 1776137950735-9527
gh pr comment 122 --body 'BLOCKED: ...'
\`\`\`

Copy-paste ready.

## Test plan

- [x] 1692 tests pass, 100% coverage
- [x] \`test_early_attempt_is_gentle_and_includes_complete_command\`
- [x] \`test_late_attempt_offers_three_concrete_actions\`
- [x] \`test_late_attempt_without_pr_uses_placeholder\`

*no more guessing the task id*