### PR TITLE
Drive a single persistent claude per worker via bidirectional stream-json (closes #455)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Multi-repo: one kennel process handles multiple repos. Each repo has its own tas
 
 **Concurrency model**: one fido per repo, one issue per fido, one PR per issue. Fido finishes the current issue (PR merged or closed) before picking up the next. Two repos = two fidos max, running in parallel, each on their own issue.
 
+**ClaudeSession persistence**: the persistent `ClaudeSession` (bidirectional stream-json subprocess) is held on `WorkerThread._session` and survives individual `Worker` crashes — the watchdog restarts the thread and the next `Worker` inherits the same session. It does *not* survive a kennel/home restart: `os.execvp` replaces the process entirely, so the new kennel starts with `_session = None` and creates a fresh session on its first iteration.
+
 ## Runner vs workspace clones
 
 Kennel runs from a dedicated **runner clone** at `/home/rhencke/home-runner/`, separate from the **workspace clone** at `/home/rhencke/workspace/home/`.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -811,9 +811,11 @@ class ClaudeSession:
                 self._proc.wait(timeout=1.0)
             except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
                 log.debug("ClaudeSession.stop: kill/wait failed: %s", exc)
+                raise
         except (OSError, ProcessLookupError) as exc:
             log.debug("ClaudeSession.stop: wait failed: %s", exc)
-        _unregister_child(self._proc)
+        finally:
+            _unregister_child(self._proc)
 
 
 def resume_status(

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -90,6 +90,11 @@ def _claude(
     )
 
 
+_RETURNCODE_IDLE_TIMEOUT = -1
+"""Sentinel returncode used in :class:`ClaudeStreamError` when the process is
+killed due to an idle timeout rather than exiting with a real non-zero code."""
+
+
 class ClaudeStreamError(Exception):
     """Raised by _run_streaming when the subprocess exits with a non-zero code or times out."""
 
@@ -249,8 +254,9 @@ def _run_streaming(
     """Run a command, streaming stdout with idle-timeout detection.
 
     Yields each line of stdout as it arrives.  If no new output arrives for
-    *idle_timeout* seconds, the process is killed and ``ClaudeStreamError(-1)``
-    is raised.  If the process exits with a non-zero code,
+    *idle_timeout* seconds, the process is killed and
+    ``ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)`` is raised.  If the process
+    exits with a non-zero code,
     ``ClaudeStreamError(returncode)`` is raised.  ``FileNotFoundError``
     propagates naturally if the command is not found.
     """
@@ -282,7 +288,7 @@ def _run_streaming(
                 log.warning("claude idle for %.0fs — killing", idle_timeout)
                 proc.kill()
                 proc.wait()
-                raise ClaudeStreamError(-1)
+                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
 
         proc.wait()
         # Drain any remaining output
@@ -712,7 +718,8 @@ class ClaudeSession:
         Reads lines from stdout, parsing each as JSON.  Stops (and returns)
         when a ``type=result`` or ``type=error`` event is yielded, when the
         process exits (EOF), or when no output arrives for *idle_timeout*
-        seconds (raises :class:`ClaudeStreamError` ``(-1)`` in that case).
+        seconds (raises :class:`ClaudeStreamError` with
+        :data:`_RETURNCODE_IDLE_TIMEOUT` in that case).
 
         Raises ``json.JSONDecodeError`` if a non-empty stdout line cannot be
         parsed — this is a protocol violation from the claude subprocess and
@@ -750,7 +757,7 @@ class ClaudeSession:
                 )
                 self._proc.kill()
                 self._proc.wait()
-                raise ClaudeStreamError(-1)
+                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
 
     def consume_until_result(self) -> str:
         """Drain events for the current turn and return the result text.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -804,6 +804,7 @@ class ClaudeSession:
                 self._proc.stdin.close()
         except OSError as exc:
             log.debug("ClaudeSession.stop: stdin close failed: %s", exc)
+            raise
         try:
             self._proc.wait(timeout=grace_seconds)
         except subprocess.TimeoutExpired:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -779,6 +779,7 @@ class ClaudeSession:
                 )
                 self._proc.kill()
                 self._proc.wait()
+                self.restart()
                 raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
 
     def consume_until_result(self) -> str:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -627,6 +627,19 @@ class ClaudeSession:
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
 
+    def interrupt(self, content: str) -> None:
+        """Write a user message to stdin, bypassing the session lock.
+
+        This is the explicit lock-break path for preempt and interrupt use
+        cases (e.g. rescope abort, CI-failure cancel) where the lock is
+        already held by the in-flight turn and waiting for it would defeat
+        the purpose of the interrupt.  Only call from threads that have a
+        legitimate need to preempt the current holder; all normal turns
+        should go through the :meth:`__enter__` / :meth:`__exit__` context
+        manager instead.
+        """
+        self.send(content)
+
     def switch_model(self, model: str) -> None:
         """Switch the active model by sending a /model slash command.
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -562,6 +562,7 @@ class ClaudeSession:
         self._work_dir = work_dir
         self._popen_fn = popen
         self._lock = threading.Lock()
+        self._cancel = threading.Event()
         self._queued_content: str | None = None
         self._proc = self._spawn()
         _register_child(self._proc)
@@ -611,8 +612,13 @@ class ClaudeSession:
         _register_child(self._proc)
 
     def __enter__(self) -> "ClaudeSession":
-        """Acquire the session lock, serializing send/receive across threads."""
+        """Acquire the session lock, serializing send/receive across threads.
+
+        Also clears the cancel event so a turn that follows a preempt or
+        interrupt starts with a clean slate.
+        """
         self._lock.acquire()
+        self._cancel.clear()
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -629,7 +635,12 @@ class ClaudeSession:
         self._proc.stdin.flush()
 
     def interrupt(self, content: str) -> None:
-        """Write a user message to stdin, bypassing the session lock.
+        """Signal the in-flight turn to stop, then send a follow-up message.
+
+        Sets the cancel event so :meth:`iter_events` exits on its next poll
+        cycle, causing the lock holder to finish its ``with session:`` block
+        and release the lock.  Also writes *content* to stdin as a user
+        message (bypassing the lock) so it is queued as the next turn.
 
         This is the explicit lock-break path for preempt and interrupt use
         cases (e.g. rescope abort, CI-failure cancel) where the lock is
@@ -639,6 +650,7 @@ class ClaudeSession:
         should go through the :meth:`__enter__` / :meth:`__exit__` context
         manager instead.
         """
+        self._cancel.set()
         self.send(content)
 
     def preempt(self, content: str) -> None:
@@ -653,6 +665,7 @@ class ClaudeSession:
         Only for preempt paths (rescope abort, CI-failure cancel).  Normal
         turns must go through the context-manager lock.
         """
+        self._cancel.set()
         msg = json.dumps({"type": "control_request", "request": {"type": "interrupt"}})
         assert self._proc.stdin is not None
         self._proc.stdin.write(msg + "\n")
@@ -698,6 +711,9 @@ class ClaudeSession:
         last_activity = time.monotonic()
 
         while True:
+            if self._cancel.is_set():
+                log.debug("ClaudeSession: cancelled — exiting turn early")
+                break
             ready, _, _ = self._selector(
                 [self._proc.stdout], [], [], _SELECT_POLL_INTERVAL
             )

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -13,8 +13,6 @@ import uuid
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
-from kennel.state import PreemptQueue
-
 log = logging.getLogger(__name__)
 
 # How many seconds select.select waits for stdout before checking for
@@ -605,7 +603,6 @@ class ClaudeSession:
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list, list, list]] = select.select,
-        preempt_queue: PreemptQueue | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -614,7 +611,6 @@ class ClaudeSession:
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
-        self._preempt_queue = preempt_queue
         self._owner: str | None = None
         self._proc = self._spawn()
         _register_child(self._proc)
@@ -746,42 +742,6 @@ class ClaudeSession:
             self.consume_until_result()
             self.send(content)
 
-    def preempt(self, content: str) -> None:
-        """Signal the in-flight turn to stop and queue a follow-up user turn.
-
-        Sets the cancel event so :meth:`iter_events` exits on its next poll
-        cycle.  The lock holder's ``with session:`` block then unwinds and
-        releases the lock.  This method acquires the lock (blocking until the
-        holder releases it), appends *content* to the durable FIFO queue, and
-        releases the lock.  Multiple consecutive preempts accumulate — no
-        message is lost even if preempt is called again before the first
-        queued turn is consumed.  The queued content is retrieved one item at
-        a time via :meth:`take_queued_content` by the next caller that holds
-        the lock.
-
-        Only for preempt paths (rescope abort, CI-failure cancel).  Normal
-        turns must go through the context-manager lock.
-        """
-        self._cancel.set()
-        with self._lock:
-            assert self._preempt_queue is not None, (
-                "preempt_queue required for preempt()"
-            )
-            self._preempt_queue.push(content)
-
-    def take_queued_content(self) -> str | None:
-        """Pop and return the oldest queued preempt content, or ``None``.
-
-        Returns ``None`` if the queue is empty.  Call this while holding the
-        session lock (via the context manager) so that reading and removing
-        from the queue is serialized with respect to a concurrent
-        :meth:`preempt` appending to it.
-        """
-        assert self._preempt_queue is not None, (
-            "preempt_queue required for take_queued_content()"
-        )
-        return self._preempt_queue.pop()
-
     def switch_model(self, model: str) -> None:
         """Switch the active model by sending a /model slash command.
 
@@ -800,7 +760,7 @@ class ClaudeSession:
         the lock-handoff window (between the previous holder's :meth:`__exit__`
         and this call) is consumed here rather than immediately aborting the
         new turn.  After that, checks the event on each poll cycle so a
-        concurrent :meth:`interrupt` or :meth:`preempt` can abort mid-turn.
+        concurrent :meth:`interrupt` can abort mid-turn.
 
         Reads lines from stdout, parsing each as JSON.  Stops (and returns)
         when a ``type=result`` or ``type=error`` event is yielded, when the

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -552,6 +552,7 @@ class ClaudeSession:
         self,
         system_file: Path,
         work_dir: Path | str | None = None,
+        model: str = "claude-sonnet-4-6",
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list, list, list]] = select.select,
@@ -560,6 +561,7 @@ class ClaudeSession:
         self._selector = selector
         self._system_file = system_file
         self._work_dir = work_dir
+        self._model = model
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
@@ -571,6 +573,8 @@ class ClaudeSession:
         """Spawn the claude subprocess with bidirectional stream-json I/O."""
         cmd = [
             "claude",
+            "--model",
+            self._model,
             "--input-format",
             "stream-json",
             "--output-format",

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -554,7 +554,6 @@ class ClaudeSession:
         self,
         system_file: Path,
         work_dir: Path | str | None = None,
-        model: str = "claude-sonnet-4-6",
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list, list, list]] = select.select,
@@ -564,7 +563,6 @@ class ClaudeSession:
         self._selector = selector
         self._system_file = system_file
         self._work_dir = work_dir
-        self._model = model
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
@@ -576,8 +574,6 @@ class ClaudeSession:
         """Spawn the claude subprocess with bidirectional stream-json I/O."""
         cmd = [
             "claude",
-            "--model",
-            self._model,
             "--input-format",
             "stream-json",
             "--output-format",

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -25,6 +25,32 @@ _SELECT_POLL_INTERVAL = 10.0
 # claude subprocess, to keep log records readable.
 _LOG_LINE_TRUNCATE = 200
 
+
+class _Trunc:
+    """Lazy-truncating wrapper for log arguments.
+
+    Pass an instance as a ``%s`` or ``%r`` log argument instead of slicing
+    inline.  The truncation is deferred to format time, so it is free when
+    the log level is disabled.
+
+    Usage::
+
+        log.debug("event: %s", _Trunc(line))
+        log.warning("stderr=%r", _Trunc(result.stderr))
+    """
+
+    __slots__ = ("_s",)
+
+    def __init__(self, s: str) -> None:
+        self._s = s
+
+    def __str__(self) -> str:
+        return self._s[:_LOG_LINE_TRUNCATE]
+
+    def __repr__(self) -> str:
+        return repr(self._s[:_LOG_LINE_TRUNCATE])
+
+
 # Tracked long-running claude subprocesses (the streaming ones), so kennel
 # can clean them up on shutdown.  Short-lived ``subprocess.run`` calls cap
 # at 30s and aren't tracked.  Use ``kill_active_children`` from a signal
@@ -187,10 +213,8 @@ def print_prompt(
             if text:
                 return text
             if result.stderr:
-                log.warning(
-                    "print_prompt: stderr=%r", result.stderr[:_LOG_LINE_TRUNCATE]
-                )
-            log.debug("print_prompt: stdout=%r", result.stdout[:_LOG_LINE_TRUNCATE])
+                log.warning("print_prompt: stderr=%r", _Trunc(result.stderr))
+            log.debug("print_prompt: stdout=%r", _Trunc(result.stdout))
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "print_prompt: empty output on attempt %d — retrying",
@@ -519,13 +543,9 @@ def generate_status_with_session(
                 return text, sid
             if result.stderr:
                 log.warning(
-                    "generate_status_with_session: stderr=%r",
-                    result.stderr[:_LOG_LINE_TRUNCATE],
+                    "generate_status_with_session: stderr=%r", _Trunc(result.stderr)
                 )
-            log.debug(
-                "generate_status_with_session: stdout=%r",
-                result.stdout[:_LOG_LINE_TRUNCATE],
-            )
+            log.debug("generate_status_with_session: stdout=%r", _Trunc(result.stdout))
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "generate_status_with_session: empty output on attempt %d — retrying",
@@ -744,7 +764,7 @@ class ClaudeSession:
                     last_activity = time.monotonic()
                     continue
                 obj = json.loads(line)
-                log.debug("ClaudeSession event: %s", line[:_LOG_LINE_TRUNCATE])
+                log.debug("ClaudeSession event: %s", _Trunc(line))
                 last_activity = time.monotonic()
                 yield obj
                 if obj.get("type") in ("result", "error"):

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -519,6 +519,129 @@ def generate_status_with_session(
     return "", ""
 
 
+# ── Persistent bidirectional session ─────────────────────────────────────────
+
+
+class ClaudeSession:
+    """A long-lived claude process driven via bidirectional stream-json.
+
+    Spawns ``claude --input-format stream-json --output-format stream-json``
+    and keeps it running across multiple turns.  Each :meth:`send` writes one
+    JSON user message to stdin; :meth:`iter_events` reads structured events
+    from stdout until the turn completes (``type=result`` or ``type=error``).
+
+    Pass *popen* and *selector* to override subprocess creation and
+    ``select.select`` in tests; these default to the real implementations.
+    """
+
+    def __init__(
+        self,
+        system_file: Path,
+        work_dir: Path | str | None = None,
+        idle_timeout: float = 1800.0,
+        popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
+        selector: Callable[..., tuple[list, list, list]] = select.select,
+    ) -> None:
+        self._idle_timeout = idle_timeout
+        self._selector = selector
+        cmd = [
+            "claude",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+            "--system-prompt-file",
+            str(system_file),
+        ]
+        self._proc = popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=work_dir,
+        )
+        _register_child(self._proc)
+
+    def send(self, content: str) -> None:
+        """Write a user message to the session stdin, flushing immediately."""
+        msg = json.dumps(
+            {"type": "user", "message": {"role": "user", "content": content}}
+        )
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+
+    def iter_events(self) -> Iterator[dict]:
+        """Yield parsed stream-json events for the current turn.
+
+        Reads lines from stdout, parsing each as JSON.  Stops (and returns)
+        when a ``type=result`` or ``type=error`` event is yielded, when the
+        process exits (EOF), or when no output arrives for *idle_timeout*
+        seconds (raises :class:`ClaudeStreamError` ``(-1)`` in that case).
+
+        Unparseable lines are logged at WARNING and skipped.
+        """
+        assert self._proc.stdout is not None
+        last_activity = time.monotonic()
+
+        while True:
+            ready, _, _ = self._selector([self._proc.stdout], [], [], 10.0)
+            if ready:
+                line = self._proc.stdout.readline()
+                if not line:
+                    break  # EOF
+                line = line.strip()
+                if not line:
+                    last_activity = time.monotonic()
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    log.warning("ClaudeSession: unparseable line: %r", line[:200])
+                    last_activity = time.monotonic()
+                    continue
+                log.debug("ClaudeSession event: %s", line[:200])
+                last_activity = time.monotonic()
+                yield obj
+                if obj.get("type") in ("result", "error"):
+                    break
+            elif self._proc.poll() is not None:
+                break  # process exited
+            elif time.monotonic() - last_activity > self._idle_timeout:
+                log.warning(
+                    "ClaudeSession: idle for %.0fs — killing", self._idle_timeout
+                )
+                self._proc.kill()
+                self._proc.wait()
+                raise ClaudeStreamError(-1)
+
+    def stop(self, grace_seconds: float = 2.0) -> None:
+        """Shut down the session: close stdin, wait for exit, kill if needed.
+
+        Always unregisters the process from ``_active_children``, even if the
+        process has already exited before :meth:`stop` is called.
+        """
+        try:
+            if self._proc.stdin and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            self._proc.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            try:
+                self._proc.kill()
+                self._proc.wait(timeout=1.0)
+            except OSError, ProcessLookupError, subprocess.TimeoutExpired:
+                pass
+        except OSError, ProcessLookupError:
+            pass
+        _unregister_child(self._proc)
+
+
 def resume_status(
     session_id: str,
     prompt: str,

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -676,11 +676,8 @@ class ClaudeSession:
         where the in-flight turn must be cancelled and a follow-up sent.
         """
         self._cancel.set()
-        self._lock.acquire()
-        try:
+        with self._lock:
             self.send(content)
-        finally:
-            self._lock.release()
 
     def preempt(self, content: str) -> None:
         """Signal the in-flight turn to stop and queue a follow-up user turn.
@@ -699,14 +696,11 @@ class ClaudeSession:
         turns must go through the context-manager lock.
         """
         self._cancel.set()
-        self._lock.acquire()
-        try:
+        with self._lock:
             assert self._preempt_queue is not None, (
                 "preempt_queue required for preempt()"
             )
             self._preempt_queue.push(content)
-        finally:
-            self._lock.release()
 
     def take_queued_content(self) -> str | None:
         """Pop and return the oldest queued preempt content, or ``None``.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -544,6 +544,14 @@ class ClaudeSession:
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
+        self._system_file = system_file
+        self._work_dir = work_dir
+        self._popen_fn = popen
+        self._proc = self._spawn()
+        _register_child(self._proc)
+
+    def _spawn(self) -> subprocess.Popen[str]:
+        """Spawn the claude subprocess with bidirectional stream-json I/O."""
         cmd = [
             "claude",
             "--input-format",
@@ -553,16 +561,37 @@ class ClaudeSession:
             "--verbose",
             "--dangerously-skip-permissions",
             "--system-prompt-file",
-            str(system_file),
+            str(self._system_file),
         ]
-        self._proc = popen(
+        return self._popen_fn(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            cwd=work_dir,
+            cwd=self._work_dir,
         )
+
+    def is_alive(self) -> bool:
+        """Return True if the claude subprocess is still running."""
+        return self._proc.poll() is None
+
+    def restart(self) -> None:
+        """Stop the current subprocess and start a fresh one.
+
+        Unregisters the dead process from ``_active_children``, kills it if
+        still running, then spawns a replacement and registers it.  The
+        conversation transcript is lost — callers are responsible for
+        re-sending any context the new process needs.
+        """
+        log.warning("ClaudeSession: restarting after unexpected process death")
+        _unregister_child(self._proc)
+        try:
+            self._proc.kill()
+            self._proc.wait(timeout=1.0)
+        except OSError, ProcessLookupError, subprocess.TimeoutExpired:
+            pass
+        self._proc = self._spawn()
         _register_child(self._proc)
 
     def send(self, content: str) -> None:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -599,6 +599,7 @@ class ClaudeSession:
         self._lock = threading.Lock()
         self._cancel = threading.Event()
         self._preempt_queue = preempt_queue
+        self._owner: str | None = None
         self._proc = self._spawn()
         _register_child(self._proc)
 
@@ -648,18 +649,33 @@ class ClaudeSession:
         self._proc = self._spawn()
         _register_child(self._proc)
 
+    @property
+    def owner(self) -> str | None:
+        """Name of the thread currently holding the session lock, or ``None``.
+
+        Set to :func:`threading.current_thread().name <threading.current_thread>`
+        immediately after the lock is acquired in :meth:`__enter__` and
+        cleared before it is released in :meth:`__exit__`.  Read without
+        holding the lock — safe to poll from status-display threads for a
+        best-effort snapshot of who is actively driving the session.
+        """
+        return self._owner
+
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
 
         Also clears the cancel event so a turn that follows a preempt or
-        interrupt starts with a clean slate.
+        interrupt starts with a clean slate.  Records the current thread name
+        in :attr:`owner` so status display can show who holds the session.
         """
         self._lock.acquire()
         self._cancel.clear()
+        self._owner = threading.current_thread().name
         return self
 
     def __exit__(self, *args: object) -> None:
-        """Release the session lock."""
+        """Release the session lock.  Clears :attr:`owner` before releasing."""
+        self._owner = None
         self._lock.release()
 
     def send(self, content: str) -> None:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -574,6 +574,17 @@ class ClaudeSession:
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
 
+    def switch_model(self, model: str) -> None:
+        """Switch the active model by sending a /model slash command.
+
+        Sends ``/model <model>`` as a user message and drains any response
+        events so the turn boundary is clean before the next call to
+        :meth:`send` + :meth:`iter_events`.
+        """
+        self.send(f"/model {model}")
+        for _ in self.iter_events():
+            pass
+
     def iter_events(self) -> Iterator[dict]:
         """Yield parsed stream-json events for the current turn.
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -841,22 +841,23 @@ class ClaudeSession:
         process has already exited before :meth:`stop` is called.
         """
         try:
-            if self._proc.stdin and not self._proc.stdin.closed:
-                self._proc.stdin.close()
-        except OSError as exc:
-            log.debug("ClaudeSession.stop: stdin close failed: %s", exc)
-            raise
-        try:
-            self._proc.wait(timeout=grace_seconds)
-        except subprocess.TimeoutExpired:
             try:
-                self._proc.kill()
-                self._proc.wait(timeout=1.0)
-            except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
-                log.debug("ClaudeSession.stop: kill/wait failed: %s", exc)
+                if self._proc.stdin and not self._proc.stdin.closed:
+                    self._proc.stdin.close()
+            except OSError as exc:
+                log.debug("ClaudeSession.stop: stdin close failed: %s", exc)
                 raise
-        except (OSError, ProcessLookupError) as exc:
-            log.debug("ClaudeSession.stop: wait failed: %s", exc)
+            try:
+                self._proc.wait(timeout=grace_seconds)
+            except subprocess.TimeoutExpired:
+                try:
+                    self._proc.kill()
+                    self._proc.wait(timeout=1.0)
+                except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
+                    log.debug("ClaudeSession.stop: kill/wait failed: %s", exc)
+                    raise
+            except (OSError, ProcessLookupError) as exc:
+                log.debug("ClaudeSession.stop: wait failed: %s", exc)
         finally:
             _unregister_child(self._proc)
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -636,7 +636,9 @@ class ClaudeSession:
         process exits (EOF), or when no output arrives for *idle_timeout*
         seconds (raises :class:`ClaudeStreamError` ``(-1)`` in that case).
 
-        Unparseable lines are logged at WARNING and skipped.
+        Raises ``json.JSONDecodeError`` if a non-empty stdout line cannot be
+        parsed — this is a protocol violation from the claude subprocess and
+        should not be silently swallowed.
         """
         assert self._proc.stdout is not None
         last_activity = time.monotonic()
@@ -653,14 +655,7 @@ class ClaudeSession:
                 if not line:
                     last_activity = time.monotonic()
                     continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    log.warning(
-                        "ClaudeSession: unparseable line: %r", line[:_LOG_LINE_TRUNCATE]
-                    )
-                    last_activity = time.monotonic()
-                    continue
+                obj = json.loads(line)
                 log.debug("ClaudeSession event: %s", line[:_LOG_LINE_TRUNCATE])
                 last_activity = time.monotonic()
                 yield obj

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -698,18 +698,18 @@ class ClaudeSession:
         try:
             if self._proc.stdin and not self._proc.stdin.closed:
                 self._proc.stdin.close()
-        except OSError:
-            pass
+        except OSError as exc:
+            log.debug("ClaudeSession.stop: stdin close failed: %s", exc)
         try:
             self._proc.wait(timeout=grace_seconds)
         except subprocess.TimeoutExpired:
             try:
                 self._proc.kill()
                 self._proc.wait(timeout=1.0)
-            except OSError, ProcessLookupError, subprocess.TimeoutExpired:
-                pass
-        except OSError, ProcessLookupError:
-            pass
+            except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
+                log.debug("ClaudeSession.stop: kill/wait failed: %s", exc)
+        except (OSError, ProcessLookupError) as exc:
+            log.debug("ClaudeSession.stop: wait failed: %s", exc)
         _unregister_child(self._proc)
 
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -629,6 +629,19 @@ class ClaudeSession:
                 self._proc.wait()
                 raise ClaudeStreamError(-1)
 
+    def consume_until_result(self) -> str:
+        """Drain events for the current turn and return the result text.
+
+        Exhausts :meth:`iter_events` and returns the ``result`` field from
+        the ``type=result`` event, or an empty string if the turn ends
+        without one (EOF, ``type=error``, or idle-timeout kill).
+        """
+        result_text = ""
+        for event in self.iter_events():
+            if event.get("type") == "result" and isinstance(event.get("result"), str):
+                result_text = event["result"]
+        return result_text
+
     def stop(self, grace_seconds: float = 2.0) -> None:
         """Shut down the session: close stdin, wait for exit, kill if needed.
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -578,6 +578,21 @@ class ClaudeSession:
     JSON user message to stdin; :meth:`iter_events` reads structured events
     from stdout until the turn completes (``type=result`` or ``type=error``).
 
+    **Lifetime / persistence model**
+
+    The session outlives individual :class:`~kennel.worker.Worker` crashes:
+    :class:`~kennel.worker.WorkerThread` holds the session in
+    ``_session`` across iterations and passes it into each new ``Worker``
+    instance, so an unexpected exception in ``Worker.run()`` does not tear the
+    session down.  The watchdog restarts the thread and the next Worker
+    inherits the same session.
+
+    The session does *not* survive a kennel/home restart.  When kennel
+    replaces itself via ``os.execvp`` (e.g. after a self-update), all
+    in-memory state is lost, including the ``WorkerThread`` and its session.
+    The new process starts with ``_session = None`` and creates a fresh session
+    on the first iteration.
+
     Pass *popen* and *selector* to override subprocess creation and
     ``select.select`` in tests; these default to the real implementations.
     """

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -562,6 +562,7 @@ class ClaudeSession:
         self._work_dir = work_dir
         self._popen_fn = popen
         self._lock = threading.Lock()
+        self._queued_content: str | None = None
         self._proc = self._spawn()
         _register_child(self._proc)
 
@@ -639,6 +640,36 @@ class ClaudeSession:
         manager instead.
         """
         self.send(content)
+
+    def preempt(self, content: str) -> None:
+        """Send a control_request interrupt and queue a follow-up user turn.
+
+        Bypasses the session lock so this can be called while another thread
+        holds the lock during the in-flight turn.  The running turn receives
+        a stream-json ``control_request`` interrupt signal and should
+        complete early; *content* is saved so the next holder of the lock
+        can retrieve and send it via :meth:`take_queued_content`.
+
+        Only for preempt paths (rescope abort, CI-failure cancel).  Normal
+        turns must go through the context-manager lock.
+        """
+        msg = json.dumps({"type": "control_request", "request": {"type": "interrupt"}})
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+        self._queued_content = content
+
+    def take_queued_content(self) -> str | None:
+        """Return and clear any content queued by :meth:`preempt`.
+
+        Returns ``None`` if no preempt is pending.  Call this while holding
+        the session lock (via the context manager) so that reading and
+        clearing the queue is serialized with respect to a concurrent
+        :meth:`preempt` writing to it.
+        """
+        content = self._queued_content
+        self._queued_content = None
+        return content
 
     def switch_model(self, model: str) -> None:
         """Switch the active model by sending a /model slash command.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -638,12 +638,13 @@ class ClaudeSession:
         """
         log.warning("ClaudeSession: restarting after unexpected process death")
         _unregister_child(self._proc)
-        try:
-            self._proc.kill()
-            self._proc.wait(timeout=1.0)
-        except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
-            log.warning("ClaudeSession.restart: kill/wait failed: %s", exc)
-            raise
+        if self._proc.poll() is None:
+            try:
+                self._proc.kill()
+                self._proc.wait(timeout=1.0)
+            except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
+                log.warning("ClaudeSession.restart: kill/wait failed: %s", exc)
+                raise
         self._proc = self._spawn()
         _register_child(self._proc)
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -561,6 +561,7 @@ class ClaudeSession:
         self._system_file = system_file
         self._work_dir = work_dir
         self._popen_fn = popen
+        self._lock = threading.Lock()
         self._proc = self._spawn()
         _register_child(self._proc)
 
@@ -607,6 +608,15 @@ class ClaudeSession:
             pass
         self._proc = self._spawn()
         _register_child(self._proc)
+
+    def __enter__(self) -> "ClaudeSession":
+        """Acquire the session lock, serializing send/receive across threads."""
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Release the session lock."""
+        self._lock.release()
 
     def send(self, content: str) -> None:
         """Write a user message to the session stdin, flushing immediately."""

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -9,6 +9,7 @@ import select
 import subprocess
 import threading
 import time
+from collections import deque
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
@@ -565,7 +566,7 @@ class ClaudeSession:
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
-        self._queued_content: str | None = None
+        self._queued_content: deque[str] = deque()
         self._proc = self._spawn()
         _register_child(self._proc)
 
@@ -663,9 +664,12 @@ class ClaudeSession:
         Sets the cancel event so :meth:`iter_events` exits on its next poll
         cycle.  The lock holder's ``with session:`` block then unwinds and
         releases the lock.  This method acquires the lock (blocking until the
-        holder releases it), stores *content* as the queued follow-up turn,
-        and releases the lock.  The queued content is retrieved via
-        :meth:`take_queued_content` by the next caller that holds the lock.
+        holder releases it), appends *content* to the durable FIFO queue, and
+        releases the lock.  Multiple consecutive preempts accumulate — no
+        message is lost even if preempt is called again before the first
+        queued turn is consumed.  The queued content is retrieved one item at
+        a time via :meth:`take_queued_content` by the next caller that holds
+        the lock.
 
         Only for preempt paths (rescope abort, CI-failure cancel).  Normal
         turns must go through the context-manager lock.
@@ -673,21 +677,19 @@ class ClaudeSession:
         self._cancel.set()
         self._lock.acquire()
         try:
-            self._queued_content = content
+            self._queued_content.append(content)
         finally:
             self._lock.release()
 
     def take_queued_content(self) -> str | None:
-        """Return and clear any content queued by :meth:`preempt`.
+        """Pop and return the oldest queued preempt content, or ``None``.
 
-        Returns ``None`` if no preempt is pending.  Call this while holding
-        the session lock (via the context manager) so that reading and
-        clearing the queue is serialized with respect to a concurrent
-        :meth:`preempt` writing to it.
+        Returns ``None`` if the queue is empty.  Call this while holding the
+        session lock (via the context manager) so that reading and removing
+        from the queue is serialized with respect to a concurrent
+        :meth:`preempt` appending to it.
         """
-        content = self._queued_content
-        self._queued_content = None
-        return content
+        return self._queued_content.popleft() if self._queued_content else None
 
     def switch_model(self, model: str) -> None:
         """Switch the active model by sending a /model slash command.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -635,42 +635,43 @@ class ClaudeSession:
         self._proc.stdin.flush()
 
     def interrupt(self, content: str) -> None:
-        """Signal the in-flight turn to stop, then send a follow-up message.
+        """Signal the in-flight turn to stop, then send *content* under the lock.
 
         Sets the cancel event so :meth:`iter_events` exits on its next poll
-        cycle, causing the lock holder to finish its ``with session:`` block
-        and release the lock.  Also writes *content* to stdin as a user
-        message (bypassing the lock) so it is queued as the next turn.
+        cycle.  The lock holder's ``with session:`` block then unwinds and
+        releases the lock.  This method acquires the lock (blocking until the
+        holder releases it), sends *content* as a normal user message, and
+        releases the lock.  No stdin write ever races with the holder's writes.
 
-        This is the explicit lock-break path for preempt and interrupt use
-        cases (e.g. rescope abort, CI-failure cancel) where the lock is
-        already held by the in-flight turn and waiting for it would defeat
-        the purpose of the interrupt.  Only call from threads that have a
-        legitimate need to preempt the current holder; all normal turns
-        should go through the :meth:`__enter__` / :meth:`__exit__` context
-        manager instead.
+        For preempt/interrupt use cases (rescope abort, CI-failure cancel)
+        where the in-flight turn must be cancelled and a follow-up sent.
         """
         self._cancel.set()
-        self.send(content)
+        self._lock.acquire()
+        try:
+            self.send(content)
+        finally:
+            self._lock.release()
 
     def preempt(self, content: str) -> None:
-        """Send a control_request interrupt and queue a follow-up user turn.
+        """Signal the in-flight turn to stop and queue a follow-up user turn.
 
-        Bypasses the session lock so this can be called while another thread
-        holds the lock during the in-flight turn.  The running turn receives
-        a stream-json ``control_request`` interrupt signal and should
-        complete early; *content* is saved so the next holder of the lock
-        can retrieve and send it via :meth:`take_queued_content`.
+        Sets the cancel event so :meth:`iter_events` exits on its next poll
+        cycle.  The lock holder's ``with session:`` block then unwinds and
+        releases the lock.  This method acquires the lock (blocking until the
+        holder releases it), stores *content* as the queued follow-up turn,
+        and releases the lock.  The queued content is retrieved via
+        :meth:`take_queued_content` by the next caller that holds the lock.
 
         Only for preempt paths (rescope abort, CI-failure cancel).  Normal
         turns must go through the context-manager lock.
         """
         self._cancel.set()
-        msg = json.dumps({"type": "control_request", "request": {"type": "interrupt"}})
-        assert self._proc.stdin is not None
-        self._proc.stdin.write(msg + "\n")
-        self._proc.stdin.flush()
-        self._queued_content = content
+        self._lock.acquire()
+        try:
+            self._queued_content = content
+        finally:
+            self._lock.release()
 
     def take_queued_content(self) -> str | None:
         """Return and clear any content queued by :meth:`preempt`.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -9,9 +9,10 @@ import select
 import subprocess
 import threading
 import time
-from collections import deque
 from collections.abc import Callable, Iterator
 from pathlib import Path
+
+from kennel.state import PreemptQueue
 
 log = logging.getLogger(__name__)
 
@@ -557,6 +558,7 @@ class ClaudeSession:
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list, list, list]] = select.select,
+        preempt_queue: PreemptQueue | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -566,7 +568,7 @@ class ClaudeSession:
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
-        self._queued_content: deque[str] = deque()
+        self._preempt_queue = preempt_queue
         self._proc = self._spawn()
         _register_child(self._proc)
 
@@ -677,7 +679,10 @@ class ClaudeSession:
         self._cancel.set()
         self._lock.acquire()
         try:
-            self._queued_content.append(content)
+            assert self._preempt_queue is not None, (
+                "preempt_queue required for preempt()"
+            )
+            self._preempt_queue.push(content)
         finally:
             self._lock.release()
 
@@ -689,7 +694,10 @@ class ClaudeSession:
         from the queue is serialized with respect to a concurrent
         :meth:`preempt` appending to it.
         """
-        return self._queued_content.popleft() if self._queued_content else None
+        assert self._preempt_queue is not None, (
+            "preempt_queue required for take_queued_content()"
+        )
+        return self._preempt_queue.pop()
 
     def switch_model(self, model: str) -> None:
         """Switch the active model by sending a /model slash command.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -9,6 +9,7 @@ import select
 import subprocess
 import threading
 import time
+import uuid
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
@@ -703,20 +704,46 @@ class ClaudeSession:
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
 
+    def _send_control_interrupt(self) -> None:
+        """Write a stream-json ``control_request`` interrupt to subprocess stdin.
+
+        Tells the Claude subprocess to abort the current turn at the protocol
+        level.  The subprocess responds with a ``control_response`` on stdout
+        and then emits a ``type=result`` to close the turn.  Call this while
+        holding the session lock so it does not race with other stdin writes.
+        """
+        msg = json.dumps(
+            {
+                "type": "control_request",
+                "request_id": str(uuid.uuid4()),
+                "request": {"subtype": "interrupt"},
+            }
+        )
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+
     def interrupt(self, content: str) -> None:
-        """Signal the in-flight turn to stop, then send *content* under the lock.
+        """Interrupt the in-flight turn at the protocol level, then send *content*.
 
-        Sets the cancel event so :meth:`iter_events` exits on its next poll
-        cycle.  The lock holder's ``with session:`` block then unwinds and
-        releases the lock.  This method acquires the lock (blocking until the
-        holder releases it), sends *content* as a normal user message, and
-        releases the lock.  No stdin write ever races with the holder's writes.
+        One owner-controlled sequence while holding the lock:
 
-        For preempt/interrupt use cases (rescope abort, CI-failure cancel)
-        where the in-flight turn must be cancelled and a follow-up sent.
+        1. Sets the cancel event so any concurrent :meth:`iter_events` caller
+           exits on its next poll cycle and releases the lock.
+        2. Acquires the lock (blocks until the holder exits).
+        3. Sends a stream-json ``control_request`` interrupt so the Claude
+           subprocess aborts the current turn (not just our local reading of it).
+        4. Drains events until the turn boundary (``type=result`` /
+           ``type=error`` / EOF) so the stream is clean for the next caller.
+        5. Sends *content* as the follow-up user message.
+
+        This guarantees no unread old-turn output is left on stdout for the
+        next :meth:`iter_events` caller to inherit.
         """
         self._cancel.set()
         with self._lock:
+            self._send_control_interrupt()
+            self.consume_until_result()
             self.send(content)
 
     def preempt(self, content: str) -> None:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -208,6 +208,7 @@ def print_prompt(
         try:
             result = _claude(*args, timeout=timeout, runner=runner)
             if result.returncode != 0:
+                log.warning("print_prompt: claude exited %d", result.returncode)
                 return ""
             text = result.stdout.strip()
             if text:
@@ -221,7 +222,8 @@ def print_prompt(
                     attempt + 1,
                 )
                 _sleep(_EMPTY_RETRY_DELAY)
-        except subprocess.TimeoutExpired, FileNotFoundError:
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            log.warning("print_prompt: %s", exc)
             return ""
     log.warning("print_prompt: empty output after %d attempts", _EMPTY_RETRY_COUNT + 1)
     return ""
@@ -535,6 +537,9 @@ def generate_status_with_session(
                 runner=runner,
             )
             if result.returncode != 0:
+                log.warning(
+                    "generate_status_with_session: claude exited %d", result.returncode
+                )
                 return "", ""
             raw = result.stdout.strip()
             text = extract_result_text(raw)
@@ -552,7 +557,8 @@ def generate_status_with_session(
                     attempt + 1,
                 )
                 _sleep(_EMPTY_RETRY_DELAY)
-        except subprocess.TimeoutExpired, FileNotFoundError:
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            log.warning("generate_status_with_session: %s", exc)
             return "", ""
     log.warning(
         "generate_status_with_session: empty output after %d attempts",

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -641,8 +641,9 @@ class ClaudeSession:
         try:
             self._proc.kill()
             self._proc.wait(timeout=1.0)
-        except OSError, ProcessLookupError, subprocess.TimeoutExpired:
-            pass
+        except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
+            log.warning("ClaudeSession.restart: kill/wait failed: %s", exc)
+            raise
         self._proc = self._spawn()
         _register_child(self._proc)
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -14,6 +14,14 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+# How many seconds select.select waits for stdout before checking for
+# process exit or idle-timeout.  Short enough to react quickly, long enough
+# not to busy-loop.
+_SELECT_POLL_INTERVAL = 10.0
+
+# Maximum number of characters included when logging a raw line from the
+# claude subprocess, to keep log records readable.
+_LOG_LINE_TRUNCATE = 200
 
 # Tracked long-running claude subprocesses (the streaming ones), so kennel
 # can clean them up on shutdown.  Short-lived ``subprocess.run`` calls cap
@@ -172,8 +180,10 @@ def print_prompt(
             if text:
                 return text
             if result.stderr:
-                log.warning("print_prompt: stderr=%r", result.stderr[:200])
-            log.debug("print_prompt: stdout=%r", result.stdout[:200])
+                log.warning(
+                    "print_prompt: stderr=%r", result.stderr[:_LOG_LINE_TRUNCATE]
+                )
+            log.debug("print_prompt: stdout=%r", result.stdout[:_LOG_LINE_TRUNCATE])
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "print_prompt: empty output on attempt %d — retrying",
@@ -256,7 +266,7 @@ def _run_streaming(
         last_activity = time.monotonic()
 
         while True:
-            ready, _, _ = selector([proc.stdout], [], [], 10.0)
+            ready, _, _ = selector([proc.stdout], [], [], _SELECT_POLL_INTERVAL)
             if ready:
                 line = proc.stdout.readline()
                 if not line:
@@ -501,9 +511,13 @@ def generate_status_with_session(
                 return text, sid
             if result.stderr:
                 log.warning(
-                    "generate_status_with_session: stderr=%r", result.stderr[:200]
+                    "generate_status_with_session: stderr=%r",
+                    result.stderr[:_LOG_LINE_TRUNCATE],
                 )
-            log.debug("generate_status_with_session: stdout=%r", result.stdout[:200])
+            log.debug(
+                "generate_status_with_session: stdout=%r",
+                result.stdout[:_LOG_LINE_TRUNCATE],
+            )
             if attempt < _EMPTY_RETRY_COUNT:
                 log.warning(
                     "generate_status_with_session: empty output on attempt %d — retrying",
@@ -628,7 +642,9 @@ class ClaudeSession:
         last_activity = time.monotonic()
 
         while True:
-            ready, _, _ = self._selector([self._proc.stdout], [], [], 10.0)
+            ready, _, _ = self._selector(
+                [self._proc.stdout], [], [], _SELECT_POLL_INTERVAL
+            )
             if ready:
                 line = self._proc.stdout.readline()
                 if not line:
@@ -640,10 +656,12 @@ class ClaudeSession:
                 try:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
-                    log.warning("ClaudeSession: unparseable line: %r", line[:200])
+                    log.warning(
+                        "ClaudeSession: unparseable line: %r", line[:_LOG_LINE_TRUNCATE]
+                    )
                     last_activity = time.monotonic()
                     continue
-                log.debug("ClaudeSession event: %s", line[:200])
+                log.debug("ClaudeSession event: %s", line[:_LOG_LINE_TRUNCATE])
                 last_activity = time.monotonic()
                 yield obj
                 if obj.get("type") in ("result", "error"):

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -679,12 +679,13 @@ class ClaudeSession:
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
 
-        Also clears the cancel event so a turn that follows a preempt or
-        interrupt starts with a clean slate.  Records the current thread name
-        in :attr:`owner` so status display can show who holds the session.
+        Records the current thread name in :attr:`owner` so status display can
+        show who holds the session.  Does *not* clear the cancel event — that
+        is deferred to :meth:`iter_events` so a signal that lands between one
+        holder's :meth:`__exit__` and the next holder's :meth:`iter_events` is
+        not silently dropped.
         """
         self._lock.acquire()
-        self._cancel.clear()
         self._owner = threading.current_thread().name
         return self
 
@@ -768,6 +769,12 @@ class ClaudeSession:
     def iter_events(self) -> Iterator[dict]:
         """Yield parsed stream-json events for the current turn.
 
+        Clears the cancel event at the start so any signal that arrived during
+        the lock-handoff window (between the previous holder's :meth:`__exit__`
+        and this call) is consumed here rather than immediately aborting the
+        new turn.  After that, checks the event on each poll cycle so a
+        concurrent :meth:`interrupt` or :meth:`preempt` can abort mid-turn.
+
         Reads lines from stdout, parsing each as JSON.  Stops (and returns)
         when a ``type=result`` or ``type=error`` event is yielded, when the
         process exits (EOF), or when no output arrives for *idle_timeout*
@@ -779,6 +786,7 @@ class ClaudeSession:
         should not be silently swallowed.
         """
         assert self._proc.stdout is not None
+        self._cancel.clear()
         last_activity = time.monotonic()
 
         while True:

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -248,6 +248,16 @@ class WorkerRegistry:
         thread = self._threads.get(repo_name)
         return thread.crash_error if thread is not None else None
 
+    def get_session_owner(self, repo_name: str) -> str | None:
+        """Return the name of the thread currently holding the ClaudeSession lock.
+
+        Delegates to :attr:`~kennel.worker.WorkerThread.session_owner` on the
+        registered thread.  Returns ``None`` when no thread is registered for
+        the repo, no session exists, or the lock is currently free.
+        """
+        thread = self._threads.get(repo_name)
+        return thread.session_owner if thread is not None else None
+
 
 def _make_thread(
     repo_cfg: RepoConfig,

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -69,7 +69,7 @@ class WorkerRegistry:
         registry.stop_all()          # clean shutdown
     """
 
-    def __init__(self, thread_factory: Callable[[RepoConfig], WorkerThread]) -> None:
+    def __init__(self, thread_factory: Callable[..., WorkerThread]) -> None:
         self._threads: dict[str, WorkerThread] = {}
         self._factory = thread_factory
         self._activities: dict[str, WorkerActivity] = {}
@@ -83,8 +83,24 @@ class WorkerRegistry:
         self._webhook_lock = threading.Lock()
 
     def start(self, repo_cfg: RepoConfig) -> None:
-        """Create and start a WorkerThread for *repo_cfg*."""
-        thread = self._factory(repo_cfg)
+        """Create and start a WorkerThread for *repo_cfg*.
+
+        If a previous thread for this repo crashed (dead but not stopped
+        orderly), its live session is rescued and handed to the replacement so
+        the persistent :class:`~kennel.claude.ClaudeSession` survives the crash.
+        """
+        session = None
+        session_issue = None
+        old_thread = self._threads.get(repo_cfg.name)
+        if (
+            old_thread is not None
+            and not old_thread.is_alive()
+            and not old_thread._stop
+        ):
+            # Crashed thread — rescue the live session before replacing it
+            session, old_thread._session = old_thread._session, None
+            session_issue, old_thread._session_issue = old_thread._session_issue, None
+        thread = self._factory(repo_cfg, session=session, session_issue=session_issue)
         self._threads[repo_cfg.name] = thread
         with self._started_at_lock:
             self._started_at[repo_cfg.name] = _utcnow()
@@ -264,6 +280,8 @@ def _make_thread(
     registry: WorkerRegistry,
     *,
     gh: GitHub,
+    session=None,
+    session_issue=None,
     _WorkerThread=WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client."""
@@ -273,6 +291,8 @@ def _make_thread(
         gh,
         registry,
         repo_cfg.membership,
+        session=session,
+        session_issue=session_issue,
     )
 
 
@@ -289,8 +309,10 @@ def make_registry(
     (with a mock factory) in tests instead of calling this.
     """
 
-    def factory(cfg: RepoConfig) -> WorkerThread:
-        return _thread_factory(cfg, registry, gh=gh)
+    def factory(cfg: RepoConfig, *, session=None, session_issue=None) -> WorkerThread:
+        return _thread_factory(
+            cfg, registry, gh=gh, session=session, session_issue=session_issue
+        )
 
     registry = WorkerRegistry(factory)
     for repo_cfg in repos.values():

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -547,6 +547,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         ),
                         "worker_uptime_seconds": worker_uptime,
                         "webhook_activities": webhooks,
+                        "session_owner": self.registry.get_session_owner(a.repo_name),
                     }
                 )
             body = json.dumps(activities).encode()

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -134,36 +134,6 @@ class State(JsonFileStore):
         clear_state(self._fido_dir)
 
 
-class PreemptQueue(JsonFileStore):
-    """Durable FIFO queue for preempt content backed by a JSON file.
-
-    Survives process restarts.  Use :meth:`push` to enqueue a string and
-    :meth:`pop` to dequeue the oldest entry.  Both operations are atomic
-    under an exclusive ``flock`` via the inherited :meth:`~JsonFileStore.modify`
-    context manager.
-    """
-
-    def __init__(self, path: Path) -> None:
-        self._path = path
-
-    @property
-    def _data_path(self) -> Path:
-        return self._path
-
-    def _default(self) -> list:
-        return []
-
-    def push(self, content: str) -> None:
-        """Append *content* to the end of the queue."""
-        with self.modify() as q:
-            q.append(content)
-
-    def pop(self) -> str | None:
-        """Remove and return the oldest entry, or ``None`` if empty."""
-        with self.modify() as q:
-            return q.pop(0) if q else None
-
-
 def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
     """Return the absolute .git directory for *work_dir*."""
     result = _run(

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -134,6 +134,36 @@ class State(JsonFileStore):
         clear_state(self._fido_dir)
 
 
+class PreemptQueue(JsonFileStore):
+    """Durable FIFO queue for preempt content backed by a JSON file.
+
+    Survives process restarts.  Use :meth:`push` to enqueue a string and
+    :meth:`pop` to dequeue the oldest entry.  Both operations are atomic
+    under an exclusive ``flock`` via the inherited :meth:`~JsonFileStore.modify`
+    context manager.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def _data_path(self) -> Path:
+        return self._path
+
+    def _default(self) -> list:
+        return []
+
+    def push(self, content: str) -> None:
+        """Append *content* to the end of the queue."""
+        with self.modify() as q:
+            q.append(content)
+
+    def pop(self) -> str | None:
+        """Remove and return the oldest entry, or ``None`` if empty."""
+        with self.modify() as q:
+            return q.pop(0) if q else None
+
+
 def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
     """Return the absolute .git directory for *work_dir*."""
     result = _run(

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -47,6 +47,7 @@ class RepoStatus:
     task_total: int | None = None
     worker_uptime: int | None = None
     webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
+    session_owner: str | None = None
 
 
 @dataclass
@@ -196,6 +197,7 @@ def _fetch_activities(
                 "is_stuck": item.get("is_stuck", False),
                 "worker_uptime_seconds": item.get("worker_uptime_seconds"),
                 "webhook_activities": item.get("webhook_activities", []),
+                "session_owner": item.get("session_owner"),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -317,6 +319,7 @@ def repo_status(
     worker_stuck: bool = False,
     worker_uptime: int | None = None,
     webhook_activities: list[WebhookActivityInfo] | None = None,
+    session_owner: str | None = None,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     webhook_activities = list(webhook_activities or [])
@@ -343,6 +346,7 @@ def repo_status(
             last_crash_error=last_crash_error,
             worker_stuck=worker_stuck,
             webhook_activities=webhook_activities,
+            session_owner=session_owner,
         )
 
     fido_dir = git_dir / "fido"
@@ -388,6 +392,7 @@ def repo_status(
         last_crash_error=last_crash_error,
         worker_stuck=worker_stuck,
         webhook_activities=webhook_activities,
+        session_owner=session_owner,
     )
 
 
@@ -427,6 +432,7 @@ def collect() -> KennelStatus:
                 worker_stuck=info["is_stuck"] if info else False,
                 worker_uptime=worker_uptime_val,
                 webhook_activities=webhook_list,
+                session_owner=info.get("session_owner") if info else None,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
@@ -497,8 +503,13 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
 
     if repo.claude_pid is not None:
         claude_str = f"  └─ claude pid {repo.claude_pid}"
+        parts: list[str] = []
         if repo.claude_uptime is not None:
-            claude_str += f" (running {_format_uptime(repo.claude_uptime)})"
+            parts.append(f"running {_format_uptime(repo.claude_uptime)}")
+        if repo.session_owner is not None:
+            parts.append(f"held by {repo.session_owner}")
+        if parts:
+            claude_str += f" ({', '.join(parts)})"
         body.append(claude_str)
 
     for w in repo.webhook_activities:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -678,6 +678,7 @@ class Worker:
         registry: ActivityReporter | None = None,
         membership: RepoMembership | None = None,
         session: claude.ClaudeSession | None = None,
+        session_issue: int | None = None,
         _tasks: Tasks | None = None,
     ) -> None:
         self.work_dir = work_dir
@@ -687,6 +688,7 @@ class Worker:
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
         self._session: claude.ClaudeSession | None = session
+        self._session_issue: int | None = session_issue
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
 
     def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
@@ -1829,6 +1831,17 @@ class Worker:
                 if issue is None:
                     return 0
 
+                if not session_fresh and issue != self._session_issue:
+                    log.info(
+                        "worker: new issue #%s — restarting session at issue boundary",
+                        issue,
+                    )
+                    assert self._session is not None
+                    self._session.restart()
+                    self._session.switch_model("claude-opus-4-6")
+                    session_fresh = True
+                self._session_issue = issue
+
                 issue_data = self.gh.view_issue(repo_ctx.repo, issue)
                 issue_title = issue_data["title"]
                 issue_body = issue_data.get("body", "") or ""
@@ -1892,6 +1905,7 @@ class WorkerThread(threading.Thread):
         self._stop = False
         self.crash_error: str | None = None
         self._session: claude.ClaudeSession | None = None
+        self._session_issue: int | None = None
 
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
@@ -1922,11 +1936,13 @@ class WorkerThread(threading.Thread):
                     self._registry,
                     self._membership,
                     session=self._session,
+                    session_issue=self._session_issue,
                 )
                 try:
                     result = worker.run()
                 finally:
                     self._session = worker._session
+                    self._session_issue = worker._session_issue
 
                 if result == 1:
                     # Did work — loop immediately without waiting.

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1223,7 +1223,7 @@ class Worker:
             f" (JSON — may be empty):\n{json.dumps(ci_threads)}"
         )
         build_prompt(fido_dir, "ci", context)
-        session_id, _ = claude_run(fido_dir, cwd=self.work_dir)
+        session_id, _ = claude_run(fido_dir, cwd=self.work_dir, session=self._session)
         log.info("CI fix done (session=%s)", session_id)
 
         # CI failures have no task entry — no complete call needed
@@ -1347,7 +1347,7 @@ class Worker:
             f"\nUnresolved threads (JSON):\n{json.dumps({'threads': threads})}"
         )
         build_prompt(fido_dir, "comments", context)
-        session_id, _ = claude_run(fido_dir, cwd=self.work_dir)
+        session_id, _ = claude_run(fido_dir, cwd=self.work_dir, session=self._session)
         log.info("threads done (session=%s)", session_id)
         tasks.sync_tasks_background(self.work_dir, self.gh)
         return True

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -20,7 +20,6 @@ from kennel.config import RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts, rewrite_description_prompt
 from kennel.state import (
-    PreemptQueue,
     State,
     _resolve_git_dir,
 )
@@ -730,16 +729,12 @@ class Worker:
         hooks.remove_hooks(self.work_dir, compact_cmd, sync_cmd)
         (fido_dir / "compact.sh").unlink(missing_ok=True)
 
-    def create_session(self, fido_dir: Path) -> None:
+    def create_session(self) -> None:
         """Start a persistent ClaudeSession for this work iteration.
 
         Uses the fido persona as the session system prompt.  Task-specific
         instructions are delivered via user messages in later phases.
         Stores the session on ``self._session`` so worker methods can access it.
-
-        The session is given a :class:`~kennel.state.PreemptQueue` backed by
-        ``fido_dir/preempt.json`` so queued preempt content survives process
-        restarts.
 
         Immediately switches to Opus for the planning phase; the caller is
         responsible for switching to Sonnet once planning is complete.
@@ -748,7 +743,6 @@ class Worker:
         self._session = claude.ClaudeSession(
             persona_file,
             work_dir=self.work_dir,
-            preempt_queue=PreemptQueue(fido_dir / "preempt.json"),
         )
         self._session.switch_model("claude-opus-4-6")
 
@@ -1823,7 +1817,7 @@ class Worker:
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
             session_fresh = self._session is None
             if session_fresh:
-                self.create_session(ctx.fido_dir)
+                self.create_session()
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -676,6 +676,7 @@ class Worker:
         repo_name: str = "",
         registry: ActivityReporter | None = None,
         membership: RepoMembership | None = None,
+        session: claude.ClaudeSession | None = None,
         _tasks: Tasks | None = None,
     ) -> None:
         self.work_dir = work_dir
@@ -684,8 +685,8 @@ class Worker:
         self._repo_name = repo_name
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
+        self._session: claude.ClaudeSession | None = session
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
-        self._session: claude.ClaudeSession | None = None
 
     def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
         """Return the absolute .git directory for self.work_dir."""
@@ -1814,7 +1815,9 @@ class Worker:
             )
 
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
-            self.create_session(ctx.fido_dir, model="claude-opus-4-6")
+            session_fresh = self._session is None
+            if session_fresh:
+                self.create_session(ctx.fido_dir, model="claude-opus-4-6")
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:
@@ -1832,7 +1835,7 @@ class Worker:
                     ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
                 )
                 self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
-                if self._session is not None:
+                if session_fresh and self._session is not None:
                     self._session.switch_model("claude-sonnet-4-6")
                 self._ensure_session_alive(ctx.fido_dir)
                 if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
@@ -1846,7 +1849,6 @@ class Worker:
                     ctx.fido_dir, repo_ctx, pr_number, slug, issue
                 )
             finally:
-                self.stop_session()
                 self.teardown_hooks(ctx.fido_dir, compact_cmd, sync_cmd)
 
 
@@ -1885,6 +1887,7 @@ class WorkerThread(threading.Thread):
         self._abort_task = threading.Event()
         self._stop = False
         self.crash_error: str | None = None
+        self._session: claude.ClaudeSession | None = None
 
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
@@ -1907,14 +1910,19 @@ class WorkerThread(threading.Thread):
             while not self._stop:
                 if self._registry is not None:
                     self._registry.report_activity(self._repo_name, "idle", busy=False)
-                result = Worker(
+                worker = Worker(
                     self.work_dir,
                     self._gh,
                     self._abort_task,
                     self._repo_name,
                     self._registry,
                     self._membership,
-                ).run()
+                    session=self._session,
+                )
+                try:
+                    result = worker.run()
+                finally:
+                    self._session = worker._session
 
                 if result == 1:
                     # Did work — loop immediately without waiting.
@@ -1927,6 +1935,10 @@ class WorkerThread(threading.Thread):
             self.crash_error = f"{type(exc).__name__}: {exc}"
             log.exception("WorkerThread %s: unexpected error", self.name)
             raise
+        finally:
+            if self._session is not None:
+                self._session.stop()
+                self._session = None
 
 
 def run(work_dir: Path, *, _GitHub: type[GitHub] = GitHub) -> int:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -232,18 +232,28 @@ def claude_run(
     model: str = "claude-sonnet-4-6",
     timeout: int = 300,
     cwd: Path | str | None = None,
+    session: claude.ClaudeSession | None = None,
 ) -> tuple[str, str]:
     """Continue or start a sub-Claude session, streaming progress as JSON.
 
-    If *session_id* is non-empty the existing session is resumed via
-    ``claude --resume``.  Otherwise a new session is started from
-    *fido_dir/system* and *fido_dir/prompt*.
+    When *session* is provided the prompt is sent through the persistent
+    session (via :meth:`~claude.ClaudeSession.send` +
+    :meth:`~claude.ClaudeSession.consume_until_result`) and ``("", "")``
+    is returned — there is no subprocess session_id to track.
 
-    Returns ``(session_id, raw_output)`` where *raw_output* is the full
-    stream-json text produced by the claude CLI.  Raises
-    ``ClaudeStreamError`` or ``FileNotFoundError`` on subprocess failure —
-    these propagate to the worker's crash handler.
+    When *session* is ``None``: if *session_id* is non-empty the existing
+    session is resumed via ``claude --resume``; otherwise a new session is
+    started from *fido_dir/system* and *fido_dir/prompt*.  Returns
+    ``(session_id, raw_output)`` where *raw_output* is the full stream-json
+    text.  Raises ``ClaudeStreamError`` or ``FileNotFoundError`` on
+    subprocess failure — these propagate to the worker's crash handler.
     """
+    if session is not None:
+        prompt = (fido_dir / "prompt").read_text()
+        with session:
+            session.send(prompt)
+            session.consume_until_result()
+        return "", ""
     prompt_file = fido_dir / "prompt"
     if session_id:
         output = claude.resume_session(session_id, prompt_file, model, timeout, cwd=cwd)
@@ -1481,7 +1491,10 @@ class Worker:
             setup_session_id = state.get("setup_session_id", "")
             state["current_task_id"] = task["id"]
         session_id, output = claude_run(
-            fido_dir, session_id=setup_session_id, cwd=self.work_dir
+            fido_dir,
+            session_id=setup_session_id,
+            cwd=self.work_dir,
+            session=self._session,
         )
         log.info("task done (session=%s)", session_id)
         head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
@@ -1525,14 +1538,19 @@ class Worker:
                     attempt,
                 )
                 session_id, output = claude_run(
-                    fido_dir, session_id=session_id, cwd=self.work_dir
+                    fido_dir,
+                    session_id=session_id,
+                    cwd=self.work_dir,
+                    session=self._session,
                 )
             else:
                 log.info(
                     "task produced no commits — fresh session with nudge (attempt %d)",
                     attempt,
                 )
-                session_id, output = claude_run(fido_dir, cwd=self.work_dir)
+                session_id, output = claude_run(
+                    fido_dir, cwd=self.work_dir, session=self._session
+                )
             log.info("task resume done (session=%s)", session_id)
             head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -228,7 +228,6 @@ def claude_start(
 
 def claude_run(
     fido_dir: Path,
-    session_id: str = "",
     model: str = "claude-sonnet-4-6",
     timeout: int = 300,
     cwd: Path | str | None = None,
@@ -239,14 +238,13 @@ def claude_run(
     When *session* is provided the prompt is sent through the persistent
     session (via :meth:`~claude.ClaudeSession.send` +
     :meth:`~claude.ClaudeSession.consume_until_result`) and ``("", "")``
-    is returned — there is no subprocess session_id to track.
+    is returned.
 
-    When *session* is ``None``: if *session_id* is non-empty the existing
-    session is resumed via ``claude --resume``; otherwise a new session is
-    started from *fido_dir/system* and *fido_dir/prompt*.  Returns
-    ``(session_id, raw_output)`` where *raw_output* is the full stream-json
-    text.  Raises ``ClaudeStreamError`` or ``FileNotFoundError`` on
-    subprocess failure — these propagate to the worker's crash handler.
+    When *session* is ``None`` a new session is started from *fido_dir/system*
+    and *fido_dir/prompt*.  Returns ``(session_id, raw_output)`` where
+    *raw_output* is the full stream-json text.  Raises ``ClaudeStreamError``
+    or ``FileNotFoundError`` on subprocess failure — these propagate to the
+    worker's crash handler.
     """
     if session is not None:
         prompt = (fido_dir / "prompt").read_text()
@@ -254,11 +252,8 @@ def claude_run(
             session.send(prompt)
             session.consume_until_result()
         return "", ""
-    prompt_file = fido_dir / "prompt"
-    if session_id:
-        output = claude.resume_session(session_id, prompt_file, model, timeout, cwd=cwd)
-        return session_id, output
     system_file = fido_dir / "system"
+    prompt_file = fido_dir / "prompt"
     output = claude.print_prompt_from_file(
         system_file, prompt_file, model, timeout, cwd=cwd
     )
@@ -480,13 +475,6 @@ def _has_pending_asks(task_list: list[dict[str, Any]]) -> bool:
 
 
 _DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
-
-# Number of session-resume attempts with escalating nudges before we
-# abandon the stale session and start a fresh one.  Resuming the same
-# session forever can get stuck in a rut where claude keeps replying
-# with the same "nothing to do" no matter how hard we nudge; rebuilding
-# the context from scratch usually unsticks it.  See #452.
-_NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION: int = 5
 
 
 def _no_commit_nudge(
@@ -1032,12 +1020,7 @@ class Worker:
                     f"Work dir: {self.work_dir}"
                 )
                 build_prompt(fido_dir, "setup", context)
-                session_id = claude_start(
-                    fido_dir, cwd=self.work_dir, session=self._session
-                )
-                log.info("setup session: %s", session_id)
-                with State(fido_dir).modify() as state:
-                    state["setup_session_id"] = session_id
+                claude_start(fido_dir, cwd=self.work_dir, session=self._session)
                 if not self._tasks.list():
                     raise RuntimeError(f"setup produced no tasks for PR #{pr_number}")
             log.info(
@@ -1079,10 +1062,7 @@ class Worker:
             f"Work dir: {self.work_dir}"
         )
         build_prompt(fido_dir, "setup", context)
-        session_id = claude_start(fido_dir, cwd=self.work_dir, session=self._session)
-        log.info("setup session: %s", session_id)
-        with State(fido_dir).modify() as state:
-            state["setup_session_id"] = session_id
+        claude_start(fido_dir, cwd=self.work_dir, session=self._session)
 
         if not self._tasks.list():
             raise RuntimeError("setup produced no tasks")
@@ -1488,11 +1468,9 @@ class Worker:
         build_prompt(fido_dir, "task", context)
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
         with State(fido_dir).modify() as state:
-            setup_session_id = state.get("setup_session_id", "")
             state["current_task_id"] = task["id"]
         session_id, output = claude_run(
             fido_dir,
-            session_id=setup_session_id,
             cwd=self.work_dir,
             session=self._session,
         )
@@ -1519,48 +1497,25 @@ class Worker:
                 )
                 break
             attempt += 1
-            # After _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION nudges fail, drop
-            # the stale session and start a fresh one.  Do not give up on
-            # the task — just reset context and keep going.
-            if session_id and attempt > _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION:
-                log.warning(
-                    "task produced no commits after %d nudges — starting fresh session",
-                    _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION,
-                )
-                session_id = ""
             nudge = _no_commit_nudge(
                 attempt, task_title, task["id"], self.work_dir, pr_number
             )
             (fido_dir / "prompt").write_text(nudge)
-            if session_id:
-                log.info(
-                    "task produced no commits — nudging session (attempt %d)",
-                    attempt,
-                )
-                session_id, output = claude_run(
-                    fido_dir,
-                    session_id=session_id,
-                    cwd=self.work_dir,
-                    session=self._session,
-                )
-            else:
-                log.info(
-                    "task produced no commits — fresh session with nudge (attempt %d)",
-                    attempt,
-                )
-                session_id, output = claude_run(
-                    fido_dir, cwd=self.work_dir, session=self._session
-                )
+            log.info(
+                "task produced no commits — nudging session (attempt %d)",
+                attempt,
+            )
+            session_id, output = claude_run(
+                fido_dir,
+                cwd=self.work_dir,
+                session=self._session,
+            )
             log.info("task resume done (session=%s)", session_id)
             head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
 
             if self._abort_task.is_set():
                 self._cleanup_aborted_task(fido_dir, task["id"], task_title)
                 return True
-
-        if session_id:
-            with State(fido_dir).modify() as state:
-                state["setup_session_id"] = session_id
 
         self._squash_wip_commit("origin", slug, repo_ctx.default_branch)
         pushed = self.ensure_pushed("origin", slug)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -726,7 +726,11 @@ class Worker:
         hooks.remove_hooks(self.work_dir, compact_cmd, sync_cmd)
         (fido_dir / "compact.sh").unlink(missing_ok=True)
 
-    def create_session(self, fido_dir: Path) -> None:  # noqa: ARG002
+    def create_session(
+        self,
+        fido_dir: Path,  # noqa: ARG002
+        model: str = "claude-sonnet-4-6",
+    ) -> None:
         """Start a persistent ClaudeSession for this work iteration.
 
         Uses the fido persona as the session system prompt.  Task-specific
@@ -737,7 +741,9 @@ class Worker:
         but is not used at this stage.
         """
         persona_file = _sub_dir() / "persona.md"
-        self._session = claude.ClaudeSession(persona_file, work_dir=self.work_dir)
+        self._session = claude.ClaudeSession(
+            persona_file, work_dir=self.work_dir, model=model
+        )
 
     def stop_session(self) -> None:
         """Stop the ClaudeSession if one is running, then clear it.
@@ -1808,7 +1814,7 @@ class Worker:
             )
 
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
-            self.create_session(ctx.fido_dir)
+            self.create_session(ctx.fido_dir, model="claude-opus-4-6")
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:
@@ -1826,6 +1832,8 @@ class Worker:
                     ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
                 )
                 self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
+                if self._session is not None:
+                    self._session.switch_model("claude-sonnet-4-6")
                 self._ensure_session_alive(ctx.fido_dir)
                 if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -737,6 +737,20 @@ class Worker:
             self._session.stop()
             self._session = None
 
+    def _ensure_session_alive(self, fido_dir: Path) -> None:  # noqa: ARG002
+        """Restart the session if the claude process has died unexpectedly.
+
+        Called before each work phase (CI, threads, task execution) so tasks
+        are never lost because the session died between iterations.  No-op
+        when the session is healthy or not yet created.
+
+        *fido_dir* is accepted for future use (e.g. writing per-phase context
+        into the session system file) but is not used at this stage.
+        """
+        if self._session is not None and not self._session.is_alive():
+            log.warning("worker: ClaudeSession died — restarting before next phase")
+            self._session.restart()
+
     # ------------------------------------------------------------------
     # Business logic
     # ------------------------------------------------------------------
@@ -1824,6 +1838,7 @@ class Worker:
                     ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
                 )
                 self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
+                self._ensure_session_alive(ctx.fido_dir)
                 if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1
                 if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -674,6 +674,7 @@ class Worker:
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
+        self._session: claude.ClaudeSession | None = None
 
     def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
         """Return the absolute .git directory for self.work_dir."""
@@ -713,6 +714,28 @@ class Worker:
         """Remove hooks and the compact script created by setup_hooks."""
         hooks.remove_hooks(self.work_dir, compact_cmd, sync_cmd)
         (fido_dir / "compact.sh").unlink(missing_ok=True)
+
+    def create_session(self, fido_dir: Path) -> None:  # noqa: ARG002
+        """Start a persistent ClaudeSession for this work iteration.
+
+        Uses the fido persona as the session system prompt.  Task-specific
+        instructions are delivered via user messages in later phases.
+        Stores the session on ``self._session`` so worker methods can access it.
+
+        *fido_dir* is accepted for future use (e.g. per-issue session files)
+        but is not used at this stage.
+        """
+        persona_file = _sub_dir() / "persona.md"
+        self._session = claude.ClaudeSession(persona_file, work_dir=self.work_dir)
+
+    def stop_session(self) -> None:
+        """Stop the ClaudeSession if one is running, then clear it.
+
+        Safe to call when no session has been created (no-op).
+        """
+        if self._session is not None:
+            self._session.stop()
+            self._session = None
 
     # ------------------------------------------------------------------
     # Business logic
@@ -1783,6 +1806,7 @@ class Worker:
             )
 
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
+            self.create_session(ctx.fido_dir)
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:
@@ -1811,6 +1835,7 @@ class Worker:
                     ctx.fido_dir, repo_ctx, pr_number, slug, issue
                 )
             finally:
+                self.stop_session()
                 self.teardown_hooks(ctx.fido_dir, compact_cmd, sync_cmd)
 
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1907,6 +1907,17 @@ class WorkerThread(threading.Thread):
         self._session: claude.ClaudeSession | None = None
         self._session_issue: int | None = None
 
+    @property
+    def session_owner(self) -> str | None:
+        """Name of the thread currently holding the ClaudeSession lock, or ``None``.
+
+        Delegates to :attr:`~kennel.claude.ClaudeSession.owner` on the active
+        session.  Returns ``None`` when no session exists or the lock is free.
+        Safe to call from any thread — reads a volatile field for display only.
+        """
+        session = self._session
+        return session.owner if session is not None else None
+
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -728,11 +728,7 @@ class Worker:
         hooks.remove_hooks(self.work_dir, compact_cmd, sync_cmd)
         (fido_dir / "compact.sh").unlink(missing_ok=True)
 
-    def create_session(
-        self,
-        fido_dir: Path,
-        model: str = "claude-sonnet-4-6",
-    ) -> None:
+    def create_session(self, fido_dir: Path) -> None:
         """Start a persistent ClaudeSession for this work iteration.
 
         Uses the fido persona as the session system prompt.  Task-specific
@@ -742,14 +738,17 @@ class Worker:
         The session is given a :class:`~kennel.state.PreemptQueue` backed by
         ``fido_dir/preempt.json`` so queued preempt content survives process
         restarts.
+
+        Immediately switches to Opus for the planning phase; the caller is
+        responsible for switching to Sonnet once planning is complete.
         """
         persona_file = _sub_dir() / "persona.md"
         self._session = claude.ClaudeSession(
             persona_file,
             work_dir=self.work_dir,
-            model=model,
             preempt_queue=PreemptQueue(fido_dir / "preempt.json"),
         )
+        self._session.switch_model("claude-opus-4-6")
 
     def stop_session(self) -> None:
         """Stop the ClaudeSession if one is running, then clear it.
@@ -1822,7 +1821,7 @@ class Worker:
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
             session_fresh = self._session is None
             if session_fresh:
-                self.create_session(ctx.fido_dir, model="claude-opus-4-6")
+                self.create_session(ctx.fido_dir)
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -20,6 +20,7 @@ from kennel.config import RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts, rewrite_description_prompt
 from kennel.state import (
+    PreemptQueue,
     State,
     _resolve_git_dir,
 )
@@ -729,7 +730,7 @@ class Worker:
 
     def create_session(
         self,
-        fido_dir: Path,  # noqa: ARG002
+        fido_dir: Path,
         model: str = "claude-sonnet-4-6",
     ) -> None:
         """Start a persistent ClaudeSession for this work iteration.
@@ -738,12 +739,16 @@ class Worker:
         instructions are delivered via user messages in later phases.
         Stores the session on ``self._session`` so worker methods can access it.
 
-        *fido_dir* is accepted for future use (e.g. per-issue session files)
-        but is not used at this stage.
+        The session is given a :class:`~kennel.state.PreemptQueue` backed by
+        ``fido_dir/preempt.json`` so queued preempt content survives process
+        restarts.
         """
         persona_file = _sub_dir() / "persona.md"
         self._session = claude.ClaudeSession(
-            persona_file, work_dir=self.work_dir, model=model
+            persona_file,
+            work_dir=self.work_dir,
+            model=model,
+            preempt_queue=PreemptQueue(fido_dir / "preempt.json"),
         )
 
     def stop_session(self) -> None:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -197,14 +197,27 @@ def claude_start(
     model: str = "claude-opus-4-6",
     timeout: int = 300,
     cwd: Path | str | None = None,
+    session: claude.ClaudeSession | None = None,
 ) -> str:
     """Start a new sub-Claude session from fido_dir/system and fido_dir/prompt.
 
-    Returns the session_id extracted from stream-json output, or an empty
-    string if the session_id is absent from the output.  Raises
-    ``ClaudeStreamError`` or ``FileNotFoundError`` on subprocess failure —
-    these propagate to the worker's crash handler.
+    When *session* is provided the setup prompt is sent through the
+    persistent session (via :meth:`~claude.ClaudeSession.send` +
+    :meth:`~claude.ClaudeSession.consume_until_result`) and an empty string
+    is returned — there is no subprocess session_id to track.
+
+    When *session* is ``None`` a fresh subprocess is spawned via
+    ``claude.print_prompt_from_file`` and the session_id extracted from its
+    stream-json output is returned.  Raises ``ClaudeStreamError`` or
+    ``FileNotFoundError`` on subprocess failure — these propagate to the
+    worker's crash handler.
     """
+    if session is not None:
+        prompt = (fido_dir / "prompt").read_text()
+        with session:
+            session.send(prompt)
+            session.consume_until_result()
+        return ""
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
     output = claude.print_prompt_from_file(
@@ -1009,7 +1022,9 @@ class Worker:
                     f"Work dir: {self.work_dir}"
                 )
                 build_prompt(fido_dir, "setup", context)
-                session_id = claude_start(fido_dir, cwd=self.work_dir)
+                session_id = claude_start(
+                    fido_dir, cwd=self.work_dir, session=self._session
+                )
                 log.info("setup session: %s", session_id)
                 with State(fido_dir).modify() as state:
                     state["setup_session_id"] = session_id
@@ -1054,7 +1069,7 @@ class Worker:
             f"Work dir: {self.work_dir}"
         )
         build_prompt(fido_dir, "setup", context)
-        session_id = claude_start(fido_dir, cwd=self.work_dir)
+        session_id = claude_start(fido_dir, cwd=self.work_dir, session=self._session)
         log.info("setup session: %s", session_id)
         with State(fido_dir).modify() as state:
             state["setup_session_id"] = session_id

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1884,6 +1884,19 @@ class WorkerThread(threading.Thread):
 
     Call :meth:`wake` to interrupt any wait early (e.g. when a webhook arrives).
     Call :meth:`stop` to request a clean shutdown.
+
+    **Session persistence**
+
+    ``_session`` and ``_session_issue`` survive individual :class:`Worker`
+    crashes: each new ``Worker`` receives the existing session via the
+    constructor and hands it back after ``run()`` returns (even on exception).
+    The watchdog then restarts this thread, which will again inherit whatever
+    session remains.
+
+    Neither ``_session`` nor ``_session_issue`` survive a kennel/home restart
+    — ``os.execvp`` replaces the process, so a new ``WorkerThread`` starts
+    with both fields set to ``None`` and creates a fresh session on its first
+    iteration.
     """
 
     def __init__(

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1890,8 +1890,10 @@ class WorkerThread(threading.Thread):
     ``_session`` and ``_session_issue`` survive individual :class:`Worker`
     crashes: each new ``Worker`` receives the existing session via the
     constructor and hands it back after ``run()`` returns (even on exception).
-    The watchdog then restarts this thread, which will again inherit whatever
-    session remains.
+    When this thread itself crashes, :class:`~kennel.registry.WorkerRegistry`
+    rescues the live session from the dead thread and passes it to the
+    replacement thread via the *session* constructor parameter, so the session
+    persists across both Worker-level and WorkerThread-level crashes.
 
     Neither ``_session`` nor ``_session_issue`` survive a kennel/home restart
     — ``os.execvp`` replaces the process, so a new ``WorkerThread`` starts
@@ -1906,6 +1908,8 @@ class WorkerThread(threading.Thread):
         gh: GitHub,
         registry: ActivityReporter | None = None,
         membership: RepoMembership | None = None,
+        session: claude.ClaudeSession | None = None,
+        session_issue: int | None = None,
     ) -> None:
         super().__init__(name=f"worker-{work_dir.name}", daemon=True)
         self.work_dir = work_dir
@@ -1917,8 +1921,8 @@ class WorkerThread(threading.Thread):
         self._abort_task = threading.Event()
         self._stop = False
         self.crash_error: str | None = None
-        self._session: claude.ClaudeSession | None = None
-        self._session_issue: int | None = None
+        self._session: claude.ClaudeSession | None = session
+        self._session_issue: int | None = session_issue
 
     @property
     def session_owner(self) -> str | None:
@@ -1980,7 +1984,9 @@ class WorkerThread(threading.Thread):
             log.exception("WorkerThread %s: unexpected error", self.name)
             raise
         finally:
-            if self._session is not None:
+            # Only stop the session on orderly shutdown — a crashed thread
+            # leaves it alive so the registry can hand it to the replacement.
+            if self._stop and self._session is not None:
                 self._session.stop()
                 self._session = None
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1345,6 +1345,20 @@ class TestClaudeSessionIterEvents:
         assert exc_info.value.returncode == -1
         proc.kill.assert_called()
 
+    def test_stops_immediately_when_cancel_set(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=None)  # never exits
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
+        session._cancel.set()
+        events = list(session.iter_events())
+        assert events == []
+        fake_selector.assert_not_called()  # cancel check fires before select
+        session.stop()
+
 
 class TestClaudeSessionStop:
     def test_closes_stdin_and_waits(self, tmp_path: Path) -> None:
@@ -1612,6 +1626,14 @@ class TestClaudeSessionLock:
         session._lock.release()
         session.stop()
 
+    def test_enter_clears_cancel_event(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        session._cancel.set()
+        session.__enter__()
+        assert not session._cancel.is_set()
+        session._lock.release()
+        session.stop()
+
     def test_exit_releases_lock(self, tmp_path: Path) -> None:
         session = _make_session(tmp_path, _make_session_proc([]))
         session.__enter__()
@@ -1674,6 +1696,14 @@ class TestClaudeSessionInterrupt:
             session._lock.release()
         session.stop()
 
+    def test_interrupt_sets_cancel_event(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert not session._cancel.is_set()
+        session.interrupt("stop")
+        assert session._cancel.is_set()
+        session.stop()
+
 
 class TestClaudeSessionPreempt:
     def test_preempt_writes_control_request_to_stdin(self, tmp_path: Path) -> None:
@@ -1714,4 +1744,12 @@ class TestClaudeSessionPreempt:
         session.preempt("once")
         session.take_queued_content()
         assert session.take_queued_content() is None
+        session.stop()
+
+    def test_preempt_sets_cancel_event(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert not session._cancel.is_set()
+        session.preempt("follow up")
+        assert session._cancel.is_set()
         session.stop()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1405,12 +1405,13 @@ class TestClaudeSessionStop:
         session.stop(grace_seconds=0.0)
         proc.kill.assert_called()
 
-    def test_logs_oserror_on_stdin_close(self, tmp_path: Path, caplog) -> None:
+    def test_raises_oserror_on_stdin_close(self, tmp_path: Path, caplog) -> None:
         proc = _make_session_proc([])
         proc.stdin.close = MagicMock(side_effect=OSError("broken pipe"))
         session = _make_session(tmp_path, proc)
         with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            session.stop()  # must not raise
+            with pytest.raises(OSError):
+                session.stop()
         assert any("stdin close failed" in r.message for r in caplog.records)
 
     def test_logs_oserror_on_wait(self, tmp_path: Path, caplog) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1700,6 +1700,26 @@ class TestClaudeSessionLock:
         session._lock.release()
         session.stop()
 
+    def test_owner_none_when_lock_free(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        assert session.owner is None
+        session.stop()
+
+    def test_owner_set_to_thread_name_while_held(self, tmp_path: Path) -> None:
+        import threading as _threading
+
+        session = _make_session(tmp_path, _make_session_proc([]))
+        with session:
+            assert session.owner == _threading.current_thread().name
+        session.stop()
+
+    def test_owner_cleared_after_exit(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        with session:
+            pass
+        assert session.owner is None
+        session.stop()
+
     def test_context_manager_blocks_second_thread(self, tmp_path: Path) -> None:
         import threading as _threading
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1403,3 +1403,33 @@ class TestClaudeSessionStop:
         session.stop()
         proc.stdin.close.assert_not_called()
         proc.wait.assert_called()
+
+
+class TestClaudeSessionSwitchModel:
+    def test_sends_model_slash_command(self, tmp_path: Path) -> None:
+        import json as _json
+
+        result_line = _json.dumps({"type": "result", "result": ""}) + "\n"
+        proc = _make_session_proc([result_line])
+        session = _make_session(tmp_path, proc)
+        session.switch_model("claude-opus-4-6")
+        written = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(written.strip())
+        assert obj["message"]["content"] == "/model claude-opus-4-6"
+
+    def test_drains_response_events(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "assistant", "text": "Switching..."}) + "\n",
+            _json.dumps({"type": "result", "result": ""}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        # Must not raise or leave unread events blocking future reads
+        session.switch_model("claude-sonnet-4-6")
+
+    def test_works_when_command_produces_no_output(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])  # immediate EOF
+        session = _make_session(tmp_path, proc)
+        session.switch_model("claude-haiku-4-5-20251001")  # must not raise

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1433,3 +1433,50 @@ class TestClaudeSessionSwitchModel:
         proc = _make_session_proc([])  # immediate EOF
         session = _make_session(tmp_path, proc)
         session.switch_model("claude-haiku-4-5-20251001")  # must not raise
+
+
+class TestClaudeSessionConsumeUntilResult:
+    def test_returns_result_text(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "assistant", "text": "thinking..."}) + "\n",
+            _json.dumps({"type": "result", "result": "all done"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        assert session.consume_until_result() == "all done"
+
+    def test_returns_empty_on_eof_without_result(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert session.consume_until_result() == ""
+
+    def test_returns_empty_on_error_event(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [_json.dumps({"type": "error", "error": "something broke"}) + "\n"]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        assert session.consume_until_result() == ""
+
+    def test_returns_empty_when_result_field_not_a_string(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [_json.dumps({"type": "result", "result": None}) + "\n"]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        assert session.consume_until_result() == ""
+
+    def test_drains_all_intermediate_events(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "system", "subtype": "init"}) + "\n",
+            _json.dumps({"type": "assistant", "text": "a"}) + "\n",
+            _json.dumps({"type": "assistant", "text": "b"}) + "\n",
+            _json.dumps({"type": "result", "result": "output"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        assert session.consume_until_result() == "output"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1317,19 +1317,14 @@ class TestClaudeSessionIterEvents:
         assert len(events) == 1
         assert events[0]["type"] == "result"
 
-    def test_skips_unparseable_lines(self, tmp_path: Path, caplog) -> None:
+    def test_raises_on_unparseable_line(self, tmp_path: Path) -> None:
         import json as _json
 
-        lines = [
-            "not json at all\n",
-            _json.dumps({"type": "result", "result": "ok"}) + "\n",
-        ]
+        lines = ["not json at all\n"]
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
-        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            events = list(session.iter_events())
-        assert any("unparseable" in r.message for r in caplog.records)
-        assert len(events) == 1
+        with pytest.raises(_json.JSONDecodeError):
+            list(session.iter_events())
 
     def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1650,3 +1650,26 @@ class TestClaudeSessionLock:
         t2.join(timeout=2)
         assert could_not_acquire.is_set()
         session.stop()
+
+
+class TestClaudeSessionInterrupt:
+    def test_interrupt_writes_json_to_stdin(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.interrupt("abort now")
+        written = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(written.strip())
+        assert obj["type"] == "user"
+        assert obj["message"]["content"] == "abort now"
+
+    def test_interrupt_bypasses_held_lock(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._lock.acquire()
+        try:
+            session.interrupt("urgent")  # must not block or raise
+        finally:
+            session._lock.release()
+        session.stop()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -32,7 +32,6 @@ from kennel.claude import (
     resume_status,
     triage_comment,
 )
-from kennel.state import PreemptQueue
 
 
 def _completed(
@@ -1179,7 +1178,6 @@ def _make_session(
         idle_timeout=idle_timeout,
         popen=fake_popen,
         selector=fake_selector,
-        preempt_queue=PreemptQueue(tmp_path / "preempt.json"),
     )
 
 
@@ -1968,82 +1966,4 @@ class TestClaudeSessionInterrupt:
         t_interrupt.join(timeout=2)
 
         assert proc.stdin.write.call_count > 0
-        session.stop()
-
-
-class TestClaudeSessionPreempt:
-    def test_preempt_queues_content(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session.preempt("handle ci failure")
-        assert session.take_queued_content() == "handle ci failure"
-
-    def test_preempt_does_not_write_to_stdin(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session.preempt("follow up")
-        proc.stdin.write.assert_not_called()
-        session.stop()
-
-    def test_preempt_sets_cancel_event(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        assert not session._cancel.is_set()
-        session.preempt("follow up")
-        assert session._cancel.is_set()
-        session.stop()
-
-    def test_preempt_waits_for_lock_holder_then_queues(self, tmp_path: Path) -> None:
-        import threading as _threading
-
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        acquired = _threading.Event()
-        release = _threading.Event()
-
-        def holder() -> None:
-            session._lock.acquire()
-            acquired.set()
-            release.wait()
-            session._lock.release()
-
-        t_holder = _threading.Thread(target=holder)
-        t_holder.start()
-        acquired.wait()  # holder definitely has the lock
-
-        t_preempt = _threading.Thread(target=lambda: session.preempt("queued"))
-        t_preempt.start()
-
-        # preempt is blocked on lock.acquire(); queue must still be empty
-        assert session.take_queued_content() is None
-
-        release.set()
-        t_holder.join(timeout=2)
-        t_preempt.join(timeout=2)
-
-        assert session.take_queued_content() == "queued"
-        assert session.take_queued_content() is None
-        session.stop()
-
-    def test_preempt_twice_preserves_both_messages(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session.preempt("first")
-        session.preempt("second")
-        assert session.take_queued_content() == "first"
-        assert session.take_queued_content() == "second"
-        assert session.take_queued_content() is None
-        session.stop()
-
-    def test_take_queued_content_returns_none_when_empty(self, tmp_path: Path) -> None:
-        session = _make_session(tmp_path, _make_session_proc([]))
-        assert session.take_queued_content() is None
-        session.stop()
-
-    def test_take_queued_content_clears_after_return(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session.preempt("once")
-        session.take_queued_content()
-        assert session.take_queued_content() is None
         session.stop()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1185,32 +1185,6 @@ class TestClaudeSessionInit:
         assert "--system-prompt-file" in cmd
         assert str(system_file) in cmd
 
-    def test_spawns_with_model_flag(self, tmp_path: Path) -> None:
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        proc = _make_session_proc([])
-        fake_popen = MagicMock(return_value=proc)
-        fake_selector = MagicMock(return_value=([], [], []))
-        ClaudeSession(
-            system_file,
-            model="claude-opus-4-6",
-            popen=fake_popen,
-            selector=fake_selector,
-        )
-        cmd = fake_popen.call_args.args[0]
-        assert "--model" in cmd
-        assert cmd[cmd.index("--model") + 1] == "claude-opus-4-6"
-
-    def test_default_model_is_sonnet(self, tmp_path: Path) -> None:
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        proc = _make_session_proc([])
-        fake_popen = MagicMock(return_value=proc)
-        fake_selector = MagicMock(return_value=([], [], []))
-        ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
-        cmd = fake_popen.call_args.args[0]
-        assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
-
     def test_opens_stdin_stdout_pipes(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -8,12 +8,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from kennel.claude import (
+    _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
     ClaudeSession,
     ClaudeStreamError,
     _active_children,
     _claude,
     _register_child,
+    _Trunc,
     _unregister_child,
     extract_result_text,
     extract_session_id,
@@ -39,6 +41,22 @@ def _completed(
     return subprocess.CompletedProcess(
         args=[], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+class TestTrunc:
+    def test_str_truncates_long_string(self) -> None:
+        t = _Trunc("x" * (_LOG_LINE_TRUNCATE + 50))
+        assert str(t) == "x" * _LOG_LINE_TRUNCATE
+
+    def test_str_passes_short_string_unchanged(self) -> None:
+        assert str(_Trunc("hi")) == "hi"
+
+    def test_repr_truncates_and_quotes(self) -> None:
+        t = _Trunc("x" * (_LOG_LINE_TRUNCATE + 50))
+        assert repr(t) == repr("x" * _LOG_LINE_TRUNCATE)
+
+    def test_repr_passes_short_string_unchanged(self) -> None:
+        assert repr(_Trunc("hi")) == repr("hi")
 
 
 class TestClaudeHelper:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1375,26 +1375,32 @@ class TestClaudeSessionStop:
         session.stop(grace_seconds=0.0)
         proc.kill.assert_called()
 
-    def test_swallows_oserror_on_stdin_close(self, tmp_path: Path) -> None:
+    def test_logs_oserror_on_stdin_close(self, tmp_path: Path, caplog) -> None:
         proc = _make_session_proc([])
         proc.stdin.close = MagicMock(side_effect=OSError("broken pipe"))
         session = _make_session(tmp_path, proc)
-        session.stop()  # must not raise
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            session.stop()  # must not raise
+        assert any("stdin close failed" in r.message for r in caplog.records)
 
-    def test_swallows_oserror_on_wait(self, tmp_path: Path) -> None:
+    def test_logs_oserror_on_wait(self, tmp_path: Path, caplog) -> None:
         proc = _make_session_proc([])
         proc.wait = MagicMock(side_effect=OSError("already gone"))
         session = _make_session(tmp_path, proc)
-        session.stop()  # must not raise
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            session.stop()  # must not raise
+        assert any("wait failed" in r.message for r in caplog.records)
 
-    def test_swallows_errors_on_kill_after_timeout(self, tmp_path: Path) -> None:
+    def test_logs_errors_on_kill_after_timeout(self, tmp_path: Path, caplog) -> None:
         proc = _make_session_proc([])
         proc.wait = MagicMock(
             side_effect=[subprocess.TimeoutExpired(cmd="x", timeout=2), None]
         )
         proc.kill = MagicMock(side_effect=ProcessLookupError())
         session = _make_session(tmp_path, proc)
-        session.stop(grace_seconds=0.0)  # must not raise
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            session.stop(grace_seconds=0.0)  # must not raise
+        assert any("kill/wait failed" in r.message for r in caplog.records)
 
     def test_skips_close_when_stdin_already_closed(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from kennel.claude import (
+    ClaudeSession,
     ClaudeStreamError,
+    _active_children,
     _claude,
     _register_child,
     _unregister_child,
@@ -1113,3 +1115,291 @@ class TestRunStreamingTracksChildren:
         # Was registered (popen sees it not yet in set, but it is by the time
         # the generator runs); after exhaustion it should be unregistered.
         assert proc not in _active_children
+
+
+# ── ClaudeSession tests ───────────────────────────────────────────────────────
+
+
+def _make_session_proc(
+    stdout_lines: list[str],
+    poll_returns: int | None = None,
+) -> MagicMock:
+    """Build a mock Popen object for ClaudeSession tests.
+
+    *stdout_lines* are returned by successive ``readline()`` calls; an empty
+    string is appended automatically to signal EOF.  *poll_returns* is the
+    value ``poll()`` yields (``None`` = still running; ``0`` = exited).
+    """
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.stdin = MagicMock()
+    proc.stdin.closed = False
+    proc.stdout = MagicMock()
+    proc.stdout.readline = MagicMock(side_effect=stdout_lines + [""])
+    proc.stderr = MagicMock()
+    proc.poll = MagicMock(return_value=poll_returns)
+    proc.wait = MagicMock(return_value=0)
+    proc.returncode = 0
+    return proc
+
+
+def _make_session(
+    tmp_path: Path,
+    proc: MagicMock,
+    *,
+    idle_timeout: float = 1800.0,
+) -> ClaudeSession:
+    """Construct a ClaudeSession injecting *proc* as the subprocess."""
+    system_file = tmp_path / "system.md"
+    system_file.write_text("you are fido")
+    fake_popen = MagicMock(return_value=proc)
+    fake_selector = MagicMock(return_value=([proc.stdout], [], []))
+    return ClaudeSession(
+        system_file,
+        work_dir=tmp_path,
+        idle_timeout=idle_timeout,
+        popen=fake_popen,
+        selector=fake_selector,
+    )
+
+
+class TestClaudeSessionInit:
+    def test_spawns_with_stream_json_flags(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        cmd = fake_popen.call_args.args[0]
+        assert cmd[0] == "claude"
+        assert "--input-format" in cmd
+        assert "stream-json" in cmd[cmd.index("--input-format") + 1]
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd[cmd.index("--output-format") + 1]
+        assert "--verbose" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--system-prompt-file" in cmd
+        assert str(system_file) in cmd
+
+    def test_opens_stdin_stdout_pipes(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
+        kwargs = fake_popen.call_args.kwargs
+        assert kwargs["stdin"] == subprocess.PIPE
+        assert kwargs["stdout"] == subprocess.PIPE
+        assert kwargs["text"] is True
+
+    def test_passes_cwd(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        assert fake_popen.call_args.kwargs["cwd"] == tmp_path
+
+    def test_registers_in_active_children(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
+        assert proc in _active_children
+        # cleanup
+        session.stop()
+
+
+class TestClaudeSessionSend:
+    def test_writes_json_user_message_to_stdin(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.send("hello fido")
+        written = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(written.strip())
+        assert obj["type"] == "user"
+        assert obj["message"]["role"] == "user"
+        assert obj["message"]["content"] == "hello fido"
+
+    def test_flushes_after_write(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.send("ping")
+        proc.stdin.flush.assert_called()
+
+    def test_appends_newline(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.send("msg")
+        written = proc.stdin.write.call_args.args[0]
+        assert written.endswith("\n")
+
+
+class TestClaudeSessionIterEvents:
+    def test_yields_parsed_json_events(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "assistant", "text": "thinking"}) + "\n",
+            _json.dumps({"type": "result", "result": "done", "session_id": "s1"})
+            + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        events = list(session.iter_events())
+        assert events[0]["type"] == "assistant"
+        assert events[1]["type"] == "result"
+
+    def test_stops_after_result_event(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "result", "result": "done"}) + "\n",
+            _json.dumps({"type": "assistant", "text": "extra"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        events = list(session.iter_events())
+        # Only the result event should be yielded; extra line is not consumed
+        assert len(events) == 1
+        assert events[0]["type"] == "result"
+
+    def test_stops_after_error_event(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "error", "error": "oops"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        events = list(session.iter_events())
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+
+    def test_stops_on_eof(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])  # immediately EOF
+        session = _make_session(tmp_path, proc)
+        events = list(session.iter_events())
+        assert events == []
+
+    def test_stops_when_process_exits(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([], poll_returns=0)
+        fake_popen = MagicMock(return_value=proc)
+        # selector never returns ready — forces poll() branch
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
+        events = list(session.iter_events())
+        assert events == []
+
+    def test_skips_blank_lines(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            "\n",
+            "   \n",
+            _json.dumps({"type": "result", "result": "ok"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        events = list(session.iter_events())
+        assert len(events) == 1
+        assert events[0]["type"] == "result"
+
+    def test_skips_unparseable_lines(self, tmp_path: Path, caplog) -> None:
+        import json as _json
+
+        lines = [
+            "not json at all\n",
+            _json.dumps({"type": "result", "result": "ok"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            events = list(session.iter_events())
+        assert any("unparseable" in r.message for r in caplog.records)
+        assert len(events) == 1
+
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=None)  # never exits
+        fake_popen = MagicMock(return_value=proc)
+        # selector never ready, process never exits → triggers idle timeout
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file,
+            idle_timeout=0.0,
+            popen=fake_popen,
+            selector=fake_selector,
+        )
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            list(session.iter_events())
+        assert exc_info.value.returncode == -1
+        proc.kill.assert_called()
+
+
+class TestClaudeSessionStop:
+    def test_closes_stdin_and_waits(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.stop()
+        proc.stdin.close.assert_called()
+        proc.wait.assert_called()
+
+    def test_unregisters_from_active_children(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert proc in _active_children
+        session.stop()
+        assert proc not in _active_children
+
+    def test_kills_if_wait_times_out(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.wait = MagicMock(
+            side_effect=[subprocess.TimeoutExpired(cmd="claude", timeout=2), None]
+        )
+        session = _make_session(tmp_path, proc)
+        session.stop(grace_seconds=0.0)
+        proc.kill.assert_called()
+
+    def test_swallows_oserror_on_stdin_close(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.stdin.close = MagicMock(side_effect=OSError("broken pipe"))
+        session = _make_session(tmp_path, proc)
+        session.stop()  # must not raise
+
+    def test_swallows_oserror_on_wait(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.wait = MagicMock(side_effect=OSError("already gone"))
+        session = _make_session(tmp_path, proc)
+        session.stop()  # must not raise
+
+    def test_swallows_errors_on_kill_after_timeout(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.wait = MagicMock(
+            side_effect=[subprocess.TimeoutExpired(cmd="x", timeout=2), None]
+        )
+        proc.kill = MagicMock(side_effect=ProcessLookupError())
+        session = _make_session(tmp_path, proc)
+        session.stop(grace_seconds=0.0)  # must not raise
+
+    def test_skips_close_when_stdin_already_closed(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.stdin.closed = True
+        session = _make_session(tmp_path, proc)
+        session.stop()
+        proc.stdin.close.assert_not_called()
+        proc.wait.assert_called()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1183,6 +1183,32 @@ class TestClaudeSessionInit:
         assert "--system-prompt-file" in cmd
         assert str(system_file) in cmd
 
+    def test_spawns_with_model_flag(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(
+            system_file,
+            model="claude-opus-4-6",
+            popen=fake_popen,
+            selector=fake_selector,
+        )
+        cmd = fake_popen.call_args.args[0]
+        assert "--model" in cmd
+        assert cmd[cmd.index("--model") + 1] == "claude-opus-4-6"
+
+    def test_default_model_is_sonnet(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
+        cmd = fake_popen.call_args.args[0]
+        assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
+
     def test_opens_stdin_stdout_pipes(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from kennel.claude import (
+    _RETURNCODE_IDLE_TIMEOUT,
     ClaudeSession,
     ClaudeStreamError,
     _active_children,
@@ -305,7 +306,7 @@ class TestRunStreaming:
 
         with pytest.raises(ClaudeStreamError) as exc_info:
             list(_run_streaming(["sleep", "60"], stdin_file, idle_timeout=0.1))
-        assert exc_info.value.returncode == -1
+        assert exc_info.value.returncode == _RETURNCODE_IDLE_TIMEOUT
 
     def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming
@@ -407,7 +408,7 @@ class TestPrintPromptFromFile:
 
     def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT))
         with pytest.raises(ClaudeStreamError):
             print_prompt_from_file(
                 sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
@@ -472,7 +473,7 @@ class TestResumeSession:
     def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("p")
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(-1))
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT))
         with pytest.raises(ClaudeStreamError):
             resume_session(
                 "sess-123",
@@ -1344,7 +1345,7 @@ class TestClaudeSessionIterEvents:
         )
         with pytest.raises(ClaudeStreamError) as exc_info:
             list(session.iter_events())
-        assert exc_info.value.returncode == -1
+        assert exc_info.value.returncode == _RETURNCODE_IDLE_TIMEOUT
         proc.kill.assert_called()
 
     def test_stops_immediately_when_cancel_set(self, tmp_path: Path) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1421,7 +1421,9 @@ class TestClaudeSessionStop:
             session.stop()  # must not raise
         assert any("wait failed" in r.message for r in caplog.records)
 
-    def test_logs_errors_on_kill_after_timeout(self, tmp_path: Path, caplog) -> None:
+    def test_raises_and_logs_on_kill_after_timeout(
+        self, tmp_path: Path, caplog
+    ) -> None:
         proc = _make_session_proc([])
         proc.wait = MagicMock(
             side_effect=[subprocess.TimeoutExpired(cmd="x", timeout=2), None]
@@ -1429,8 +1431,21 @@ class TestClaudeSessionStop:
         proc.kill = MagicMock(side_effect=ProcessLookupError())
         session = _make_session(tmp_path, proc)
         with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            session.stop(grace_seconds=0.0)  # must not raise
+            with pytest.raises(ProcessLookupError):
+                session.stop(grace_seconds=0.0)
         assert any("kill/wait failed" in r.message for r in caplog.records)
+
+    def test_unregisters_even_when_kill_raises(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.wait = MagicMock(
+            side_effect=[subprocess.TimeoutExpired(cmd="x", timeout=2), None]
+        )
+        proc.kill = MagicMock(side_effect=ProcessLookupError())
+        session = _make_session(tmp_path, proc)
+        assert proc in _active_children
+        with pytest.raises(ProcessLookupError):
+            session.stop(grace_seconds=0.0)
+        assert proc not in _active_children
 
     def test_skips_close_when_stdin_already_closed(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1480,3 +1480,125 @@ class TestClaudeSessionConsumeUntilResult:
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
         assert session.consume_until_result() == "output"
+
+
+class TestClaudeSessionIsAliveAndRestart:
+    def test_is_alive_true_when_process_running(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=None)
+        session = _make_session(tmp_path, proc)
+        assert session.is_alive() is True
+
+    def test_is_alive_false_when_process_exited(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=0)
+        session = _make_session(tmp_path, proc)
+        assert session.is_alive() is False
+
+    def test_restart_spawns_new_process(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()
+        assert session._proc is new_proc
+        assert fake_popen.call_count == 2
+
+    def test_restart_registers_new_proc_in_active_children(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()
+        assert new_proc in _active_children
+        assert old_proc not in _active_children
+        # cleanup
+        session.stop()
+
+    def test_restart_unregisters_old_proc(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()
+        assert old_proc not in _active_children
+        # cleanup
+        session.stop()
+
+    def test_restart_logs_warning(self, tmp_path: Path, caplog) -> None:
+        import logging as _logging
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        with caplog.at_level(_logging.WARNING, logger="kennel.claude"):
+            session.restart()
+        assert any("restart" in r.message.lower() for r in caplog.records)
+        session.stop()
+
+    def test_restart_swallows_oserror_on_kill(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        old_proc.kill = MagicMock(side_effect=OSError("already dead"))
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()  # must not raise
+        session.stop()
+
+    def test_restart_swallows_timeout_on_wait(self, tmp_path: Path) -> None:
+        import subprocess as _subprocess
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        old_proc.wait = MagicMock(side_effect=_subprocess.TimeoutExpired("x", 1))
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()  # must not raise
+        session.stop()
+
+    def test_stop_after_restart_cleans_up_new_proc(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([])
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()
+        session.stop()
+        assert new_proc not in _active_children

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1365,6 +1365,8 @@ class TestClaudeSessionIterEvents:
             list(session.iter_events())
         assert exc_info.value.returncode == _RETURNCODE_IDLE_TIMEOUT
         proc.kill.assert_called()
+        # restart() must spawn a replacement process after killing
+        assert fake_popen.call_count == 2
 
     def test_stops_immediately_when_cancel_set(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1442,6 +1442,15 @@ class TestClaudeSessionStop:
                 session.stop()
         assert any("stdin close failed" in r.message for r in caplog.records)
 
+    def test_unregisters_even_when_stdin_close_raises(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.stdin.close = MagicMock(side_effect=OSError("broken pipe"))
+        session = _make_session(tmp_path, proc)
+        assert proc in _active_children
+        with pytest.raises(OSError):
+            session.stop()
+        assert proc not in _active_children  # outer finally must still unregister
+
     def test_logs_oserror_on_wait(self, tmp_path: Path, caplog) -> None:
         proc = _make_session_proc([])
         proc.wait = MagicMock(side_effect=OSError("already gone"))

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1603,3 +1603,50 @@ class TestClaudeSessionIsAliveAndRestart:
         session.restart()
         session.stop()
         assert new_proc not in _active_children
+
+
+class TestClaudeSessionLock:
+    def test_enter_returns_self(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        assert session.__enter__() is session
+        session._lock.release()
+        session.stop()
+
+    def test_exit_releases_lock(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        session.__enter__()
+        session.__exit__(None, None, None)
+        assert session._lock.acquire(blocking=False)
+        session._lock.release()
+        session.stop()
+
+    def test_context_manager_blocks_second_thread(self, tmp_path: Path) -> None:
+        import threading as _threading
+
+        session = _make_session(tmp_path, _make_session_proc([]))
+        entered = _threading.Event()
+        done_checking = _threading.Event()
+        could_not_acquire = _threading.Event()
+
+        def first_thread() -> None:
+            with session:
+                entered.set()
+                done_checking.wait()  # hold the lock until t2 is done checking
+
+        def second_thread() -> None:
+            entered.wait()  # t1 holds the lock and is blocked on done_checking
+            acquired = session._lock.acquire(blocking=False)
+            if not acquired:
+                could_not_acquire.set()
+            else:
+                session._lock.release()
+            done_checking.set()  # let t1 exit the context manager
+
+        t1 = _threading.Thread(target=first_thread)
+        t2 = _threading.Thread(target=second_thread)
+        t1.start()
+        t2.start()
+        t1.join(timeout=2)
+        t2.join(timeout=2)
+        assert could_not_acquire.is_set()
+        session.stop()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1796,13 +1796,23 @@ class TestClaudeSessionPreempt:
         t_preempt.start()
 
         # preempt is blocked on lock.acquire(); queue must still be empty
-        assert session._queued_content is None
+        assert len(session._queued_content) == 0
 
         release.set()
         t_holder.join(timeout=2)
         t_preempt.join(timeout=2)
 
-        assert session._queued_content == "queued"
+        assert list(session._queued_content) == ["queued"]
+        session.stop()
+
+    def test_preempt_twice_preserves_both_messages(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.preempt("first")
+        session.preempt("second")
+        assert session.take_queued_content() == "first"
+        assert session.take_queued_content() == "second"
+        assert session.take_queued_content() is None
         session.stop()
 
     def test_take_queued_content_returns_none_when_empty(self, tmp_path: Path) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1611,6 +1611,21 @@ class TestClaudeSessionIsAliveAndRestart:
         assert any("restart" in r.message.lower() for r in caplog.records)
         session.stop()
 
+    def test_restart_skips_kill_when_process_already_dead(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        old_proc = _make_session_proc([], poll_returns=0)  # already dead
+        new_proc = _make_session_proc([])
+        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
+        fake_selector = MagicMock(return_value=([], [], []))
+        session = ClaudeSession(
+            system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
+        )
+        session.restart()
+        old_proc.kill.assert_not_called()
+        assert session._proc is new_proc
+        session.stop()
+
     def test_restart_raises_oserror_on_kill(self, tmp_path: Path, caplog) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1368,18 +1368,44 @@ class TestClaudeSessionIterEvents:
         # restart() must spawn a replacement process after killing
         assert fake_popen.call_count == 2
 
-    def test_stops_immediately_when_cancel_set(self, tmp_path: Path) -> None:
+    def test_cancel_cleared_at_iter_events_start(self, tmp_path: Path) -> None:
+        # A cancel set before iter_events() is called is cleared at the start of
+        # the method — it represents a stale signal from a previous turn, not a
+        # request to abort the new turn.
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._cancel.set()
+        assert session._cancel.is_set()
+        # Drain iter_events; proc has EOF so loop exits naturally
+        list(session.iter_events())
+        # cancel must have been cleared at start of iter_events
+        assert not session._cancel.is_set()
+        session.stop()
+
+    def test_stops_when_cancel_set_during_turn(self, tmp_path: Path) -> None:
+        # A cancel set AFTER iter_events() starts (i.e., during polling) must
+        # abort the loop on the next cycle.
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")
         proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=None)  # never exits
+        proc.poll = MagicMock(return_value=None)  # never exits on its own
         fake_popen = MagicMock(return_value=proc)
-        fake_selector = MagicMock(return_value=([], [], []))
-        session = ClaudeSession(system_file, popen=fake_popen, selector=fake_selector)
-        session._cancel.set()
+
+        session_ref: list[ClaudeSession] = []
+
+        def selector_that_cancels(
+            *_args: object, **_kwargs: object
+        ) -> tuple[list, list, list]:
+            # Set cancel on first poll — simulates an interrupt arriving mid-turn
+            session_ref[0]._cancel.set()
+            return ([], [], [])
+
+        session = ClaudeSession(
+            system_file, popen=fake_popen, selector=selector_that_cancels
+        )
+        session_ref.append(session)
         events = list(session.iter_events())
         assert events == []
-        fake_selector.assert_not_called()  # cancel check fires before select
         session.stop()
 
 
@@ -1684,12 +1710,53 @@ class TestClaudeSessionLock:
         session._lock.release()
         session.stop()
 
-    def test_enter_clears_cancel_event(self, tmp_path: Path) -> None:
+    def test_enter_preserves_cancel_event(self, tmp_path: Path) -> None:
+        # __enter__ must NOT clear _cancel — a signal that lands between one
+        # holder's __exit__ and the next holder's iter_events() must survive.
         session = _make_session(tmp_path, _make_session_proc([]))
         session._cancel.set()
         session.__enter__()
-        assert not session._cancel.is_set()
+        assert session._cancel.is_set()  # still set; iter_events() will clear it
         session._lock.release()
+        session.stop()
+
+    def test_cancel_survives_lock_handoff(self, tmp_path: Path) -> None:
+        import threading as _threading
+
+        # Simulate the lost-interrupt race: interrupt() is called after holder
+        # releases the lock but before the next holder calls iter_events().
+        # The signal must still be set when the new holder enters __enter__.
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+
+        cancel_set_after_exit = _threading.Event()
+        new_holder_entered = _threading.Event()
+        new_holder_cancel_was_set: list[bool] = []
+
+        def first_holder() -> None:
+            session._lock.acquire()
+            # Release without calling iter_events; then interrupt() sets cancel
+            session._lock.release()
+            # Simulate interrupt arriving right after release
+            session._cancel.set()
+            cancel_set_after_exit.set()
+
+        def second_holder() -> None:
+            cancel_set_after_exit.wait()
+            session.__enter__()
+            # Record whether cancel is still set before iter_events clears it
+            new_holder_cancel_was_set.append(session._cancel.is_set())
+            new_holder_entered.set()
+            session._lock.release()
+
+        t1 = _threading.Thread(target=first_holder)
+        t2 = _threading.Thread(target=second_holder)
+        t1.start()
+        t2.start()
+        t1.join(timeout=2)
+        t2.join(timeout=2)
+
+        assert new_holder_cancel_was_set == [True]
         session.stop()
 
     def test_exit_releases_lock(self, tmp_path: Path) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1673,3 +1673,45 @@ class TestClaudeSessionInterrupt:
         finally:
             session._lock.release()
         session.stop()
+
+
+class TestClaudeSessionPreempt:
+    def test_preempt_writes_control_request_to_stdin(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.preempt("follow up")
+        written = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(written.strip())
+        assert obj["type"] == "control_request"
+        assert obj["request"]["type"] == "interrupt"
+
+    def test_preempt_queues_content(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.preempt("handle ci failure")
+        assert session.take_queued_content() == "handle ci failure"
+
+    def test_preempt_bypasses_held_lock(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._lock.acquire()
+        try:
+            session.preempt("urgent follow-up")  # must not block or raise
+        finally:
+            session._lock.release()
+        session.stop()
+
+    def test_take_queued_content_returns_none_when_empty(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        assert session.take_queued_content() is None
+        session.stop()
+
+    def test_take_queued_content_clears_after_return(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session.preempt("once")
+        session.take_queued_content()
+        assert session.take_queued_content() is None
+        session.stop()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -29,6 +29,7 @@ from kennel.claude import (
     resume_status,
     triage_comment,
 )
+from kennel.state import PreemptQueue
 
 
 def _completed(
@@ -1159,6 +1160,7 @@ def _make_session(
         idle_timeout=idle_timeout,
         popen=fake_popen,
         selector=fake_selector,
+        preempt_queue=PreemptQueue(tmp_path / "preempt.json"),
     )
 
 
@@ -1796,13 +1798,14 @@ class TestClaudeSessionPreempt:
         t_preempt.start()
 
         # preempt is blocked on lock.acquire(); queue must still be empty
-        assert len(session._queued_content) == 0
+        assert session.take_queued_content() is None
 
         release.set()
         t_holder.join(timeout=2)
         t_preempt.join(timeout=2)
 
-        assert list(session._queued_content) == ["queued"]
+        assert session.take_queued_content() == "queued"
+        assert session.take_queued_content() is None
         session.stop()
 
     def test_preempt_twice_preserves_both_messages(self, tmp_path: Path) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1828,24 +1828,115 @@ class TestClaudeSessionLock:
         session.stop()
 
 
+class TestClaudeSessionSendControlInterrupt:
+    def test_writes_control_request_type(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._send_control_interrupt()
+        written = proc.stdin.write.call_args.args[0]
+        assert _json.loads(written.strip())["type"] == "control_request"
+        session.stop()
+
+    def test_writes_interrupt_subtype(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._send_control_interrupt()
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert obj["request"]["subtype"] == "interrupt"
+        session.stop()
+
+    def test_includes_request_id(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._send_control_interrupt()
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert isinstance(obj.get("request_id"), str) and obj["request_id"]
+        session.stop()
+
+
 class TestClaudeSessionInterrupt:
-    def test_interrupt_writes_json_to_stdin(self, tmp_path: Path) -> None:
+    def test_interrupt_sends_control_request_first(self, tmp_path: Path) -> None:
+        """interrupt() sends control_request as the first stdin write."""
         import json as _json
 
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         session.interrupt("abort now")
-        written = proc.stdin.write.call_args.args[0]
-        obj = _json.loads(written.strip())
-        assert obj["type"] == "user"
-        assert obj["message"]["content"] == "abort now"
+        first_write = proc.stdin.write.call_args_list[0].args[0]
+        obj = _json.loads(first_write.strip())
+        assert obj["type"] == "control_request"
+        assert obj["request"]["subtype"] == "interrupt"
+        session.stop()
 
-    def test_interrupt_sets_cancel_event(self, tmp_path: Path) -> None:
+    def test_interrupt_sends_follow_up_as_user_message(self, tmp_path: Path) -> None:
+        """interrupt() sends follow-up content as the last stdin write."""
+        import json as _json
+
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        assert not session._cancel.is_set()
-        session.interrupt("stop")
-        assert session._cancel.is_set()
+        session.interrupt("abort now")
+        last_write = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(last_write.strip())
+        assert obj["type"] == "user"
+        assert obj["message"]["content"] == "abort now"
+        session.stop()
+
+    def test_interrupt_drains_turn_before_follow_up(self, tmp_path: Path) -> None:
+        """interrupt() reads all old-turn events before sending the follow-up."""
+        import json as _json
+
+        result_line = _json.dumps({"type": "result", "result": "done"})
+        proc = _make_session_proc([result_line])
+        session = _make_session(tmp_path, proc)
+        session.interrupt("next")
+        # stdout was read (drain happened — readline called at least once)
+        assert proc.stdout.readline.call_count >= 1
+        # and follow-up was still sent
+        last_write = proc.stdin.write.call_args.args[0]
+        obj = _json.loads(last_write.strip())
+        assert obj["type"] == "user"
+        assert obj["message"]["content"] == "next"
+        session.stop()
+
+    def test_interrupt_sets_cancel_while_waiting_for_lock(self, tmp_path: Path) -> None:
+        """_cancel is set before interrupt() acquires the lock."""
+        import threading as _threading
+        import time as _time
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        lock_held = _threading.Event()
+        release = _threading.Event()
+        cancel_seen: list[bool] = []
+
+        def holder() -> None:
+            session._lock.acquire()
+            lock_held.set()
+            release.wait()
+            cancel_seen.append(session._cancel.is_set())
+            session._lock.release()
+
+        t_holder = _threading.Thread(target=holder)
+        t_holder.start()
+        lock_held.wait()
+
+        t_int = _threading.Thread(target=lambda: session.interrupt("follow"))
+        t_int.start()
+
+        # _cancel.set() is the very first thing interrupt() does — 50ms is
+        # far more than enough for the thread to reach it before we check.
+        _time.sleep(0.05)
+        release.set()
+        t_holder.join(timeout=2)
+        t_int.join(timeout=2)
+
+        assert cancel_seen == [True]
         session.stop()
 
     def test_interrupt_waits_for_lock_holder_then_sends(self, tmp_path: Path) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1610,7 +1610,7 @@ class TestClaudeSessionIsAliveAndRestart:
         assert any("restart" in r.message.lower() for r in caplog.records)
         session.stop()
 
-    def test_restart_swallows_oserror_on_kill(self, tmp_path: Path) -> None:
+    def test_restart_raises_oserror_on_kill(self, tmp_path: Path, caplog) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")
         old_proc = _make_session_proc([])
@@ -1621,10 +1621,12 @@ class TestClaudeSessionIsAliveAndRestart:
         session = ClaudeSession(
             system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
         )
-        session.restart()  # must not raise
-        session.stop()
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            with pytest.raises(OSError):
+                session.restart()
+        assert any("kill/wait failed" in r.message for r in caplog.records)
 
-    def test_restart_swallows_timeout_on_wait(self, tmp_path: Path) -> None:
+    def test_restart_raises_timeout_on_wait(self, tmp_path: Path, caplog) -> None:
         import subprocess as _subprocess
 
         system_file = tmp_path / "system.md"
@@ -1637,8 +1639,10 @@ class TestClaudeSessionIsAliveAndRestart:
         session = ClaudeSession(
             system_file, work_dir=tmp_path, popen=fake_popen, selector=fake_selector
         )
-        session.restart()  # must not raise
-        session.stop()
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            with pytest.raises(_subprocess.TimeoutExpired):
+                session.restart()
+        assert any("kill/wait failed" in r.message for r in caplog.records)
 
     def test_stop_after_restart_cleans_up_new_proc(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1686,16 +1686,6 @@ class TestClaudeSessionInterrupt:
         assert obj["type"] == "user"
         assert obj["message"]["content"] == "abort now"
 
-    def test_interrupt_bypasses_held_lock(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session._lock.acquire()
-        try:
-            session.interrupt("urgent")  # must not block or raise
-        finally:
-            session._lock.release()
-        session.stop()
-
     def test_interrupt_sets_cancel_event(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
@@ -1704,33 +1694,89 @@ class TestClaudeSessionInterrupt:
         assert session._cancel.is_set()
         session.stop()
 
-
-class TestClaudeSessionPreempt:
-    def test_preempt_writes_control_request_to_stdin(self, tmp_path: Path) -> None:
-        import json as _json
+    def test_interrupt_waits_for_lock_holder_then_sends(self, tmp_path: Path) -> None:
+        import threading as _threading
 
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session.preempt("follow up")
-        written = proc.stdin.write.call_args.args[0]
-        obj = _json.loads(written.strip())
-        assert obj["type"] == "control_request"
-        assert obj["request"]["type"] == "interrupt"
+        acquired = _threading.Event()
+        release = _threading.Event()
 
+        def holder() -> None:
+            session._lock.acquire()
+            acquired.set()
+            release.wait()
+            session._lock.release()
+
+        t_holder = _threading.Thread(target=holder)
+        t_holder.start()
+        acquired.wait()  # holder definitely has the lock
+
+        t_interrupt = _threading.Thread(target=lambda: session.interrupt("msg"))
+        t_interrupt.start()
+
+        # interrupt is blocked on lock.acquire(); stdin must not be written yet
+        assert proc.stdin.write.call_count == 0
+
+        release.set()
+        t_holder.join(timeout=2)
+        t_interrupt.join(timeout=2)
+
+        assert proc.stdin.write.call_count > 0
+        session.stop()
+
+
+class TestClaudeSessionPreempt:
     def test_preempt_queues_content(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         session.preempt("handle ci failure")
         assert session.take_queued_content() == "handle ci failure"
 
-    def test_preempt_bypasses_held_lock(self, tmp_path: Path) -> None:
+    def test_preempt_does_not_write_to_stdin(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._lock.acquire()
-        try:
-            session.preempt("urgent follow-up")  # must not block or raise
-        finally:
+        session.preempt("follow up")
+        proc.stdin.write.assert_not_called()
+        session.stop()
+
+    def test_preempt_sets_cancel_event(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert not session._cancel.is_set()
+        session.preempt("follow up")
+        assert session._cancel.is_set()
+        session.stop()
+
+    def test_preempt_waits_for_lock_holder_then_queues(self, tmp_path: Path) -> None:
+        import threading as _threading
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        acquired = _threading.Event()
+        release = _threading.Event()
+
+        def holder() -> None:
+            session._lock.acquire()
+            acquired.set()
+            release.wait()
             session._lock.release()
+
+        t_holder = _threading.Thread(target=holder)
+        t_holder.start()
+        acquired.wait()  # holder definitely has the lock
+
+        t_preempt = _threading.Thread(target=lambda: session.preempt("queued"))
+        t_preempt.start()
+
+        # preempt is blocked on lock.acquire(); queue must still be empty
+        assert session._queued_content is None
+
+        release.set()
+        t_holder.join(timeout=2)
+        t_preempt.join(timeout=2)
+
+        assert session._queued_content == "queued"
         session.stop()
 
     def test_take_queued_content_returns_none_when_empty(self, tmp_path: Path) -> None:
@@ -1744,12 +1790,4 @@ class TestClaudeSessionPreempt:
         session.preempt("once")
         session.take_queued_content()
         assert session.take_queued_content() is None
-        session.stop()
-
-    def test_preempt_sets_cancel_event(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        assert not session._cancel.is_set()
-        session.preempt("follow up")
-        assert session._cancel.is_set()
         session.stop()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -140,6 +140,16 @@ class TestWorkerRegistry:
         reg, _ = self._make_registry()
         assert reg.get_thread_crash_error("unknown/repo") is None
 
+    def test_get_session_owner_returns_none_for_unknown_repo(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_session_owner("unknown/repo") is None
+
+    def test_get_session_owner_delegates_to_thread(self, tmp_path: Path) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.session_owner = "worker-home"
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_session_owner("foo/bar") == "worker-home"
+
     def test_get_thread_crash_error_returns_thread_crash_error(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -29,7 +29,48 @@ class TestWorkerRegistry:
         reg, factory = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
-        factory.assert_called_once_with(cfg)
+        factory.assert_called_once_with(cfg, session=None, session_issue=None)
+
+    def test_start_rescues_session_from_crashed_thread(self, tmp_path: Path) -> None:
+        """Session rescued from a crashed (dead, not _stop) thread and passed to replacement."""
+        mock_session = MagicMock()
+        threads = [MagicMock(), MagicMock()]
+        factory = MagicMock(side_effect=threads)
+        reg = WorkerRegistry(factory)
+        cfg = _repo("foo/bar", tmp_path)
+        # First start — no prior thread
+        reg.start(cfg)
+        # Simulate crash: thread died, _stop is False, session is alive
+        threads[0].is_alive.return_value = False
+        threads[0]._stop = False
+        threads[0]._session = mock_session
+        threads[0]._session_issue = 42
+        # Second start — should rescue session from crashed thread
+        reg.start(cfg)
+        _, kwargs = factory.call_args_list[1]
+        assert kwargs["session"] is mock_session
+        assert kwargs["session_issue"] == 42
+        # Old thread's session must be cleared to prevent double-stop
+        assert threads[0]._session is None
+
+    def test_start_does_not_rescue_session_from_orderly_shutdown_thread(
+        self, tmp_path: Path
+    ) -> None:
+        """No session rescue when the old thread exited via orderly stop()."""
+        mock_session = MagicMock()
+        threads = [MagicMock(), MagicMock()]
+        factory = MagicMock(side_effect=threads)
+        reg = WorkerRegistry(factory)
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        # Simulate orderly shutdown: _stop is True (session was already stopped)
+        threads[0].is_alive.return_value = False
+        threads[0]._stop = True
+        threads[0]._session = mock_session  # shouldn't happen, but test the guard
+        reg.start(cfg)
+        _, kwargs = factory.call_args_list[1]
+        assert kwargs["session"] is None
+        assert kwargs["session_issue"] is None
 
     def test_start_starts_thread(self, tmp_path: Path) -> None:
         reg, factory = self._make_registry()
@@ -451,6 +492,8 @@ class TestMakeThread:
             mock_gh,
             mock_registry,
             RepoMembership(),
+            session=None,
+            session_issue=None,
         )
         assert result is mock_wt_cls.return_value
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -156,6 +156,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.is_stale.return_value = False
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
@@ -169,6 +170,30 @@ class TestGetEndpoint:
         assert entry["is_stuck"] is False
         assert entry["worker_uptime_seconds"] is None
         assert entry["webhook_activities"] == []
+        assert entry["session_owner"] is None
+
+    def test_status_endpoint_includes_session_owner(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = "worker-home"
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["session_owner"] == "worker-home"
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
         from datetime import datetime, timezone
@@ -192,6 +217,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.is_stale.return_value = False
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -228,6 +254,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.is_stale.return_value = True
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -409,6 +409,7 @@ class TestFetchActivities:
                 "is_stuck": False,
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
+                "session_owner": None,
             }
         }
 
@@ -442,6 +443,7 @@ class TestFetchActivities:
                 "is_stuck": False,
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
+                "session_owner": None,
             },
             "c/d": {
                 "what": "Fixing CI",
@@ -450,6 +452,7 @@ class TestFetchActivities:
                 "is_stuck": True,
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
+                "session_owner": None,
             },
         }
 
@@ -856,6 +859,7 @@ class TestCollect:
         is_stuck: bool = False,
         worker_uptime_seconds: int | None = None,
         webhook_activities: list | None = None,
+        session_owner: str | None = None,
     ) -> dict:
         return {
             "what": what,
@@ -864,6 +868,7 @@ class TestCollect:
             "is_stuck": is_stuck,
             "worker_uptime_seconds": worker_uptime_seconds,
             "webhook_activities": webhook_activities or [],
+            "session_owner": session_owner,
         }
 
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:
@@ -919,6 +924,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            session_owner=None,
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -949,6 +955,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            session_owner=None,
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -972,6 +979,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            session_owner=None,
         )
 
     def test_passes_is_stuck_to_repo_status(self, tmp_path: Path) -> None:
@@ -998,6 +1006,7 @@ class TestCollect:
             worker_stuck=True,
             worker_uptime=None,
             webhook_activities=[],
+            session_owner=None,
         )
 
 
@@ -1097,6 +1106,22 @@ class TestFormatStatus:
         output = format_status(status)
         assert "└─ claude pid 9999" in output
         assert "running" not in output
+
+    def test_claude_pid_with_session_owner(self) -> None:
+        repo = self._repo(
+            issue=1, claude_pid=9999, claude_uptime=60, session_owner="worker-home"
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "└─ claude pid 9999 (running 1m, held by worker-home)" in output
+
+    def test_claude_pid_session_owner_no_uptime(self) -> None:
+        repo = self._repo(
+            issue=1, claude_pid=9999, claude_uptime=None, session_owner="worker-home"
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "└─ claude pid 9999 (held by worker-home)" in output
 
     def test_multiple_repos(self) -> None:
         # Each repo emits a header + "no assigned issues" body line.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2420,44 +2420,6 @@ class TestClaudeRun:
         (fido_dir / "prompt").write_text("prompt")
         return fido_dir
 
-    # ── Resume path ────────────────────────────────────────────────────────
-
-    def test_resume_returns_existing_session_id(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with patch("kennel.worker.claude.resume_session", return_value="output text"):
-            session_id, _ = claude_run(fido_dir, session_id="existing-id")
-        assert session_id == "existing-id"
-
-    def test_resume_returns_output(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with patch("kennel.worker.claude.resume_session", return_value="stream output"):
-            _, output = claude_run(fido_dir, session_id="sid")
-        assert output == "stream output"
-
-    def test_resume_calls_resume_session_with_correct_args(
-        self, tmp_path: Path
-    ) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with patch("kennel.worker.claude.resume_session", return_value="") as mock_rs:
-            claude_run(
-                fido_dir,
-                session_id="my-session",
-                model="claude-opus-4-6",
-                timeout=120,
-            )
-        mock_rs.assert_called_once_with(
-            "my-session", fido_dir / "prompt", "claude-opus-4-6", 120, cwd=None
-        )
-
-    def test_resume_does_not_call_print_prompt_from_file(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch("kennel.worker.claude.resume_session", return_value=""),
-            patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf,
-        ):
-            claude_run(fido_dir, session_id="sid")
-        mock_ppf.assert_not_called()
-
     # ── Start path ─────────────────────────────────────────────────────────
 
     def test_start_returns_new_session_id(self, tmp_path: Path) -> None:
@@ -2500,16 +2462,6 @@ class TestClaudeRun:
             cwd=None,
         )
 
-    def test_start_does_not_call_resume_session(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=""),
-            patch("kennel.claude.extract_session_id", return_value=""),
-            patch("kennel.worker.claude.resume_session") as mock_rs,
-        ):
-            claude_run(fido_dir)
-        mock_rs.assert_not_called()
-
     def test_start_returns_empty_session_id_on_failure(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         with (
@@ -2540,18 +2492,6 @@ class TestClaudeRun:
         ):
             claude_run(fido_dir)
         assert mock_ppf.call_args[0][3] == 300
-
-    def test_passes_custom_model_to_resume(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with patch("kennel.worker.claude.resume_session", return_value="") as mock_rs:
-            claude_run(fido_dir, session_id="sid", model="claude-haiku-4-5-20251001")
-        assert mock_rs.call_args[0][2] == "claude-haiku-4-5-20251001"
-
-    def test_passes_custom_timeout_to_resume(self, tmp_path: Path) -> None:
-        fido_dir = self._setup_fido_dir(tmp_path)
-        with patch("kennel.worker.claude.resume_session", return_value="") as mock_rs:
-            claude_run(fido_dir, session_id="sid", timeout=90)
-        assert mock_rs.call_args[0][3] == 90
 
     # ── Session path ──────────────────────────────────────────────────────
 
@@ -2585,13 +2525,9 @@ class TestClaudeRun:
         session = MagicMock()
         session.__enter__ = MagicMock(return_value=session)
         session.__exit__ = MagicMock(return_value=None)
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf,
-            patch("kennel.worker.claude.resume_session") as mock_rs,
-        ):
+        with patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf:
             claude_run(fido_dir, session=session)
         mock_ppf.assert_not_called()
-        mock_rs.assert_not_called()
 
     def test_session_path_uses_context_manager(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -3166,10 +3102,9 @@ class TestFindOrCreatePr:
             patch("kennel.worker.tasks.list_tasks", side_effect=list_tasks_side_effect),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_start", return_value="setup-sess-open"),
+            patch("kennel.worker.claude_start", return_value=""),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
-        assert load_state(fido_dir).get("setup_session_id") == "setup-sess-open"
 
     def test_open_pr_seeds_from_pr_body_before_setup(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3482,52 +3417,6 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
         gh.create_pr.assert_not_called()
-
-    def test_no_pr_setup_persists_session_id(self, tmp_path: Path) -> None:
-        """New-PR path: setup session_id is saved to state.json."""
-        worker, gh = self._make_worker(tmp_path)
-        gh.find_pr.return_value = None
-        gh.create_pr.return_value = "https://github.com/owner/proj/pull/77"
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
-        with (
-            patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_start", return_value="setup-sess-new"),
-            patch("kennel.worker._write_pr_description"),
-            patch(
-                "kennel.worker.tasks.list_tasks",
-                return_value=[{"title": "t", "status": "pending"}],
-            ),
-        ):
-            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "Fix it")
-        assert load_state(fido_dir).get("setup_session_id") == "setup-sess-new"
-
-    def test_no_pr_setup_persists_session_id_preserves_issue(
-        self, tmp_path: Path
-    ) -> None:
-        """New-PR path: persisting session_id does not clobber the issue key."""
-        worker, gh = self._make_worker(tmp_path)
-        gh.find_pr.return_value = None
-        gh.create_pr.return_value = "https://github.com/owner/proj/pull/77"
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
-        with (
-            patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_start", return_value="setup-sess-new"),
-            patch("kennel.worker._write_pr_description"),
-            patch(
-                "kennel.worker.tasks.list_tasks",
-                return_value=[{"title": "t", "status": "pending"}],
-            ),
-        ):
-            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "Fix it")
-        state = load_state(fido_dir)
-        assert state.get("issue") == 5
-        assert state.get("setup_session_id") == "setup-sess-new"
 
     def test_no_pr_logs_pr_number(self, tmp_path: Path, caplog) -> None:
         import logging
@@ -5722,9 +5611,7 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(
-            fido_dir, session_id="", cwd=tmp_path, session=None
-        )
+        mock_run.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
 
     def test_calls_ensure_pushed_with_origin_and_slug(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -5946,9 +5833,7 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        # First call: fresh start. Second call: resume with session_id.
         assert mock_run.call_count == 2
-        assert mock_run.call_args_list[1][1]["session_id"] == "sess-1"
 
     def test_starts_fresh_when_no_session_id(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -6020,47 +5905,6 @@ class TestExecuteTask:
         assert mock_run.call_count == 4
         mock_complete.assert_called_once()
 
-    def test_drops_stale_session_after_nudge_limit(self, tmp_path: Path) -> None:
-        """After _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION nudges, the next retry
-        drops the session id so claude starts from scratch.  We don't give
-        up on the task — just reset context."""
-        from kennel.worker import _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION
-
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        task = self._pending_task("Stubborn task")
-
-        n = _NUDGE_ATTEMPTS_BEFORE_FRESH_SESSION
-        # head_before=aaa, then n+1 resumes return aaa (no commits), then
-        # the fresh session lands commits at bbb so loop exits.  Every
-        # iteration rev-parses HEAD once.
-        head_seq = ["aaa"] * (1 + (n + 1)) + ["bbb"]
-        head_iter = iter(head_seq)
-
-        def git_side(args, **kw):
-            if args == ["rev-parse", "HEAD"]:
-                return MagicMock(returncode=0, stdout=next(head_iter, "bbb"), stderr="")
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        # Initial + n nudged resumes on sess-1, then the fresh start returns sess-2.
-        runs = [("sess-1", "o")] * (n + 1) + [("sess-2", "fresh")]
-
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_run", side_effect=runs) as mock_run,
-            patch.object(worker, "_git", side_effect=git_side),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
-
-        # Call index (n+1) is the fresh start — session_id kwarg missing/empty.
-        fresh_call = mock_run.call_args_list[n + 1]
-        assert fresh_call.kwargs.get("session_id", "") == ""
-
     def test_breaks_retry_loop_when_task_externally_completed(
         self, tmp_path: Path
     ) -> None:
@@ -6100,108 +5944,6 @@ class TestExecuteTask:
         mock_run.assert_called_once()
         # complete_by_id still called (idempotent — task already completed externally)
         mock_complete.assert_called_once_with(tmp_path, task["id"])
-
-    def test_resumes_setup_session_when_present_in_state(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1, "setup_session_id": "setup-sess-42"})
-        task = self._pending_task("Do the thing")
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch(
-                "kennel.worker.claude_run", return_value=("setup-sess-42", "")
-            ) as mock_run,
-            patch.object(worker, "_git", self._git_with_new_commits()),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(
-            fido_dir, session_id="setup-sess-42", cwd=tmp_path, session=None
-        )
-
-    def test_uses_empty_session_id_when_not_in_state(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
-        task = self._pending_task("Do something")
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch(
-                "kennel.worker.claude_run", return_value=("new-sess", "")
-            ) as mock_run,
-            patch.object(worker, "_git", self._git_with_new_commits()),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(
-            fido_dir, session_id="", cwd=tmp_path, session=None
-        )
-
-    def test_updates_state_with_returned_session_id(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
-        task = self._pending_task("Update state")
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_run", return_value=("returned-sess", "")),
-            patch.object(worker, "_git", self._git_with_new_commits()),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        assert load_state(fido_dir).get("setup_session_id") == "returned-sess"
-
-    def test_does_not_update_state_when_session_id_empty(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
-        task = self._pending_task("No session")
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_run", return_value=("", "")),
-            patch.object(worker, "_git", self._git_with_new_commits()),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        assert "setup_session_id" not in load_state(fido_dir)
-
-    def test_preserves_existing_state_keys_when_updating_session_id(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 99, "setup_session_id": "old-sess"})
-        task = self._pending_task("Preserve keys")
-        with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
-            patch.object(worker, "set_status"),
-            patch("kennel.worker.build_prompt"),
-            patch("kennel.worker.claude_run", return_value=("new-sess", "")),
-            patch.object(worker, "_git", self._git_with_new_commits()),
-            patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
-            patch("kennel.tasks.sync_tasks"),
-        ):
-            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        state = load_state(fido_dir)
-        assert state.get("setup_session_id") == "new-sess"
-        assert state.get("issue") == 99
 
     def test_saves_current_task_id_to_state_before_claude_run(
         self, tmp_path: Path
@@ -6252,7 +5994,7 @@ class TestExecuteTask:
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5, "setup_session_id": "old-sess"})
+        save_state(fido_dir, {"issue": 5})
         task = {"id": "t-111", "title": "Preserve", "status": "pending"}
         captured: dict = {}
 
@@ -6272,7 +6014,6 @@ class TestExecuteTask:
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "br")
         assert captured.get("issue") == 5
-        assert captured.get("setup_session_id") == "old-sess"
         assert captured.get("current_task_id") == "t-111"
 
     def test_current_task_id_not_cleared_when_push_fails(self, tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -750,14 +750,14 @@ class TestWorker:
         from kennel import claude
 
         worker = Worker(tmp_path, MagicMock())
-        worker.create_session(tmp_path)
+        worker.create_session()
         claude.ClaudeSession.assert_called_once()
 
     def test_create_session_passes_work_dir(self, tmp_path: Path) -> None:
         from kennel import claude
 
         worker = Worker(tmp_path, MagicMock())
-        worker.create_session(tmp_path)
+        worker.create_session()
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("work_dir") == tmp_path
 
@@ -767,7 +767,7 @@ class TestWorker:
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
         worker = Worker(tmp_path, MagicMock())
-        worker.create_session(tmp_path)
+        worker.create_session()
         mock_session.switch_model.assert_called_once_with("claude-opus-4-6")
 
     def test_create_session_stores_on_self(self, tmp_path: Path) -> None:
@@ -776,7 +776,7 @@ class TestWorker:
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
         worker = Worker(tmp_path, MagicMock())
-        worker.create_session(tmp_path)
+        worker.create_session()
         assert worker._session is mock_session
 
     def test_stop_session_calls_stop(self, tmp_path: Path) -> None:
@@ -879,7 +879,7 @@ class TestWorker:
             patch.object(worker, "find_next_issue", return_value=None),
         ):
             worker.run()
-        mock_create.assert_called_once_with(mock_ctx.fido_dir)
+        mock_create.assert_called_once_with()
 
     def test_run_switches_to_sonnet_after_setup_for_fresh_session(
         self, tmp_path: Path

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -761,6 +761,22 @@ class TestWorker:
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("work_dir") == tmp_path
 
+    def test_create_session_passes_model(self, tmp_path: Path) -> None:
+        from kennel import claude
+
+        worker = Worker(tmp_path, MagicMock())
+        worker.create_session(tmp_path, model="claude-opus-4-6")
+        _, kwargs = claude.ClaudeSession.call_args
+        assert kwargs.get("model") == "claude-opus-4-6"
+
+    def test_create_session_default_model_is_sonnet(self, tmp_path: Path) -> None:
+        from kennel import claude
+
+        worker = Worker(tmp_path, MagicMock())
+        worker.create_session(tmp_path)
+        _, kwargs = claude.ClaudeSession.call_args
+        assert kwargs.get("model") == "claude-sonnet-4-6"
+
     def test_create_session_stores_on_self(self, tmp_path: Path) -> None:
         from kennel import claude
 
@@ -870,7 +886,36 @@ class TestWorker:
             patch.object(worker, "find_next_issue", return_value=None),
         ):
             worker.run()
-        mock_create.assert_called_once_with(mock_ctx.fido_dir)
+        mock_create.assert_called_once_with(mock_ctx.fido_dir, model="claude-opus-4-6")
+
+    def test_run_switches_to_sonnet_after_setup(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        mock_session = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive"),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker._session = mock_session
+            worker.run()
+        mock_session.switch_model.assert_called_once_with("claude-sonnet-4-6")
 
     def test_run_stops_session_on_exit(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -921,7 +921,8 @@ class TestWorker:
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
         mock_session = MagicMock()
-        worker = Worker(tmp_path, gh, session=mock_session)  # carry-over
+        # same issue as last time — no boundary restart, no model switch
+        worker = Worker(tmp_path, gh, session=mock_session, session_issue=7)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -941,6 +942,64 @@ class TestWorker:
         ):
             worker.run()
         mock_session.switch_model.assert_not_called()
+
+    def test_run_restarts_session_at_issue_boundary(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        mock_session = MagicMock()
+        # session was working on issue 5; now issue 7 is picked — boundary
+        worker = Worker(tmp_path, gh, session=mock_session, session_issue=5)
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive"),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        mock_session.restart.assert_called_once()
+        # opus first (boundary restart), then sonnet (session_fresh path)
+        assert mock_session.switch_model.call_args_list == [
+            call("claude-opus-4-6"),
+            call("claude-sonnet-4-6"),
+        ]
+
+    def test_run_sets_session_issue_after_picking_issue(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        mock_session = MagicMock()
+        worker = Worker(tmp_path, gh, session=mock_session, session_issue=7)
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive"),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        assert worker._session_issue == 7
 
     def test_run_does_not_create_session_when_provided(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
@@ -8658,12 +8717,14 @@ class TestWorkerThread:
             registry=None,
             membership=None,
             session=None,
+            session_issue=None,
         ):
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
             self_w._session = session
+            self_w._session_issue = session_issue
 
         def fake_worker_run(self_w):
             wt._stop = True
@@ -8697,9 +8758,9 @@ class TestWorkerThread:
 
         assert call_count == 2
         assert mock_registry.report_activity.call_count == 2
-        for call in mock_registry.report_activity.call_args_list:
-            assert call.args[0] == "owner/repo"
-            assert call.kwargs.get("busy") is False or call.args[2] is False
+        for c in mock_registry.report_activity.call_args_list:
+            assert c.args[0] == "owner/repo"
+            assert c.kwargs.get("busy") is False or c.args[2] is False
 
     def test_heartbeat_not_emitted_when_no_registry(self, tmp_path: Path) -> None:
         """WorkerThread without a registry must not crash on the heartbeat path."""
@@ -8731,11 +8792,13 @@ class TestWorkerThread:
             registry=None,
             membership=None,
             session=None,
+            session_issue=None,
         ) -> None:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
             self_w._session = session
+            self_w._session_issue = session_issue
             sessions_received.append(session)
 
         call_count = 0
@@ -8758,6 +8821,51 @@ class TestWorkerThread:
         assert len(sessions_received) == 2
         assert sessions_received[0] is None  # no carry-over on first iteration
         assert sessions_received[1] is mock_session  # carried forward
+
+    def test_session_issue_carried_to_next_iteration(self, tmp_path: Path) -> None:
+        """session_issue set by one Worker.run() is passed to the next."""
+        wt = self._make_thread(tmp_path)
+        wt._wake = MagicMock()
+        issues_received: list = []
+
+        def fake_worker_init(
+            self_w,
+            work_dir,
+            gh,
+            abort_task=None,
+            repo_name="",
+            registry=None,
+            membership=None,
+            session=None,
+            session_issue=None,
+        ) -> None:
+            self_w.work_dir = work_dir
+            self_w.gh = gh
+            self_w._abort_task = abort_task
+            self_w._session = session
+            self_w._session_issue = session_issue
+            issues_received.append(session_issue)
+
+        call_count = 0
+
+        def fake_worker_run(self_w) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                self_w._session_issue = 42  # first worker picks issue 42
+                return 1
+            wt._stop = True
+            return 0
+
+        with (
+            patch.object(Worker, "__init__", fake_worker_init),
+            patch.object(Worker, "run", fake_worker_run),
+        ):
+            self._run_thread(wt)
+
+        assert len(issues_received) == 2
+        assert issues_received[0] is None  # no carry-over on first iteration
+        assert issues_received[1] == 42  # carried forward
 
     def test_session_stopped_when_thread_exits(self, tmp_path: Path) -> None:
         """WorkerThread stops the session when its loop finishes."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4267,7 +4267,7 @@ class TestHandleCi:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
-        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path)
+        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
 
     def test_does_not_complete_ci_task(self, tmp_path: Path) -> None:
         """CI failures have no task entry — no complete call needed."""
@@ -4960,7 +4960,7 @@ class TestHandleThreads:
             patch("kennel.tasks.sync_tasks_background"),
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
-        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path)
+        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
 
     def test_spawns_sync_script(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -888,12 +888,18 @@ class TestWorker:
             worker.run()
         mock_create.assert_called_once_with(mock_ctx.fido_dir, model="claude-opus-4-6")
 
-    def test_run_switches_to_sonnet_after_setup(self, tmp_path: Path) -> None:
+    def test_run_switches_to_sonnet_after_setup_for_fresh_session(
+        self, tmp_path: Path
+    ) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh)  # no session — fresh
         mock_session = MagicMock()
+
+        def set_session(*args, **kwargs):
+            worker._session = mock_session
+
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -901,8 +907,7 @@ class TestWorker:
             ),
             patch.object(worker, "setup_hooks", return_value=("c", "s")),
             patch.object(worker, "teardown_hooks"),
-            patch.object(worker, "create_session"),
-            patch.object(worker, "stop_session"),
+            patch.object(worker, "create_session", side_effect=set_session),
             patch.object(worker, "get_current_issue", return_value=7),
             patch.object(worker, "post_pickup_comment"),
             patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
@@ -913,15 +918,17 @@ class TestWorker:
             patch.object(worker, "execute_task", return_value=False),
             patch.object(worker, "handle_promote_merge", return_value=0),
         ):
-            worker._session = mock_session
             worker.run()
         mock_session.switch_model.assert_called_once_with("claude-sonnet-4-6")
 
-    def test_run_stops_session_on_exit(self, tmp_path: Path) -> None:
+    def test_run_does_not_switch_model_for_carry_over_session(
+        self, tmp_path: Path
+    ) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
-        mock_stop = MagicMock()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        mock_session = MagicMock()
+        worker = Worker(tmp_path, gh, session=mock_session)  # carry-over
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -929,33 +936,37 @@ class TestWorker:
             ),
             patch.object(worker, "setup_hooks", return_value=("c", "s")),
             patch.object(worker, "teardown_hooks"),
-            patch.object(worker, "create_session"),
-            patch.object(worker, "stop_session", mock_stop),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive"),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        mock_session.switch_model.assert_not_called()
+
+    def test_run_does_not_create_session_when_provided(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        mock_session = MagicMock()
+        worker = Worker(tmp_path, gh, session=mock_session)
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session") as mock_create,
             patch.object(worker, "get_current_issue", return_value=None),
             patch.object(worker, "find_next_issue", return_value=None),
         ):
             worker.run()
-        mock_stop.assert_called_once()
-
-    def test_run_stops_session_even_on_exception(self, tmp_path: Path) -> None:
-        mock_ctx = self._make_mock_ctx(tmp_path)
-        gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
-        mock_stop = MagicMock()
-        with (
-            patch.object(worker, "create_context", return_value=mock_ctx),
-            patch.object(
-                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
-            ),
-            patch.object(worker, "setup_hooks", return_value=("c", "s")),
-            patch.object(worker, "teardown_hooks"),
-            patch.object(worker, "create_session"),
-            patch.object(worker, "stop_session", mock_stop),
-            patch.object(worker, "get_current_issue", side_effect=RuntimeError("boom")),
-        ):
-            with pytest.raises(RuntimeError):
-                worker.run()
-        mock_stop.assert_called_once()
+        mock_create.assert_not_called()
 
     # --- run() ---
 
@@ -8653,11 +8664,13 @@ class TestWorkerThread:
             repo_name="",
             registry=None,
             membership=None,
+            session=None,
         ):
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
+            self_w._session = session
 
         def fake_worker_run(self_w):
             wt._stop = True
@@ -8706,3 +8719,80 @@ class TestWorkerThread:
 
         with patch.object(Worker, "run", fake_worker_run):
             self._run_thread(wt)  # must not raise
+
+    # ── session lifecycle ─────────────────────────────────────────────────
+
+    def test_session_carried_to_next_iteration(self, tmp_path: Path) -> None:
+        """Session created by one Worker.run() is passed to the next."""
+        wt = self._make_thread(tmp_path)
+        wt._wake = MagicMock()
+        mock_session = MagicMock()
+        sessions_received: list = []
+
+        def fake_worker_init(
+            self_w,
+            work_dir,
+            gh,
+            abort_task=None,
+            repo_name="",
+            registry=None,
+            membership=None,
+            session=None,
+        ) -> None:
+            self_w.work_dir = work_dir
+            self_w.gh = gh
+            self_w._abort_task = abort_task
+            self_w._session = session
+            sessions_received.append(session)
+
+        call_count = 0
+
+        def fake_worker_run(self_w) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                self_w._session = mock_session  # first worker creates a session
+                return 1
+            wt._stop = True
+            return 0
+
+        with (
+            patch.object(Worker, "__init__", fake_worker_init),
+            patch.object(Worker, "run", fake_worker_run),
+        ):
+            self._run_thread(wt)
+
+        assert len(sessions_received) == 2
+        assert sessions_received[0] is None  # no carry-over on first iteration
+        assert sessions_received[1] is mock_session  # carried forward
+
+    def test_session_stopped_when_thread_exits(self, tmp_path: Path) -> None:
+        """WorkerThread stops the session when its loop finishes."""
+        wt = self._make_thread(tmp_path)
+        mock_session = MagicMock()
+        wt._session = mock_session
+        wt._stop = True  # exit immediately without running any Worker
+
+        with patch.object(Worker, "run"):
+            wt.run()
+
+        mock_session.stop.assert_called_once()
+        assert wt._session is None
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_session_stopped_when_worker_raises(self, tmp_path: Path) -> None:
+        """WorkerThread stops the session even when Worker.run() raises."""
+        wt = self._make_thread(tmp_path)
+        mock_session = MagicMock()
+
+        def fake_worker_run(self_w) -> int:
+            self_w._session = mock_session
+            raise RuntimeError("boom")
+
+        with patch.object(Worker, "run", fake_worker_run):
+            wt.start()
+            wt.join(timeout=5.0)
+
+        assert not wt.is_alive()
+        mock_session.stop.assert_called_once()
+        assert wt._session is None

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2553,6 +2553,55 @@ class TestClaudeRun:
             claude_run(fido_dir, session_id="sid", timeout=90)
         assert mock_rs.call_args[0][3] == 90
 
+    # ── Session path ──────────────────────────────────────────────────────
+
+    def test_session_path_returns_empty_tuple(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        result = claude_run(fido_dir, session=session)
+        assert result == ("", "")
+
+    def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        (fido_dir / "prompt").write_text("run this task")
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_run(fido_dir, session=session)
+        session.send.assert_called_once_with("run this task")
+
+    def test_session_path_calls_consume_until_result(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_run(fido_dir, session=session)
+        session.consume_until_result.assert_called_once()
+
+    def test_session_path_does_not_call_subprocess(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        with (
+            patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf,
+            patch("kennel.worker.claude.resume_session") as mock_rs,
+        ):
+            claude_run(fido_dir, session=session)
+        mock_ppf.assert_not_called()
+        mock_rs.assert_not_called()
+
+    def test_session_path_uses_context_manager(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_run(fido_dir, session=session)
+        session.__enter__.assert_called_once()
+        session.__exit__.assert_called_once()
+
 
 class TestSanitizeSlug:
     """Tests for _sanitize_slug."""
@@ -5673,7 +5722,9 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(fido_dir, session_id="", cwd=tmp_path)
+        mock_run.assert_called_once_with(
+            fido_dir, session_id="", cwd=tmp_path, session=None
+        )
 
     def test_calls_ensure_pushed_with_origin_and_slug(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -6069,7 +6120,7 @@ class TestExecuteTask:
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_run.assert_called_once_with(
-            fido_dir, session_id="setup-sess-42", cwd=tmp_path
+            fido_dir, session_id="setup-sess-42", cwd=tmp_path, session=None
         )
 
     def test_uses_empty_session_id_when_not_in_state(self, tmp_path: Path) -> None:
@@ -6090,7 +6141,9 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(fido_dir, session_id="", cwd=tmp_path)
+        mock_run.assert_called_once_with(
+            fido_dir, session_id="", cwd=tmp_path, session=None
+        )
 
     def test_updates_state_with_returned_session_id(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -788,6 +788,70 @@ class TestWorker:
         assert worker._session is None
         worker.stop_session()  # must not raise
 
+    # --- _ensure_session_alive ---
+
+    def test_ensure_session_alive_restarts_dead_session(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        mock_session = MagicMock()
+        mock_session.is_alive.return_value = False
+        worker._session = mock_session
+        worker._ensure_session_alive(tmp_path)
+        mock_session.restart.assert_called_once()
+
+    def test_ensure_session_alive_noop_when_alive(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        mock_session = MagicMock()
+        mock_session.is_alive.return_value = True
+        worker._session = mock_session
+        worker._ensure_session_alive(tmp_path)
+        mock_session.restart.assert_not_called()
+
+    def test_ensure_session_alive_noop_when_no_session(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        assert worker._session is None
+        worker._ensure_session_alive(tmp_path)  # must not raise
+
+    def test_ensure_session_alive_logs_warning_on_restart(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        import logging
+
+        worker = Worker(tmp_path, MagicMock())
+        mock_session = MagicMock()
+        mock_session.is_alive.return_value = False
+        worker._session = mock_session
+        with caplog.at_level(logging.WARNING, logger="kennel.worker"):
+            worker._ensure_session_alive(tmp_path)
+        assert any("restart" in r.message.lower() for r in caplog.records)
+
+    def test_run_ensures_session_alive_before_handlers(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        mock_ensure = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive", mock_ensure),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        mock_ensure.assert_called_once_with(mock_ctx.fido_dir)
+
     def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -761,21 +761,14 @@ class TestWorker:
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("work_dir") == tmp_path
 
-    def test_create_session_passes_model(self, tmp_path: Path) -> None:
+    def test_create_session_switches_to_opus(self, tmp_path: Path) -> None:
         from kennel import claude
 
-        worker = Worker(tmp_path, MagicMock())
-        worker.create_session(tmp_path, model="claude-opus-4-6")
-        _, kwargs = claude.ClaudeSession.call_args
-        assert kwargs.get("model") == "claude-opus-4-6"
-
-    def test_create_session_default_model_is_sonnet(self, tmp_path: Path) -> None:
-        from kennel import claude
-
+        mock_session = MagicMock()
+        claude.ClaudeSession.return_value = mock_session
         worker = Worker(tmp_path, MagicMock())
         worker.create_session(tmp_path)
-        _, kwargs = claude.ClaudeSession.call_args
-        assert kwargs.get("model") == "claude-sonnet-4-6"
+        mock_session.switch_model.assert_called_once_with("claude-opus-4-6")
 
     def test_create_session_stores_on_self(self, tmp_path: Path) -> None:
         from kennel import claude
@@ -886,7 +879,7 @@ class TestWorker:
             patch.object(worker, "find_next_issue", return_value=None),
         ):
             worker.run()
-        mock_create.assert_called_once_with(mock_ctx.fido_dir, model="claude-opus-4-6")
+        mock_create.assert_called_once_with(mock_ctx.fido_dir)
 
     def test_run_switches_to_sonnet_after_setup_for_fresh_session(
         self, tmp_path: Path

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -52,6 +52,20 @@ from kennel.worker import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_claude_session_spawn(monkeypatch):
+    """Patch ClaudeSession for every test in this module.
+
+    Worker.run() now creates a ClaudeSession on entry.  Without this fixture
+    every test that calls worker.run() would try to spawn a real claude
+    subprocess.  The mock is a MagicMock so all attribute and method accesses
+    (stop, send, iter_events, …) work without raising AttributeError.
+    """
+    from kennel import claude
+
+    monkeypatch.setattr(claude, "ClaudeSession", MagicMock(return_value=MagicMock()))
+
+
 class TestRepoContextFilter:
     def test_filter_injects_repo_name_from_thread_local(self) -> None:
         _thread_repo.repo_name = "confusio"
@@ -729,6 +743,112 @@ class TestWorker:
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
         return repo_ctx
+
+    # --- create_session / stop_session ---
+
+    def test_create_session_instantiates_claude_session(self, tmp_path: Path) -> None:
+        from kennel import claude
+
+        worker = Worker(tmp_path, MagicMock())
+        worker.create_session(tmp_path)
+        claude.ClaudeSession.assert_called_once()
+
+    def test_create_session_passes_work_dir(self, tmp_path: Path) -> None:
+        from kennel import claude
+
+        worker = Worker(tmp_path, MagicMock())
+        worker.create_session(tmp_path)
+        _, kwargs = claude.ClaudeSession.call_args
+        assert kwargs.get("work_dir") == tmp_path
+
+    def test_create_session_stores_on_self(self, tmp_path: Path) -> None:
+        from kennel import claude
+
+        mock_session = MagicMock()
+        claude.ClaudeSession.return_value = mock_session
+        worker = Worker(tmp_path, MagicMock())
+        worker.create_session(tmp_path)
+        assert worker._session is mock_session
+
+    def test_stop_session_calls_stop(self, tmp_path: Path) -> None:
+        mock_session = MagicMock()
+        worker = Worker(tmp_path, MagicMock())
+        worker._session = mock_session
+        worker.stop_session()
+        mock_session.stop.assert_called_once()
+
+    def test_stop_session_clears_session(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        worker._session = MagicMock()
+        worker.stop_session()
+        assert worker._session is None
+
+    def test_stop_session_is_noop_when_none(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        assert worker._session is None
+        worker.stop_session()  # must not raise
+
+    def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        worker = Worker(tmp_path, gh)
+        mock_create = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session", mock_create),
+            patch.object(worker, "stop_session"),
+            patch.object(worker, "get_current_issue", return_value=None),
+            patch.object(worker, "find_next_issue", return_value=None),
+        ):
+            worker.run()
+        mock_create.assert_called_once_with(mock_ctx.fido_dir)
+
+    def test_run_stops_session_on_exit(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        worker = Worker(tmp_path, gh)
+        mock_stop = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session", mock_stop),
+            patch.object(worker, "get_current_issue", return_value=None),
+            patch.object(worker, "find_next_issue", return_value=None),
+        ):
+            worker.run()
+        mock_stop.assert_called_once()
+
+    def test_run_stops_session_even_on_exception(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        worker = Worker(tmp_path, gh)
+        mock_stop = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session", mock_stop),
+            patch.object(worker, "get_current_issue", side_effect=RuntimeError("boom")),
+        ):
+            with pytest.raises(RuntimeError):
+                worker.run()
+        mock_stop.assert_called_once()
+
+    # --- run() ---
 
     def test_run_returns_2_when_lock_held(self, tmp_path: Path) -> None:
         gh = self._make_gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8897,3 +8897,15 @@ class TestWorkerThread:
         assert not wt.is_alive()
         mock_session.stop.assert_called_once()
         assert wt._session is None
+
+    def test_session_owner_returns_none_when_no_session(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt._session is None
+        assert wt.session_owner is None
+
+    def test_session_owner_delegates_to_session(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        mock_session = MagicMock()
+        mock_session.owner = "worker-home"
+        wt._session = mock_session
+        assert wt.session_owner == "worker-home"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8881,8 +8881,12 @@ class TestWorkerThread:
         assert wt._session is None
 
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
-    def test_session_stopped_when_worker_raises(self, tmp_path: Path) -> None:
-        """WorkerThread stops the session even when Worker.run() raises."""
+    def test_session_preserved_when_worker_raises(self, tmp_path: Path) -> None:
+        """WorkerThread leaves the session alive when Worker.run() raises.
+
+        The registry rescues the live session and passes it to the replacement
+        thread so the persistent ClaudeSession survives the crash.
+        """
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
 
@@ -8895,8 +8899,17 @@ class TestWorkerThread:
             wt.join(timeout=5.0)
 
         assert not wt.is_alive()
-        mock_session.stop.assert_called_once()
-        assert wt._session is None
+        mock_session.stop.assert_not_called()  # session must NOT be stopped
+        assert wt._session is mock_session  # still reachable for registry to rescue
+
+    def test_session_accepted_via_constructor(self, tmp_path: Path) -> None:
+        """Session passed to WorkerThread constructor is used as the initial session."""
+        mock_session = MagicMock()
+        wt = WorkerThread(
+            tmp_path, "owner/repo", MagicMock(), session=mock_session, session_issue=7
+        )
+        assert wt._session is mock_session
+        assert wt._session_issue == 7
 
     def test_session_owner_returns_none_when_no_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2364,6 +2364,51 @@ class TestClaudeStart:
             claude_start(fido_dir)
         mock_ext.assert_called_once_with(raw)
 
+    # ── Session path ──────────────────────────────────────────────────────
+
+    def test_session_path_returns_empty_string(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        result = claude_start(fido_dir, session=session)
+        assert result == ""
+
+    def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        (fido_dir / "prompt").write_text("the task prompt")
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_start(fido_dir, session=session)
+        session.send.assert_called_once_with("the task prompt")
+
+    def test_session_path_calls_consume_until_result(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_start(fido_dir, session=session)
+        session.consume_until_result.assert_called_once()
+
+    def test_session_path_does_not_call_subprocess(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        with patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf:
+            claude_start(fido_dir, session=session)
+        mock_ppf.assert_not_called()
+
+    def test_session_path_uses_context_manager(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=None)
+        claude_start(fido_dir, session=session)
+        session.__enter__.assert_called_once()
+        session.__exit__.assert_called_once()
+
 
 class TestClaudeRun:
     """Tests for claude_run."""
@@ -3021,7 +3066,7 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY)
-        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path)
+        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
 
     def test_open_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3243,7 +3288,7 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY)
-        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path)
+        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
 
     def test_no_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)


### PR DESCRIPTION
Introduces a persistent ClaudeSession that keeps a single stream-json subprocess alive across a worker's setup, task, nudge, thread, and CI phases, switching between Opus for planning/triage and Sonnet for implementation, and bounds context growth by restarting on issue boundaries. Remaining work fixes a session teardown bug so cleanup only runs on orderly shutdown (with a crash-recovery test and an outer try/finally around `stop()` to always unregister the child), resolves a lost-interrupt race from clearing `_cancel` on every lock acquisition, sends a stream-json `control_request` interrupt in `ClaudeSession.interrupt` before follow-up content, and removes the durable preempt queue since it has no production path.

Fixes #455.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (40)</summary>

- [x] [Blocking: clearing `_cancel` on every lock acquisition creates a lost-interrupt](https://github.com/FidoCanCode/home/pull/456#discussion_r3080536956) <!-- type:thread -->
- [x] [Woof, you are absolutely right — caught me red-pawed! That unconditional stop()](https://github.com/FidoCanCode/home/pull/456#discussion_r3080537674) <!-- type:thread -->
- [x] PR comment: fix session teardown — only on orderly shutdown, add crash-recovery test <!-- type:thread -->
- [x] [wrap stop() body in outer try/finally to always unregister child](https://github.com/FidoCanCode/home/pull/456#discussion_r3080536964) <!-- type:thread -->
- [x] [send stream-json control_request interrupt in ClaudeSession.interrupt before sending follow-up content](https://github.com/FidoCanCode/home/pull/456#discussion_r3080537011) <!-- type:thread -->
- [x] [High: this persists a durable preempt queue, but I cant find a production path t](https://github.com/FidoCanCode/home/pull/456#discussion_r3080536979) <!-- type:thread -->
- [x] PR comment: remove unnecessary default model setting <!-- type:thread -->
- [x] [replace ClaudeStreamError(-1) magic number with a named constant or sentinel](https://github.com/FidoCanCode/home/pull/456#discussion_r3078130409) <!-- type:thread -->
- [x] [replace repeated truncation slicing with a helper that wraps log calls](https://github.com/FidoCanCode/home/pull/456#discussion_r3078089657) <!-- type:thread -->
- [x] [use context manager for lock acquire/release in interrupt](https://github.com/FidoCanCode/home/pull/456#discussion_r3078119263) <!-- type:thread -->
- [x] [reuse State's thread-safe JSON base class with modify method for the preempt intent queue](https://github.com/FidoCanCode/home/pull/456#discussion_r3077914220) <!-- type:thread -->
- [x] [surface errors instead of swallowing them silently](https://github.com/FidoCanCode/home/pull/456#discussion_r3078080087) <!-- type:thread -->
- [x] [Reraise the exception](https://github.com/FidoCanCode/home/pull/456#discussion_r3078136917) <!-- type:thread -->
- [x] [reraise exceptions in restart cleanup instead of swallowing](https://github.com/FidoCanCode/home/pull/456#discussion_r3078135681) <!-- type:thread -->
- [x] [reraise exceptions in restart() instead of swallowing them](https://github.com/FidoCanCode/home/pull/456#discussion_r3078132643) <!-- type:thread -->
- [x] [We can't spawn a new one if the old one running when timeout happens?](https://github.com/FidoCanCode/home/pull/456#discussion_r3078114474) <!-- type:thread -->
- [x] [We have to kill and safe restart. Kind of our mantra.](https://github.com/FidoCanCode/home/pull/456#discussion_r3078157964) <!-- type:thread -->
- [x] [Yes](https://github.com/FidoCanCode/home/pull/456#discussion_r3078160653) <!-- type:thread -->
- [x] Bound context growth: restart ClaudeSession on issue boundary <!-- type:spec -->
- [x] [surface current ClaudeSession owner thread in kennel status line](https://github.com/FidoCanCode/home/pull/456#discussion_r3077897600) <!-- type:thread -->
- [x] [clarify ClaudeSession persists across worker death but not kennel/home restarts](https://github.com/FidoCanCode/home/pull/456#issuecomment-4242164254) <!-- type:thread -->
- [x] [persist preempt intent to durable queue so interrupts survive re-preemption without losing messages](https://github.com/FidoCanCode/home/pull/456#discussion_r3077907037) <!-- type:thread -->
- [x] [preserve ClaudeSession across worker death so webhook-driven interrupts keep the subprocess alive and hand it back when the worker reclaims the lock](https://github.com/FidoCanCode/home/pull/456#discussion_r3077883250) <!-- type:thread -->
- [x] Route execute_task and nudge loop through the persistent ClaudeSession <!-- type:spec -->
- [x] Route handle_threads and handle_ci claude_run calls through the persistent session <!-- type:spec -->
- [x] Remove setup_session_id state and dead --resume plumbing now superseded by session <!-- type:spec -->
- [x] Switch models per phase: Opus for planning/triage, Sonnet for implementation <!-- type:spec -->
- [x] [make interrupt cancel the in-flight turn so the lock holder exits](https://github.com/FidoCanCode/home/pull/456#discussion_r3077863522) <!-- type:thread -->
- [x] [make interrupt cancel the in-flight turn so the lock holder exits](https://github.com/FidoCanCode/home/pull/456#discussion_r3077863522) <!-- type:thread -->
- [x] [extract idle timeout poll interval and event line log-truncation length into named constants](https://github.com/FidoCanCode/home/pull/456#discussion_r3077710926) <!-- type:thread -->
- [x] [log exceptions in stop() cleanup instead of swallowing silently](https://github.com/FidoCanCode/home/pull/456#discussion_r3077714034) <!-- type:thread -->
- [x] [remove JSONDecodeError handler and let the exception propagate](https://github.com/FidoCanCode/home/pull/456#discussion_r3077729802) <!-- type:thread -->
- [x] [Add threading lock and context manager to ClaudeSession for send/receive serialization](https://github.com/FidoCanCode/home/pull/456#discussion_r3077724061) <!-- type:thread -->
- [x] [Expose lock-break path so preempt/interrupt can bypass the session lock](https://github.com/FidoCanCode/home/pull/456#discussion_r3077741867) <!-- type:thread -->
- [x] [Implement preempt via control_request interrupt with queued follow-up turn](https://github.com/FidoCanCode/home/pull/456#issuecomment-4241910137) <!-- type:thread -->
- [x] Add ClaudeSession: bidirectional stream-json subprocess with send/events/stop <!-- type:spec -->
- [x] ClaudeSession: idle-timeout reader and _active_children registration for shutdown <!-- type:spec -->
- [x] ClaudeSession.switch_model via /model slash command with tests <!-- type:spec -->
- [x] ClaudeSession.consume_until_result: drain events until type=result boundary <!-- type:spec -->
- [x] [make interrupt kill the in-flight turn, then acquire the lock before sending](https://github.com/FidoCanCode/home/pull/456#discussion_r3077871290) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->