### PR TITLE
ClaudeTalker registry + session_alive + halt on leak (closes #473)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,14 @@ When a `thread`-type task is created (PR comment feedback), `create_task()` trig
 - **Pre-commit hook** — blocks commits that fail format/lint/tests
 - **One entry point** — `kennel` (heading toward all-threads architecture)
 - **No `@staticmethod`** — use module-level functions instead; static methods can't be patched via `self` and resist the dependency injection pattern
+- **Thread safety (Python 3.14t, free-threaded, no GIL)** — kennel runs on
+  the free-threaded build.  Do **not** rely on the GIL for atomicity.  Every
+  shared mutable state (dicts, sets, lists, counters, attribute mutations
+  observed from other threads) must be guarded by an explicit lock, or use a
+  primitive that documents its own thread-safe contract (`threading.Event`,
+  `queue.Queue`, `threading.local`).  In particular: `dict.setdefault`,
+  attribute reads, and integer increments are **not** safe across threads
+  without a lock.  When in doubt, hold the lock.
 
 ### Dependency injection pattern
 

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -11,7 +11,10 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +69,106 @@ def _register_child(proc: subprocess.Popen) -> None:
 def _unregister_child(proc: subprocess.Popen) -> None:
     with _active_children_lock:
         _active_children.discard(proc)
+
+
+# ── Claude-talker registry ────────────────────────────────────────────────────
+# At most one thread per repo may be "talking to" a claude subprocess at any
+# moment — either via the persistent :class:`ClaudeSession` lock or via a
+# one-shot ``claude --print`` (streaming or batch).  Concurrent registration
+# for the same repo means something is leaking a sub-claude and we halt loud
+# rather than silently proliferate processes.
+
+
+class ClaudeLeakError(RuntimeError):
+    """Raised when a second thread tries to talk to claude for a repo that
+    already has an active talker.  Fatal — kennel halts rather than let
+    sub-claudes multiply silently."""
+
+
+@dataclass(frozen=True)
+class ClaudeTalker:
+    """Snapshot of the thread currently driving a claude subprocess.
+
+    *kind* distinguishes between the persistent session path (``"worker"`` —
+    the worker thread is inside a ``with session:`` block) and one-shot
+    ``claude --print`` invocations from a webhook handler (``"webhook"``).
+    *description* is a short human label for status display.
+    """
+
+    repo_name: str
+    thread_name: str
+    kind: Literal["worker", "webhook"]
+    description: str
+    claude_pid: int
+    started_at: datetime
+
+
+_talkers: dict[str, ClaudeTalker] = {}
+_talkers_lock = threading.Lock()
+
+# Thread-local repo_name so downstream one-shot claude calls know which
+# repo they belong to without plumbing repo_name through every helper in
+# :mod:`kennel.events`.  Set at :func:`kennel.server.WebhookHandler._process_action`
+# entry and at :meth:`kennel.worker.WorkerThread.run` entry, cleared on
+# exit.  Reads fall back to ``None`` in tests and tools that do not set it.
+_thread_local: threading.local = threading.local()
+
+
+def set_thread_repo(repo_name: str | None) -> None:
+    """Set (or clear, with ``None``) the repo_name for this thread."""
+    if repo_name is None:
+        if hasattr(_thread_local, "repo_name"):
+            del _thread_local.repo_name
+    else:
+        _thread_local.repo_name = repo_name
+
+
+def current_repo() -> str | None:
+    """Return the repo_name set by :func:`set_thread_repo` on this thread."""
+    return getattr(_thread_local, "repo_name", None)
+
+
+def register_talker(talker: ClaudeTalker) -> None:
+    """Register *talker* as the active claude driver for its repo.
+
+    Raises :class:`ClaudeLeakError` if a talker for the same repo is already
+    registered — the guarantee is one claude per repo at a time.
+    """
+    with _talkers_lock:
+        existing = _talkers.get(talker.repo_name)
+        if existing is not None:
+            raise ClaudeLeakError(
+                f"claude leak for repo {talker.repo_name}: "
+                f"{existing.thread_name} ({existing.kind}, "
+                f"{existing.description}, pid={existing.claude_pid}) "
+                f"still active when {talker.thread_name} ({talker.kind}, "
+                f"{talker.description}, pid={talker.claude_pid}) tried to start"
+            )
+        _talkers[talker.repo_name] = talker
+
+
+def unregister_talker(repo_name: str, thread_name: str) -> None:
+    """Remove the talker entry for *repo_name* if it belongs to *thread_name*.
+
+    Idempotent — safe to call from cleanup paths that may race the registry.
+    Non-matching thread_name is a no-op (defensive against cross-thread
+    cleanup bugs).
+    """
+    with _talkers_lock:
+        existing = _talkers.get(repo_name)
+        if existing is not None and existing.thread_name == thread_name:
+            del _talkers[repo_name]
+
+
+def get_talker(repo_name: str) -> ClaudeTalker | None:
+    """Return the active talker for *repo_name*, or ``None`` if idle."""
+    with _talkers_lock:
+        return _talkers.get(repo_name)
+
+
+def _talker_now() -> datetime:
+    """Seam for tests — override this module attribute to freeze time."""
+    return datetime.now(tz=timezone.utc)
 
 
 def kill_active_children(grace_seconds: float = 2.0) -> None:
@@ -294,6 +397,21 @@ def _run_streaming(
         cwd=cwd,
     )
     _register_child(proc)
+    repo_name = current_repo()
+    thread_name = threading.current_thread().name
+    talker_registered = False
+    if repo_name is not None:
+        register_talker(
+            ClaudeTalker(
+                repo_name=repo_name,
+                thread_name=thread_name,
+                kind="webhook",
+                description=f"one-shot claude --print (pid {proc.pid})",
+                claude_pid=proc.pid,
+                started_at=_talker_now(),
+            )
+        )
+        talker_registered = True
 
     try:
         last_activity = time.monotonic()
@@ -323,6 +441,8 @@ def _run_streaming(
         if proc.returncode != 0:
             raise ClaudeStreamError(proc.returncode)
     finally:
+        if talker_registered and repo_name is not None:
+            unregister_talker(repo_name, thread_name)
         _unregister_child(proc)
 
 
@@ -603,6 +723,7 @@ class ClaudeSession:
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list, list, list]] = select.select,
+        repo_name: str | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -611,9 +732,14 @@ class ClaudeSession:
         self._popen_fn = popen
         self._lock = threading.Lock()
         self._cancel = threading.Event()
-        self._owner: str | None = None
+        self._repo_name = repo_name
         self._proc = self._spawn()
         _register_child(self._proc)
+
+    @property
+    def repo_name(self) -> str | None:
+        """Repo this session belongs to, for :class:`ClaudeTalker` registration."""
+        return self._repo_name
 
     def _spawn(self) -> subprocess.Popen[str]:
         """Spawn the claude subprocess with bidirectional stream-json I/O."""
@@ -665,30 +791,58 @@ class ClaudeSession:
     def owner(self) -> str | None:
         """Name of the thread currently holding the session lock, or ``None``.
 
-        Set to :func:`threading.current_thread().name <threading.current_thread>`
-        immediately after the lock is acquired in :meth:`__enter__` and
-        cleared before it is released in :meth:`__exit__`.  Read without
-        holding the lock — safe to poll from status-display threads for a
-        best-effort snapshot of who is actively driving the session.
+        Derived from the global :class:`ClaudeTalker` registry so reads are
+        always serialized through ``_talkers_lock`` — correct under the
+        free-threaded (3.14t) runtime without relying on the GIL.  Returns
+        ``None`` for sessions without a ``repo_name`` (unit-test fixtures)
+        and when the active talker is a webhook rather than the worker.
         """
-        return self._owner
+        if self._repo_name is None:
+            return None
+        talker = get_talker(self._repo_name)
+        if talker is None or talker.kind != "worker":
+            return None
+        return talker.thread_name
 
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
 
-        Records the current thread name in :attr:`owner` so status display can
-        show who holds the session.  Does *not* clear the cancel event — that
-        is deferred to :meth:`iter_events` so a signal that lands between one
-        holder's :meth:`__exit__` and the next holder's :meth:`iter_events` is
-        not silently dropped.
+        Registers a ``worker``-kind :class:`ClaudeTalker` so status surfaces
+        this thread as the one driving claude.  Does *not* clear the cancel
+        event — that is deferred to :meth:`iter_events` so a signal that
+        lands between one holder's :meth:`__exit__` and the next holder's
+        :meth:`iter_events` is not silently dropped.
+
+        Raises :class:`ClaudeLeakError` if another thread is already
+        registered as the talker for this repo — indicates a sub-claude is
+        leaking.  On leak, the session lock is released before raising so the
+        holder we would have taken over from does not deadlock.
         """
         self._lock.acquire()
-        self._owner = threading.current_thread().name
+        if self._repo_name is not None:
+            try:
+                register_talker(
+                    ClaudeTalker(
+                        repo_name=self._repo_name,
+                        thread_name=threading.current_thread().name,
+                        kind="worker",
+                        description="persistent session turn",
+                        claude_pid=self._proc.pid,
+                        started_at=_talker_now(),
+                    )
+                )
+            except ClaudeLeakError:
+                self._lock.release()
+                raise
         return self
 
     def __exit__(self, *args: object) -> None:
-        """Release the session lock.  Clears :attr:`owner` before releasing."""
-        self._owner = None
+        """Release the session lock.  Unregisters the :class:`ClaudeTalker`
+        before releasing the lock so no other thread can race in and see our
+        stale talker entry.
+        """
+        if self._repo_name is not None:
+            unregister_talker(self._repo_name, threading.current_thread().name)
         self._lock.release()
 
     def send(self, content: str) -> None:

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -274,6 +274,16 @@ class WorkerRegistry:
         thread = self._threads.get(repo_name)
         return thread.session_owner if thread is not None else None
 
+    def get_session_alive(self, repo_name: str) -> bool:
+        """Return True if the persistent ClaudeSession subprocess is alive.
+
+        Distinct from :meth:`get_session_owner` — an idle session that nobody
+        currently holds still reports ``session_alive=True`` so status display
+        can distinguish "session exists, idle" from "no session".
+        """
+        thread = self._threads.get(repo_name)
+        return thread.session_alive if thread is not None else False
+
 
 def _make_thread(
     repo_cfg: RepoConfig,

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -16,8 +16,10 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
+from kennel import claude
 from kennel.claude import kill_active_children
 from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.events import (
@@ -56,6 +58,23 @@ class PreflightError(RuntimeError):
 def _runner_dir() -> Path:
     """Return the runner clone directory — where the running kennel code lives."""
     return Path(__file__).resolve().parents[1]
+
+
+def _serialize_talker(talker: claude.ClaudeTalker | None) -> dict[str, Any] | None:
+    """Convert a :class:`~kennel.claude.ClaudeTalker` to a JSON-friendly dict.
+
+    Returns ``None`` when nobody is talking to claude for the repo.
+    """
+    if talker is None:
+        return None
+    return {
+        "repo_name": talker.repo_name,
+        "thread_name": talker.thread_name,
+        "kind": talker.kind,
+        "description": talker.description,
+        "claude_pid": talker.claude_pid,
+        "started_at": talker.started_at.isoformat(),
+    }
 
 
 def _parse_repo_from_url(url: str) -> str | None:
@@ -393,8 +412,21 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _process_action(self, action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)
-        with self.registry.webhook_activity(repo_cfg.name, description):
-            self._process_action_inner(action, repo_cfg)
+        claude.set_thread_repo(repo_cfg.name)
+        try:
+            with self.registry.webhook_activity(repo_cfg.name, description):
+                self._process_action_inner(action, repo_cfg)
+        except claude.ClaudeLeakError:
+            # A webhook and a worker tried to talk to the same repo's claude
+            # at the same time — the only safe action is to halt the whole
+            # process so the supervisor (start-kennel.sh) restarts us fresh.
+            log.exception(
+                "claude leak detected in webhook handler for %s — halting",
+                repo_cfg.name,
+            )
+            os._exit(3)
+        finally:
+            claude.set_thread_repo(None)
 
     def _describe_action(self, action) -> str:
         """Short label for status display — what this webhook handler is doing."""
@@ -468,6 +500,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
             # Non-comment events just trigger kennel worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)
+        except claude.ClaudeLeakError:
+            # Let the outer _process_action handler halt kennel — we must not
+            # swallow a leak into the generic "confused reaction" path below.
+            raise
         except Exception:
             log.exception("error processing action")
             self._signal_action_error(action)
@@ -548,6 +584,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         "worker_uptime_seconds": worker_uptime,
                         "webhook_activities": webhooks,
                         "session_owner": self.registry.get_session_owner(a.repo_name),
+                        "session_alive": self.registry.get_session_alive(a.repo_name),
+                        "claude_talker": _serialize_talker(
+                            claude.get_talker(a.repo_name)
+                        ),
                     }
                 )
             body = json.dumps(activities).encode()

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -48,6 +48,7 @@ class RepoStatus:
     worker_uptime: int | None = None
     webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
     session_owner: str | None = None
+    session_alive: bool = False
 
 
 @dataclass
@@ -198,6 +199,7 @@ def _fetch_activities(
                 "worker_uptime_seconds": item.get("worker_uptime_seconds"),
                 "webhook_activities": item.get("webhook_activities", []),
                 "session_owner": item.get("session_owner"),
+                "session_alive": item.get("session_alive", False),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -320,6 +322,7 @@ def repo_status(
     worker_uptime: int | None = None,
     webhook_activities: list[WebhookActivityInfo] | None = None,
     session_owner: str | None = None,
+    session_alive: bool = False,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     webhook_activities = list(webhook_activities or [])
@@ -347,6 +350,7 @@ def repo_status(
             worker_stuck=worker_stuck,
             webhook_activities=webhook_activities,
             session_owner=session_owner,
+            session_alive=session_alive,
         )
 
     fido_dir = git_dir / "fido"
@@ -393,6 +397,7 @@ def repo_status(
         worker_stuck=worker_stuck,
         webhook_activities=webhook_activities,
         session_owner=session_owner,
+        session_alive=session_alive,
     )
 
 
@@ -433,6 +438,7 @@ def collect() -> KennelStatus:
                 worker_uptime=worker_uptime_val,
                 webhook_activities=webhook_list,
                 session_owner=info.get("session_owner") if info else None,
+                session_alive=bool(info.get("session_alive")) if info else False,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
@@ -508,9 +514,13 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
             parts.append(f"running {_format_uptime(repo.claude_uptime)}")
         if repo.session_owner is not None:
             parts.append(f"held by {repo.session_owner}")
+        elif repo.session_alive:
+            parts.append("session idle")
         if parts:
             claude_str += f" ({', '.join(parts)})"
         body.append(claude_str)
+    elif repo.session_alive:
+        body.append("  └─ session alive (no pgrep match)")
 
     for w in repo.webhook_activities:
         body.append(

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -743,6 +744,7 @@ class Worker:
         self._session = claude.ClaudeSession(
             persona_file,
             work_dir=self.work_dir,
+            repo_name=self._repo_name or None,
         )
         self._session.switch_model("claude-opus-4-6")
 
@@ -1929,6 +1931,18 @@ class WorkerThread(threading.Thread):
         session = self._session
         return session.owner if session is not None else None
 
+    @property
+    def session_alive(self) -> bool:
+        """True if the persistent ClaudeSession subprocess is alive.
+
+        Distinct from :attr:`session_owner` — a session that nobody currently
+        holds still reports alive so status display can distinguish
+        "session exists, idle" from "no session".  Returns ``False`` when no
+        session object exists or its subprocess has exited.
+        """
+        session = self._session
+        return session is not None and session.is_alive()
+
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()
@@ -1946,6 +1960,7 @@ class WorkerThread(threading.Thread):
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
+        claude.set_thread_repo(self._repo_name)
         try:
             while not self._stop:
                 if self._registry is not None:
@@ -1973,11 +1988,21 @@ class WorkerThread(threading.Thread):
                 timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
                 self._wake.wait(timeout=timeout)
                 self._wake.clear()
+        except claude.ClaudeLeakError:
+            # A worker and webhook tried to talk to the same repo's claude
+            # at the same time — halt kennel so the supervisor restarts fresh
+            # rather than let sub-claudes multiply silently.
+            log.exception(
+                "claude leak detected in worker thread for %s — halting",
+                self._repo_name,
+            )
+            os._exit(3)
         except Exception as exc:
             self.crash_error = f"{type(exc).__name__}: {exc}"
             log.exception("WorkerThread %s: unexpected error", self.name)
             raise
         finally:
+            claude.set_thread_repo(None)
             # Only stop the session on orderly shutdown — a crashed thread
             # leaves it alive so the registry can hand it to the replacement.
             if self._stop and self._session is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.14"
 dependencies = ["requests"]
 
 [dependency-groups]
-dev = ["ruff", "pytest", "pytest-cov"]
+dev = ["ruff", "pytest", "pytest-cov", "pytest-xdist"]
 
 [build-system]
 requires = ["hatchling"]
@@ -24,6 +24,7 @@ ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-n auto"
 
 [tool.coverage.run]
 source = ["kennel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures for kennel tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from kennel import claude
+
+
+@pytest.fixture(autouse=True)
+def _reset_claude_talker_registry():
+    """Clear the global :class:`~kennel.claude.ClaudeTalker` registry between
+    tests so entries from one test can't leak into the next and cause a
+    spurious :class:`~kennel.claude.ClaudeLeakError`.  Also clears any
+    thread-local repo_name the test may have set via
+    :func:`kennel.claude.set_thread_repo`.
+    """
+    yield
+    with claude._talkers_lock:
+        claude._talkers.clear()
+    claude.set_thread_repo(None)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1135,6 +1135,53 @@ class TestRunStreamingTracksChildren:
         # the generator runs); after exhaustion it should be unregistered.
         assert proc not in _active_children
 
+    def test_registers_and_unregisters_talker_when_thread_repo_set(
+        self, tmp_path: Path
+    ) -> None:
+        """When thread-local repo_name is set, _run_streaming registers a
+        webhook-kind ClaudeTalker for the duration of the subprocess and
+        unregisters it on exit."""
+        from kennel.claude import (
+            _run_streaming,
+            get_talker,
+            set_thread_repo,
+        )
+
+        stdin_file = tmp_path / "in"
+        stdin_file.write_text("hi")
+        proc = self._make_proc(["one\n"])
+        proc.pid = 77777
+
+        observed: list = []
+
+        def fake_popen(*args, **kwargs):
+            return proc
+
+        def fake_select(rs, ws, xs, t):
+            observed.append(get_talker("owner/repo"))
+            return (rs, [], [])
+
+        set_thread_repo("owner/repo")
+        try:
+            list(
+                _run_streaming(
+                    ["claude"],
+                    stdin_file,
+                    idle_timeout=1.0,
+                    popen=fake_popen,
+                    selector=fake_select,
+                )
+            )
+        finally:
+            set_thread_repo(None)
+        # During the subprocess lifetime the talker was present and described
+        # the one-shot pid.
+        assert observed[0] is not None
+        assert observed[0].kind == "webhook"
+        assert observed[0].claude_pid == 77777
+        # Cleanly unregistered after the generator exhausts.
+        assert get_talker("owner/repo") is None
+
 
 # ── ClaudeSession tests ───────────────────────────────────────────────────────
 
@@ -1150,6 +1197,7 @@ def _make_session_proc(
     value ``poll()`` yields (``None`` = still running; ``0`` = exited).
     """
     proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 99999
     proc.stdin = MagicMock()
     proc.stdin.closed = False
     proc.stdout = MagicMock()
@@ -1178,6 +1226,7 @@ def _make_session(
         idle_timeout=idle_timeout,
         popen=fake_popen,
         selector=fake_selector,
+        repo_name="owner/repo",
     )
 
 
@@ -1792,6 +1841,59 @@ class TestClaudeSessionLock:
         with session:
             pass
         assert session.owner is None
+        session.stop()
+
+    def test_repo_name_exposed(self, tmp_path: Path) -> None:
+        session = _make_session(tmp_path, _make_session_proc([]))
+        assert session.repo_name == "owner/repo"
+        session.stop()
+
+    def test_owner_is_none_without_repo_name(self, tmp_path: Path) -> None:
+        """Session without repo_name never registers a talker → owner None."""
+        from kennel.claude import ClaudeSession
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("you are fido")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        session = ClaudeSession(
+            system_file,
+            work_dir=tmp_path,
+            popen=fake_popen,
+            selector=MagicMock(return_value=([proc.stdout], [], [])),
+        )
+        with session:
+            assert session.owner is None
+        session.stop()
+
+    def test_enter_raises_on_concurrent_talker_and_releases_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """__enter__ raises ClaudeLeakError if another talker is registered and
+        releases the session lock so callers don't deadlock."""
+        from datetime import datetime, timezone
+
+        from kennel import claude as claude_module
+        from kennel.claude import ClaudeLeakError, ClaudeTalker, register_talker
+
+        session = _make_session(tmp_path, _make_session_proc([]))
+        register_talker(
+            ClaudeTalker(
+                repo_name="owner/repo",
+                thread_name="intruder",
+                kind="webhook",
+                description="leaked",
+                claude_pid=555,
+                started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        with pytest.raises(ClaudeLeakError):
+            session.__enter__()
+        # Session lock must be released so we don't deadlock future callers.
+        assert session._lock.acquire(blocking=False)
+        session._lock.release()
+        with claude_module._talkers_lock:
+            claude_module._talkers.clear()
         session.stop()
 
     def test_context_manager_blocks_second_thread(self, tmp_path: Path) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -191,6 +191,16 @@ class TestWorkerRegistry:
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_owner("foo/bar") == "worker-home"
 
+    def test_get_session_alive_returns_false_for_unknown_repo(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_session_alive("unknown/repo") is False
+
+    def test_get_session_alive_delegates_to_thread(self, tmp_path: Path) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.session_alive = True
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_session_alive("foo/bar") is True
+
     def test_get_thread_crash_error_returns_thread_crash_error(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -157,6 +157,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
@@ -191,9 +192,35 @@ class TestGetEndpoint:
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
+        WebhookHandler.registry.get_session_alive.return_value = True
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["session_owner"] == "worker-home"
+
+    def test_status_endpoint_includes_session_alive(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="idle",
+                busy=False,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = True
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["session_alive"] is True
+        assert data[0]["session_owner"] is None
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
         from datetime import datetime, timezone
@@ -218,6 +245,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -255,6 +283,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True
@@ -647,6 +676,70 @@ class TestProcessAction:
         WebhookHandler.registry.report_activity.assert_called_with(
             "owner/repo", "handling webhook action", busy=True
         )
+
+    def test_status_endpoint_includes_claude_talker(self, server: tuple) -> None:
+        """Active ClaudeTalker appears in /status as a structured object."""
+        from datetime import datetime, timezone
+
+        from kennel.claude import ClaudeTalker
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        talker = ClaudeTalker(
+            repo_name="owner/repo",
+            thread_name="worker-repo",
+            kind="worker",
+            description="persistent session turn",
+            claude_pid=12345,
+            started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
+        )
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="running",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = True
+        with patch("kennel.claude.get_talker", return_value=talker):
+            resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        talker_data = data[0]["claude_talker"]
+        assert talker_data["repo_name"] == "owner/repo"
+        assert talker_data["thread_name"] == "worker-repo"
+        assert talker_data["kind"] == "worker"
+        assert talker_data["claude_pid"] == 12345
+
+    def test_claude_leak_halts_process(
+        self,
+        server: tuple,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ClaudeLeakError from a webhook handler calls os._exit(3)."""
+        from kennel import claude
+        from kennel import server as server_module
+
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "closed",
+            "pull_request": {"number": 99, "merged": True},
+        }
+        WebhookHandler.gh = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock(
+            side_effect=claude.ClaudeLeakError("leaked")
+        )
+        exits: list[int] = []
+        monkeypatch.setattr(server_module.os, "_exit", exits.append)
+        _post_webhook(url, cfg, "pull_request", payload)
+        time.sleep(0.2)
+        assert exits == [3]
 
     def test_exception_in_process_action_does_not_crash(self, server: tuple) -> None:
         url, cfg = server

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -410,6 +410,7 @@ class TestFetchActivities:
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
                 "session_owner": None,
+                "session_alive": False,
             }
         }
 
@@ -444,6 +445,7 @@ class TestFetchActivities:
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
                 "session_owner": None,
+                "session_alive": False,
             },
             "c/d": {
                 "what": "Fixing CI",
@@ -453,6 +455,7 @@ class TestFetchActivities:
                 "worker_uptime_seconds": None,
                 "webhook_activities": [],
                 "session_owner": None,
+                "session_alive": False,
             },
         }
 
@@ -925,6 +928,7 @@ class TestCollect:
             worker_uptime=None,
             webhook_activities=[],
             session_owner=None,
+            session_alive=False,
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -956,6 +960,7 @@ class TestCollect:
             worker_uptime=None,
             webhook_activities=[],
             session_owner=None,
+            session_alive=False,
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -980,6 +985,7 @@ class TestCollect:
             worker_uptime=None,
             webhook_activities=[],
             session_owner=None,
+            session_alive=False,
         )
 
     def test_passes_is_stuck_to_repo_status(self, tmp_path: Path) -> None:
@@ -1007,6 +1013,7 @@ class TestCollect:
             worker_uptime=None,
             webhook_activities=[],
             session_owner=None,
+            session_alive=False,
         )
 
 
@@ -1122,6 +1129,31 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "└─ claude pid 9999 (held by worker-home)" in output
+
+    def test_claude_pid_session_alive_no_owner(self) -> None:
+        """Session subprocess alive but nobody holds the lock → shows 'session idle'."""
+        repo = self._repo(
+            issue=1,
+            claude_pid=9999,
+            claude_uptime=60,
+            session_owner=None,
+            session_alive=True,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "└─ claude pid 9999 (running 1m, session idle)" in output
+
+    def test_session_alive_without_claude_pid(self) -> None:
+        """Session alive but pgrep didn't match → fallback line noting the mismatch."""
+        repo = self._repo(
+            issue=1,
+            claude_pid=None,
+            session_owner=None,
+            session_alive=True,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "└─ session alive (no pgrep match)" in output
 
     def test_multiple_repos(self) -> None:
         # Each repo emits a header + "no assigned issues" body line.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8922,3 +8922,33 @@ class TestWorkerThread:
         mock_session.owner = "worker-home"
         wt._session = mock_session
         assert wt.session_owner == "worker-home"
+
+    def test_session_alive_false_when_no_session(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt._session is None
+        assert wt.session_alive is False
+
+    def test_session_alive_delegates_to_session_is_alive(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        mock_session = MagicMock()
+        mock_session.is_alive.return_value = True
+        wt._session = mock_session
+        assert wt.session_alive is True
+        mock_session.is_alive.return_value = False
+        assert wt.session_alive is False
+
+    def test_run_halts_on_claude_leak_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ClaudeLeakError in the worker loop calls os._exit(3)."""
+        from kennel import claude
+        from kennel import worker as worker_module
+
+        wt = self._make_thread(tmp_path)
+        exits: list[int] = []
+        monkeypatch.setattr(worker_module.os, "_exit", exits.append)
+        # Force the loop to raise a leak error on the first iteration.
+        wt._registry = MagicMock()
+        wt._registry.report_activity.side_effect = claude.ClaudeLeakError("leak")
+        wt.run()
+        assert exits == [3]

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -130,6 +139,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -140,6 +150,7 @@ requires-dist = [{ name = "requests" }]
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -198,6 +209,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Redesigns claude-subprocess tracking per #473.

## What's in

- **ClaudeTalker registry** in \`kennel/claude.py\` — at most one thread per repo may drive a claude subprocess at any moment
- \`ClaudeSession.__enter__\` registers a \`worker\`-kind talker; \`_run_streaming\` registers a \`webhook\`-kind talker when the thread-local \`current_repo()\` is set
- Thread-local repo is pinned by \`WorkerThread.run\` + \`WebhookHandler._process_action\`
- **Halt on leak**: concurrent registration raises \`ClaudeLeakError\` → \`os._exit(3)\`
- \`/status\` gains \`session_alive\` (subprocess up) + \`claude_talker\` (structured snapshot of who's driving)
- \`session.owner\` now reads under lock via the talker registry — correct under free-threaded 3.14t (noted in CLAUDE.md)
- Drive-by: \`pytest-xdist\` wired with \`addopts = -n auto\` (37s → 16s)

## What's not in (follow-ups)

Routing webhook handlers through the persistent session (so they stop using one-shot \`print_prompt\` entirely) is the follow-up — the leak detector will scream the moment a webhook and worker collide, which motivates that change.

Also filed #474 to kill \`test_raises_on_idle_timeout\`'s 10s \`sleep 60\` (caps xdist parallelism).

Closes #473.