### PR TITLE
Deliver sub-skill instructions to persistent ClaudeSession turns (closes #477)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -214,9 +214,8 @@ def claude_start(
     worker's crash handler.
     """
     if session is not None:
-        prompt = (fido_dir / "prompt").read_text()
         with session:
-            session.send(prompt)
+            session.send(_session_turn_prompt(fido_dir))
             session.consume_until_result()
         return ""
     system_file = fido_dir / "system"
@@ -225,6 +224,21 @@ def claude_start(
         system_file, prompt_file, model, timeout, cwd=cwd
     )
     return claude.extract_session_id(output)
+
+
+def _session_turn_prompt(fido_dir: Path) -> str:
+    """Build the user-message body for a persistent :class:`ClaudeSession` turn.
+
+    The persistent session is constructed with only ``sub/persona.md`` as
+    its system prompt.  Each turn (setup, task, ci, threads, resume,
+    comments) has its own sub-skill instructions in ``fido_dir/system``
+    which must be delivered as part of the user message — otherwise claude
+    sees only the bare context and doesn't know what to do, producing
+    empty output (observed as ``setup produced no tasks``).
+    """
+    system = (fido_dir / "system").read_text()
+    prompt = (fido_dir / "prompt").read_text()
+    return f"{system}\n\n---\n\n{prompt}"
 
 
 def claude_run(
@@ -248,9 +262,8 @@ def claude_run(
     worker's crash handler.
     """
     if session is not None:
-        prompt = (fido_dir / "prompt").read_text()
         with session:
-            session.send(prompt)
+            session.send(_session_turn_prompt(fido_dir))
             session.consume_until_result()
         return "", ""
     system_file = fido_dir / "system"

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -160,7 +160,14 @@ def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Pat
     """Write system and prompt files for a sub-Claude session.
 
     The system file contains ``persona.md`` and ``<subskill>.md`` joined by a
-    blank line (matching bash ``printf '%s\\n\\n%s\\n' "$PERSONA" "$skill"``).
+    blank line (matching bash ``printf '%s\\n\\n%s\\n' "$PERSONA" "$skill"``) —
+    used by the one-shot ``print_prompt_from_file`` path.
+
+    The skill file contains only ``<subskill>.md`` — used by the persistent
+    :class:`~kennel.claude.ClaudeSession` path where the session already has
+    ``persona.md`` loaded as system prompt and each turn just needs the
+    sub-skill instructions as a user-message preamble.
+
     The prompt file contains the context string.
 
     Returns ``(system_file, prompt_file)`` where both live in *fido_dir*.
@@ -169,8 +176,10 @@ def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Pat
     persona = (sub / "persona.md").read_text().rstrip()
     skill = (sub / f"{subskill}.md").read_text().rstrip()
     system_file = fido_dir / "system"
+    skill_file = fido_dir / "skill"
     prompt_file = fido_dir / "prompt"
     system_file.write_text(f"{persona}\n\n{skill}\n")
+    skill_file.write_text(f"{skill}\n")
     prompt_file.write_text(f"{context}\n")
     return system_file, prompt_file
 
@@ -229,16 +238,16 @@ def claude_start(
 def _session_turn_prompt(fido_dir: Path) -> str:
     """Build the user-message body for a persistent :class:`ClaudeSession` turn.
 
-    The persistent session is constructed with only ``sub/persona.md`` as
-    its system prompt.  Each turn (setup, task, ci, threads, resume,
-    comments) has its own sub-skill instructions in ``fido_dir/system``
-    which must be delivered as part of the user message — otherwise claude
-    sees only the bare context and doesn't know what to do, producing
-    empty output (observed as ``setup produced no tasks``).
+    The persistent session is constructed with ``sub/persona.md`` as its
+    system prompt, so we only need to deliver the sub-skill instructions
+    (``fido_dir/skill``) as a user-message preamble — not the full
+    ``fido_dir/system`` which would duplicate the persona.  Without this,
+    claude saw only the bare context and produced empty output (observed
+    as ``setup produced no tasks``).
     """
-    system = (fido_dir / "system").read_text()
+    skill = (fido_dir / "skill").read_text()
     prompt = (fido_dir / "prompt").read_text()
-    return f"{system}\n\n---\n\n{prompt}"
+    return f"{skill}\n\n---\n\n{prompt}"
 
 
 def claude_run(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2484,12 +2484,15 @@ class TestClaudeStart:
 
     def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
+        (fido_dir / "system").write_text("setup instructions")
         (fido_dir / "prompt").write_text("the task prompt")
         session = MagicMock()
         session.__enter__ = MagicMock(return_value=session)
         session.__exit__ = MagicMock(return_value=None)
         claude_start(fido_dir, session=session)
-        session.send.assert_called_once_with("the task prompt")
+        session.send.assert_called_once_with(
+            "setup instructions\n\n---\n\nthe task prompt"
+        )
 
     def test_session_path_calls_consume_until_result(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -2613,12 +2616,15 @@ class TestClaudeRun:
 
     def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
+        (fido_dir / "system").write_text("task instructions")
         (fido_dir / "prompt").write_text("run this task")
         session = MagicMock()
         session.__enter__ = MagicMock(return_value=session)
         session.__exit__ = MagicMock(return_value=None)
         claude_run(fido_dir, session=session)
-        session.send.assert_called_once_with("run this task")
+        session.send.assert_called_once_with(
+            "task instructions\n\n---\n\nrun this task"
+        )
 
     def test_session_path_calls_consume_until_result(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2374,6 +2374,7 @@ class TestClaudeStart:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (fido_dir / "system").write_text("system prompt")
+        (fido_dir / "skill").write_text("sub-skill instructions")
         (fido_dir / "prompt").write_text("user prompt")
         return fido_dir
 
@@ -2484,7 +2485,7 @@ class TestClaudeStart:
 
     def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        (fido_dir / "system").write_text("setup instructions")
+        (fido_dir / "skill").write_text("setup instructions")
         (fido_dir / "prompt").write_text("the task prompt")
         session = MagicMock()
         session.__enter__ = MagicMock(return_value=session)
@@ -2528,6 +2529,7 @@ class TestClaudeRun:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (fido_dir / "system").write_text("system")
+        (fido_dir / "skill").write_text("skill")
         (fido_dir / "prompt").write_text("prompt")
         return fido_dir
 
@@ -2616,7 +2618,7 @@ class TestClaudeRun:
 
     def test_session_path_sends_prompt_content(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        (fido_dir / "system").write_text("task instructions")
+        (fido_dir / "skill").write_text("task instructions")
         (fido_dir / "prompt").write_text("run this task")
         session = MagicMock()
         session.__enter__ = MagicMock(return_value=session)


### PR DESCRIPTION
Fixes the \"setup produced no tasks\" regression from #456.

## Problem

When the persistent \`ClaudeSession\` was introduced in #456, \`claude_start\` / \`claude_run\` started sending only \`fido_dir/prompt\` (context) to the session.  The sub-skill instructions — \`setup.md\`, \`task.md\`, \`ci.md\`, \`comments.md\`, \`resume.md\` — were built into \`fido_dir/system\` by \`build_prompt\` but **never delivered** to the session.

Claude saw only the bare \"Request: ... Repo: ... Branch: ...\" with no instructions, produced empty output, and \`find_or_create_pr\` raised \`setup produced no tasks\`.  Observed live after #475 landed: fido stuck on #465, watchdog kept restarting, three abandoned branches.

## Fix

The persistent session already has \`persona.md\` as its system prompt, so prepending the full \`fido_dir/system\` (persona + sub-skill) would duplicate the persona.  Instead:

- \`build_prompt\` now writes a third file \`fido_dir/skill\` containing just the sub-skill content (\`setup.md\`, \`task.md\`, …)
- New \`_session_turn_prompt\` helper reads \`fido_dir/skill\` + \`fido_dir/prompt\` and joins them with \`\\n\\n---\\n\\n\`
- Both \`claude_start\` and \`claude_run\` persistent-session paths now send \`_session_turn_prompt(fido_dir)\`

Tests updated: \`_setup_fido_dir\` fixtures now write \`skill\`, and the \`session_path_sends_prompt_content\` tests expect the combined \`<skill>\\n\\n---\\n\\n<prompt>\` body.

100% coverage, suite passes.

Closes #477.