### PR TITLE
Redesign kennel status display around ClaudeTalker (closes #476)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -89,6 +89,12 @@ class ClaudeLeakError(RuntimeError):
 class ClaudeTalker:
     """Snapshot of the thread currently driving a claude subprocess.
 
+    *thread_id* is :func:`threading.get_ident` — a globally-unique integer
+    identifier for the live thread, used to match this talker entry to a
+    specific thread (e.g. a webhook handler's :class:`WebhookActivity`) when
+    rendering status.  The human-readable thread name is looked up at
+    display time rather than cached here.
+
     *kind* distinguishes between the persistent session path (``"worker"`` —
     the worker thread is inside a ``with session:`` block) and one-shot
     ``claude --print`` invocations from a webhook handler (``"webhook"``).
@@ -96,7 +102,7 @@ class ClaudeTalker:
     """
 
     repo_name: str
-    thread_name: str
+    thread_id: int
     kind: Literal["worker", "webhook"]
     description: str
     claude_pid: int
@@ -139,24 +145,24 @@ def register_talker(talker: ClaudeTalker) -> None:
         if existing is not None:
             raise ClaudeLeakError(
                 f"claude leak for repo {talker.repo_name}: "
-                f"{existing.thread_name} ({existing.kind}, "
+                f"tid={existing.thread_id} ({existing.kind}, "
                 f"{existing.description}, pid={existing.claude_pid}) "
-                f"still active when {talker.thread_name} ({talker.kind}, "
+                f"still active when tid={talker.thread_id} ({talker.kind}, "
                 f"{talker.description}, pid={talker.claude_pid}) tried to start"
             )
         _talkers[talker.repo_name] = talker
 
 
-def unregister_talker(repo_name: str, thread_name: str) -> None:
-    """Remove the talker entry for *repo_name* if it belongs to *thread_name*.
+def unregister_talker(repo_name: str, thread_id: int) -> None:
+    """Remove the talker entry for *repo_name* if it belongs to *thread_id*.
 
     Idempotent — safe to call from cleanup paths that may race the registry.
-    Non-matching thread_name is a no-op (defensive against cross-thread
+    Non-matching ``thread_id`` is a no-op (defensive against cross-thread
     cleanup bugs).
     """
     with _talkers_lock:
         existing = _talkers.get(repo_name)
-        if existing is not None and existing.thread_name == thread_name:
+        if existing is not None and existing.thread_id == thread_id:
             del _talkers[repo_name]
 
 
@@ -169,6 +175,20 @@ def get_talker(repo_name: str) -> ClaudeTalker | None:
 def _talker_now() -> datetime:
     """Seam for tests — override this module attribute to freeze time."""
     return datetime.now(tz=timezone.utc)
+
+
+def _thread_name_for_id(thread_id: int) -> str | None:
+    """Return the human-readable name of the live thread with *thread_id*,
+    or ``None`` if that thread has exited.
+
+    Used by status display to render a :class:`ClaudeTalker`'s thread
+    without caching the name in the registry — a dead thread's entry is
+    already being cleaned up and the name would be stale.
+    """
+    for t in threading.enumerate():
+        if t.ident == thread_id:
+            return t.name
+    return None
 
 
 def kill_active_children(grace_seconds: float = 2.0) -> None:
@@ -398,13 +418,13 @@ def _run_streaming(
     )
     _register_child(proc)
     repo_name = current_repo()
-    thread_name = threading.current_thread().name
+    thread_id = threading.get_ident()
     talker_registered = False
     if repo_name is not None:
         register_talker(
             ClaudeTalker(
                 repo_name=repo_name,
-                thread_name=thread_name,
+                thread_id=thread_id,
                 kind="webhook",
                 description=f"one-shot claude --print (pid {proc.pid})",
                 claude_pid=proc.pid,
@@ -442,7 +462,7 @@ def _run_streaming(
             raise ClaudeStreamError(proc.returncode)
     finally:
         if talker_registered and repo_name is not None:
-            unregister_talker(repo_name, thread_name)
+            unregister_talker(repo_name, thread_id)
         _unregister_child(proc)
 
 
@@ -767,6 +787,17 @@ class ClaudeSession:
         """Return True if the claude subprocess is still running."""
         return self._proc.poll() is None
 
+    @property
+    def pid(self) -> int:
+        """PID of the live claude subprocess.
+
+        Read directly off the tracked ``Popen`` — callers should use this
+        rather than pgrep, since :class:`ClaudeSession` uses
+        ``sub/persona.md`` (outside any ``fido_dir``) as its system prompt
+        and the pgrep-based heuristic in :mod:`kennel.status` can't find it.
+        """
+        return self._proc.pid
+
     def restart(self) -> None:
         """Stop the current subprocess and start a fresh one.
 
@@ -802,7 +833,7 @@ class ClaudeSession:
         talker = get_talker(self._repo_name)
         if talker is None or talker.kind != "worker":
             return None
-        return talker.thread_name
+        return _thread_name_for_id(talker.thread_id)
 
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
@@ -824,7 +855,7 @@ class ClaudeSession:
                 register_talker(
                     ClaudeTalker(
                         repo_name=self._repo_name,
-                        thread_name=threading.current_thread().name,
+                        thread_id=threading.get_ident(),
                         kind="worker",
                         description="persistent session turn",
                         claude_pid=self._proc.pid,
@@ -842,7 +873,7 @@ class ClaudeSession:
         stale talker entry.
         """
         if self._repo_name is not None:
-            unregister_talker(self._repo_name, threading.current_thread().name)
+            unregister_talker(self._repo_name, threading.get_ident())
         self._lock.release()
 
     def send(self, content: str) -> None:

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -48,11 +48,18 @@ class WebhookActivity:
     when that handler returns (success or failure).  Surfaced in ``kennel
     status`` as a sub-bullet under the repo so we can see what's being
     handled beyond the worker's own task.
+
+    *thread_id* is :func:`threading.get_ident` captured at context entry so
+    status display can match this webhook to the active
+    :class:`~kennel.claude.ClaudeTalker` (whose ``thread_id`` field is from
+    the same call) — letting the CLI attach claude stats to the specific
+    webhook line that's driving claude.
     """
 
     handle_id: int
     description: str
     started_at: datetime
+    thread_id: int
 
 
 class WorkerRegistry:
@@ -209,6 +216,7 @@ class WorkerRegistry:
             handle_id=id(object()),  # cheap unique id per call
             description=description,
             started_at=_now(),
+            thread_id=threading.get_ident(),
         )
         with self._webhook_lock:
             self._webhook_activities.setdefault(repo_name, []).append(activity)
@@ -283,6 +291,16 @@ class WorkerRegistry:
         """
         thread = self._threads.get(repo_name)
         return thread.session_alive if thread is not None else False
+
+    def get_session_pid(self, repo_name: str) -> int | None:
+        """Return the PID of the persistent ClaudeSession subprocess, or None.
+
+        Read authoritatively from the kennel-tracked session rather than
+        pgrep — the system prompt file path changed in #456 so the pgrep
+        heuristic in :mod:`kennel.status` can no longer locate it.
+        """
+        thread = self._threads.get(repo_name)
+        return thread.session_pid if thread is not None else None
 
 
 def _make_thread(

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -69,7 +69,7 @@ def _serialize_talker(talker: claude.ClaudeTalker | None) -> dict[str, Any] | No
         return None
     return {
         "repo_name": talker.repo_name,
-        "thread_name": talker.thread_name,
+        "thread_id": talker.thread_id,
         "kind": talker.kind,
         "description": talker.description,
         "claude_pid": talker.claude_pid,
@@ -440,10 +440,13 @@ class WebhookHandler(BaseHTTPRequestHandler):
         return "handling webhook action"
 
     def _process_action_inner(self, action, repo_cfg: RepoConfig) -> None:
+        # The worker thread's own ``worker_what`` is not touched here — this
+        # handler runs on a separate webhook thread and its activity is
+        # surfaced in the repo's :class:`~kennel.registry.WebhookActivity`
+        # list (via :meth:`~kennel.registry.WorkerRegistry.webhook_activity`).
+        # Writing here would clobber the worker thread's own state, which is
+        # what caused the old ``Doing: handling webhook action`` display bug.
         try:
-            self.registry.report_activity(
-                repo_cfg.name, "handling webhook action", busy=True
-            )
             gh = self.gh
             handled = False
 
@@ -568,6 +571,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     {
                         "description": w.description,
                         "elapsed_seconds": (now - w.started_at).total_seconds(),
+                        "thread_id": w.thread_id,
                     }
                     for w in self.registry.get_webhook_activities(a.repo_name)
                 ]
@@ -585,6 +589,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         "webhook_activities": webhooks,
                         "session_owner": self.registry.get_session_owner(a.repo_name),
                         "session_alive": self.registry.get_session_alive(a.repo_name),
+                        "session_pid": self.registry.get_session_pid(a.repo_name),
                         "claude_talker": _serialize_talker(
                             claude.get_talker(a.repo_name)
                         ),

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -18,10 +18,26 @@ from kennel.state import State
 
 @dataclass
 class WebhookActivityInfo:
-    """Lightweight in-flight webhook handler, used purely for display."""
+    """Lightweight in-flight webhook handler, used purely for display.
+
+    *thread_id* matches the ``thread_id`` stored on
+    :class:`~kennel.claude.ClaudeTalker` so display can identify which
+    webhook (if any) is currently driving claude.
+    """
 
     description: str
     elapsed_seconds: int
+    thread_id: int = 0
+
+
+@dataclass
+class ClaudeTalkerInfo:
+    """Who is currently driving this repo's claude subprocess."""
+
+    thread_id: int
+    kind: str  # "worker" | "webhook"
+    description: str
+    claude_pid: int
 
 
 @dataclass
@@ -49,6 +65,7 @@ class RepoStatus:
     webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
     session_owner: str | None = None
     session_alive: bool = False
+    claude_talker: ClaudeTalkerInfo | None = None
 
 
 @dataclass
@@ -200,6 +217,8 @@ def _fetch_activities(
                 "webhook_activities": item.get("webhook_activities", []),
                 "session_owner": item.get("session_owner"),
                 "session_alive": item.get("session_alive", False),
+                "session_pid": item.get("session_pid"),
+                "claude_talker": item.get("claude_talker"),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -323,6 +342,8 @@ def repo_status(
     webhook_activities: list[WebhookActivityInfo] | None = None,
     session_owner: str | None = None,
     session_alive: bool = False,
+    session_pid: int | None = None,
+    claude_talker: ClaudeTalkerInfo | None = None,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     webhook_activities = list(webhook_activities or [])
@@ -351,6 +372,7 @@ def repo_status(
             webhook_activities=webhook_activities,
             session_owner=session_owner,
             session_alive=session_alive,
+            claude_talker=claude_talker,
         )
 
     fido_dir = git_dir / "fido"
@@ -370,7 +392,10 @@ def repo_status(
     current = _current_task(task_list)
     task_number, task_total = _task_position(task_list)
 
-    claude_pid = _claude_pid(fido_dir)
+    # Prefer the kennel-tracked session pid (authoritative, known from the
+    # ClaudeSession subprocess) over a pgrep heuristic that can't find the
+    # persistent session (its system file is outside fido_dir).
+    claude_pid = session_pid if session_pid is not None else _claude_pid(fido_dir)
     claude_uptime = (
         _process_uptime_seconds(claude_pid) if claude_pid is not None else None
     )
@@ -398,6 +423,7 @@ def repo_status(
         webhook_activities=webhook_activities,
         session_owner=session_owner,
         session_alive=session_alive,
+        claude_talker=claude_talker,
     )
 
 
@@ -418,16 +444,29 @@ def collect() -> KennelStatus:
         info = activities.get(rc.name)
         webhook_list = []
         worker_uptime_val: int | None = None
+        talker_info: ClaudeTalkerInfo | None = None
+        session_pid_val: int | None = None
         if info:
             for w in info.get("webhook_activities") or []:
                 webhook_list.append(
                     WebhookActivityInfo(
                         description=w["description"],
                         elapsed_seconds=int(w["elapsed_seconds"]),
+                        thread_id=int(w.get("thread_id", 0)),
                     )
                 )
             wu = info.get("worker_uptime_seconds")
             worker_uptime_val = int(wu) if wu is not None else None
+            talker_raw = info.get("claude_talker")
+            if talker_raw is not None:
+                talker_info = ClaudeTalkerInfo(
+                    thread_id=int(talker_raw["thread_id"]),
+                    kind=talker_raw["kind"],
+                    description=talker_raw["description"],
+                    claude_pid=int(talker_raw["claude_pid"]),
+                )
+            sp = info.get("session_pid")
+            session_pid_val = int(sp) if sp is not None else None
         repos.append(
             repo_status(
                 rc,
@@ -439,6 +478,8 @@ def collect() -> KennelStatus:
                 webhook_activities=webhook_list,
                 session_owner=info.get("session_owner") if info else None,
                 session_alive=bool(info.get("session_alive")) if info else False,
+                session_pid=session_pid_val,
+                claude_talker=talker_info,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
@@ -447,13 +488,40 @@ def collect() -> KennelStatus:
 _SILENT_DISPLAY_THRESHOLD: int = 300  # seconds of claude silence before we note it
 
 
-def _format_repo_header(repo: RepoStatus) -> str:
-    """Top line: `<name>: fido <state> — <compact stats>`.
+_WEBHOOK_DISPLAY_CAP: int = 5
+"""Max webhook lines to print per repo; overflow rolled into a +N-more line."""
 
-    Stats are comma-separated and only shown when they matter right now:
-    `crashes N` (skipped when 0), `up X` (worker thread uptime, always
-    shown when known), `BUSY Xm` (no activity for ≥5m; since #444 this is
-    informational only, not a restart signal).
+
+def _claude_stats_suffix(repo: RepoStatus) -> str:
+    """`" → claude pid 123 (running 1m, session idle)"` or ``""``.
+
+    Used both as the inline trailer on whatever line is "talking to" claude
+    and, when nobody is talking, appended to the worker summary line.
+    """
+    if repo.claude_pid is None and not repo.session_alive:
+        return ""
+    parts: list[str] = []
+    if repo.claude_uptime is not None:
+        parts.append(f"running {_format_uptime(repo.claude_uptime)}")
+    if repo.session_alive and repo.claude_talker is None:
+        parts.append("session idle")
+    pid_str = (
+        f"claude pid {repo.claude_pid}" if repo.claude_pid is not None else "claude"
+    )
+    if parts:
+        return f" → {pid_str} ({', '.join(parts)})"
+    return f" → {pid_str}"
+
+
+def _format_repo_header(repo: RepoStatus) -> str:
+    """Top line per repo: ``<name>: fido <state> — <stats>[ → <claude>]``.
+
+    Stats list is comma-separated and only shows what matters right now:
+    ``crashes N`` (skipped when 0), ``up X`` (worker thread uptime), ``BUSY``
+    (no activity for ≥5m, informational since #444), optional ``last crash``
+    line when crash_count > 0.  If nobody is currently talking to claude the
+    claude pid/uptime suffix appears on this line; when a worker or webhook
+    IS talking, the suffix attaches to that line instead.
     """
     state = "fido running" if repo.fido_running else "fido idle"
     stats: list[str] = []
@@ -462,8 +530,6 @@ def _format_repo_header(repo: RepoStatus) -> str:
     if repo.worker_uptime is not None:
         stats.append(f"up {_format_uptime(repo.worker_uptime)}")
     if repo.worker_stuck:
-        # worker_uptime includes time on the current task; there isn't a
-        # separate "silent" counter yet, so we just flag BUSY.
         stats.append("BUSY")
     if repo.crash_count > 0 and repo.last_crash_error:
         stats.append(f"last crash: {repo.last_crash_error}")
@@ -471,11 +537,24 @@ def _format_repo_header(repo: RepoStatus) -> str:
     header = f"{repo.name}: {state}"
     if stats:
         header += " — " + ", ".join(stats)
+    # Claude stats ride the worker summary only when nobody is talking.
+    if repo.claude_talker is None:
+        header += _claude_stats_suffix(repo)
     return header
 
 
 def _format_repo_body(repo: RepoStatus) -> list[str]:
-    """Indented sub-lines: Issue / PR / Task / claude / webhooks."""
+    """Per-repo body lines in fixed order:
+
+    1. ``Issue:  #N — title  (elapsed Xm)``
+    2. ``PR:     #N — title``
+    3. ``Worker: <state>`` (idle / task N/M — title / waiting on …), with
+       claude stats suffix when the worker thread is talking to claude
+    4. Webhook threads (indented ``├─`` / ``└─``), up to
+       :data:`_WEBHOOK_DISPLAY_CAP`; a webhook currently talking to claude
+       sorts to the top and gets the claude stats suffix; overflow rolled
+       into ``+N more webhook(s)``.
+    """
     body: list[str] = []
 
     if repo.issue is None:
@@ -495,39 +574,72 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
             pr_line += f" — {repo.pr_title}"
         body.append(pr_line)
 
-    if repo.task_number is not None and repo.task_total is not None:
-        task_line = f"  Task:   {repo.task_number}/{repo.task_total}"
-        if repo.current_task:
-            task_line += f" — {repo.current_task}"
-        body.append(task_line)
-    elif repo.current_task:
-        body.append(f"  Task:   {repo.current_task}")
+    body.append(_format_worker_thread_line(repo))
 
-    if repo.worker_what and not (repo.current_task or repo.pr_number):
-        # Only show the live activity when nothing more specific fits.
-        body.append(f"  Doing:  {repo.worker_what}")
-
-    if repo.claude_pid is not None:
-        claude_str = f"  └─ claude pid {repo.claude_pid}"
-        parts: list[str] = []
-        if repo.claude_uptime is not None:
-            parts.append(f"running {_format_uptime(repo.claude_uptime)}")
-        if repo.session_owner is not None:
-            parts.append(f"held by {repo.session_owner}")
-        elif repo.session_alive:
-            parts.append("session idle")
-        if parts:
-            claude_str += f" ({', '.join(parts)})"
-        body.append(claude_str)
-    elif repo.session_alive:
-        body.append("  └─ session alive (no pgrep match)")
-
-    for w in repo.webhook_activities:
-        body.append(
-            f"  └─ webhook: {w.description} ({_format_uptime(w.elapsed_seconds)})"
-        )
+    body.extend(_format_webhook_lines(repo))
 
     return body
+
+
+def _format_worker_thread_line(repo: RepoStatus) -> str:
+    """Worker-thread state line.  Attach claude stats when this thread is
+    the one talking to claude.
+    """
+    state = _worker_thread_state(repo)
+    line = f"  Worker: {state}"
+    talker = repo.claude_talker
+    if talker is not None and talker.kind == "worker":
+        line += _claude_stats_suffix(repo)
+    return line
+
+
+def _worker_thread_state(repo: RepoStatus) -> str:
+    """Compact string describing what the worker thread itself is doing.
+
+    Prefers the richest descriptor available: current task (with position
+    and title) > PR-but-no-task > the live ``worker_what`` field > ``idle``.
+    Never shows webhook-thread activity — that's surfaced separately.
+    """
+    if repo.task_number is not None and repo.task_total is not None:
+        suffix = f" — {repo.current_task}" if repo.current_task else ""
+        return f"task {repo.task_number}/{repo.task_total}{suffix}"
+    if repo.current_task is not None:
+        return f"task: {repo.current_task}"
+    what = (repo.worker_what or "").strip()
+    if what and what.lower() != "idle":
+        return what
+    return "idle"
+
+
+def _format_webhook_lines(repo: RepoStatus) -> list[str]:
+    """Render up to :data:`_WEBHOOK_DISPLAY_CAP` webhook lines with the
+    talker sorted to the top.  Returns ``[]`` when there are no webhooks.
+    """
+    webhooks = list(repo.webhook_activities)
+    if not webhooks:
+        return []
+    talker = repo.claude_talker
+    talker_tid = (
+        talker.thread_id if talker is not None and talker.kind == "webhook" else None
+    )
+    # Stable sort: webhooks driving claude first, then everything else in
+    # original order.
+    webhooks.sort(key=lambda w: 0 if w.thread_id == talker_tid else 1)
+
+    shown = webhooks[:_WEBHOOK_DISPLAY_CAP]
+    overflow = len(webhooks) - len(shown)
+    lines: list[str] = []
+    for i, w in enumerate(shown):
+        branch = "└─" if overflow == 0 and i == len(shown) - 1 else "├─"
+        line = (
+            f"  {branch} webhook: {w.description} ({_format_uptime(w.elapsed_seconds)})"
+        )
+        if talker_tid is not None and w.thread_id == talker_tid:
+            line += _claude_stats_suffix(repo)
+        lines.append(line)
+    if overflow > 0:
+        lines.append(f"  └─ +{overflow} more webhook{'s' if overflow != 1 else ''}")
+    return lines
 
 
 def format_status(status: KennelStatus) -> str:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1965,6 +1965,20 @@ class WorkerThread(threading.Thread):
         session = self._session
         return session is not None and session.is_alive()
 
+    @property
+    def session_pid(self) -> int | None:
+        """PID of the persistent ClaudeSession subprocess, or ``None``.
+
+        Reads directly from the tracked session rather than relying on
+        pgrep — the :class:`~kennel.claude.ClaudeSession` uses
+        ``sub/persona.md`` (outside ``fido_dir``) as its system prompt, which
+        the pgrep-based :func:`kennel.status._claude_pid` heuristic can't find.
+        """
+        session = self._session
+        if session is None:
+            return None
+        return session.pid
+
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1135,6 +1135,12 @@ class TestRunStreamingTracksChildren:
         # the generator runs); after exhaustion it should be unregistered.
         assert proc not in _active_children
 
+    def test_thread_name_for_id_returns_none_when_not_found(self) -> None:
+        from kennel.claude import _thread_name_for_id
+
+        # Pick a thread_id that's very unlikely to match any live thread.
+        assert _thread_name_for_id(0xDEADBEEF) is None
+
     def test_registers_and_unregisters_talker_when_thread_repo_set(
         self, tmp_path: Path
     ) -> None:
@@ -1843,6 +1849,13 @@ class TestClaudeSessionLock:
         assert session.owner is None
         session.stop()
 
+    def test_pid_property_returns_popen_pid(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        proc.pid = 424242
+        session = _make_session(tmp_path, proc)
+        assert session.pid == 424242
+        session.stop()
+
     def test_repo_name_exposed(self, tmp_path: Path) -> None:
         session = _make_session(tmp_path, _make_session_proc([]))
         assert session.repo_name == "owner/repo"
@@ -1880,7 +1893,7 @@ class TestClaudeSessionLock:
         register_talker(
             ClaudeTalker(
                 repo_name="owner/repo",
-                thread_name="intruder",
+                thread_id=999,
                 kind="webhook",
                 description="leaked",
                 claude_pid=555,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -201,6 +201,16 @@ class TestWorkerRegistry:
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_alive("foo/bar") is True
 
+    def test_get_session_pid_returns_none_for_unknown_repo(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_session_pid("unknown/repo") is None
+
+    def test_get_session_pid_delegates_to_thread(self, tmp_path: Path) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.session_pid = 77777
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_session_pid("foo/bar") == 77777
+
     def test_get_thread_crash_error_returns_thread_crash_error(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -158,6 +158,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
@@ -193,6 +194,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
         WebhookHandler.registry.get_session_alive.return_value = True
+        WebhookHandler.registry.get_session_pid.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["session_owner"] == "worker-home"
@@ -217,6 +219,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
+        WebhookHandler.registry.get_session_pid.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["session_alive"] is True
@@ -246,6 +249,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -284,6 +288,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True
@@ -661,8 +666,12 @@ class TestProcessAction:
         time.sleep(0.2)
         mock_task.assert_not_called()
 
-    def test_process_action_emits_heartbeat(self, server: tuple) -> None:
-        """_process_action calls registry.report_activity at the start."""
+    def test_process_action_does_not_overwrite_worker_what(self, server: tuple) -> None:
+        """_process_action must not call report_activity — the webhook runs on
+        a separate thread and writing the worker's own worker_what field
+        from here clobbers the worker thread's state.  Webhook activity is
+        tracked via registry.webhook_activity instead.
+        """
         url, cfg = server
         payload = {
             **self._payload(),
@@ -673,9 +682,9 @@ class TestProcessAction:
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
         time.sleep(0.2)
-        WebhookHandler.registry.report_activity.assert_called_with(
-            "owner/repo", "handling webhook action", busy=True
-        )
+        for call in WebhookHandler.registry.report_activity.call_args_list:
+            args = call.args
+            assert "handling webhook action" not in args
 
     def test_status_endpoint_includes_claude_talker(self, server: tuple) -> None:
         """Active ClaudeTalker appears in /status as a structured object."""
@@ -687,7 +696,7 @@ class TestProcessAction:
         url, _ = server
         talker = ClaudeTalker(
             repo_name="owner/repo",
-            thread_name="worker-repo",
+            thread_id=12321,
             kind="worker",
             description="persistent session turn",
             claude_pid=12345,
@@ -707,12 +716,13 @@ class TestProcessAction:
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
+        WebhookHandler.registry.get_session_pid.return_value = None
         with patch("kennel.claude.get_talker", return_value=talker):
             resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         talker_data = data[0]["claude_talker"]
         assert talker_data["repo_name"] == "owner/repo"
-        assert talker_data["thread_name"] == "worker-repo"
+        assert talker_data["thread_id"] == 12321
         assert talker_data["kind"] == "worker"
         assert talker_data["claude_pid"] == 12345
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from kennel.config import RepoConfig
 from kennel.status import (
+    ClaudeTalkerInfo,
     KennelStatus,
     RepoStatus,
     WebhookActivityInfo,
@@ -411,6 +412,8 @@ class TestFetchActivities:
                 "webhook_activities": [],
                 "session_owner": None,
                 "session_alive": False,
+                "session_pid": None,
+                "claude_talker": None,
             }
         }
 
@@ -446,6 +449,8 @@ class TestFetchActivities:
                 "webhook_activities": [],
                 "session_owner": None,
                 "session_alive": False,
+                "session_pid": None,
+                "claude_talker": None,
             },
             "c/d": {
                 "what": "Fixing CI",
@@ -456,6 +461,8 @@ class TestFetchActivities:
                 "webhook_activities": [],
                 "session_owner": None,
                 "session_alive": False,
+                "session_pid": None,
+                "claude_talker": None,
             },
         }
 
@@ -929,6 +936,8 @@ class TestCollect:
             webhook_activities=[],
             session_owner=None,
             session_alive=False,
+            session_pid=None,
+            claude_talker=None,
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -961,6 +970,8 @@ class TestCollect:
             webhook_activities=[],
             session_owner=None,
             session_alive=False,
+            session_pid=None,
+            claude_talker=None,
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -986,7 +997,54 @@ class TestCollect:
             webhook_activities=[],
             session_owner=None,
             session_alive=False,
+            session_pid=None,
+            claude_talker=None,
         )
+
+    def test_passes_claude_talker_to_repo_status(self, tmp_path: Path) -> None:
+        """An active ClaudeTalker in /status → ClaudeTalkerInfo on RepoStatus."""
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        activity_info = {
+            "what": "running",
+            "crash_count": 0,
+            "last_crash_error": None,
+            "is_stuck": False,
+            "worker_uptime_seconds": None,
+            "webhook_activities": [],
+            "session_owner": None,
+            "session_alive": True,
+            "session_pid": 42,
+            "claude_talker": {
+                "repo_name": "owner/repo",
+                "thread_id": 1234,
+                "kind": "worker",
+                "description": "persistent session turn",
+                "claude_pid": 42,
+                "started_at": "2026-04-14T18:00:00+00:00",
+            },
+        }
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch(
+                "kennel.status._fetch_activities",
+                return_value={"owner/repo": activity_info},
+            ),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_rs,
+        ):
+            collect()
+        kwargs = mock_rs.call_args.kwargs
+        assert kwargs["claude_talker"] == ClaudeTalkerInfo(
+            thread_id=1234,
+            kind="worker",
+            description="persistent session turn",
+            claude_pid=42,
+        )
+        assert kwargs["session_pid"] == 42
 
     def test_passes_is_stuck_to_repo_status(self, tmp_path: Path) -> None:
         rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -1014,6 +1072,8 @@ class TestCollect:
             webhook_activities=[],
             session_owner=None,
             session_alive=False,
+            session_pid=None,
+            claude_talker=None,
         )
 
 
@@ -1085,75 +1145,92 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue:  #42 — Add widget" in output
-        assert "Task:   3/3 — Do the thing" in output
+        assert "Worker: task 3/3 — Do the thing" in output
 
     def test_repo_issue_without_title(self) -> None:
         repo = self._repo(issue=5, pending=2, completed=0, task_number=1, task_total=2)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue:  #5" in output
-        assert "Task:   1/2" in output
+        assert "Worker: task 1/2" in output
 
     def test_repo_issue_no_tasks(self) -> None:
         repo = self._repo(issue=3)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue:  #3" in output
-        assert "Task:" not in output
+        # No task → Worker line shows idle
+        assert "Worker: idle" in output
 
-    def test_claude_pid_with_uptime(self) -> None:
+    def test_claude_pid_on_worker_summary_when_no_talker(self) -> None:
+        """Claude stats ride the worker summary line when nobody is currently
+        talking to claude for this repo."""
         repo = self._repo(issue=1, claude_pid=9999, claude_uptime=185)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "└─ claude pid 9999 (running 3m)" in output
+        assert "→ claude pid 9999 (running 3m)" in output
+        # Header (worker summary) line carries the suffix.
+        assert any(
+            line.startswith("owner/repo:") and "→ claude pid 9999" in line
+            for line in output.splitlines()
+        )
 
-    def test_claude_pid_no_uptime(self) -> None:
+    def test_claude_pid_no_uptime_on_worker_summary(self) -> None:
         repo = self._repo(issue=1, claude_pid=9999, claude_uptime=None)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "└─ claude pid 9999" in output
+        assert "→ claude pid 9999" in output
         assert "running" not in output
 
-    def test_claude_pid_with_session_owner(self) -> None:
-        repo = self._repo(
-            issue=1, claude_pid=9999, claude_uptime=60, session_owner="worker-home"
-        )
-        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
-        output = format_status(status)
-        assert "└─ claude pid 9999 (running 1m, held by worker-home)" in output
-
-    def test_claude_pid_session_owner_no_uptime(self) -> None:
-        repo = self._repo(
-            issue=1, claude_pid=9999, claude_uptime=None, session_owner="worker-home"
-        )
-        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
-        output = format_status(status)
-        assert "└─ claude pid 9999 (held by worker-home)" in output
-
-    def test_claude_pid_session_alive_no_owner(self) -> None:
-        """Session subprocess alive but nobody holds the lock → shows 'session idle'."""
+    def test_claude_pid_attaches_to_worker_line_when_worker_talker(self) -> None:
+        """Worker-kind talker → claude stats on the Worker thread line."""
         repo = self._repo(
             issue=1,
             claude_pid=9999,
             claude_uptime=60,
-            session_owner=None,
             session_alive=True,
+            claude_talker=ClaudeTalkerInfo(
+                thread_id=111,
+                kind="worker",
+                description="persistent session turn",
+                claude_pid=9999,
+            ),
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "└─ claude pid 9999 (running 1m, session idle)" in output
+        # Worker line has the claude suffix.
+        worker_lines = [
+            line for line in output.splitlines() if line.startswith("  Worker:")
+        ]
+        assert any("→ claude pid 9999 (running 1m)" in line for line in worker_lines)
+        # Header does not duplicate it.
+        header = next(line for line in output.splitlines() if line.startswith("owner"))
+        assert "→ claude pid" not in header
+
+    def test_claude_pid_session_alive_no_talker(self) -> None:
+        """Session subprocess alive but nobody holds the lock → 'session idle'."""
+        repo = self._repo(
+            issue=1,
+            claude_pid=9999,
+            claude_uptime=60,
+            session_alive=True,
+            claude_talker=None,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        # Suffix appears on worker summary and mentions session idle.
+        assert "→ claude pid 9999 (running 1m, session idle)" in output
 
     def test_session_alive_without_claude_pid(self) -> None:
-        """Session alive but pgrep didn't match → fallback line noting the mismatch."""
+        """Session_alive with no pid still signals claude presence via 'session idle'."""
         repo = self._repo(
             issue=1,
             claude_pid=None,
-            session_owner=None,
             session_alive=True,
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "└─ session alive (no pgrep match)" in output
+        assert "→ claude (session idle)" in output
 
     def test_multiple_repos(self) -> None:
         # Each repo emits a header + "no assigned issues" body line.
@@ -1247,23 +1324,97 @@ class TestFormatStatus:
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "Task:   Freeform task" in output
+        # Worker line shows the free-form task title.
+        assert "Worker: task: Freeform task" in output
+
+    def test_webhook_talker_sorts_to_top_with_claude_stats(self) -> None:
+        """When a webhook is the ClaudeTalker, its line sorts to the top of
+        the webhook section and carries the claude pid suffix."""
+        repo = self._repo(
+            issue=1,
+            claude_pid=8888,
+            claude_uptime=45,
+            session_alive=True,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description="triaging comment", elapsed_seconds=30, thread_id=1
+                ),
+                WebhookActivityInfo(
+                    description="replying to review", elapsed_seconds=2, thread_id=2
+                ),
+            ],
+            claude_talker=ClaudeTalkerInfo(
+                thread_id=2,
+                kind="webhook",
+                description="one-shot claude --print",
+                claude_pid=8888,
+            ),
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        webhook_lines = [
+            line for line in format_status(status).splitlines() if "webhook:" in line
+        ]
+        assert "replying to review" in webhook_lines[0]
+        assert "→ claude pid 8888" in webhook_lines[0]
+        assert "triaging comment" in webhook_lines[1]
+        assert "→ claude pid" not in webhook_lines[1]
+
+    def test_webhook_overflow_summary_when_more_than_five(self) -> None:
+        """More than 5 webhook activities → first 5 shown + '+N more' line."""
+        repo = self._repo(
+            issue=1,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description=f"wh{i}", elapsed_seconds=i, thread_id=i
+                )
+                for i in range(9)
+            ],
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        lines = [
+            line
+            for line in format_status(status).splitlines()
+            if "webhook" in line or "more" in line
+        ]
+        # 5 shown + 1 overflow summary.
+        assert len(lines) == 6
+        assert "+4 more webhooks" in lines[-1]
+
+    def test_webhook_overflow_singular_for_one_extra(self) -> None:
+        """Overflow of exactly 1 uses singular 'webhook'."""
+        repo = self._repo(
+            issue=1,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description=f"wh{i}", elapsed_seconds=i, thread_id=i
+                )
+                for i in range(6)
+            ],
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        assert "+1 more webhook" in format_status(status)
+        assert "+1 more webhooks" not in format_status(status)
 
     def test_webhook_activities_rendered_as_sub_bullets(self) -> None:
         repo = self._repo(
             issue=1,
             webhook_activities=[
                 WebhookActivityInfo(
-                    description="triaging comment on PR #9", elapsed_seconds=12
+                    description="triaging comment on PR #9",
+                    elapsed_seconds=12,
+                    thread_id=1,
                 ),
                 WebhookActivityInfo(
-                    description="replying to review", elapsed_seconds=3
+                    description="replying to review",
+                    elapsed_seconds=3,
+                    thread_id=2,
                 ),
             ],
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "└─ webhook: triaging comment on PR #9 (12s)" in output
+        # First webhook uses ├─ (not last), second uses └─ (last).
+        assert "├─ webhook: triaging comment on PR #9 (12s)" in output
         assert "└─ webhook: replying to review (3s)" in output
 
     def test_worker_busy_false_not_shown(self) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8936,6 +8936,18 @@ class TestWorkerThread:
         assert wt._session is None
         assert wt.session_alive is False
 
+    def test_session_pid_none_when_no_session(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt._session is None
+        assert wt.session_pid is None
+
+    def test_session_pid_delegates_to_session_pid(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        mock_session = MagicMock()
+        mock_session.pid = 54321
+        wt._session = mock_session
+        assert wt.session_pid == 54321
+
     def test_session_alive_delegates_to_session_is_alive(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()


### PR DESCRIPTION
Implements the per-repo layout spec from #476.

## New layout

\`\`\`
repo: fido <state> — <stats>[ → claude pid …]
  Issue:  #N — title  (elapsed …)
  PR:     #N — title
  Worker: <state>[ → claude pid …]
  ├─ webhook: <description> (elapsed)[ → claude pid …]
  ├─ …up to 5 shown…
  └─ +N more webhooks
\`\`\`

- **\`Doing:\` line is gone.**
- Claude pid/uptime/session-alive attach to **exactly one** line per repo — routed by the \`ClaudeTalker.kind\`:
  - \`worker\` → \`Worker:\` line
  - \`webhook\` → that webhook's own line, which **sorts to the top** of the webhook section
  - nobody talking → the worker summary line
- Webhook list capped at 5 entries with a \`+N more webhook(s)\` overflow line.
- \`Worker:\` state is now derived only from the worker thread's own \`worker_what\`; webhook handlers no longer mutate it.

## Plumbing

- \`ClaudeTalker\` and \`WebhookActivity\` now store \`thread_id\` (\`threading.get_ident()\`) — strictly unique for live threads, unlike thread names. Human-readable name looked up at display time via \`_thread_name_for_id\`.
- \`WorkerThread.session_pid\` + \`WorkerRegistry.get_session_pid\` expose the tracked session subprocess pid directly; \`/status\` ships it so \`status.py\` can skip the pgrep heuristic (which can't find the new persistent sessions — their system prompt file lives outside \`fido_dir\`).
- \`server.WebhookHandler._process_action_inner\` no longer calls \`report_activity(\"handling webhook action\", …)\` — that was clobbering the worker thread's \`worker_what\` and caused the \`Doing: handling webhook action\` bug.

## Out of scope

\`#479\` (routing webhook handlers through the persistent session via interrupt/steal semantics) is the critical follow-up — that's what makes the exclusivity invariant true in practice. This PR only makes the display honest about the current state.

Closes #476.