### PR TITLE
Kill 10s sleep in test_raises_on_idle_timeout (closes #474)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -419,6 +419,7 @@ def _run_streaming(
     cwd: Path | str | None = None,
     popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
     selector: Callable[..., tuple[list, list, list]] = select.select,
+    clock: Callable[[], float] = time.monotonic,
 ) -> Iterator[str]:
     """Run a command, streaming stdout with idle-timeout detection.
 
@@ -455,7 +456,7 @@ def _run_streaming(
         talker_registered = True
 
     try:
-        last_activity = time.monotonic()
+        last_activity = clock()
 
         while True:
             ready, _, _ = selector([proc.stdout], [], [], _SELECT_POLL_INTERVAL)
@@ -465,10 +466,10 @@ def _run_streaming(
                     break  # EOF
                 yield line
                 log.debug(line.rstrip())
-                last_activity = time.monotonic()
+                last_activity = clock()
             elif proc.poll() is not None:
                 break  # process exited
-            elif time.monotonic() - last_activity > idle_timeout:
+            elif clock() - last_activity > idle_timeout:
                 log.warning("claude idle for %.0fs — killing", idle_timeout)
                 proc.kill()
                 proc.wait()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -233,15 +233,46 @@ class TestRunStreaming:
             list(_run_streaming(["/nonexistent/binary"], stdin_file))
 
     def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
+        """Idle-timeout kills the subprocess when no output for N seconds.
+
+        Uses a virtual clock and mocked popen/selector so the test runs in
+        microseconds — no real ``sleep`` subprocess, no wall-clock waiting.
+        """
         from kennel.claude import _run_streaming
 
         stdin_file = tmp_path / "input.txt"
         stdin_file.write_text("")
-        import pytest
+
+        proc = MagicMock()
+        proc.stdout = MagicMock()
+        proc.stderr = MagicMock()
+        proc.poll = MagicMock(return_value=None)  # still alive
+        proc.wait = MagicMock(return_value=None)
+        proc.kill = MagicMock()
+        proc.returncode = 0
+
+        # Selector always reports stdout-not-ready → loop falls through to
+        # the idle-timeout check on every iteration.
+        fake_selector = MagicMock(return_value=([], [], []))
+        # Virtual clock: first call seeds ``last_activity`` at 0; subsequent
+        # calls jump past idle_timeout so the check trips on iteration one.
+        times = iter([0.0, 1.0])
+        fake_clock = MagicMock(side_effect=lambda: next(times))
 
         with pytest.raises(ClaudeStreamError) as exc_info:
-            list(_run_streaming(["sleep", "60"], stdin_file, idle_timeout=0.1))
+            list(
+                _run_streaming(
+                    ["anything"],
+                    stdin_file,
+                    idle_timeout=0.1,
+                    popen=MagicMock(return_value=proc),
+                    selector=fake_selector,
+                    clock=fake_clock,
+                )
+            )
         assert exc_info.value.returncode == _RETURNCODE_IDLE_TIMEOUT
+        proc.kill.assert_called_once()
+        proc.wait.assert_called_once()
 
     def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming


### PR DESCRIPTION
Remove the real \`sleep 60\` subprocess + 10-second wall-clock wait from \`TestRunStreaming::test_raises_on_idle_timeout\`.

## The bug

The test did \`_run_streaming([\"sleep\", \"60\"], ..., idle_timeout=0.1)\`, but \`_run_streaming\`'s \`select.select\` poll interval is \`_SELECT_POLL_INTERVAL = 10.0\`.  The sleep produces no output, so select blocked for a full 10s before the loop could check the idle-timeout math — making this one test a ~10s anchor on the suite, and a worker-pinning bottleneck under pytest-xdist.

## The fix

- \`_run_streaming\` now takes an optional \`clock\` callable (default \`time.monotonic\`) so tests can provide a virtual clock.
- The test rewrites to use \`MagicMock\` popen + a selector that always reports stdout-not-ready + an iter-backed clock that jumps \`0.0 → 1.0\`, tripping the idle-timeout check on the first iteration.

Zero real sleeps, zero subprocess spawn, runs in microseconds.

Serial pytest wall time: **37s → 26.5s** (the whole 10s saved comes from this single test).

Closes #474.