### PR TITLE
Pre-create ClaudeSession in WorkerThread.run (closes #483)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2014,6 +2014,25 @@ class WorkerThread(threading.Thread):
         self._stop = True
         self._wake.set()
 
+    def _create_session(self) -> claude.ClaudeSession:
+        """Spawn the per-worker persistent :class:`~kennel.claude.ClaudeSession`.
+
+        Used from :meth:`run` so the thread's ``_session`` attribute is
+        populated before the inner :class:`Worker` begins — that way the
+        registry's resolver (and therefore :func:`claude.print_prompt`)
+        can find the session from any other thread (status updates, webhook
+        handlers) the moment the worker thread starts up, not only after
+        its first full iteration has completed.
+        """
+        persona_file = _sub_dir() / "persona.md"
+        session = claude.ClaudeSession(
+            persona_file,
+            work_dir=self.work_dir,
+            repo_name=self._repo_name or None,
+        )
+        session.switch_model("claude-opus-4-6")
+        return session
+
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
@@ -2022,6 +2041,19 @@ class WorkerThread(threading.Thread):
             while not self._stop:
                 if self._registry is not None:
                     self._registry.report_activity(self._repo_name, "idle", busy=False)
+                # Create the persistent ClaudeSession eagerly — before the
+                # Worker runs — so it's always reachable via
+                # registry.get_session() for :func:`claude.print_prompt`
+                # callers (e.g. cosmetic set_status on repos with no
+                # eligible issues).  Writing here, on ``self._session``,
+                # rather than inside Worker.create_session, means the
+                # registry's resolver sees the session even while the
+                # Worker is mid-iteration.  Spawning unconditionally is
+                # fine: sessions persist across Worker crashes and idle
+                # between iterations; we'd create one on the first
+                # iteration anyway.
+                if self._session is None:
+                    self._session = self._create_session()
                 worker = Worker(
                     self.work_dir,
                     self._gh,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8800,10 +8800,11 @@ class TestWorkerThread:
     # ── session lifecycle ─────────────────────────────────────────────────
 
     def test_session_carried_to_next_iteration(self, tmp_path: Path) -> None:
-        """Session created by one Worker.run() is passed to the next."""
+        """Session pre-created by WorkerThread on first iteration is carried forward."""
         wt = self._make_thread(tmp_path)
         wt._wake = MagicMock()
-        mock_session = MagicMock()
+        pre_session = MagicMock()
+        wt._create_session = MagicMock(return_value=pre_session)
         sessions_received: list = []
 
         def fake_worker_init(
@@ -8830,7 +8831,6 @@ class TestWorkerThread:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                self_w._session = mock_session  # first worker creates a session
                 return 1
             wt._stop = True
             return 0
@@ -8842,8 +8842,12 @@ class TestWorkerThread:
             self._run_thread(wt)
 
         assert len(sessions_received) == 2
-        assert sessions_received[0] is None  # no carry-over on first iteration
-        assert sessions_received[1] is mock_session  # carried forward
+        # WorkerThread pre-creates the session before the first Worker runs,
+        # so the first Worker already inherits it, and subsequent Workers
+        # continue to inherit it (no carry-over / re-create on iteration 2).
+        assert sessions_received[0] is pre_session
+        assert sessions_received[1] is pre_session
+        wt._create_session.assert_called_once()
 
     def test_session_issue_carried_to_next_iteration(self, tmp_path: Path) -> None:
         """session_issue set by one Worker.run() is passed to the next."""


### PR DESCRIPTION
Fixes the \"setup produced no tasks\" / \"Worker: idle\" crash loop on repos with no assigned issues (e.g. confusio at kennel startup).

## Root cause

\`Worker.create_session()\` wrote only to \`worker._session\`. The thread's own \`_session\` stayed \`None\` until \`Worker.run\` returned. Meanwhile the registry's session resolver (\`registry.get_session\`) reads \`thread._session\` — so any other thread (status update, webhook handler) calling \`claude.print_prompt\` mid-iteration saw \"no session\" and crashed per the strict resolver from #479/#481.

Concretely on confusio:

\`\`\`
find_next_issue → set_status(\"All done — no issues to fetch\")
  → generate_status_emoji → print_prompt → _session_for_current_repo
  → RuntimeError(\"no ClaudeSession registered\")
\`\`\`

Watchdog restart, same crash, indefinite loop. The display showed \`Worker: idle\` on a thread that was actually crash-spinning.

## Fix

Move session creation from \`Worker.create_session\` (lazy, inside \`Worker.run\`) to a new \`WorkerThread._create_session\`, called eagerly in \`WorkerThread.run\` before the first \`Worker\` is constructed. The thread's own \`_session\` is now populated the moment the thread starts, so the registry's resolver can always find it.

Claude should never go down, and restarting it on demand is too slow — so we always have one alive per worker thread.

Semantics preserved:

- **Survives Worker death**: next Worker in the thread's loop inherits the same session via the existing \`session=\` kwarg.
- **Survives WorkerThread death**: registry rescues \`_session\` from the dead thread and hands it to the replacement.
- **Dies on kennel exec**: \`os.execvp\` replaces the process; the next kennel starts with a fresh session on each worker's first iteration.

Closes #483.