### PR TITLE
Strip timeout= kwargs from print_prompt callers missed in #481

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -243,7 +243,7 @@ def maybe_react(
         _print_prompt = claude.print_prompt
     prompts = Prompts(_load_persona(config))
     reaction = (
-        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6", timeout=15)
+        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6")
         .lower()
         .split("\n")[0]
         .strip()
@@ -476,7 +476,7 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
         "to act on alone)?\n\n"
         "Reply with exactly YES or NO."
     )
-    answer = _print_prompt(prompt, "claude-haiku-4-5", timeout=10).upper()
+    answer = _print_prompt(prompt, "claude-haiku-4-5").upper()
     return answer.startswith("YES")
 
 
@@ -496,7 +496,7 @@ def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
         "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
         f"Comment: {comment_body}"
     )
-    result = _print_prompt(prompt, "claude-opus-4-6", timeout=15).strip()
+    result = _print_prompt(prompt, "claude-opus-4-6").strip()
     for _ in range(3):
         if not result or len(result) <= _MAX_TITLE_LEN:
             break
@@ -525,7 +525,7 @@ def _triage(
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = triage_prompt(comment_body, is_bot, context)
-    text = _print_prompt(prompt, "claude-opus-4-6", timeout=15)
+    text = _print_prompt(prompt, "claude-opus-4-6")
     category: str | None = None
     titles: list[str] = []
     for line in text.splitlines() if text else []:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -526,7 +526,7 @@ def reorder_tasks(
 
     original_ids = frozenset(t["id"] for t in task_list)
     prompt = _rescope_prompt_fn(task_list, commit_summary)
-    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    raw = _print_prompt(prompt, "claude-opus-4-6")
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -686,7 +686,7 @@ def _write_pr_description(
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
     prompt = rewrite_description_prompt(existing_body, task_list)
-    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    raw = _print_prompt(prompt, "claude-opus-4-6")
     new_desc = _extract_body(raw)
     if not new_desc:
         raise ValueError(


### PR DESCRIPTION
Hotfix.  #481 dropped the `timeout` param from `claude.print_prompt` / `print_prompt_json` when the subprocess path was deleted, but six callers in `events.py`, `worker.py`, and `tasks.py` still passed `timeout=N`.  Every one crashed with:

```
TypeError: print_prompt() got an unexpected keyword argument 'timeout'
```

Kennel's watchdog kept restarting the worker thread after each crash; fido never actually made progress on an issue.

This PR strips the dead `timeout=` kwargs.  No other behavior change.