### PR TITLE
Fix set_status subprocess hang + entry/exit logs (closes #489)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -283,13 +283,53 @@ def _claude(
     timeout: int = 30,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> subprocess.CompletedProcess[str]:
-    """Run the claude CLI with the given args, optionally piping prompt to stdin."""
-    return runner(
-        ["claude", *args],
-        input=prompt,
-        capture_output=True,
+    """Run the claude CLI with the given args, optionally piping prompt to stdin.
+
+    Under the free-threaded (3.14t) runtime we observed
+    ``subprocess.run(..., timeout=...)`` failing to fire on long-hung
+    claude children — the worker sat on a futex for minutes past the
+    requested timeout (closes #489).  When the default runner is used,
+    drive the subprocess with explicit ``Popen`` + ``communicate`` so
+    the child is guaranteed to be killed and reaped when the budget
+    elapses.  Test overrides via *runner* still flow through whatever
+    mock the test supplies.  Logs entry and exit so a stalled status
+    call is localisable in the kennel log.
+    """
+    cmd = ["claude", *args]
+    log.debug("_claude: running (timeout=%ds) %s", timeout, cmd[:3])
+    if runner is not subprocess.run:
+        return runner(
+            cmd, input=prompt, capture_output=True, text=True, timeout=timeout
+        )
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE if prompt is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=timeout,
+    )
+    stdout = ""
+    stderr = ""
+    try:
+        stdout, stderr = proc.communicate(input=prompt, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "_claude: subprocess exceeded %ds — killing and re-raising", timeout
+        )
+        proc.kill()
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        raise subprocess.TimeoutExpired(
+            proc.args, timeout, output=stdout, stderr=stderr
+        )
+    log.debug("_claude: returned rc=%d", proc.returncode)
+    return subprocess.CompletedProcess(
+        args=proc.args,
+        returncode=proc.returncode,
+        stdout=stdout,
+        stderr=stderr,
     )
 
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -243,7 +243,7 @@ def maybe_react(
         _print_prompt = claude.print_prompt
     prompts = Prompts(_load_persona(config))
     reaction = (
-        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6", timeout=15)
+        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6")
         .lower()
         .split("\n")[0]
         .strip()
@@ -476,7 +476,7 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
         "to act on alone)?\n\n"
         "Reply with exactly YES or NO."
     )
-    answer = _print_prompt(prompt, "claude-haiku-4-5", timeout=10).upper()
+    answer = _print_prompt(prompt, "claude-haiku-4-5").upper()
     return answer.startswith("YES")
 
 
@@ -496,7 +496,7 @@ def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
         "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
         f"Comment: {comment_body}"
     )
-    result = _print_prompt(prompt, "claude-opus-4-6", timeout=15).strip()
+    result = _print_prompt(prompt, "claude-opus-4-6").strip()
     for _ in range(3):
         if not result or len(result) <= _MAX_TITLE_LEN:
             break
@@ -525,7 +525,7 @@ def _triage(
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = triage_prompt(comment_body, is_bot, context)
-    text = _print_prompt(prompt, "claude-opus-4-6", timeout=15)
+    text = _print_prompt(prompt, "claude-opus-4-6")
     category: str | None = None
     titles: list[str] = []
     for line in text.splitlines() if text else []:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -526,7 +526,7 @@ def reorder_tasks(
 
     original_ids = frozenset(t["id"] for t in task_list)
     prompt = _rescope_prompt_fn(task_list, commit_summary)
-    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    raw = _print_prompt(prompt, "claude-opus-4-6")
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -686,7 +686,7 @@ def _write_pr_description(
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
     prompt = rewrite_description_prompt(existing_body, task_list)
-    raw = _print_prompt(prompt, "claude-opus-4-6", timeout=30)
+    raw = _print_prompt(prompt, "claude-opus-4-6")
     new_desc = _extract_body(raw)
     if not new_desc:
         raise ValueError(
@@ -897,9 +897,13 @@ class Worker:
                 activities = [(self.work_dir.name, what, busy)]
 
             # Call 1: generate status text
+            log.info("set_status: requesting status text from claude")
             text, session_id = _generate_status_with_session(
                 prompt=prompts.status_text_prompt(activities),
                 system_prompt=prompts.status_text_system_prompt(),
+            )
+            log.info(
+                "set_status: status text returned (%d chars)", len(text) if text else 0
             )
             if not text:
                 log.warning(
@@ -925,10 +929,12 @@ class Worker:
                 text = text[:80]
 
             # Call 2: generate emoji
+            log.info("set_status: requesting emoji from claude")
             emoji = _generate_status_emoji(
                 prompt=prompts.status_emoji_prompt(text),
                 system_prompt=prompts.status_emoji_system_prompt(),
             )
+            log.info("set_status: emoji returned (%r)", emoji)
             if not emoji:
                 emoji = ":dog:"
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -85,6 +85,83 @@ class TestClaudeHelper:
         _claude("--help", runner=mock_run)
         assert mock_run.call_args.kwargs["input"] is None
 
+    def test_default_runner_uses_explicit_popen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no runner is overridden, _claude drives Popen directly so
+        TimeoutExpired actually reaps the child (closes #489)."""
+        import subprocess
+
+        fake_proc = MagicMock()
+        fake_proc.args = ["claude", "--print"]
+        fake_proc.returncode = 0
+        fake_proc.communicate = MagicMock(return_value=("hello", ""))
+        fake_popen = MagicMock(return_value=fake_proc)
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        result = _claude("--print", "-p", "hi", prompt="body", timeout=5)
+        fake_popen.assert_called_once()
+        fake_proc.communicate.assert_called_once_with(input="body", timeout=5)
+        assert result.stdout == "hello"
+        assert result.returncode == 0
+
+    def test_default_runner_no_prompt_uses_devnull(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+
+        fake_proc = MagicMock()
+        fake_proc.args = ["claude", "--version"]
+        fake_proc.returncode = 0
+        fake_proc.communicate = MagicMock(return_value=("1.0", ""))
+        fake_popen = MagicMock(return_value=fake_proc)
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        _claude("--version")
+        assert fake_popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+    def test_default_runner_kills_on_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TimeoutExpired from communicate → kill → re-raise with output."""
+        import subprocess
+
+        fake_proc = MagicMock()
+        fake_proc.args = ["claude", "--print"]
+        fake_proc.returncode = -9
+        # First communicate call times out; second (after kill) returns.
+        fake_proc.communicate = MagicMock(
+            side_effect=[
+                subprocess.TimeoutExpired("claude", 5),
+                ("partial", "err"),
+            ]
+        )
+        fake_proc.kill = MagicMock()
+        monkeypatch.setattr(subprocess, "Popen", MagicMock(return_value=fake_proc))
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            _claude("--print", "-p", "hi", prompt="x", timeout=5)
+        fake_proc.kill.assert_called_once()
+        assert exc_info.value.output == "partial"
+        assert exc_info.value.stderr == "err"
+
+    def test_default_runner_unresponsive_after_kill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Child that ignores SIGKILL too — still re-raise TimeoutExpired."""
+        import subprocess
+
+        fake_proc = MagicMock()
+        fake_proc.args = ["claude", "--print"]
+        fake_proc.returncode = -9
+        fake_proc.communicate = MagicMock(
+            side_effect=[
+                subprocess.TimeoutExpired("claude", 5),
+                subprocess.TimeoutExpired("claude", 5),
+            ]
+        )
+        fake_proc.kill = MagicMock()
+        monkeypatch.setattr(subprocess, "Popen", MagicMock(return_value=fake_proc))
+        with pytest.raises(subprocess.TimeoutExpired):
+            _claude("--print", "-p", "hi", prompt="x", timeout=5)
+
 
 @pytest.fixture
 def session_resolver():


### PR DESCRIPTION
`set_status` is intentionally transient: a fresh one-shot `claude --print` subprocess every few minutes, independent of the persistent ClaudeSession (status depends on workers being honest about what they're doing — the persistent session is for work, not introspection).

The bug was the subprocess **hung past its own timeout**.

## Symptom

Home worker at 19:22:26 logged `task: Gate draft PR promote on CI green` and then **nothing for 4+ minutes**.  Worker thread blocked on a futex.  `kennel status` showed `session idle` because the persistent session wasn't involved — but the one-shot subprocess from `set_status`/`generate_status_with_session` was wedged, with `subprocess.run(..., timeout=15)` failing to fire.

## Fix

Rewrite `_claude`'s default path to use explicit `subprocess.Popen` + `communicate(timeout=...)` + `kill/wait` on `TimeoutExpired`.  That guarantees the child is killed and reaped within `timeout + 5s` regardless of whatever state the free-threaded runtime's `subprocess.run` timeout is in.

The test runner override path is preserved — tests that inject `runner=MagicMock()` still get the delegated path.

## Observability

Added INFO-level entry/exit logs around the two claude calls in `set_status`:

```
set_status: requesting status text from claude
set_status: status text returned (42 chars)
set_status: requesting emoji from claude
set_status: emoji returned (':dog:')
```

So next time a status call stalls, the kennel log pinpoints which claude call is stuck rather than leaving a 4-minute silent gap.

Closes #489.
EOF
)