### PR TITLE
ClaudeSession.prompt: skip control_request on fresh subprocess (fixes set_status hang)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1045,17 +1045,21 @@ class ClaudeSession:
         2. Acquire ``self`` as a context manager — blocks while the previous
            holder is winding down.  Registers a fresh :class:`ClaudeTalker`
            so status display attributes claude to this thread.
-        3. Send a stream-json ``control_request`` interrupt + drain stale
-           events from the cancelled turn so stdout is clean.
-        4. Switch model if *model* is provided and differs from the session
+        3. Switch model if *model* is provided and differs from the session
            default.
-        5. Send *content* (optionally prefixed with *system_prompt*) and
+        4. Send *content* (optionally prefixed with *system_prompt*) and
            consume until the result boundary, returning the text.
+
+        Does **not** send a ``control_request`` interrupt to the subprocess
+        before the user message.  On a fresh subprocess with no in-flight
+        turn, claude ignores the control_request and never emits a
+        ``type=result``, so ``consume_until_result`` would hang
+        indefinitely.  The :attr:`_cancel` signal + lock hand-off already
+        ensures the previous holder's :meth:`iter_events` has exited, so
+        there is nothing in-flight to interrupt.
         """
         self._cancel.set()
         with self:
-            self._send_control_interrupt()
-            self.consume_until_result()
             if model is not None:
                 self.switch_model(model)
             if system_prompt:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1947,7 +1947,6 @@ class TestClaudeSessionLock:
         system_file.write_text("persona")
         proc = _make_session_proc(
             [
-                '{"type":"result","result":""}\n',  # drain after interrupt
                 '{"type":"result","result":"hello world"}\n',  # actual turn
             ]
         )


### PR DESCRIPTION
`set_status`'s first `session.prompt` call on a freshly-spawned subprocess hung indefinitely.  `prompt()` was sending a stream-json `control_request` interrupt before the user message and then draining with `consume_until_result`.  On a fresh subprocess with no in-flight turn, claude ignores the control_request and never emits a `type=result` — the drain blocks forever.

Drop the control_request + drain dance entirely.  The `_cancel` signal + `_lock` hand-off already guarantee the previous holder's `iter_events` has exited and released the session — there's nothing in-flight to interrupt.

Unblocks set_status on repos that just started up with no prior turn history (i.e. every kennel restart).