### PR TITLE
ClaudeSession: RLock so switch_model/restart don't self-deadlock

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -797,7 +797,12 @@ class ClaudeSession:
         self._system_file = system_file
         self._work_dir = work_dir
         self._popen_fn = popen
-        self._lock = threading.Lock()
+        # Reentrant so :meth:`switch_model` and :meth:`restart` can
+        # reacquire while called from inside a ``with session:`` block
+        # (e.g. ``prompt()`` acquires the lock, then calls switch_model
+        # which also needs to serialize with other sessions' access —
+        # a plain threading.Lock self-deadlocks).
+        self._lock = threading.RLock()
         self._cancel = threading.Event()
         self._repo_name = repo_name
         self._model = model


### PR DESCRIPTION
`session.prompt` acquires `self._lock` via `with self:` then calls `switch_model`, which ALSO does `with self._lock:` to serialize the swap.  `threading.Lock` is non-reentrant — the second acquire from the same thread blocks forever.  `restart()` has the same shape.

Use `threading.RLock` so the inner acquire is allowed when called from the outer context.  Other callers (external threads) still serialize correctly because the RLock counter only increments for the owning thread.

Unblocks `set_status` on phase-2 (emoji) when it needs to switch back to opus — every `set_status` after the first phase was wedging on this self-deadlock.