### PR TITLE
Add pyright to dev deps, gate CI + pre-commit on clean run (closes #466)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,5 +7,8 @@ uv run ruff format --check .
 echo "==> checking lint"
 uv run ruff check .
 
+echo "==> checking types"
+uv run pyright
+
 echo "==> running tests"
 uv run python -m pytest --cov --cov-report=term-missing --cov-fail-under=100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: uv run pyright
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -14,7 +14,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 log = logging.getLogger(__name__)
 
@@ -57,16 +57,16 @@ class _Trunc:
 # can clean them up on shutdown.  Short-lived ``subprocess.run`` calls cap
 # at 30s and aren't tracked.  Use ``kill_active_children`` from a signal
 # handler to terminate everything before exiting.
-_active_children: set[subprocess.Popen] = set()
+_active_children: set[subprocess.Popen[str]] = set()
 _active_children_lock = threading.Lock()
 
 
-def _register_child(proc: subprocess.Popen) -> None:
+def _register_child(proc: subprocess.Popen[str]) -> None:
     with _active_children_lock:
         _active_children.add(proc)
 
 
-def _unregister_child(proc: subprocess.Popen) -> None:
+def _unregister_child(proc: subprocess.Popen[str]) -> None:
     with _active_children_lock:
         _active_children.discard(proc)
 
@@ -458,7 +458,7 @@ def _run_streaming(
     idle_timeout: float = 1800.0,
     cwd: Path | str | None = None,
     popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
-    selector: Callable[..., tuple[list, list, list]] = select.select,
+    selector: Callable[..., tuple[list[Any], list[Any], list[Any]]] = select.select,
     clock: Callable[[], float] = time.monotonic,
 ) -> Iterator[str]:
     """Run a command, streaming stdout with idle-timeout detection.
@@ -789,7 +789,7 @@ class ClaudeSession:
         work_dir: Path | str | None = None,
         idle_timeout: float = 1800.0,
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
-        selector: Callable[..., tuple[list, list, list]] = select.select,
+        selector: Callable[..., tuple[list[Any], list[Any], list[Any]]] = select.select,
         repo_name: str | None = None,
         model: str = "claude-opus-4-6",
     ) -> None:
@@ -1113,7 +1113,7 @@ class ClaudeSession:
             _register_child(self._proc)
         log.info("switch_model: new pid %d ready (model=%s)", self._proc.pid, model)
 
-    def iter_events(self) -> Iterator[dict]:
+    def iter_events(self) -> Iterator[dict[str, Any]]:
         """Yield parsed stream-json events for the current turn.
 
         Clears the cancel event at the start so any signal that arrived during

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -479,6 +479,7 @@ def _run_streaming(
         cwd=cwd,
     )
     _register_child(proc)
+    assert proc.stdout is not None  # guaranteed by stdout=PIPE
     repo_name = current_repo()
     thread_id = threading.get_ident()
     talker_registered = False

--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 from kennel.github import GitHub
 from kennel.tasks import Tasks
@@ -20,7 +21,7 @@ class Cmd:
     def __init__(self, *, github: GitHub) -> None:
         self._github = github
 
-    def _resolve_thread_if_ours(self, thread: dict) -> None:
+    def _resolve_thread_if_ours(self, thread: dict[str, Any]) -> None:
         """Resolve the review thread if the last reply came from us."""
         repo = thread.get("repo", "")
         pr = thread.get("pr")
@@ -70,8 +71,8 @@ class Cmd:
         comment_id: int | None = None,
         repo: str | None = None,
         pr: int | None = None,
-    ) -> dict:
-        thread: dict | None = None
+    ) -> dict[str, Any]:
+        thread: dict[str, Any] | None = None
         if comment_id is not None:
             thread = {"comment_id": comment_id}
             if repo:
@@ -131,7 +132,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None, *, _GitHub=GitHub) -> None:
+def main(argv: list[str] | None = None, *, _GitHub: type[GitHub] = GitHub) -> None:
     parser = build_parser()
     args = parser.parse_args(argv)
     cmd = Cmd(github=_GitHub())

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -5,6 +5,7 @@ import logging
 import re
 import subprocess
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,9 +25,13 @@ from kennel.types import TaskType
 
 log = logging.getLogger(__name__)
 
+# Type alias for the claude.print_prompt DI callback.
+# Uses Callable[..., str] because some callsites pass system_prompt= as a kwarg.
+_PrintPrompt = Callable[..., str]
+
 # Per-work_dir coalescing state for _reorder_tasks_background.
 # Ensures at most one Opus call in-flight + one pending per repo.
-_reorder_coalesce: dict[str, dict] = {}
+_reorder_coalesce: dict[str, dict[str, Any]] = {}
 _reorder_coalesce_lock = threading.Lock()
 
 
@@ -233,7 +238,7 @@ def maybe_react(
     config: Config,
     gh: GitHub,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> None:
     """Let Fido decide whether to react to a comment with an emoji.
 
@@ -267,7 +272,7 @@ def reply_to_comment(
     repo_cfg: RepoConfig,
     gh: GitHub,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> tuple[str, list[str]]:
     """Triage a comment via Opus, generate a reply via Opus, post it.
 
@@ -396,7 +401,7 @@ def reply_to_review(
     gh: GitHub,
     already_replied: set[int] | None = None,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> None:
     """Fetch inline comments from a review and reply to each."""
     if _print_prompt is None:
@@ -455,7 +460,9 @@ def reply_to_review(
             already_replied.add(cid)
 
 
-def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
+def needs_more_context(
+    comment_body: str, *, _print_prompt: _PrintPrompt | None = None
+) -> bool:
     """Ask Haiku whether this comment needs sibling thread context to act on.
 
     Returns True if Haiku thinks the comment is too vague or cross-referential
@@ -479,7 +486,9 @@ def needs_more_context(comment_body: str, *, _print_prompt=None) -> bool:
 _MAX_TITLE_LEN = 80
 
 
-def _summarize_as_action_item(comment_body: str, *, _print_prompt=None) -> str:
+def _summarize_as_action_item(
+    comment_body: str, *, _print_prompt: _PrintPrompt | None = None
+) -> str:
     """Ask Opus to convert a comment into a short imperative action-item title.
 
     If the result is too long, asks Claude to shorten it up to 3 times before
@@ -511,7 +520,7 @@ def _triage(
     is_bot: bool,
     context: dict[str, Any] | None = None,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> tuple[str, list[str]]:
     """Ask Opus to triage a comment. Returns (category, titles).
 
@@ -551,7 +560,7 @@ def reply_to_issue_comment(
     repo_cfg: RepoConfig,
     gh: GitHub,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> tuple[str, list[str]]:
     """Triage and reply to a top-level PR comment (issue_comment event).
 
@@ -645,8 +654,8 @@ def _maybe_abort_for_new_task(
     new_task: dict[str, Any],
     registry: WorkerRegistry,
     *,
-    _state=None,
-    _tasks=None,
+    _state: Any = None,
+    _tasks: Any = None,
 ) -> None:
     """Abort the current task if the new task has higher priority.
 
@@ -714,7 +723,7 @@ def _notify_thread_change(
     config: Config,
     gh: GitHub,
     *,
-    _print_prompt=None,
+    _print_prompt: _PrintPrompt | None = None,
 ) -> None:
     """Post a brief comment notifying a commenter that their task was rescoped.
 
@@ -787,7 +796,7 @@ def _notify_thread_change(
         log.exception("failed to notify thread %s", comment_id)
 
 
-def _task_snapshot(task_list: list[dict[str, Any]]) -> list[tuple]:
+def _task_snapshot(task_list: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
     """Summarise task_list as an ordered list of (id, status, title) tuples.
 
     Used by :func:`_rewrite_pr_description` to detect whether the task list
@@ -800,9 +809,9 @@ def _rewrite_pr_description(
     work_dir: Path,
     gh: Any,
     *,
-    _print_prompt=None,
-    _state=None,
-    _tasks=None,
+    _print_prompt: _PrintPrompt | None = None,
+    _state: Any = None,
+    _tasks: Any = None,
     _max_retries: int = 3,
 ) -> None:
     """Rewrite the PR description summary after a successful rescope.
@@ -821,7 +830,9 @@ def _rewrite_pr_description(
     """
     from kennel.state import State
     from kennel.tasks import Tasks
-    from kennel.worker import _write_pr_description
+    from kennel.worker import (
+        _write_pr_description,  # pyright: ignore[reportPrivateUsage]
+    )
 
     if _state is None:
         _state = State(work_dir / ".git" / "fido")
@@ -911,11 +922,11 @@ def _reorder_tasks_background(
     repo_cfg: RepoConfig | None = None,
     registry: WorkerRegistry | None = None,
     *,
-    _start=threading.Thread.start,
-    _print_prompt=None,
-    _rewrite_fn=None,
-    _reorder_fn=None,
-    _coalesce_state: dict | None = None,
+    _start: Callable[[threading.Thread], None] = threading.Thread.start,
+    _print_prompt: _PrintPrompt | None = None,
+    _rewrite_fn: Callable[..., None] | None = None,
+    _reorder_fn: Callable[..., None] | None = None,
+    _coalesce_state: dict[str, Any] | None = None,
 ) -> None:
     """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread.
 
@@ -987,8 +998,8 @@ def create_task(
     thread: dict[str, Any] | None = None,
     registry: WorkerRegistry | None = None,
     *,
-    _get_commit_summary_fn=_get_commit_summary,
-    _reorder_background_fn=_reorder_tasks_background,
+    _get_commit_summary_fn: Callable[[Path], str] = _get_commit_summary,
+    _reorder_background_fn: Callable[..., None] = _reorder_tasks_background,
     _tasks: Tasks | None = None,
 ) -> dict[str, Any]:
     """Write a task to the shared task file, then trigger sync.

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -76,7 +76,7 @@ def set_gh_status(
     _gh.set_user_status(text, emoji, busy=True)
 
 
-def main(argv: list[str], *, _GitHub=GitHub) -> None:
+def main(argv: list[str], *, _GitHub: type[GitHub] = GitHub) -> None:
     if len(argv) < 2 or argv[0] != "set":
         print("Usage: kennel gh-status set <message>", file=sys.stderr)
         raise SystemExit(1)

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -20,7 +20,7 @@ _HTTP_TIMEOUT: int = 30  # seconds for all outbound GitHub HTTP requests
 class _TimeoutSession(_requests.Session):
     """requests.Session that applies _HTTP_TIMEOUT to every request by default."""
 
-    def request(
+    def request(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, method: str | bytes, url: str | bytes, **kwargs: Any
     ) -> _requests.Response:  # type: ignore[override]
         kwargs.setdefault("timeout", _HTTP_TIMEOUT)

--- a/kennel/hooks.py
+++ b/kennel/hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 
 def _settings_path(work_dir: Path) -> Path:
@@ -28,7 +29,7 @@ def ensure_gitexcluded(work_dir: Path) -> None:
         f.write(entry + "\n")
 
 
-def _load(path: Path) -> dict:
+def _load(path: Path) -> dict[str, Any]:
     if path.exists():
         try:
             return json.loads(path.read_text())
@@ -37,12 +38,12 @@ def _load(path: Path) -> dict:
     return {}
 
 
-def _save(path: Path, cfg: dict) -> None:
+def _save(path: Path, cfg: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(cfg, indent=2))
 
 
-def _hook_entry(command: str, matcher: str = "") -> dict:
+def _hook_entry(command: str, matcher: str = "") -> dict[str, Any]:
     return {"matcher": matcher, "hooks": [{"type": "command", "command": command}]}
 
 

--- a/kennel/main.py
+++ b/kennel/main.py
@@ -8,7 +8,7 @@ import sys
 def main(
     argv: list[str] | None = None,
     *,
-    _GitHub=None,
+    _GitHub: type | None = None,
 ) -> None:
     args = sys.argv[1:] if argv is None else argv
 

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -103,11 +103,11 @@ class WorkerRegistry:
         if (
             old_thread is not None
             and not old_thread.is_alive()
-            and not old_thread._stop
+            and not old_thread._stop  # pyright: ignore[reportPrivateUsage]
         ):
             # Crashed thread — rescue the live session before replacing it
-            session, old_thread._session = old_thread._session, None
-            session_issue, old_thread._session_issue = old_thread._session_issue, None
+            session, old_thread._session = old_thread._session, None  # pyright: ignore[reportPrivateUsage]
+            session_issue, old_thread._session_issue = old_thread._session_issue, None  # pyright: ignore[reportPrivateUsage]
         thread = self._factory(repo_cfg, session=session, session_issue=session_issue)
         self._threads[repo_cfg.name] = thread
         with self._started_at_lock:
@@ -313,7 +313,7 @@ class WorkerRegistry:
         not yet created its session.
         """
         thread = self._threads.get(repo_name)
-        return thread._session if thread is not None else None
+        return thread._session if thread is not None else None  # pyright: ignore[reportPrivateUsage]
 
 
 def _make_thread(
@@ -321,9 +321,9 @@ def _make_thread(
     registry: WorkerRegistry,
     *,
     gh: GitHub,
-    session=None,
-    session_issue=None,
-    _WorkerThread=WorkerThread,
+    session: ClaudeSession | None = None,
+    session_issue: int | None = None,
+    _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client."""
     return _WorkerThread(
@@ -341,7 +341,7 @@ def make_registry(
     repos: dict[str, RepoConfig],
     gh: GitHub,
     *,
-    _thread_factory=_make_thread,
+    _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
     """Create a :class:`WorkerRegistry` and start threads for all repos.
 
@@ -350,7 +350,12 @@ def make_registry(
     (with a mock factory) in tests instead of calling this.
     """
 
-    def factory(cfg: RepoConfig, *, session=None, session_issue=None) -> WorkerThread:
+    def factory(
+        cfg: RepoConfig,
+        *,
+        session: ClaudeSession | None = None,
+        session_issue: int | None = None,
+    ) -> WorkerThread:
         return _thread_factory(
             cfg, registry, gh=gh, session=session, session_issue=session_issue
         )

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -23,6 +23,7 @@ from kennel import claude
 from kennel.claude import kill_active_children
 from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.events import (
+    Action,
     create_task,
     dispatch,
     launch_worker,
@@ -32,7 +33,10 @@ from kennel.events import (
 )
 from kennel.github import GitHub
 from kennel.registry import WorkerRegistry, make_registry
-from kennel.watchdog import _STALE_THRESHOLD, Watchdog  # noqa: PLC2701
+from kennel.watchdog import (  # noqa: PLC2701
+    _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
+    Watchdog,
+)
 from kennel.worker import RepoContextFilter, RepoNameFilter
 
 log = logging.getLogger(__name__)
@@ -410,7 +414,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 daemon=True,
             ).start()
 
-    def _process_action(self, action, repo_cfg: RepoConfig) -> None:
+    def _process_action(self, action: Action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)
         claude.set_thread_repo(repo_cfg.name)
         try:
@@ -428,7 +432,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         finally:
             claude.set_thread_repo(None)
 
-    def _describe_action(self, action) -> str:
+    def _describe_action(self, action: Action) -> str:
         """Short label for status display — what this webhook handler is doing."""
         if action.reply_to:
             cid = action.reply_to.get("comment_id")
@@ -439,7 +443,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             return "triaging PR comment"
         return "handling webhook action"
 
-    def _process_action_inner(self, action, repo_cfg: RepoConfig) -> None:
+    def _process_action_inner(self, action: Action, repo_cfg: RepoConfig) -> None:
         # The worker thread's own ``worker_what`` is not touched here — this
         # handler runs on a separate webhook thread and its activity is
         # surfaced in the repo's :class:`~kennel.registry.WebhookActivity`
@@ -511,7 +515,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             log.exception("error processing action")
             self._signal_action_error(action)
 
-    def _signal_action_error(self, action) -> None:
+    def _signal_action_error(self, action: Action) -> None:
         """Post a 'confused' reaction on the triggering comment, if any.
 
         Called when _process_action raises so the comment author sees something
@@ -525,6 +529,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         repo = thread.get("repo")
         comment_id = thread.get("comment_id")
         comment_type = thread.get("comment_type", "issues")
+        if not repo or not comment_id:
+            return
         try:
             if self.gh is not None:
                 self.gh.add_reaction(repo, comment_type, comment_id, "confused")
@@ -670,22 +676,22 @@ def _startup_pull(
 
 def run(
     *,
-    _from_args=Config.from_args,
-    _HTTPServer=HTTPServer,
-    _make_registry=make_registry,
-    _path_home=Path.home,
-    _basic_config=logging.basicConfig,
-    _stderr=sys.stderr,
-    _populate_memberships=populate_memberships,
-    _signal=signal.signal,
-    _kill_active_children=kill_active_children,
-    _startup_pull=_startup_pull,
-    _Watchdog=Watchdog,
-    _preflight_repo_identity=preflight_repo_identity,
-    _preflight_tools=preflight_tools,
-    _preflight_sub_dir=preflight_sub_dir,
-    _preflight_gh_auth=preflight_gh_auth,
-    _GitHub=GitHub,
+    _from_args: Callable[..., Config] = Config.from_args,
+    _HTTPServer: Callable[..., HTTPServer] = HTTPServer,
+    _make_registry: Callable[..., WorkerRegistry] = make_registry,
+    _path_home: Callable[[], Path] = Path.home,
+    _basic_config: Callable[..., None] = logging.basicConfig,
+    _stderr: Any = sys.stderr,
+    _populate_memberships: Callable[..., None] = populate_memberships,
+    _signal: Callable[..., Any] = signal.signal,
+    _kill_active_children: Callable[..., None] = kill_active_children,
+    _startup_pull: Callable[..., None] = _startup_pull,
+    _Watchdog: type[Watchdog] = Watchdog,
+    _preflight_repo_identity: Callable[..., None] = preflight_repo_identity,
+    _preflight_tools: Callable[..., None] = preflight_tools,
+    _preflight_sub_dir: Callable[..., None] = preflight_sub_dir,
+    _preflight_gh_auth: Callable[..., None] = preflight_gh_auth,
+    _GitHub: type[GitHub] = GitHub,
 ) -> None:
     config = _from_args()
 
@@ -718,14 +724,17 @@ def run(
     # kennel.log, not just ~/log/kennel-crash.log (where start-kennel.sh
     # redirects stderr).  Before this, RCA on crashes required reading two
     # different log files.
-    def _log_uncaught(exc_type, exc_value, exc_tb):
+    def _log_uncaught(
+        exc_type: type[BaseException], exc_value: BaseException, exc_tb: Any
+    ) -> None:
         log.critical("uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
 
-    def _log_thread_exception(args):
+    def _log_thread_exception(args: threading.ExceptHookArgs) -> None:
+        exc_info: Any = (args.exc_type, args.exc_value, args.exc_traceback)
         log.critical(
             "uncaught exception in thread %s",
             args.thread.name if args.thread else "?",
-            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+            exc_info=exc_info,
         )
 
     sys.excepthook = _log_uncaught

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from kennel import claude
@@ -308,18 +308,18 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
-    _fn_dispatch = dispatch
-    _fn_reply_to_comment = reply_to_comment
-    _fn_reply_to_review = reply_to_review
-    _fn_reply_to_issue_comment = reply_to_issue_comment
-    _fn_create_task = create_task
-    _fn_launch_worker = launch_worker
-    _fn_runner_dir = _runner_dir
-    _fn_get_self_repo = _get_self_repo
-    _fn_get_head = _get_head
-    _fn_pull_with_backoff = _pull_with_backoff
-    _fn_os_chdir = os.chdir
-    _fn_os_execvp = os.execvp
+    _fn_dispatch = staticmethod(dispatch)
+    _fn_reply_to_comment = staticmethod(reply_to_comment)
+    _fn_reply_to_review = staticmethod(reply_to_review)
+    _fn_reply_to_issue_comment = staticmethod(reply_to_issue_comment)
+    _fn_create_task = staticmethod(create_task)
+    _fn_launch_worker = staticmethod(launch_worker)
+    _fn_runner_dir = staticmethod(_runner_dir)
+    _fn_get_self_repo = staticmethod(_get_self_repo)
+    _fn_get_head = staticmethod(_get_head)
+    _fn_pull_with_backoff = staticmethod(_pull_with_backoff)
+    _fn_os_chdir = staticmethod(os.chdir)
+    _fn_os_execvp = staticmethod(os.execvp)
 
     def do_POST(self) -> None:
         content_length = int(self.headers.get("Content-Length", 0))
@@ -447,7 +447,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # Writing here would clobber the worker thread's own state, which is
         # what caused the old ``Doing: handling webhook action`` display bug.
         try:
-            gh = self.gh
+            gh = cast(GitHub, self.gh)  # always set by serve() before first request
             handled = False
 
             if action.reply_to:
@@ -526,7 +526,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         comment_id = thread.get("comment_id")
         comment_type = thread.get("comment_type", "issues")
         try:
-            self.gh.add_reaction(repo, comment_type, comment_id, "confused")
+            if self.gh is not None:
+                self.gh.add_reaction(repo, comment_type, comment_id, "confused")
         except Exception:
             log.exception("failed to post error reaction on comment %s", comment_id)
 

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -6,6 +6,7 @@ import fcntl
 import json
 import subprocess
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any, Generator
@@ -134,7 +135,11 @@ class State(JsonFileStore):
         clear_state(self._fido_dir)
 
 
-def _resolve_git_dir(work_dir: Path, *, _run=subprocess.run) -> Path:
+def _resolve_git_dir(  # pyright: ignore[reportUnusedFunction]  # imported by tasks/worker
+    work_dir: Path,
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Path:
     """Return the absolute .git directory for *work_dir*."""
     result = _run(
         ["git", "rev-parse", "--absolute-git-dir"],

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -266,7 +266,7 @@ def _git_dir(
         return None
 
 
-def _read_state(fido_dir: Path) -> dict[str, Any]:
+def _read_state(fido_dir: Path) -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]  # used by tests
     """Read state.json from fido_dir, returning {} if absent or unreadable."""
     path = fido_dir / "state.json"
     lock_path = fido_dir / "state.lock"
@@ -320,7 +320,9 @@ def _task_position(task_list: list[dict[str, Any]]) -> tuple[int | None, int | N
     return (1, len(non_completed))
 
 
-def _elapsed_since_iso(iso: str | None, *, _now=None) -> int | None:
+def _elapsed_since_iso(
+    iso: str | None, *, _now: Callable[[], datetime] | None = None
+) -> int | None:
     """Return integer seconds since *iso* (an ISO-8601 timestamp), or None."""
     if not iso:
         return None

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -433,7 +433,7 @@ def collect() -> KennelStatus:
     uptime = _process_uptime_seconds(pid) if pid is not None else None
     repo_configs = _repos_from_pid(pid) if pid is not None else []
 
-    activities: dict[str, str] = {}
+    activities: dict[str, Any] = {}
     if pid is not None:
         port = _port_from_pid(pid)
         if port is not None:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -10,13 +10,18 @@ import re
 import subprocess
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import IO, Any
 
 from kennel.claude import print_prompt as _claude_print_prompt
 from kennel.github import GitHub
 from kennel.prompts import rescope_prompt as _rescope_prompt_default
-from kennel.state import JsonFileStore, _resolve_git_dir, load_state
+from kennel.state import (
+    JsonFileStore,
+    _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
+    load_state,
+)
 from kennel.types import TaskStatus, TaskType
 
 log = logging.getLogger(__name__)
@@ -89,7 +94,7 @@ def add_task(
     task_type: mandatory — one of TaskType.CI, TaskType.THREAD, TaskType.SPEC.
     thread: optional {repo, pr, comment_id, review_id} for comment/review tasks.
     """
-    if not isinstance(task_type, TaskType):
+    if not isinstance(task_type, TaskType):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError(f"task_type must be TaskType, got {type(task_type).__name__}")
     title = " ".join(title.split())
     task: dict[str, Any] = {
@@ -255,8 +260,8 @@ def _auto_complete_ask_tasks(
     repo: str,
     pr_number: int | str,
     *,
-    _list_tasks=list_tasks,
-    _complete_by_id=complete_by_id,
+    _list_tasks: Callable[[Path], list[dict[str, Any]]] = list_tasks,
+    _complete_by_id: Callable[[Path, str], dict[str, Any] | None] = complete_by_id,
 ) -> None:
     """Mark pending ASK tasks complete when their review thread is resolved."""
     task_list = _list_tasks(work_dir)
@@ -293,9 +298,9 @@ def sync_tasks(
     work_dir: Path,
     gh: GitHub,
     *,
-    _resolve_git_dir_fn=_resolve_git_dir,
-    _list_tasks=list_tasks,
-    _auto_complete_ask_tasks_fn=_auto_complete_ask_tasks,
+    _resolve_git_dir_fn: Callable[[Path], Path] = _resolve_git_dir,
+    _list_tasks: Callable[[Path], list[dict[str, Any]]] = list_tasks,
+    _auto_complete_ask_tasks_fn: Callable[..., None] = _auto_complete_ask_tasks,
 ) -> None:
     """Sync tasks.json → PR body work queue.
 
@@ -494,11 +499,11 @@ def reorder_tasks(
     work_dir: Path,
     commit_summary: str,
     *,
-    _print_prompt=_claude_print_prompt,
-    _rescope_prompt_fn=_rescope_prompt_default,
-    _on_changes=None,
-    _on_inprogress_affected=None,
-    _on_done=None,
+    _print_prompt: Callable[..., str] = _claude_print_prompt,
+    _rescope_prompt_fn: Callable[..., str] = _rescope_prompt_default,
+    _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
+    _on_inprogress_affected: Callable[[], None] | None = None,
+    _on_done: Callable[[], None] | None = None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
 
@@ -593,7 +598,10 @@ def reorder_tasks(
 
 
 def sync_tasks_background(
-    work_dir: Path, gh: GitHub, *, _start=threading.Thread.start
+    work_dir: Path,
+    gh: GitHub,
+    *,
+    _start: Callable[[threading.Thread], None] = threading.Thread.start,
 ) -> None:
     """Launch :func:`sync_tasks` in a daemon background thread."""
     t = threading.Thread(
@@ -622,7 +630,7 @@ class Tasks(JsonFileStore):
     def _data_path(self) -> Path:
         return _task_file(self._work_dir)
 
-    def _default(self) -> list:
+    def _default(self) -> list[dict[str, Any]]:
         return []
 
     def list(self) -> list[dict[str, Any]]:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -11,7 +11,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from kennel.claude import print_prompt as _claude_print_prompt
 from kennel.github import GitHub
@@ -31,7 +31,7 @@ def _locked(path: Path, write: bool = False):
 
     class Lock:
         def __init__(self):
-            self.fd = None
+            self.fd: IO[str] | None = None
 
         def __enter__(self):
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -45,9 +45,14 @@ def _locked(path: Path, write: bool = False):
                 fcntl.flock(self.fd, fcntl.LOCK_UN)
                 self.fd.close()
 
+        def _fd(self) -> IO[str]:
+            assert self.fd is not None, "Lock used outside context manager"
+            return self.fd
+
         def read(self) -> list[dict[str, Any]]:
-            self.fd.seek(0)
-            text = self.fd.read().strip()
+            fd = self._fd()
+            fd.seek(0)
+            text = fd.read().strip()
             if not text:
                 return []
             try:
@@ -62,10 +67,11 @@ def _locked(path: Path, write: bool = False):
             return result
 
         def write(self, tasks: list[dict[str, Any]]) -> None:
-            self.fd.seek(0)
-            self.fd.truncate()
-            json.dump(tasks, self.fd, indent=2)
-            self.fd.flush()
+            fd = self._fd()
+            fd.seek(0)
+            fd.truncate()
+            json.dump(tasks, fd, indent=2)
+            fd.flush()
 
     return Lock()
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -22,7 +22,7 @@ from kennel.github import GitHub
 from kennel.prompts import Prompts, rewrite_description_prompt
 from kennel.state import (
     State,
-    _resolve_git_dir,
+    _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
 )
 from kennel.tasks import Tasks
 from kennel.types import TaskStatus, TaskType
@@ -642,7 +642,7 @@ def _write_pr_description(
     task_list: list[dict[str, Any]],
     existing_body: str = "",
     *,
-    _print_prompt=None,
+    _print_prompt: Callable[..., str] | None = None,
 ) -> None:
     """Write or rewrite the PR description.
 
@@ -734,11 +734,15 @@ class Worker:
         self._session_issue: int | None = session_issue
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
 
-    def resolve_git_dir(self, *, _run=subprocess.run) -> Path:
+    def resolve_git_dir(
+        self, *, _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
+    ) -> Path:
         """Return the absolute .git directory for self.work_dir."""
         return _resolve_git_dir(self.work_dir, _run=_run)
 
-    def create_context(self, *, _run=subprocess.run) -> WorkerContext:
+    def create_context(
+        self, *, _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
+    ) -> WorkerContext:
         """Build a WorkerContext for self.work_dir, acquiring the fido lock.
 
         Raises LockHeld if the lock is already held.
@@ -860,10 +864,12 @@ class Worker:
         what: str,
         busy: bool = True,
         *,
-        _generate_status_with_session=claude.generate_status_with_session,
-        _generate_status_emoji=claude.generate_status_emoji,
-        _resume_status=claude.resume_status,
-        _sub_dir_fn=_sub_dir,
+        _generate_status_with_session: Callable[
+            ..., tuple[str, str]
+        ] = claude.generate_status_with_session,
+        _generate_status_emoji: Callable[..., str] = claude.generate_status_emoji,
+        _resume_status: Callable[..., str] = claude.resume_status,
+        _sub_dir_fn: Callable[..., Path] = _sub_dir,
     ) -> None:
         """Set the authenticated user's GitHub status using Claude-generated text.
 
@@ -995,7 +1001,11 @@ class Worker:
         return choice.number
 
     def _git(
-        self, args: list[str], check: bool = True, *, _run=subprocess.run
+        self,
+        args: list[str],
+        check: bool = True,
+        *,
+        _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     ) -> subprocess.CompletedProcess[str]:
         """Run a git command in self.work_dir."""
         return _run(
@@ -1527,7 +1537,7 @@ class Worker:
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
         with State(fido_dir).modify() as state:
             state["current_task_id"] = task["id"]
-        session_id, output = claude_run(
+        session_id, _output = claude_run(
             fido_dir,
             cwd=self.work_dir,
             session=self._session,
@@ -1563,7 +1573,7 @@ class Worker:
                 "task produced no commits — nudging session (attempt %d)",
                 attempt,
             )
-            session_id, output = claude_run(
+            session_id, _output = claude_run(
                 fido_dir,
                 cwd=self.work_dir,
                 session=self._session,
@@ -2082,8 +2092,8 @@ class WorkerThread(threading.Thread):
                 try:
                     result = worker.run()
                 finally:
-                    self._session = worker._session
-                    self._session_issue = worker._session_issue
+                    self._session = worker._session  # pyright: ignore[reportPrivateUsage]
+                    self._session_issue = worker._session_issue  # pyright: ignore[reportPrivateUsage]
 
                 if result == 1:
                     # Did work — loop immediately without waiting.

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1272,7 +1272,7 @@ class Worker:
         self,
         nodes: list[dict[str, Any]],
         gh_user: str,
-        collaborators: tuple[str, ...],
+        collaborators: frozenset[str],
     ) -> list[dict[str, Any]]:
         """Return unresolved review threads for the comments sub-Claude.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.14"
 dependencies = ["requests"]
 
 [dependency-groups]
-dev = ["ruff", "pytest", "pytest-cov", "pytest-xdist"]
+dev = ["pyright", "ruff", "pytest", "pytest-cov", "pytest-xdist"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,9 @@
 {
   "pythonVersion": "3.14",
   "include": ["kennel"],
-  "typeCheckingMode": "standard"
+  "typeCheckingMode": "strict",
+  "reportUnknownMemberType": false,
+  "reportUnknownVariableType": false,
+  "reportUnknownArgumentType": false,
+  "reportUnknownParameterType": false
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+  "pythonVersion": "3.14",
+  "include": ["kennel"],
+  "typeCheckingMode": "standard"
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -866,6 +866,23 @@ class TestProcessAction:
         time.sleep(0.2)
         mock_gh.add_reaction.assert_not_called()
 
+    def test_process_action_error_no_reaction_when_thread_lacks_comment_id(
+        self, server: tuple
+    ) -> None:
+        """No reaction when thread dict exists but has no comment_id key."""
+        from kennel.events import Action
+
+        url, cfg = server
+        handler = WebhookHandler.__new__(WebhookHandler)
+        mock_gh = MagicMock()
+        handler.gh = mock_gh
+        action = Action(
+            prompt="test",
+            thread={"repo": "owner/repo", "pr": 1},
+        )
+        handler._signal_action_error(action)
+        mock_gh.add_reaction.assert_not_called()
+
     def test_process_action_error_reaction_failure_doesnt_crash(
         self, server: tuple
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -148,10 +149,20 @@ requires-dist = [{ name = "requests" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
@@ -179,6 +190,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
 ]
 
 [[package]]
@@ -262,6 +286,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
     { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
     { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #466.

Adds pyright to the dev dependency group with a pyrightconfig.json targeting Python 3.14, fixes any type errors for a clean run, and gates both CI and the pre-commit hook on pyright passing.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add pyright to dev deps and configure pyrightconfig.json <!-- type:spec -->
- [x] Gate CI and pre-commit hook on pyright <!-- type:spec -->
- [x] [Switch pyrightconfig.json to strict type-checking mode](https://github.com/FidoCanCode/home/pull/498#issuecomment-4247152249) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->