### PR TITLE
Route set_status through persistent session via nudge (closes #505)

### DIFF
--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -395,12 +395,12 @@ class Prompts:
             f"{plain}"
         )
 
-    def status_text_prompt(self, activities: list[tuple[str, str, bool]]) -> str:
-        """Build the user prompt for GitHub status text generation.
+    def status_prompt(self, activities: list[tuple[str, str, bool]]) -> str:
+        """Build the combined status-text + emoji prompt for a session nudge.
 
         *activities* is a list of ``(repo_name, what, busy)`` tuples for every
-        worker.  The prompt presents the full picture so Claude can produce a
-        unified status: busy work takes priority over idle.
+        worker.  Returns a prompt that asks for both fields at once, so the
+        worker can fire a single session turn instead of multiple one-shots.
         """
         if not activities:
             activity_block = "No active workers."
@@ -412,25 +412,21 @@ class Prompts:
             activity_block = "\n".join(lines)
         return f"{self.persona}\n\nCurrent activity across all repos:\n{activity_block}"
 
-    def status_text_system_prompt(self) -> str:
-        """Return the system prompt for GitHub status text generation."""
+    def status_system_prompt(self) -> str:
+        """System prompt for combined status-text + emoji generation.
+
+        Returns JSON-format instructions so the session nudge produces both
+        fields in a single turn.
+        """
         return (
             "You are writing your GitHub profile status as Fido the dog. "
-            "Output ONLY the status text — no emoji, no quotes, no preamble. "
-            "Keep it under 80 characters. "
-            "If any worker is busy, reflect that active work. "
-            "If all workers are idle, indicate you are napping."
-        )
-
-    def status_emoji_prompt(self, text: str) -> str:
-        """Build the user prompt for GitHub status emoji selection."""
-        return f"{self.persona}\n\nYour current GitHub status text is: {text}\n\nChoose one emoji."
-
-    def status_emoji_system_prompt(self) -> str:
-        """Return the system prompt for GitHub status emoji generation."""
-        return (
-            "You are choosing an emoji for your GitHub profile status as Fido the dog. "
-            "Output ONLY a single emoji or :shortcode:. No other text."
+            "Reply with ONLY a JSON object of the form "
+            '{"status": "<=80 char status text>", "emoji": ":shortcode:"}. '
+            "Status must be under 80 characters, no emoji embedded. "
+            "Emoji must be a single GitHub shortcode like :dog: or :wrench:. "
+            "If any worker is busy, the status should reflect that active "
+            "work.  If all workers are idle, indicate you are napping. "
+            "No other text before or after the JSON."
         )
 
     def react_prompt(self, comment_body: str) -> str:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -189,6 +189,27 @@ def _sanitize_status_text(text: str) -> str:
     return re.sub(r"\s*\n\s*", " ", text).strip()
 
 
+def _parse_status_nudge(raw: str) -> tuple[str, str]:
+    """Extract ``(status, emoji)`` from the JSON nudge response.
+
+    Scans *raw* for the first ``{...}`` object with both fields.  Returns
+    ``("", "")`` if parsing fails — callers treat empty fields as "fall back".
+    """
+    if not raw:
+        return "", ""
+    candidates = [raw] + [m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)]
+    for candidate in candidates:
+        try:
+            obj = json.loads(candidate)
+        except json.JSONDecodeError, AttributeError:
+            continue
+        status = obj.get("status") if isinstance(obj, dict) else None
+        emoji = obj.get("emoji") if isinstance(obj, dict) else None
+        if isinstance(status, str) and isinstance(emoji, str):
+            return status, emoji
+    return "", ""
+
+
 def _sanitize_slug(raw: str, fallback: str) -> str:
     """Sanitize a branch name slug: lowercase, hyphens only, max 40 chars.
 
@@ -864,20 +885,19 @@ class Worker:
         what: str,
         busy: bool = True,
         *,
-        _generate_status_with_session: Callable[
-            ..., tuple[str, str]
-        ] = claude.generate_status_with_session,
-        _generate_status_emoji: Callable[..., str] = claude.generate_status_emoji,
-        _resume_status: Callable[..., str] = claude.resume_status,
         _sub_dir_fn: Callable[..., Path] = _sub_dir,
     ) -> None:
         """Set the authenticated user's GitHub status using Claude-generated text.
 
-        Makes two separate Opus calls: the first generates short status text
-        (≤80 chars), the second picks an emoji.  If the text exceeds 80
-        characters, retries up to 3 times in the same session to shorten it,
-        then truncates as a last resort.  Falls back to ``what[:80]`` if
-        Claude returns an empty response for the text call.
+        Fires a single nudge into the worker's persistent :class:`ClaudeSession`
+        asking for a JSON object with both ``status`` and ``emoji`` fields.  One
+        round-trip instead of the earlier three-to-five one-shot subprocesses
+        (closes #505) — no claude spawn overhead, no hang class, and the
+        preempt/cancel plumbing handles webhook interleaving cleanly.
+
+        When ``self._session`` is ``None`` (worker has not yet created a
+        session), logs and returns — status is best-effort and callers should
+        not block on it.
         """
         persona_path = _sub_dir_fn() / "persona.md"
         try:
@@ -902,45 +922,25 @@ class Worker:
             else:
                 activities = [(self.work_dir.name, what, busy)]
 
-            # Call 1: generate status text
-            log.info("set_status: requesting status text from claude")
-            text, session_id = _generate_status_with_session(
-                prompt=prompts.status_text_prompt(activities),
-                system_prompt=prompts.status_text_system_prompt(),
+            if self._session is None:
+                log.info("set_status: no session available — skipping")
+                return
+
+            log.info("set_status: nudging session for status + emoji")
+            raw = self._session.prompt(
+                prompts.status_prompt(activities),
+                system_prompt=prompts.status_system_prompt(),
             )
-            log.info(
-                "set_status: status text returned (%d chars)", len(text) if text else 0
-            )
+            text, emoji = _parse_status_nudge(raw)
             if not text:
                 log.warning(
-                    "set_status: claude returned empty — using plain-text fallback"
+                    "set_status: claude returned no status text — falling back to %r",
+                    what[:80],
                 )
                 text = what[:80]
-                session_id = ""
-
             text = _sanitize_status_text(text)
-
-            for _ in range(3):
-                if len(text) <= 80 or not session_id:
-                    break
-                retry_raw = _resume_status(
-                    session_id,
-                    f"The status text is {len(text)} characters — please shorten it to 80 characters or fewer.",
-                )
-                if not retry_raw:
-                    break
-                text = retry_raw.strip()
-
             if len(text) > 80:
                 text = text[:80]
-
-            # Call 2: generate emoji
-            log.info("set_status: requesting emoji from claude")
-            emoji = _generate_status_emoji(
-                prompt=prompts.status_emoji_prompt(text),
-                system_prompt=prompts.status_emoji_system_prompt(),
-            )
-            log.info("set_status: emoji returned (%r)", emoji)
             if not emoji:
                 emoji = ":dog:"
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -391,54 +391,35 @@ class TestIssueReplyInstruction:
 # ── Prompts.status_system_prompt ─────────────────────────────────────────────
 
 
-class TestStatusTextSystemPrompt:
+class TestStatusSystemPrompt:
     def test_returns_string(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
+        result = Prompts("persona").status_system_prompt()
         assert isinstance(result, str)
 
-    def test_no_emoji_instruction(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
-        assert "no emoji" in result.lower() or "ONLY the status text" in result
+    def test_mentions_json(self) -> None:
+        result = Prompts("persona").status_system_prompt()
+        assert "JSON" in result
+
+    def test_mentions_status_and_emoji_fields(self) -> None:
+        result = Prompts("persona").status_system_prompt()
+        assert '"status"' in result
+        assert '"emoji"' in result
 
     def test_mentions_80_chars(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
+        result = Prompts("persona").status_system_prompt()
         assert "80" in result
 
     def test_mentions_fido(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
+        result = Prompts("persona").status_system_prompt()
         assert "Fido" in result
 
     def test_instructs_busy_priority(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
+        result = Prompts("persona").status_system_prompt()
         assert "busy" in result
 
     def test_instructs_idle_napping(self) -> None:
-        result = Prompts("persona").status_text_system_prompt()
+        result = Prompts("persona").status_system_prompt()
         assert "idle" in result or "napping" in result.lower()
-
-
-class TestStatusEmojiSystemPrompt:
-    def test_returns_string(self) -> None:
-        result = Prompts("persona").status_emoji_system_prompt()
-        assert isinstance(result, str)
-
-    def test_mentions_emoji(self) -> None:
-        result = Prompts("persona").status_emoji_system_prompt()
-        assert "emoji" in result
-
-    def test_mentions_fido(self) -> None:
-        result = Prompts("persona").status_emoji_system_prompt()
-        assert "Fido" in result
-
-
-class TestStatusEmojiPrompt:
-    def test_includes_persona(self) -> None:
-        result = Prompts("I am Fido.").status_emoji_prompt("working hard")
-        assert "I am Fido." in result
-
-    def test_includes_text(self) -> None:
-        result = Prompts("persona").status_emoji_prompt("chasing bugs")
-        assert "chasing bugs" in result
 
 
 # ── Prompts class ─────────────────────────────────────────────────────────────
@@ -506,39 +487,37 @@ class TestPromptsReactPrompt:
         assert "emoji" in result
 
 
-class TestPromptsStatusTextPrompt:
+class TestPromptsStatusPrompt:
     def test_includes_persona(self) -> None:
-        result = Prompts("I am Fido.").status_text_prompt(
+        result = Prompts("I am Fido.").status_prompt(
             [("owner/repo", "writing tests", True)]
         )
         assert "I am Fido." in result
 
     def test_includes_what(self) -> None:
-        result = Prompts("persona").status_text_prompt(
+        result = Prompts("persona").status_prompt(
             [("owner/repo", "reviewing PRs", True)]
         )
         assert "reviewing PRs" in result
 
     def test_includes_repo_name(self) -> None:
-        result = Prompts("persona").status_text_prompt(
+        result = Prompts("persona").status_prompt(
             [("rhencke/kennel", "fixing a bug", True)]
         )
         assert "rhencke/kennel" in result
 
     def test_busy_worker_labeled(self) -> None:
-        result = Prompts("persona").status_text_prompt(
+        result = Prompts("persona").status_prompt(
             [("owner/repo", "working hard", True)]
         )
         assert "busy" in result
 
     def test_idle_worker_labeled(self) -> None:
-        result = Prompts("persona").status_text_prompt(
-            [("owner/repo", "napping", False)]
-        )
+        result = Prompts("persona").status_prompt([("owner/repo", "napping", False)])
         assert "idle" in result
 
     def test_multiple_repos_all_present(self) -> None:
-        result = Prompts("persona").status_text_prompt(
+        result = Prompts("persona").status_prompt(
             [
                 ("a/busy", "Writing code", True),
                 ("b/idle", "Napping", False),
@@ -550,7 +529,7 @@ class TestPromptsStatusTextPrompt:
         assert "Napping" in result
 
     def test_empty_activities(self) -> None:
-        result = Prompts("persona").status_text_prompt([])
+        result = Prompts("persona").status_prompt([])
         assert isinstance(result, str)
         assert "No active workers" in result
 
@@ -712,9 +691,9 @@ class TestPromptsStoresPersona:
         p1 = Prompts("persona A")
         p2 = Prompts("persona B")
         activities = [("owner/repo", "working", True)]
-        assert "persona A" in p1.status_text_prompt(activities)
-        assert "persona B" in p2.status_text_prompt(activities)
-        assert "persona A" not in p2.status_text_prompt(activities)
+        assert "persona A" in p1.status_prompt(activities)
+        assert "persona B" in p2.status_prompt(activities)
+        assert "persona A" not in p2.status_prompt(activities)
 
 
 # ── rewrite_description_prompt ────────────────────────────────────────────────

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -357,146 +357,79 @@ class TestWorker:
 
     # --- set_status ---
 
-    def _ss(
+    def _session(
         self,
-        tmp_path: Path,
         *,
-        text: str = "ok",
-        session_id: str = "sess-1",
+        status: str = "ok",
         emoji: str = "🐕",
-        resume_side_effect=None,
-        sub_dir: Path | None = None,
-    ) -> dict:
-        """Return keyword args for set_status injection."""
-        if sub_dir is None:
-            sub_dir = tmp_path
-        return {
-            "_generate_status_with_session": MagicMock(return_value=(text, session_id)),
-            "_generate_status_emoji": MagicMock(return_value=emoji),
-            "_resume_status": MagicMock(
-                side_effect=resume_side_effect,
-                return_value="" if resume_side_effect is None else None,
-            ),
-            "_sub_dir_fn": lambda: sub_dir,
-        }
+        raw: str | None = None,
+    ) -> MagicMock:
+        """Build a mock :class:`ClaudeSession` whose ``prompt`` returns a JSON nudge."""
+        session = MagicMock()
+        if raw is None:
+            raw = f'{{"status": "{status}", "emoji": "{emoji}"}}'
+        session.prompt.return_value = raw
+        return session
 
     def test_set_status_calls_set_user_status_on_success(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh).set_status(
-            "writing tests", **self._ss(tmp_path, text="writing tests")
+        Worker(tmp_path, gh, session=self._session(status="writing tests")).set_status(
+            "writing tests", _sub_dir_fn=lambda: tmp_path
         )
         gh.set_user_status.assert_called_once_with("writing tests", "🐕", busy=True)
 
     def test_set_status_busy_false_forwarded(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh).set_status(
-            "napping", busy=False, **self._ss(tmp_path, text="napping", emoji="😴")
-        )
+        Worker(
+            tmp_path, gh, session=self._session(status="napping", emoji="😴")
+        ).set_status("napping", busy=False, _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with("napping", "😴", busy=False)
 
-    def test_set_status_uses_what_as_fallback_when_claude_returns_empty(
+    def test_set_status_uses_what_as_fallback_when_status_empty(
         self, tmp_path: Path
     ) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh).set_status(
-            "idle", **self._ss(tmp_path, text="", session_id="")
-        )
-        gh.set_user_status.assert_called_once()
-        call_args = gh.set_user_status.call_args[0]
-        assert call_args[0] == "idle"
+        Worker(
+            tmp_path, gh, session=self._session(status="", emoji=":dog:")
+        ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
+        assert gh.set_user_status.call_args[0][0] == "idle"
 
     def test_set_status_emoji_fallback_when_empty(self, tmp_path: Path) -> None:
-        # generate_status_emoji returns empty → :dog: fallback
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh).set_status(
-            "idle",
-            **self._ss(tmp_path, text="Sniffing out endpoints", emoji=""),
-        )
+        Worker(
+            tmp_path, gh, session=self._session(status="Sniffing endpoints", emoji="")
+        ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with(
-            "Sniffing out endpoints", ":dog:", busy=True
+            "Sniffing endpoints", ":dog:", busy=True
         )
 
     def test_set_status_text_truncated_to_80_chars(self, tmp_path: Path) -> None:
-        # All retries fail (return empty) → fall back to truncation
         gh = self._make_gh()
         long_text = "x" * 100
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh).set_status(
-            "something",
-            **self._ss(tmp_path, text=long_text, resume_side_effect=[""]),
+        Worker(tmp_path, gh, session=self._session(status=long_text)).set_status(
+            "something", _sub_dir_fn=lambda: tmp_path
         )
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
 
-    def test_set_status_retries_when_text_exceeds_80_chars(
-        self, tmp_path: Path
-    ) -> None:
-        gh = self._make_gh()
-        long_text = "y" * 90
-        (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_resume = MagicMock(return_value="shorter text")
-        Worker(tmp_path, gh).set_status(
-            "something",
-            **{
-                **self._ss(tmp_path, text=long_text, session_id="sess-99"),
-                "_resume_status": mock_resume,
-            },
-        )
-        mock_resume.assert_called_once_with("sess-99", ANY)
-        gh.set_user_status.assert_called_once_with("shorter text", "🐕", busy=True)
+    def test_set_status_skipped_when_no_session(self, tmp_path: Path, caplog) -> None:
+        import logging
 
-    def test_set_status_stops_retrying_when_text_fits(self, tmp_path: Path) -> None:
-        # Second retry produces short text → no third retry
         gh = self._make_gh()
-        long_text = "z" * 90
         (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_resume = MagicMock(side_effect=["z" * 85, "good"])
-        Worker(tmp_path, gh).set_status(
-            "something",
-            **{
-                **self._ss(tmp_path, text=long_text, session_id="sess-7"),
-                "_resume_status": mock_resume,
-            },
-        )
-        assert mock_resume.call_count == 2
-        gh.set_user_status.assert_called_once_with("good", "🐕", busy=True)
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            Worker(tmp_path, gh, session=None).set_status(
+                "idle", _sub_dir_fn=lambda: tmp_path
+            )
+        gh.set_user_status.assert_not_called()
+        assert "no session available" in caplog.text
 
-    def test_set_status_retries_up_to_3_times_max(self, tmp_path: Path) -> None:
-        gh = self._make_gh()
-        long_text = "w" * 90
-        (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_resume = MagicMock(return_value=long_text)
-        Worker(tmp_path, gh).set_status(
-            "something",
-            **{
-                **self._ss(tmp_path, text=long_text, session_id="sess-3"),
-                "_resume_status": mock_resume,
-            },
-        )
-        assert mock_resume.call_count == 3
-
-    def test_set_status_skips_retry_when_no_session_id(self, tmp_path: Path) -> None:
-        # No session_id → retry loop is skipped, truncation applied directly
-        gh = self._make_gh()
-        long_text = "v" * 100
-        (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_resume = MagicMock()
-        Worker(tmp_path, gh).set_status(
-            "something",
-            **{
-                **self._ss(tmp_path, text=long_text, session_id=""),
-                "_resume_status": mock_resume,
-            },
-        )
-        mock_resume.assert_not_called()
-        called_text = gh.set_user_status.call_args[0][0]
-        assert len(called_text) == 80
-
-    def test_set_status_logs_warning_on_empty_response(
+    def test_set_status_logs_warning_on_empty_status(
         self, tmp_path: Path, caplog
     ) -> None:
         import logging
@@ -504,10 +437,10 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.WARNING, logger="kennel"):
-            Worker(tmp_path, gh).set_status(
-                "idle", **self._ss(tmp_path, text="", session_id="")
-            )
-        assert "fallback" in caplog.text
+            Worker(
+                tmp_path, gh, session=self._session(status="", emoji=":dog:")
+            ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
+        assert "falling back" in caplog.text
 
     def test_set_status_logs_info_on_success(self, tmp_path: Path, caplog) -> None:
         import logging
@@ -515,8 +448,8 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.INFO, logger="kennel"):
-            Worker(tmp_path, gh).set_status(
-                "fetching", **self._ss(tmp_path, text="fetching")
+            Worker(tmp_path, gh, session=self._session(status="fetching")).set_status(
+                "fetching", _sub_dir_fn=lambda: tmp_path
             )
         assert "set_status" in caplog.text
 
@@ -525,41 +458,34 @@ class TestWorker:
     ) -> None:
         gh = self._make_gh()
         missing_dir = tmp_path / "no_such_dir"
-        mock_gen = MagicMock(return_value=("working", "sess-1"))
-        Worker(tmp_path, gh).set_status(
-            "working",
-            **{
-                **self._ss(tmp_path, text="working", sub_dir=missing_dir),
-                "_generate_status_with_session": mock_gen,
-            },
+        session = self._session(status="working")
+        Worker(tmp_path, gh, session=session).set_status(
+            "working", _sub_dir_fn=lambda: missing_dir
         )
-        # persona file missing — generate_status_with_session still called with empty persona
-        prompt_arg = mock_gen.call_args[1]["prompt"]
+        prompt_arg = session.prompt.call_args[0][0]
         assert "working (busy)" in prompt_arg
 
-    def test_set_status_passes_system_prompt_to_generate_status_with_session(
-        self, tmp_path: Path
-    ) -> None:
+    def test_set_status_passes_system_prompt_to_session(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_gen = MagicMock(return_value=("working", "sess-1"))
-        Worker(tmp_path, gh).set_status(
-            "working",
-            **{
-                **self._ss(tmp_path, text="working"),
-                "_generate_status_with_session": mock_gen,
-            },
+        session = self._session(status="working")
+        Worker(tmp_path, gh, session=session).set_status(
+            "working", _sub_dir_fn=lambda: tmp_path
         )
-        assert mock_gen.call_args[1]["system_prompt"] is not None
+        assert session.prompt.call_args[1]["system_prompt"] is not None
 
     def test_set_status_reports_activity_to_registry(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         registry = MagicMock()
         registry.get_all_activities.return_value = []
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh, repo_name="owner/myrepo", registry=registry).set_status(
-            "working", busy=True, **self._ss(tmp_path, text="working")
-        )
+        Worker(
+            tmp_path,
+            gh,
+            repo_name="owner/myrepo",
+            registry=registry,
+            session=self._session(status="working"),
+        ).set_status("working", busy=True, _sub_dir_fn=lambda: tmp_path)
         registry.report_activity.assert_called_once_with(
             "owner/myrepo", "working", True
         )
@@ -579,15 +505,15 @@ class TestWorker:
         activity_b.busy = False
         registry.get_all_activities.return_value = [activity_a, activity_b]
         (tmp_path / "persona.md").write_text("I am Fido.")
-        mock_gen = MagicMock(return_value=("fixing bug", "sess-1"))
-        Worker(tmp_path, gh, repo_name="owner/repo-a", registry=registry).set_status(
-            "fixing bug",
-            **{
-                **self._ss(tmp_path, text="fixing bug"),
-                "_generate_status_with_session": mock_gen,
-            },
-        )
-        prompt_arg = mock_gen.call_args[1]["prompt"]
+        session = self._session(status="fixing bug")
+        Worker(
+            tmp_path,
+            gh,
+            repo_name="owner/repo-a",
+            registry=registry,
+            session=session,
+        ).set_status("fixing bug", _sub_dir_fn=lambda: tmp_path)
+        prompt_arg = session.prompt.call_args[0][0]
         assert "owner/repo-a" in prompt_arg
         assert "owner/repo-b" in prompt_arg
 
@@ -598,9 +524,13 @@ class TestWorker:
         registry = MagicMock()
         registry.get_all_activities.return_value = []
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh, repo_name="owner/repo", registry=registry).set_status(
-            "working", **self._ss(tmp_path, text="working")
-        )
+        Worker(
+            tmp_path,
+            gh,
+            repo_name="owner/repo",
+            registry=registry,
+            session=self._session(status="working"),
+        ).set_status("working", _sub_dir_fn=lambda: tmp_path)
         registry.status_update.assert_called_once()
 
     def test_set_status_serializes_concurrent_calls_via_registry_lock(
@@ -614,7 +544,7 @@ class TestWorker:
         max_concurrent = 0
         counter_lock = threading.Lock()
 
-        def slow_generate(*args, **kwargs) -> tuple[str, str]:
+        def slow_prompt(*args, **kwargs) -> str:
             nonlocal inside_count, max_concurrent
             with counter_lock:
                 inside_count += 1
@@ -622,11 +552,20 @@ class TestWorker:
             time.sleep(0.005)
             with counter_lock:
                 inside_count -= 1
-            return ("status text", "sess-1")
+            return '{"status": "ok", "emoji": "🐕"}'
+
+        def make_session() -> MagicMock:
+            s = MagicMock()
+            s.prompt.side_effect = slow_prompt
+            return s
 
         workers = [
             Worker(
-                tmp_path, self._make_gh(), repo_name=f"owner/repo{i}", registry=registry
+                tmp_path,
+                self._make_gh(),
+                repo_name=f"owner/repo{i}",
+                registry=registry,
+                session=make_session(),
             )
             for i in range(3)
         ]
@@ -634,12 +573,7 @@ class TestWorker:
             threading.Thread(
                 target=w.set_status,
                 args=("working",),
-                kwargs={
-                    "_generate_status_with_session": slow_generate,
-                    "_generate_status_emoji": MagicMock(return_value="🐕"),
-                    "_resume_status": MagicMock(return_value=""),
-                    "_sub_dir_fn": lambda: tmp_path / "nosub",
-                },
+                kwargs={"_sub_dir_fn": lambda: tmp_path / "nosub"},
             )
             for w in workers
         ]
@@ -2739,6 +2673,41 @@ class TestSanitizeStatusText:
 
     def test_strips_and_collapses_combined(self) -> None:
         assert _sanitize_status_text("  foo\nbar  ") == "foo bar"
+
+
+class TestParseStatusNudge:
+    """Tests for _parse_status_nudge."""
+
+    def test_empty_raw_returns_empty_tuple(self) -> None:
+        from kennel.worker import _parse_status_nudge
+
+        assert _parse_status_nudge("") == ("", "")
+
+    def test_valid_json_returns_both_fields(self) -> None:
+        from kennel.worker import _parse_status_nudge
+
+        assert _parse_status_nudge('{"status": "chasing bugs", "emoji": ":dog:"}') == (
+            "chasing bugs",
+            ":dog:",
+        )
+
+    def test_json_with_preamble_still_parsed(self) -> None:
+        from kennel.worker import _parse_status_nudge
+
+        assert _parse_status_nudge(
+            'Here you go: {"status": "ok", "emoji": ":wrench:"} thanks!'
+        ) == ("ok", ":wrench:")
+
+    def test_malformed_json_returns_empty_tuple(self) -> None:
+        from kennel.worker import _parse_status_nudge
+
+        assert _parse_status_nudge("{not json at all}") == ("", "")
+
+    def test_missing_fields_returns_empty_tuple(self) -> None:
+        from kennel.worker import _parse_status_nudge
+
+        # Valid JSON but wrong shape — no status/emoji string fields
+        assert _parse_status_nudge('{"other": "value"}') == ("", "")
 
 
 class TestGit:


### PR DESCRIPTION
## Summary
- Replace the 3-5 one-shot `_claude` subprocesses in `Worker.set_status` with a single `session.prompt()` call that returns both status and emoji fields as JSON
- Eliminates the subprocess-hang class (observed 2026-04-14 wedging home worker for 5+ minutes mid-pickup)
- Drops `_generate_status_with_session` / `_generate_status_emoji` / `_resume_status` DI parameters in favour of using `self._session` directly

## Test plan
- [x] 1763 tests pass, 100% coverage, ruff clean, pyright clean (pre-commit hook)
- [ ] Kennel restart exercises new set_status path on first issue pickup
- [ ] No more `_claude: subprocess exceeded 15s` in the log during set_status

Closes #505.