### PR TITLE
pytest wall time regressed from ~2min to ~20min (closes #469)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -306,6 +306,20 @@ def _pull_with_backoff(
             _sleep(delay)
 
 
+def _spawn_bg(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
+    """Spawn *fn* in a background daemon thread."""
+    threading.Thread(target=fn, args=args, daemon=True).start()
+
+
+def _noop_after_post() -> None:
+    """Default no-op hook called at the end of do_POST.
+
+    Tests override _fn_after_do_post to synchronise without sleeping — the
+    hook fires after _fn_spawn_bg so any captured background thread is in
+    the capture list before the test wakes up.
+    """
+
+
 class WebhookHandler(BaseHTTPRequestHandler):
     config: Config
     registry: WorkerRegistry
@@ -318,6 +332,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_reply_to_issue_comment = staticmethod(reply_to_issue_comment)
     _fn_create_task = staticmethod(create_task)
     _fn_launch_worker = staticmethod(launch_worker)
+    _fn_spawn_bg = staticmethod(_spawn_bg)
+    _fn_after_do_post = staticmethod(_noop_after_post)
     _fn_runner_dir = staticmethod(_runner_dir)
     _fn_get_self_repo = staticmethod(_get_self_repo)
     _fn_get_head = staticmethod(_get_head)
@@ -326,6 +342,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_os_execvp = staticmethod(os.execvp)
 
     def do_POST(self) -> None:
+        try:
+            self._do_post_inner()
+        finally:
+            type(self)._fn_after_do_post()
+
+    def _do_post_inner(self) -> None:
         content_length = int(self.headers.get("Content-Length", 0))
         if content_length == 0:
             self._respond(400, "empty body")
@@ -408,11 +430,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         # Process in background thread so we don't block the server.
         if action:
-            threading.Thread(
-                target=self._process_action,
-                args=(action, repo_cfg),
-                daemon=True,
-            ).start()
+            type(self)._fn_spawn_bg(self._process_action, (action, repo_cfg))
 
     def _process_action(self, action: Action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,7 +70,9 @@ def server(tmp_path: Path):
     WebhookHandler.registry = MagicMock()
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
     port = srv.server_address[1]
-    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t = threading.Thread(
+        target=srv.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+    )
     t.start()
     yield f"http://127.0.0.1:{port}", cfg
     srv.shutdown()
@@ -2115,7 +2117,9 @@ class TestSelfRestart:
         WebhookHandler.registry = mock_registry
         srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
         port = srv.server_address[1]
-        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t = threading.Thread(
+            target=srv.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+        )
         t.start()
         return srv, f"http://127.0.0.1:{port}", cfg, mock_registry
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,17 +5,49 @@ import hmac
 import json
 import subprocess
 import threading
-import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from http.server import HTTPServer
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kennel.config import Config, RepoConfig
 from kennel.server import PreflightError, WebhookHandler
+
+# Thread-capture and do_POST synchronisation helpers ---------------------------
+#
+# The wfile socket is unbuffered (wbufsize=0), so HTTP response bytes reach the
+# client the instant _respond() writes them — before do_POST() finishes.  Tests
+# that assert on work done after the ack (background threads, _self_restart)
+# therefore cannot rely on urlopen() returning to mean "server is done".
+#
+# Solution: _restore_handler_fns (autouse) overrides two injectables:
+#   _fn_after_do_post → signals _post_done so _post_webhook can wait
+#   _fn_spawn_bg      → captures the background thread so _post_webhook can join
+#
+# _post_webhook:  wait for _post_done → join any captured threads → return status
+#
+_bg_threads: list[threading.Thread] = []
+_bg_threads_lock: threading.Lock = threading.Lock()
+_post_done: threading.Event = threading.Event()
+
+
+def _capturing_spawn_bg(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
+    t = threading.Thread(target=fn, args=args, daemon=True)
+    t.start()
+    with _bg_threads_lock:
+        _bg_threads.append(t)
+
+
+def _signal_post_done() -> None:
+    _post_done.set()
+
+
+# ------------------------------------------------------------------------------
 
 
 def _config(tmp_path: Path) -> Config:
@@ -51,6 +83,8 @@ def _restore_handler_fns():
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
         "_fn_create_task": WebhookHandler._fn_create_task,
         "_fn_launch_worker": WebhookHandler._fn_launch_worker,
+        "_fn_spawn_bg": WebhookHandler._fn_spawn_bg,
+        "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
         "_fn_get_self_repo": WebhookHandler._fn_get_self_repo,
         "_fn_get_head": WebhookHandler._fn_get_head,
@@ -58,7 +92,15 @@ def _restore_handler_fns():
         "_fn_os_chdir": WebhookHandler._fn_os_chdir,
         "_fn_os_execvp": WebhookHandler._fn_os_execvp,
     }
+    # Override _fn_after_do_post for all tests so _post_webhook can wait for
+    # do_POST to complete without sleeping (see module-level comment above).
+    WebhookHandler._fn_after_do_post = staticmethod(  # type: ignore[assignment]
+        _signal_post_done
+    )
+    _post_done.clear()
     yield
+    with _bg_threads_lock:
+        _bg_threads.clear()
     for attr, val in saved.items():
         setattr(WebhookHandler, attr, val)
 
@@ -68,6 +110,7 @@ def server(tmp_path: Path):
     cfg = _config(tmp_path)
     WebhookHandler.config = cfg
     WebhookHandler.registry = MagicMock()
+    WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
     port = srv.server_address[1]
     t = threading.Thread(
@@ -349,7 +392,18 @@ def _post_webhook(url: str, cfg: Config, event: str, payload: dict) -> int:
             "X-Hub-Signature-256": sig,
         },
     )
+    _post_done.clear()
     resp = urllib.request.urlopen(req)
+    # The wfile socket is unbuffered: _respond() sends bytes immediately, so
+    # urlopen() returns before do_POST() finishes.  Wait for _fn_after_do_post
+    # to fire (set by _restore_handler_fns autouse fixture) before asserting.
+    _post_done.wait(timeout=5.0)
+    # Join any background thread captured by _capturing_spawn_bg.
+    with _bg_threads_lock:
+        threads = list(_bg_threads)
+        _bg_threads.clear()
+    for t in threads:
+        t.join()
     return resp.status
 
 
@@ -376,7 +430,6 @@ class TestProcessAction:
         WebhookHandler._fn_create_task = MagicMock()
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_worker.assert_called()
 
     def test_reply_to_comment_creates_task_for_act(self, server: tuple) -> None:
@@ -402,7 +455,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_reply.assert_called()
         mock_task.assert_called()
 
@@ -429,7 +481,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_reply.assert_called()
         mock_task.assert_not_called()
 
@@ -458,7 +509,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_task.assert_not_called()
 
     def test_reply_to_comment_failure_skips_task(self, server: tuple) -> None:
@@ -487,7 +537,6 @@ class TestProcessAction:
         WebhookHandler.gh = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_task.assert_not_called()
 
     def test_reply_to_comment_do_creates_task(self, server: tuple) -> None:
@@ -519,7 +568,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         assert task_titles == ["add result caching"]
 
     def test_already_replied_comment_skipped(self, server: tuple) -> None:
@@ -548,7 +596,6 @@ class TestProcessAction:
             WebhookHandler._fn_launch_worker = MagicMock()
             status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
             assert status == 200
-            time.sleep(0.2)
             mock_reply.assert_not_called()
         finally:
             ks._replied_comments.discard(203)
@@ -570,7 +617,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_review.assert_called()
 
     def test_issue_comment_handled(self, server: tuple) -> None:
@@ -600,7 +646,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_ic.assert_called()
         mock_task.assert_called_once_with(
             "do it",
@@ -638,7 +683,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_ic.assert_called()
         mock_task.assert_not_called()
 
@@ -665,7 +709,6 @@ class TestProcessAction:
         WebhookHandler.gh = MagicMock()
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_task.assert_not_called()
 
     def test_process_action_does_not_overwrite_worker_what(self, server: tuple) -> None:
@@ -683,7 +726,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
-        time.sleep(0.2)
         for call in WebhookHandler.registry.report_activity.call_args_list:
             args = call.args
             assert "handling webhook action" not in args
@@ -750,7 +792,6 @@ class TestProcessAction:
         exits: list[int] = []
         monkeypatch.setattr(server_module.os, "_exit", exits.append)
         _post_webhook(url, cfg, "pull_request", payload)
-        time.sleep(0.2)
         assert exits == [3]
 
     def test_exception_in_process_action_does_not_crash(self, server: tuple) -> None:
@@ -764,7 +805,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=Exception("explode"))
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
-        time.sleep(0.2)
         # server still alive — no crash
 
     def test_process_action_error_reacts_on_reply_to(self, server: tuple) -> None:
@@ -791,7 +831,6 @@ class TestProcessAction:
         )
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "pull_request_review_comment", payload)
-        time.sleep(0.2)
         mock_gh.add_reaction.assert_called_once_with(
             "owner/repo", "pulls", 500, "confused"
         )
@@ -822,7 +861,6 @@ class TestProcessAction:
         )
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "issue_comment", payload)
-        time.sleep(0.2)
         mock_gh.add_reaction.assert_called_once_with(
             "owner/repo", "issues", 501, "confused"
         )
@@ -841,7 +879,6 @@ class TestProcessAction:
         WebhookHandler.gh = mock_gh
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=RuntimeError("boom"))
         _post_webhook(url, cfg, "pull_request", payload)
-        time.sleep(0.2)
         mock_gh.add_reaction.assert_not_called()
 
     def test_process_action_error_no_reaction_when_comment_id_missing(
@@ -865,7 +902,6 @@ class TestProcessAction:
         WebhookHandler._fn_reply_to_review = MagicMock(side_effect=RuntimeError("boom"))
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "pull_request_review", payload)
-        time.sleep(0.2)
         mock_gh.add_reaction.assert_not_called()
 
     def test_process_action_error_no_reaction_when_thread_lacks_comment_id(
@@ -913,7 +949,6 @@ class TestProcessAction:
         WebhookHandler._fn_launch_worker = MagicMock()
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        time.sleep(0.2)
         mock_gh.add_reaction.assert_called_once()
 
     def test_dispatch_error_returns_500(self, server: tuple) -> None:
@@ -1485,6 +1520,13 @@ _PUSH_PAYLOAD = {
     },
     "ref": "refs/heads/main",
 }
+
+
+class TestNoop:
+    def test_noop_after_post_is_callable_and_silent(self) -> None:
+        from kennel.server import _noop_after_post
+
+        _noop_after_post()  # default hook — must not raise
 
 
 class TestParseRepoFromUrl:
@@ -2135,7 +2177,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_execvp = mock_exec
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
-            time.sleep(0.2)
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
             mock_chdir.assert_called_once_with(tmp_path)
             mock_exec.assert_called_once()
@@ -2155,7 +2196,6 @@ class TestSelfRestart:
             WebhookHandler._fn_pull_with_backoff = mock_pull
             WebhookHandler._fn_os_execvp = mock_exec
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
-            time.sleep(0.2)
             mock_registry.stop_and_join.assert_not_called()
             mock_pull.assert_not_called()
             mock_exec.assert_not_called()
@@ -2170,7 +2210,6 @@ class TestSelfRestart:
             mock_exec = MagicMock()
             WebhookHandler._fn_os_execvp = mock_exec
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
-            time.sleep(0.2)
             mock_registry.stop_and_join.assert_not_called()
             mock_exec.assert_not_called()
         finally:
@@ -2192,7 +2231,6 @@ class TestSelfRestart:
             mock_exec = MagicMock()
             WebhookHandler._fn_os_execvp = mock_exec
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
-            time.sleep(0.2)
             mock_registry.stop_and_join.assert_not_called()
             mock_exec.assert_not_called()
         finally:
@@ -2218,7 +2256,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_chdir = MagicMock()
             WebhookHandler._fn_os_execvp = MagicMock()
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
-            time.sleep(0.2)
         finally:
             srv.shutdown()
         assert call_order == ["pull", "stop_and_join"]
@@ -2234,7 +2271,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_chdir = mock_chdir
             WebhookHandler._fn_os_execvp = mock_exec
             _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
-            time.sleep(0.2)
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
             mock_exec.assert_called_once()
         finally:
@@ -2250,7 +2286,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_execvp = mock_exec
             payload = {**_PUSH_PAYLOAD, "ref": "refs/heads/feature-branch"}
             _post_webhook(url, cfg, "push", payload)
-            time.sleep(0.2)
             mock_pull.assert_not_called()
             mock_exec.assert_not_called()
         finally:
@@ -2298,7 +2333,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_execvp = mock_exec
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
-            time.sleep(0.2)
             mock_exec.assert_called_once()
         finally:
             srv.shutdown()
@@ -2318,7 +2352,6 @@ class TestSelfRestart:
             WebhookHandler._fn_os_execvp = mock_exec
             status = _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
             assert status == 200
-            time.sleep(0.2)
             mock_exec.assert_called_once()
         finally:
             srv.shutdown()


### PR DESCRIPTION
Fixes #469.

Shrink HTTPServer poll_interval in test fixtures so shutdown stops blocking 0.5s per test, and replace time.sleep(0.2) calls with deterministic thread joins. Together these cut ~21s of pure waste from the 27s serial run.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Use fast poll_interval for HTTPServer in test fixtures <!-- type:spec -->
- [x] Replace time.sleep(0.2) with background-thread join in test_server <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->