### PR TITLE
Thread task titles pull from reply body instead of root review comment (closes #470)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -307,12 +307,22 @@ def reply_to_comment(
 
     context: dict[str, Any] = dict(action.context) if action.context else {}
 
-    # Always fetch the full thread for this comment
+    # Always fetch the full thread for this comment.
+    # Normalize to list so root_body extraction below is type-safe.
+    thread_comments: list[dict[str, Any]] = []
     if info.get("repo") and info.get("pr") and info.get("comment_id"):
-        thread = gh.fetch_comment_thread(info["repo"], info["pr"], info["comment_id"])
-        if thread:
-            context["comment_thread"] = thread
-            log.info("fetched %d comment(s) in thread for context", len(thread))
+        fetched = gh.fetch_comment_thread(info["repo"], info["pr"], info["comment_id"])
+        if fetched:
+            thread_comments = list(fetched)
+            context["comment_thread"] = thread_comments
+            log.info(
+                "fetched %d comment(s) in thread for context", len(thread_comments)
+            )
+
+    # Root comment body — used for task title generation.
+    # When the webhook fires on a reply (e.g. "Yes" or "Woof, you're right!"),
+    # the task title should describe the reviewer's original feedback, not the reply.
+    root_body = thread_comments[0].get("body", comment) if thread_comments else comment
 
     # Enrich context with sibling threads when the comment needs more context
     if (
@@ -328,11 +338,20 @@ def reply_to_comment(
                 len(siblings),
             )
 
-    # Step 1: Haiku triage
+    # Step 1: Haiku triage (on the triggering comment to determine category)
     category, titles = _triage(
         comment, action.is_bot, context, _print_prompt=_print_prompt
     )
     log.info("triage: %s — %s", category, titles)
+
+    # Step 1b: Re-derive task titles from the root comment body when the
+    # triggering comment is a reply.  Triage ran on the reply body which may be
+    # a one-word acknowledgment; the root comment holds the actual requirement.
+    if category in ("ACT", "DO") and root_body != comment:
+        log.info(
+            "re-deriving task titles from root comment (triggering comment is a reply)"
+        )
+        titles = [_summarize_as_action_item(root_body, _print_prompt=_print_prompt)]
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply.
     # Raises on failure so we don't craft a reply referencing a missing issue.

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -344,13 +344,13 @@ def reply_to_comment(
     )
     log.info("triage: %s — %s", category, titles)
 
-    # Step 1b: Re-derive task titles from the root comment body when the
-    # triggering comment is a reply.  Triage ran on the reply body which may be
-    # a one-word acknowledgment; the root comment holds the actual requirement.
-    if category in ("ACT", "DO") and root_body != comment:
-        log.info(
-            "re-deriving task titles from root comment (triggering comment is a reply)"
-        )
+    # Step 1b: Always derive task titles from the root comment body for action
+    # categories.  The originating PR comment is the source of truth for what
+    # was requested; triage may have run on a short reply body ("Yes", "Done")
+    # that produces a poor title.  Using root_body here ensures the task always
+    # reflects what the reviewer originally asked.
+    if category in ("ACT", "DO"):
+        log.info("deriving task title from root comment")
         titles = [_summarize_as_action_item(root_body, _print_prompt=_print_prompt)]
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply.
@@ -381,9 +381,25 @@ def reply_to_comment(
             f"review-comment reply: print_prompt returned empty for PR #{info['pr']}"
         )
 
-    log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
-    gh.reply_to_review_comment(info["repo"], info["pr"], body, info["comment_id"])
-    log.info("reply posted")
+    # Edit the last Fido reply in the thread instead of posting a new comment.
+    # This keeps the thread tidy — one acknowledgment per thread, updated in place.
+    _fido_logins = {"fidocancode", "fido-can-code"}
+    last_fido_id = next(
+        (
+            c["id"]
+            for c in reversed(thread_comments)
+            if c.get("author", "").lower() in _fido_logins
+        ),
+        None,
+    )
+    if last_fido_id:
+        log.info("editing last fido reply %s on PR #%s", last_fido_id, info["pr"])
+        gh.edit_review_comment(info["repo"], last_fido_id, body)
+        log.info("reply edited")
+    else:
+        log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
+        gh.reply_to_review_comment(info["repo"], info["pr"], body, info["comment_id"])
+        log.info("reply posted")
 
     # Maybe react
     maybe_react(

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -165,6 +165,10 @@ class GitHub:
             in_reply_to=int(in_reply_to),
         )
 
+    def edit_review_comment(self, repo: str, comment_id: int | str, body: str) -> None:
+        """Edit the body of an existing inline review comment."""
+        self._patch(f"/repos/{repo}/pulls/comments/{comment_id}", body=body)
+
     def get_pull_comments(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return all inline review comments on a pull request."""
         return list(self._paginate(f"{self.BASE}/repos/{repo}/pulls/{pr}/comments"))
@@ -223,7 +227,11 @@ class GitHub:
         root_id = comment.get("in_reply_to_id") or comment_id
 
         return [
-            {"author": c.get("user", {}).get("login", ""), "body": c.get("body", "")}
+            {
+                "id": c["id"],
+                "author": c.get("user", {}).get("login", ""),
+                "body": c.get("body", ""),
+            }
             for c in raw
             if c["id"] == root_id or c.get("in_reply_to_id") == root_id
         ]

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -92,7 +92,11 @@ def reply_context_block(
     comment: str,
     title: str,
 ) -> str:
-    """Build the rich context block used inside a reply instruction."""
+    """Build the rich context block used inside a reply instruction.
+
+    Includes the full conversation thread so reply generation can consider
+    the entire discussion history, not just the triggering comment.
+    """
     ctx = context or {}
     parts: list[str] = []
     if ctx.get("pr_title"):
@@ -103,6 +107,13 @@ def reply_context_block(
             parts.append(f"Line: {ctx['line']}")
     if ctx.get("diff_hunk"):
         parts.append(f"Diff:\n```\n{ctx['diff_hunk']}\n```")
+    # Include comment thread so reply generation considers the full conversation
+    if ctx.get("comment_thread"):
+        thread_lines = [
+            f"  {c.get('author', '')}: {c.get('body', '')}"
+            for c in ctx["comment_thread"]
+        ]
+        parts.append("Comment thread:\n" + "\n".join(thread_lines))
     parts.append(f"Comment: {comment}")
     parts.append(f"Your plan: {title}")
     return "\n\n".join(parts)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -962,6 +962,120 @@ class TestReplyToComment:
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
 
+    def test_act_title_uses_root_comment_when_reply(self, tmp_path: Path) -> None:
+        """When the triggering comment is a reply, ACT title comes from the root."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 42},
+            comment_body="Woof, you're right!",
+            is_bot=False,
+        )
+
+        calls: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            calls.append(prompt)
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: do it"
+            if "Convert this PR review comment" in prompt:
+                return "Add null input validation"
+            return "Done!"
+
+        mock_gh = MagicMock()
+        # Thread: root is reviewer feedback, second is fido's reply
+        mock_gh.fetch_comment_thread.return_value = [
+            {"author": "reviewer", "body": "Please add null input validation"},
+            {"author": "fidocancode", "body": "Woof, you're right!"},
+        ]
+        cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            _print_prompt=fake_pp,
+        )
+        assert cat == "ACT"
+        # Title re-derived from root comment, not the "Woof" reply
+        assert titles == ["Add null input validation"]
+        # _summarize_as_action_item was called with the root body
+        summarize_calls = [p for p in calls if "Convert this PR review comment" in p]
+        assert len(summarize_calls) == 1
+        assert "Please add null input validation" in summarize_calls[0]
+
+    def test_act_title_unchanged_when_triggering_is_root(self, tmp_path: Path) -> None:
+        """When the triggering comment IS the root, title comes from triage as usual."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 43},
+            comment_body="Add error handling for null inputs",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add error handling"
+            return "Will do!"
+
+        mock_gh = MagicMock()
+        # Thread has only one comment — the triggering one IS the root
+        mock_gh.fetch_comment_thread.return_value = [
+            {"author": "reviewer", "body": "Add error handling for null inputs"},
+        ]
+        cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            _print_prompt=fake_pp,
+        )
+        assert cat == "ACT"
+        # root_body == comment → no re-derivation, title from triage
+        assert titles == ["add error handling"]
+
+    def test_ask_title_not_rederived_from_root(self, tmp_path: Path) -> None:
+        """Non-task categories (ASK) are not affected by root body re-derivation."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 44},
+            comment_body="Sure, sounds good",
+            is_bot=False,
+        )
+
+        summarize_called = False
+
+        def fake_pp(prompt, model, **kwargs):
+            nonlocal summarize_called
+            if "Convert this PR review comment" in prompt:
+                summarize_called = True
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ASK: need more info"
+            return "Could you clarify?"
+
+        mock_gh = MagicMock()
+        mock_gh.fetch_comment_thread.return_value = [
+            {"author": "reviewer", "body": "What do you think?"},
+            {"author": "fidocancode", "body": "Sure, sounds good"},
+        ]
+        cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            _print_prompt=fake_pp,
+        )
+        assert cat == "ASK"
+        # _summarize_as_action_item must not be called for non-task categories
+        assert not summarize_called
+
 
 class TestReplyToReview:
     def _cfg(self, tmp_path: Path) -> Config:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -758,6 +758,8 @@ class TestReplyToComment:
                 return "NO"
             if "Triage" in prompt:
                 return "DO: add result caching"
+            if "Convert this PR review comment" in prompt:
+                return "Cache results for performance"
             return "On it!"
 
         mock_gh = MagicMock()
@@ -769,7 +771,7 @@ class TestReplyToComment:
             _print_prompt=fake_pp,
         )
         assert cat == "DO"
-        assert titles == ["add result caching"]
+        assert titles == ["Cache results for performance"]
         mock_gh.create_issue.assert_not_called()
 
     def test_full_flow_defer(self, tmp_path: Path) -> None:
@@ -874,6 +876,8 @@ class TestReplyToComment:
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: do it"
+            if "Convert this PR review comment" in prompt:
+                return "Do something"
             return ""
 
         with pytest.raises(ValueError, match="review-comment reply"):
@@ -935,8 +939,8 @@ class TestReplyToComment:
         )
         assert cat == "ACT"
 
-    def test_multiple_tasks_from_one_comment(self, tmp_path: Path) -> None:
-        """A single comment may produce multiple ACT tasks."""
+    def test_act_title_from_summarize_not_triage(self, tmp_path: Path) -> None:
+        """ACT task title always comes from _summarize_as_action_item, not triage output."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -950,6 +954,8 @@ class TestReplyToComment:
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: add unit tests\nACT: update documentation"
+            if "Convert this PR review comment" in prompt:
+                return "Add tests and update docs"
             return "On it!"
 
         cat, titles = reply_to_comment(
@@ -960,7 +966,8 @@ class TestReplyToComment:
             _print_prompt=fake_pp,
         )
         assert cat == "ACT"
-        assert titles == ["add unit tests", "update documentation"]
+        # Title comes from _summarize_as_action_item(root_body), not multi-item triage
+        assert titles == ["Add tests and update docs"]
 
     def test_act_title_uses_root_comment_when_reply(self, tmp_path: Path) -> None:
         """When the triggering comment is a reply, ACT title comes from the root."""
@@ -987,8 +994,12 @@ class TestReplyToComment:
         mock_gh = MagicMock()
         # Thread: root is reviewer feedback, second is fido's reply
         mock_gh.fetch_comment_thread.return_value = [
-            {"author": "reviewer", "body": "Please add null input validation"},
-            {"author": "fidocancode", "body": "Woof, you're right!"},
+            {
+                "id": 100,
+                "author": "reviewer",
+                "body": "Please add null input validation",
+            },
+            {"id": 101, "author": "fidocancode", "body": "Woof, you're right!"},
         ]
         cat, titles = reply_to_comment(
             action,
@@ -998,15 +1009,18 @@ class TestReplyToComment:
             _print_prompt=fake_pp,
         )
         assert cat == "ACT"
-        # Title re-derived from root comment, not the "Woof" reply
+        # Title derived from root comment, not the "Woof" reply
         assert titles == ["Add null input validation"]
         # _summarize_as_action_item was called with the root body
         summarize_calls = [p for p in calls if "Convert this PR review comment" in p]
         assert len(summarize_calls) == 1
         assert "Please add null input validation" in summarize_calls[0]
+        # Fido's previous reply is edited in-place rather than a new reply posted
+        mock_gh.edit_review_comment.assert_called_once_with("owner/repo", 101, "Done!")
+        mock_gh.reply_to_review_comment.assert_not_called()
 
-    def test_act_title_unchanged_when_triggering_is_root(self, tmp_path: Path) -> None:
-        """When the triggering comment IS the root, title comes from triage as usual."""
+    def test_act_title_always_from_root_comment(self, tmp_path: Path) -> None:
+        """ACT title is always derived from the root comment via _summarize_as_action_item."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -1020,12 +1034,18 @@ class TestReplyToComment:
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: add error handling"
+            if "Convert this PR review comment" in prompt:
+                return "Add error handling for null inputs"
             return "Will do!"
 
         mock_gh = MagicMock()
         # Thread has only one comment — the triggering one IS the root
         mock_gh.fetch_comment_thread.return_value = [
-            {"author": "reviewer", "body": "Add error handling for null inputs"},
+            {
+                "id": 43,
+                "author": "reviewer",
+                "body": "Add error handling for null inputs",
+            },
         ]
         cat, titles = reply_to_comment(
             action,
@@ -1035,8 +1055,12 @@ class TestReplyToComment:
             _print_prompt=fake_pp,
         )
         assert cat == "ACT"
-        # root_body == comment → no re-derivation, title from triage
-        assert titles == ["add error handling"]
+        # Title always comes from _summarize_as_action_item(root_body), even when
+        # the triggering comment is the root itself
+        assert titles == ["Add error handling for null inputs"]
+        # No prior Fido reply in thread — a new reply is posted
+        mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
 
     def test_ask_title_not_rederived_from_root(self, tmp_path: Path) -> None:
         """Non-task categories (ASK) are not affected by root body re-derivation."""
@@ -1062,8 +1086,8 @@ class TestReplyToComment:
 
         mock_gh = MagicMock()
         mock_gh.fetch_comment_thread.return_value = [
-            {"author": "reviewer", "body": "What do you think?"},
-            {"author": "fidocancode", "body": "Sure, sounds good"},
+            {"id": 200, "author": "reviewer", "body": "What do you think?"},
+            {"id": 201, "author": "fidocancode", "body": "Sure, sounds good"},
         ]
         cat, titles = reply_to_comment(
             action,
@@ -1075,6 +1099,11 @@ class TestReplyToComment:
         assert cat == "ASK"
         # _summarize_as_action_item must not be called for non-task categories
         assert not summarize_called
+        # Fido's prior reply is edited in-place
+        mock_gh.edit_review_comment.assert_called_once_with(
+            "owner/repo", 201, "Could you clarify?"
+        )
+        mock_gh.reply_to_review_comment.assert_not_called()
 
 
 class TestReplyToReview:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -243,6 +243,16 @@ class TestGitHubClass:
         body = mock_s.post.call_args.kwargs["json"]
         assert body["in_reply_to"] == 99
 
+    def test_edit_review_comment(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_s.patch.return_value = mock_resp
+        gh.edit_review_comment("o/r", 77, "updated body")
+        url = mock_s.patch.call_args.args[0]
+        assert "repos/o/r/pulls/comments/77" in url
+        body = mock_s.patch.call_args.kwargs["json"]
+        assert body["body"] == "updated body"
+
     def test_get_pull_comments(self) -> None:
         gh, mock_s = self._gh()
         comments = [{"id": 42, "body": "looks good"}]
@@ -393,9 +403,9 @@ class TestGitHubClass:
         mock_s.get.return_value = mock_resp
         result = gh.fetch_comment_thread("o/r", 7, 10)
         assert result == [
-            {"author": "alice", "body": "root comment"},
-            {"author": "fido", "body": "reply one"},
-            {"author": "alice", "body": "reply two"},
+            {"id": 10, "author": "alice", "body": "root comment"},
+            {"id": 11, "author": "fido", "body": "reply one"},
+            {"id": 12, "author": "alice", "body": "reply two"},
         ]
 
     def test_fetch_comment_thread_finds_thread_by_reply_id(self) -> None:
@@ -421,8 +431,8 @@ class TestGitHubClass:
         mock_s.get.return_value = mock_resp
         result = gh.fetch_comment_thread("o/r", 7, 11)
         assert result == [
-            {"author": "alice", "body": "root"},
-            {"author": "fido", "body": "reply"},
+            {"id": 10, "author": "alice", "body": "root"},
+            {"id": 11, "author": "fido", "body": "reply"},
         ]
 
     def test_fetch_comment_thread_returns_empty_when_not_found(self) -> None:


### PR DESCRIPTION
Fixes #470.

Thread task titles currently pull from the webhook reply body (often fido's own acknowledgment or a one-word "Yes") instead of the reviewer's actual feedback. This fixes title generation to use the root review comment body, which is already fetched via `fetch_comment_thread`.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Use root review comment body for thread task title generation <!-- type:spec -->
- [x] Use originating PR comment for task titles and edit last reply instead of reposting <!-- type:thread -->
- [x] Ensure reply/edit logic properly considers entire thread context <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->