### PR TITLE
Run pytest in parallel (pytest-xdist) (closes #467)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2314,7 +2314,9 @@ class TestSelfRestart:
         WebhookHandler.registry = mock_registry
         srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
         port = srv.server_address[1]
-        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t = threading.Thread(
+            target=srv.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+        )
         t.start()
         return srv, f"http://127.0.0.1:{port}", cfg
 


### PR DESCRIPTION
Fixes #467.

pytest-xdist and `-n auto` were already added in #475 — this PR fixes the last slow-test pattern by adding `poll_interval=0.01` to `_make_unregistered_server`, which was blocking 0.5s per test on shutdown. Shaves ~1s off wall time and closes out the parallel-pytest work.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Use fast poll_interval in _make_unregistered_server test helper <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->