### PR TITLE
Tastefully colorize kennel status output (closes #511)

### DIFF
--- a/kennel/color.py
+++ b/kennel/color.py
@@ -1,0 +1,60 @@
+"""ANSI color helper for terminal output.
+
+Color is enabled when:
+- ``FORCE_COLOR=1`` is set in the environment, OR
+- stdout is a TTY and ``NO_COLOR`` is not set.
+
+``NO_COLOR`` follows https://no-color.org — presence of the variable (any
+value) disables color.  ``FORCE_COLOR=1`` overrides both TTY detection and
+``NO_COLOR`` so that tools like ``watch -c`` work without extra flags.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# ANSI escape sequences
+_RESET = "\033[0m"
+_CODES: dict[str, str] = {
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "red": "\033[31m",
+    "red_bold": "\033[1;31m",
+    "cyan": "\033[36m",
+    "magenta": "\033[35m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+}
+
+# Semantic style name constants for import convenience
+BOLD = "bold"
+DIM = "dim"
+RED = "red"
+RED_BOLD = "red_bold"
+CYAN = "cyan"
+MAGENTA = "magenta"
+GREEN = "green"
+YELLOW = "yellow"
+
+
+def _color_enabled() -> bool:
+    """Return True if ANSI color output should be used."""
+    if os.environ.get("FORCE_COLOR") == "1":
+        return True
+    if "NO_COLOR" in os.environ:
+        return False
+    return sys.stdout.isatty()
+
+
+def color(style: str, text: str) -> str:
+    """Wrap *text* in ANSI escape codes for *style* if color is enabled.
+
+    Returns *text* unchanged when color is disabled or *style* is unknown.
+    """
+    if not _color_enabled():
+        return text
+    code = _CODES.get(style, "")
+    if not code:
+        return text
+    return f"{code}{text}{_RESET}"

--- a/kennel/color.py
+++ b/kennel/color.py
@@ -14,20 +14,7 @@ from __future__ import annotations
 import os
 import sys
 
-# ANSI escape sequences
-_RESET = "\033[0m"
-_CODES: dict[str, str] = {
-    "bold": "\033[1m",
-    "dim": "\033[2m",
-    "red": "\033[31m",
-    "red_bold": "\033[1;31m",
-    "cyan": "\033[36m",
-    "magenta": "\033[35m",
-    "green": "\033[32m",
-    "yellow": "\033[33m",
-}
-
-# Semantic style name constants for import convenience
+# Semantic style names
 BOLD = "bold"
 DIM = "dim"
 RED = "red"
@@ -36,6 +23,19 @@ CYAN = "cyan"
 MAGENTA = "magenta"
 GREEN = "green"
 YELLOW = "yellow"
+
+# ANSI escape sequences
+_RESET = "\033[0m"
+_CODES: dict[str, str] = {
+    BOLD: "\033[1m",
+    DIM: "\033[2m",
+    RED: "\033[31m",
+    RED_BOLD: "\033[1;31m",
+    CYAN: "\033[36m",
+    MAGENTA: "\033[35m",
+    GREEN: "\033[32m",
+    YELLOW: "\033[33m",
+}
 
 
 def _color_enabled() -> bool:

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from kennel.color import BOLD, CYAN, DIM, GREEN, MAGENTA, RED, RED_BOLD, YELLOW, color
 from kennel.config import RepoConfig
 from kennel.state import State
 
@@ -504,9 +505,9 @@ def _claude_stats_suffix(repo: RepoStatus) -> str:
         return ""
     parts: list[str] = []
     if repo.claude_uptime is not None:
-        parts.append(f"running {_format_uptime(repo.claude_uptime)}")
+        parts.append(color(DIM, f"running {_format_uptime(repo.claude_uptime)}"))
     if repo.session_alive and repo.claude_talker is None:
-        parts.append("session idle")
+        parts.append(color(DIM, "session idle"))
     pid_str = (
         f"claude pid {repo.claude_pid}" if repo.claude_pid is not None else "claude"
     )
@@ -528,15 +529,16 @@ def _format_repo_header(repo: RepoStatus) -> str:
     state = "fido running" if repo.fido_running else "fido idle"
     stats: list[str] = []
     if repo.crash_count > 0:
-        stats.append(f"crashes {repo.crash_count}")
+        stats.append(color(RED_BOLD, f"crashes {repo.crash_count}"))
     if repo.worker_uptime is not None:
         stats.append(f"up {_format_uptime(repo.worker_uptime)}")
     if repo.worker_stuck:
-        stats.append("BUSY")
+        stats.append(color(RED, "BUSY"))
     if repo.crash_count > 0 and repo.last_crash_error:
-        stats.append(f"last crash: {repo.last_crash_error}")
+        stats.append(color(RED_BOLD, f"last crash: {repo.last_crash_error}"))
 
-    header = f"{repo.name}: {state}"
+    header_style = BOLD if repo.fido_running else DIM
+    header = color(header_style, f"{repo.name}: {state}")
     if stats:
         header += " — " + ", ".join(stats)
     # Claude stats ride the worker summary only when nobody is talking.
@@ -563,15 +565,17 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
         body.append("  no assigned issues")
         return body
 
-    issue_line = f"  Issue:  #{repo.issue}"
+    issue_line = f"  Issue:  {color(CYAN, f'#{repo.issue}')}"
     if repo.issue_title:
         issue_line += f" — {repo.issue_title}"
     if repo.issue_elapsed_seconds is not None:
-        issue_line += f"  (elapsed {_format_uptime(repo.issue_elapsed_seconds)})"
+        issue_line += (
+            f"  {color(DIM, f'(elapsed {_format_uptime(repo.issue_elapsed_seconds)})')}"
+        )
     body.append(issue_line)
 
     if repo.pr_number is not None:
-        pr_line = f"  PR:     #{repo.pr_number}"
+        pr_line = f"  PR:     {color(MAGENTA, f'#{repo.pr_number}')}"
         if repo.pr_title:
             pr_line += f" — {repo.pr_title}"
         body.append(pr_line)
@@ -588,9 +592,11 @@ def _format_worker_thread_line(repo: RepoStatus) -> str:
     the one talking to claude.
     """
     state = _worker_thread_state(repo)
-    line = f"  Worker: {state}"
     talker = repo.claude_talker
-    if talker is not None and talker.kind == "worker":
+    is_talker = talker is not None and talker.kind == "worker"
+    label = color(GREEN, "Worker:") if is_talker else "Worker:"
+    line = f"  {label} {state}"
+    if is_talker:
         line += _claude_stats_suffix(repo)
     return line
 
@@ -604,7 +610,7 @@ def _worker_thread_state(repo: RepoStatus) -> str:
     """
     if repo.task_number is not None and repo.task_total is not None:
         suffix = f" — {repo.current_task}" if repo.current_task else ""
-        return f"task {repo.task_number}/{repo.task_total}{suffix}"
+        return f"{color(BOLD, f'task {repo.task_number}/{repo.task_total}')}{suffix}"
     if repo.current_task is not None:
         return f"task: {repo.current_task}"
     what = (repo.worker_what or "").strip()
@@ -633,10 +639,11 @@ def _format_webhook_lines(repo: RepoStatus) -> list[str]:
     lines: list[str] = []
     for i, w in enumerate(shown):
         branch = "└─" if overflow == 0 and i == len(shown) - 1 else "├─"
-        line = (
-            f"  {branch} webhook: {w.description} ({_format_uptime(w.elapsed_seconds)})"
-        )
-        if talker_tid is not None and w.thread_id == talker_tid:
+        is_talker = talker_tid is not None and w.thread_id == talker_tid
+        wh_label = color(YELLOW, "webhook:") if is_talker else "webhook:"
+        elapsed = color(DIM, f"({_format_uptime(w.elapsed_seconds)})")
+        line = f"  {branch} {wh_label} {w.description} {elapsed}"
+        if is_talker:
             line += _claude_stats_suffix(repo)
         lines.append(line)
     if overflow > 0:
@@ -654,9 +661,9 @@ def format_status(status: KennelStatus) -> str:
             if status.kennel_uptime is not None
             else ""
         )
-        lines.append(f"kennel: UP (pid {status.kennel_pid}{uptime_str})")
+        lines.append(color(BOLD, f"kennel: UP (pid {status.kennel_pid}{uptime_str})"))
     else:
-        lines.append("kennel: DOWN")
+        lines.append(color(BOLD, "kennel: DOWN"))
 
     for repo in status.repos:
         lines.append(_format_repo_header(repo))

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,126 @@
+"""Tests for kennel.color — ANSI color helper."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kennel.color import (
+    _CODES,
+    _RESET,
+    BOLD,
+    CYAN,
+    DIM,
+    GREEN,
+    MAGENTA,
+    RED,
+    RED_BOLD,
+    YELLOW,
+    _color_enabled,
+    color,
+)
+
+# ---------------------------------------------------------------------------
+# _color_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestColorEnabled:
+    def test_force_color_enables(self) -> None:
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            assert _color_enabled() is True
+
+    def test_force_color_overrides_no_color(self) -> None:
+        with patch.dict("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": ""}, clear=True):
+            assert _color_enabled() is True
+
+    def test_no_color_disables(self) -> None:
+        with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
+            assert _color_enabled() is False
+
+    def test_no_color_any_value_disables(self) -> None:
+        with patch.dict("os.environ", {"NO_COLOR": "1"}, clear=True):
+            assert _color_enabled() is False
+
+    def test_tty_enables(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("sys.stdout") as mock_stdout:
+                mock_stdout.isatty.return_value = True
+                assert _color_enabled() is True
+
+    def test_non_tty_disables(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("sys.stdout") as mock_stdout:
+                mock_stdout.isatty.return_value = False
+                assert _color_enabled() is False
+
+    def test_force_color_wrong_value_falls_through_to_tty(self) -> None:
+        with patch.dict("os.environ", {"FORCE_COLOR": "0"}, clear=True):
+            with patch("sys.stdout") as mock_stdout:
+                mock_stdout.isatty.return_value = False
+                assert _color_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# color()
+# ---------------------------------------------------------------------------
+
+
+class TestColor:
+    def _enabled(self) -> dict[str, object]:
+        """Patch dict that forces color on."""
+        return {"FORCE_COLOR": "1"}
+
+    def _disabled(self) -> dict[str, object]:
+        """Patch dict that forces color off."""
+        return {"NO_COLOR": ""}
+
+    def test_disabled_returns_text_unchanged(self) -> None:
+        with patch.dict("os.environ", self._disabled(), clear=True):
+            assert color(BOLD, "hello") == "hello"
+
+    def test_unknown_style_returns_text_unchanged(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color("neon_rainbow", "oops") == "oops"
+
+    @pytest.mark.parametrize(
+        "style",
+        [BOLD, DIM, RED, RED_BOLD, CYAN, MAGENTA, GREEN, YELLOW],
+    )
+    def test_each_style_wraps_with_ansi(self, style: str) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            result = color(style, "text")
+            assert result == f"{_CODES[style]}text{_RESET}"
+
+    def test_color_enabled_bold(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(BOLD, "hi") == "\033[1mhi\033[0m"
+
+    def test_color_enabled_dim(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(DIM, "quiet") == "\033[2mquiet\033[0m"
+
+    def test_color_enabled_red(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(RED, "danger") == "\033[31mdanger\033[0m"
+
+    def test_color_enabled_red_bold(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(RED_BOLD, "alarm") == "\033[1;31malarm\033[0m"
+
+    def test_color_enabled_cyan(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(CYAN, "#42") == "\033[36m#42\033[0m"
+
+    def test_color_enabled_magenta(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(MAGENTA, "#99") == "\033[35m#99\033[0m"
+
+    def test_color_enabled_green(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(GREEN, "worker") == "\033[32mworker\033[0m"
+
+    def test_color_enabled_yellow(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(YELLOW, "webhook") == "\033[33mwebhook\033[0m"

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from kennel.color import _CODES
 from kennel.config import RepoConfig
 from kennel.status import (
     ClaudeTalkerInfo,
@@ -1437,3 +1438,178 @@ class TestFormatStatus:
         assert "crashes 1" in output
         assert "BUSY" in output
         assert "last crash: err" in output
+
+
+class TestFormatStatusColor:
+    """Color tests: verify ANSI codes appear under FORCE_COLOR=1."""
+
+    def _repo(self, **kwargs) -> RepoStatus:
+        defaults = dict(
+            name="owner/repo",
+            fido_running=False,
+            issue=None,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+        defaults.update(kwargs)
+        return RepoStatus(**defaults)
+
+    def _color_env(self) -> dict[str, str]:
+        return {"FORCE_COLOR": "1"}
+
+    def test_kennel_up_header_bold(self) -> None:
+        status = KennelStatus(kennel_pid=42, kennel_uptime=60, repos=[])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert output.startswith(_CODES["bold"])
+
+    def test_kennel_down_header_bold(self) -> None:
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert _CODES["bold"] in output
+
+    def test_repo_running_bold(self) -> None:
+        repo = self._repo(fido_running=True)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        header = [ln for ln in output.splitlines() if "owner/repo" in ln][0]
+        assert _CODES["bold"] in header
+
+    def test_repo_idle_dim(self) -> None:
+        repo = self._repo(fido_running=False)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        header = [ln for ln in output.splitlines() if "owner/repo" in ln][0]
+        assert _CODES["dim"] in header
+
+    def test_issue_number_cyan(self) -> None:
+        repo = self._repo(issue=42)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['cyan']}#42" in output
+
+    def test_pr_number_magenta(self) -> None:
+        repo = self._repo(issue=1, pr_number=99)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['magenta']}#99" in output
+
+    def test_elapsed_dim(self) -> None:
+        repo = self._repo(issue=1, issue_elapsed_seconds=120)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dim']}(elapsed 2m)" in output
+
+    def test_busy_red(self) -> None:
+        repo = self._repo(worker_stuck=True)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['red']}BUSY" in output
+
+    def test_crash_red_bold(self) -> None:
+        repo = self._repo(crash_count=2, last_crash_error="RuntimeError: boom")
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['red_bold']}crashes 2" in output
+        assert f"{_CODES['red_bold']}last crash: RuntimeError: boom" in output
+
+    def test_task_counter_bold(self) -> None:
+        repo = self._repo(issue=1, current_task="Do thing", task_number=2, task_total=5)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['bold']}task 2/5" in output
+
+    def test_worker_label_green_when_talker(self) -> None:
+        repo = self._repo(
+            issue=1,
+            claude_pid=999,
+            session_alive=True,
+            claude_talker=ClaudeTalkerInfo(
+                thread_id=1, kind="worker", description="turn", claude_pid=999
+            ),
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
+        assert f"{_CODES['green']}Worker:" in worker_line
+
+    def test_worker_label_plain_when_not_talker(self) -> None:
+        repo = self._repo(issue=1)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
+        assert _CODES["green"] not in worker_line
+
+    def test_webhook_label_yellow_when_talker(self) -> None:
+        repo = self._repo(
+            issue=1,
+            claude_pid=888,
+            session_alive=True,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description="triaging", elapsed_seconds=10, thread_id=5
+                ),
+            ],
+            claude_talker=ClaudeTalkerInfo(
+                thread_id=5, kind="webhook", description="one-shot", claude_pid=888
+            ),
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        wh_line = [ln for ln in output.splitlines() if "webhook:" in ln][0]
+        assert f"{_CODES['yellow']}webhook:" in wh_line
+
+    def test_webhook_label_plain_when_not_talker(self) -> None:
+        repo = self._repo(
+            issue=1,
+            webhook_activities=[
+                WebhookActivityInfo(
+                    description="triaging", elapsed_seconds=10, thread_id=5
+                ),
+            ],
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        wh_line = [ln for ln in output.splitlines() if "webhook:" in ln][0]
+        assert _CODES["yellow"] not in wh_line
+
+    def test_session_idle_dim(self) -> None:
+        repo = self._repo(issue=1, claude_pid=999, session_alive=True)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dim']}session idle" in output
+
+    def test_claude_running_uptime_dim(self) -> None:
+        repo = self._repo(issue=1, claude_pid=999, claude_uptime=120)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dim']}running 2m" in output
+
+    def test_no_color_env_suppresses_ansi(self) -> None:
+        repo = self._repo(fido_running=True, issue=42, worker_stuck=True)
+        status = KennelStatus(kennel_pid=1, kennel_uptime=60, repos=[repo])
+        with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
+            output = format_status(status)
+        assert "\033[" not in output


### PR DESCRIPTION
Fixes #511.

Adds a small zero-dependency ANSI color helper with TTY/NO_COLOR/FORCE_COLOR detection, then wires it into `kennel status` formatting — bold running repos, dim idle ones, cyan issues, magenta PRs, red for stuck/crash, and dim elapsed times. Color amplifies existing textual markers without replacing them.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add ANSI color helper with TTY/NO_COLOR/FORCE_COLOR detection <!-- type:spec -->
- [x] Colorize kennel status output using semantic styles from #511 <!-- type:spec -->
- [x] [Define style constants before _CODES and use them as dictionary keys](https://github.com/FidoCanCode/home/pull/515#discussion_r3083127947) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->