### PR TITLE
Strip tools from webhook reply-gen + fair preempt yield + more color

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -831,8 +831,58 @@ class ClaudeSession:
         # is dirty.  :meth:`send` drains to the boundary before writing new
         # content so every turn starts on a clean slate.
         self._in_turn = False
+        # Set by :meth:`prompt` right after :attr:`_cancel` and before it
+        # blocks on :attr:`_lock`.  Cleared inside :meth:`__enter__` once the
+        # preempter actually acquires the lock.  Workers check this in their
+        # retry loop to yield fairly: without it, a freshly-released worker
+        # thread can re-acquire :attr:`_lock` before the waiting webhook
+        # gets scheduled, and the next :meth:`iter_events` clears
+        # :attr:`_cancel` — starving the preempter for a full worker turn.
+        # See yield-starvation discussion in #499 comments.
+        self._preempt_pending = threading.Event()
         self._proc = self._spawn()
         _register_child(self._proc)
+
+    def wait_for_pending_preempt(self, timeout: float = 2.0) -> bool:
+        """Block for up to *timeout* seconds while a preempter holds the
+        lock queue.  Returns ``True`` if the preemption completed within the
+        window, ``False`` on timeout (no preempter pending in the first place
+        returns immediately with ``False``).
+
+        Workers call this after their cancelled-turn exit to let the
+        preempter actually acquire :attr:`_lock` before the worker retries —
+        Python's :class:`threading.RLock` isn't FIFO-fair under contention
+        so the worker can otherwise race ahead and starve the preempter for
+        a full turn.
+        """
+        if not self._preempt_pending.is_set():
+            return False
+        # Wait for the preempter's __enter__ to clear the event, meaning they
+        # hold the lock now.  If they don't manage within the deadline, bail.
+        # is_set() -> wait for clear: threading.Event has no "wait-for-clear",
+        # so poll with short sleeps.
+        import time as _time
+
+        started = _time.monotonic()
+        deadline = started + timeout
+        log.info(
+            "session: worker ceding lock to pending preempter (tid=%d)",
+            threading.get_ident(),
+        )
+        while self._preempt_pending.is_set():
+            if _time.monotonic() >= deadline:
+                log.warning(
+                    "session: preempter still pending after %.2fs — worker "
+                    "proceeding anyway",
+                    timeout,
+                )
+                return False
+            _time.sleep(0.01)
+        log.info(
+            "session: preempter acquired lock after %.3fs yield",
+            _time.monotonic() - started,
+        )
+        return True
 
     @property
     def repo_name(self) -> str | None:
@@ -970,6 +1020,9 @@ class ClaudeSession:
         holder we would have taken over from does not deadlock.
         """
         self._lock.acquire()
+        # We hold the lock now; any preempter waiting on this
+        # (wait_for_pending_preempt) can wake.
+        self._preempt_pending.clear()
         if self._repo_name is not None:
             try:
                 register_talker(
@@ -1148,15 +1201,30 @@ class ClaudeSession:
         there is nothing in-flight to interrupt.
         """
         self._cancel.set()
-        with self:
-            if model is not None:
-                self.switch_model(model)
-            if system_prompt:
-                body = f"{system_prompt}\n\n---\n\n{content}"
-            else:
-                body = content
-            self.send(body)
-            return self.consume_until_result()
+        # Mark that a preempter is queued so the current lock holder (a
+        # worker) can wait_for_pending_preempt and cede the lock fairly
+        # instead of racing to re-acquire after it yields.
+        self._preempt_pending.set()
+        log.info(
+            "session.prompt: preempt requested (tid=%d, model=%s)",
+            threading.get_ident(),
+            model or self._model,
+        )
+        try:
+            with self:
+                if model is not None:
+                    self.switch_model(model)
+                if system_prompt:
+                    body = f"{system_prompt}\n\n---\n\n{content}"
+                else:
+                    body = content
+                self.send(body)
+                return self.consume_until_result()
+        finally:
+            # If an exception blew us out of `with self:` before __enter__
+            # could clear the event, do it here so a stuck event doesn't
+            # trap the worker forever.
+            self._preempt_pending.clear()
 
     def switch_model(self, model: str) -> None:
         """Switch the active model.  Restart-based — stream-json does not

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1111,8 +1111,11 @@ class ClaudeSession:
                 sid = obj.get("session_id")
                 if isinstance(sid, str) and sid:
                     self._session_id = sid
+                # Humanify drained events at INFO too so a cancelled turn's
+                # tail is visible in the log rather than silently discarded.
+                self._log_event(obj)
                 if obj.get("type") in ("result", "error"):
-                    log.debug(
+                    log.info(
                         "ClaudeSession: drained stale %s event",
                         obj.get("type"),
                     )
@@ -1267,6 +1270,51 @@ class ClaudeSession:
             _register_child(self._proc)
         log.info("switch_model: new pid %d ready (model=%s)", self._proc.pid, model)
 
+    def _log_event(self, obj: dict[str, Any]) -> None:
+        """Emit a human-readable INFO log line for a stream-json *obj*.
+
+        Makes stalls pinpointable to a specific tool call or turn rather
+        than leaving a silent gap in the kennel log between "preempt
+        requested" and "preempter acquired".  Closes #493.
+        """
+        t = obj.get("type")
+        if t == "assistant":
+            message = obj.get("message", {})
+            for c in message.get("content") or []:
+                if not isinstance(c, dict):
+                    continue
+                ct = c.get("type")
+                if ct == "text":
+                    text = str(c.get("text") or "").replace("\n", " ")[:200]
+                    log.info("claude> %s", text)
+                elif ct == "tool_use":
+                    name = c.get("name") or "?"
+                    args = c.get("input") or {}
+                    preview = (
+                        args.get("command")
+                        or args.get("file_path")
+                        or (args.get("pattern") or "")
+                    )
+                    if not preview and args:
+                        preview = str(next(iter(args.values())))
+                    log.info("claude tool: %s %s", name, str(preview)[:120])
+        elif t == "user":
+            message = obj.get("message", {})
+            content = message.get("content")
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_result":
+                        tr = c.get("content", "")
+                        size = len(str(tr))
+                        log.info("claude tool result (%d chars)", size)
+        elif t == "system":
+            log.info("claude system: %s", obj.get("subtype") or "?")
+        elif t == "result":
+            result = str(obj.get("result") or "").replace("\n", " ")[:200]
+            log.info("claude result: %s", result)
+        elif t == "error":
+            log.warning("claude error: %s", obj.get("error") or obj)
+
     def iter_events(self) -> Iterator[dict[str, Any]]:
         """Yield parsed stream-json events for the current turn.
 
@@ -1312,7 +1360,7 @@ class ClaudeSession:
                     last_activity = time.monotonic()
                     continue
                 obj = json.loads(line)
-                log.debug("ClaudeSession event: %s", _Trunc(line))
+                self._log_event(obj)
                 last_activity = time.monotonic()
                 # Track the latest session_id so :meth:`switch_model` can
                 # restart with ``--resume <sid>`` and keep conversation

--- a/kennel/config.py
+++ b/kennel/config.py
@@ -61,7 +61,9 @@ class Config:
             help="Comma-separated bot allowlist",
         )
         parser.add_argument(
-            "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+            "--log-level",
+            default="DEBUG",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         )
         parser.add_argument(
             "repos",

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -366,17 +366,26 @@ class Prompts:
     def reply_system_prompt(self) -> str:
         """Return the system prompt for reply generation.
 
-        Instils the Fido persona and strictly forbids preamble framing so Opus
-        outputs the comment text directly rather than prefacing it with phrases
-        like "Here's the reply:" or "Sure, here's...".
+        Instils the Fido persona, strictly forbids preamble framing, and
+        strictly forbids tool use.  Without the no-tools clause Opus will
+        sometimes treat a review comment as a directive (*"fix this"*) and
+        launch Bash/Read/Edit calls to actually make the change — turning a
+        ~5s reply into a multi-minute session turn that holds the lock and
+        starves the worker.
         """
         return (
             f"{self.persona}\n\n"
-            "You are responding to a GitHub PR comment. "
-            "Output ONLY the comment text — no preamble, no framing. "
-            "Do NOT start with 'Here\\'s', 'Sure', 'Certainly', 'Of course', or any similar phrase. "
-            "Do NOT include meta-commentary like 'Here\\'s the reply:' or 'Here\\'s my response:'. "
-            "Start directly with the comment content. No quotes, no explanation."
+            "You are responding to a GitHub PR comment.  Reply composition "
+            "is a TEXT-ONLY task: do NOT invoke any tools.  No Bash, no Read, "
+            "no Edit, no Write, no Grep, no Glob, no Task sub-agents, no "
+            "WebFetch, no plan mode, no file modifications of any kind.  "
+            "The reviewer's feedback may look like a directive — ignore that "
+            "framing and just acknowledge the feedback.  A separate worker "
+            "turn will do the actual work later from the task queue.  "
+            "Output ONLY the comment text — no preamble, no framing.  "
+            "Do NOT start with 'Here\\'s', 'Sure', 'Certainly', 'Of course', or any similar phrase.  "
+            "Do NOT include meta-commentary like 'Here\\'s the reply:' or 'Here\\'s my response:'.  "
+            "Start directly with the comment content.  No quotes, no explanation."
         )
 
     def persona_wrap(self, instruction: str) -> str:

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -509,11 +509,15 @@ def _claude_stats_suffix(repo: RepoStatus) -> str:
     if repo.session_alive and repo.claude_talker is None:
         parts.append(color(DIM, "session idle"))
     pid_str = (
-        f"claude pid {repo.claude_pid}" if repo.claude_pid is not None else "claude"
+        color(DIM, f"claude pid {repo.claude_pid}")
+        if repo.claude_pid is not None
+        else color(DIM, "claude")
     )
+    arrow = color(DIM, "→")
     if parts:
-        return f" → {pid_str} ({', '.join(parts)})"
-    return f" → {pid_str}"
+        joined = ", ".join(parts)
+        return f" {arrow} {pid_str} {color(DIM, '(')}{joined}{color(DIM, ')')}"
+    return f" {arrow} {pid_str}"
 
 
 def _format_repo_header(repo: RepoStatus) -> str:
@@ -526,19 +530,21 @@ def _format_repo_header(repo: RepoStatus) -> str:
     claude pid/uptime suffix appears on this line; when a worker or webhook
     IS talking, the suffix attaches to that line instead.
     """
-    state = "fido running" if repo.fido_running else "fido idle"
+    state_word = "running" if repo.fido_running else "idle"
+    state_style = GREEN if repo.fido_running else DIM
     stats: list[str] = []
     if repo.crash_count > 0:
         stats.append(color(RED_BOLD, f"crashes {repo.crash_count}"))
     if repo.worker_uptime is not None:
-        stats.append(f"up {_format_uptime(repo.worker_uptime)}")
+        stats.append(color(DIM, f"up {_format_uptime(repo.worker_uptime)}"))
     if repo.worker_stuck:
         stats.append(color(RED, "BUSY"))
     if repo.crash_count > 0 and repo.last_crash_error:
         stats.append(color(RED_BOLD, f"last crash: {repo.last_crash_error}"))
 
-    header_style = BOLD if repo.fido_running else DIM
-    header = color(header_style, f"{repo.name}: {state}")
+    name_styled = color(BOLD, f"{repo.name}:")
+    state_styled = color(state_style, f"fido {state_word}")
+    header = f"{name_styled} {state_styled}"
     if stats:
         header += " — " + ", ".join(stats)
     # Claude stats ride the worker summary only when nobody is talking.
@@ -565,9 +571,9 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
         body.append("  no assigned issues")
         return body
 
-    issue_line = f"  Issue:  {color(CYAN, f'#{repo.issue}')}"
+    issue_line = f"  {color(BOLD, 'Issue:')}  {color(CYAN, f'#{repo.issue}')}"
     if repo.issue_title:
-        issue_line += f" — {repo.issue_title}"
+        issue_line += f" {color(DIM, '—')} {repo.issue_title}"
     if repo.issue_elapsed_seconds is not None:
         issue_line += (
             f"  {color(DIM, f'(elapsed {_format_uptime(repo.issue_elapsed_seconds)})')}"
@@ -575,9 +581,9 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
     body.append(issue_line)
 
     if repo.pr_number is not None:
-        pr_line = f"  PR:     {color(MAGENTA, f'#{repo.pr_number}')}"
+        pr_line = f"  {color(BOLD, 'PR:')}     {color(MAGENTA, f'#{repo.pr_number}')}"
         if repo.pr_title:
-            pr_line += f" — {repo.pr_title}"
+            pr_line += f" {color(DIM, '—')} {repo.pr_title}"
         body.append(pr_line)
 
     body.append(_format_worker_thread_line(repo))
@@ -594,7 +600,7 @@ def _format_worker_thread_line(repo: RepoStatus) -> str:
     state = _worker_thread_state(repo)
     talker = repo.claude_talker
     is_talker = talker is not None and talker.kind == "worker"
-    label = color(GREEN, "Worker:") if is_talker else "Worker:"
+    label = color(GREEN, "Worker:") if is_talker else color(BOLD, "Worker:")
     line = f"  {label} {state}"
     if is_talker:
         line += _claude_stats_suffix(repo)
@@ -638,16 +644,18 @@ def _format_webhook_lines(repo: RepoStatus) -> list[str]:
     overflow = len(webhooks) - len(shown)
     lines: list[str] = []
     for i, w in enumerate(shown):
-        branch = "└─" if overflow == 0 and i == len(shown) - 1 else "├─"
+        branch = color(DIM, "└─" if overflow == 0 and i == len(shown) - 1 else "├─")
         is_talker = talker_tid is not None and w.thread_id == talker_tid
-        wh_label = color(YELLOW, "webhook:") if is_talker else "webhook:"
+        wh_label = color(YELLOW, "webhook:") if is_talker else color(BOLD, "webhook:")
         elapsed = color(DIM, f"({_format_uptime(w.elapsed_seconds)})")
         line = f"  {branch} {wh_label} {w.description} {elapsed}"
         if is_talker:
             line += _claude_stats_suffix(repo)
         lines.append(line)
     if overflow > 0:
-        lines.append(f"  └─ +{overflow} more webhook{'s' if overflow != 1 else ''}")
+        lines.append(
+            color(DIM, f"  └─ +{overflow} more webhook{'s' if overflow != 1 else ''}")
+        )
     return lines
 
 
@@ -661,9 +669,12 @@ def format_status(status: KennelStatus) -> str:
             if status.kennel_uptime is not None
             else ""
         )
-        lines.append(color(BOLD, f"kennel: UP (pid {status.kennel_pid}{uptime_str})"))
+        lines.append(
+            f"{color(BOLD, 'kennel:')} {color(GREEN, 'UP')} "
+            f"{color(DIM, f'(pid {status.kennel_pid}{uptime_str})')}"
+        )
     else:
-        lines.append(color(BOLD, "kennel: DOWN"))
+        lines.append(f"{color(BOLD, 'kennel:')} {color(RED_BOLD, 'DOWN')}")
 
     for repo in status.repos:
         lines.append(_format_repo_header(repo))

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -275,6 +275,13 @@ def _run_session_turn(session: claude.ClaudeSession, content: str) -> str:
             # itself truthy) doesn't spin the loop forever.
             if session.last_turn_cancelled is not True:
                 return result
+        # Before racing back into `with session:`, cede to any pending
+        # preempter so they acquire the lock first.  RLock is not FIFO-fair
+        # under contention, so without this hand-off the worker can grab
+        # the lock before the preempter wakes and then iter_events clears
+        # :attr:`_cancel` — starving the preempter for a full worker turn
+        # (observed in #499 comments).
+        session.wait_for_pending_preempt()
         attempt += 1
         log.info("session turn preempted mid-flight — retry %d", attempt)
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1451,6 +1451,40 @@ class TestClaudeSessionDrainToBoundary:
         assert session._in_turn is False
 
 
+class TestClaudeSessionWaitForPendingPreempt:
+    def test_returns_false_when_not_pending(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        # _preempt_pending starts cleared
+        assert session.wait_for_pending_preempt(timeout=0.01) is False
+
+    def test_returns_true_when_pending_clears(self, tmp_path: Path) -> None:
+        import threading as _t
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._preempt_pending.set()
+
+        # Clear the event from another thread after a brief delay.
+        def _clearer() -> None:
+            import time as _time
+
+            _time.sleep(0.02)
+            session._preempt_pending.clear()
+
+        t = _t.Thread(target=_clearer)
+        t.start()
+        assert session.wait_for_pending_preempt(timeout=1.0) is True
+        t.join()
+
+    def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._preempt_pending.set()
+        # Never cleared → waits out the deadline.
+        assert session.wait_for_pending_preempt(timeout=0.05) is False
+
+
 class TestClaudeSessionIterEvents:
     def test_yields_parsed_json_events(self, tmp_path: Path) -> None:
         import json as _json

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1451,6 +1451,139 @@ class TestClaudeSessionDrainToBoundary:
         assert session._in_turn is False
 
 
+class TestClaudeSessionLogEvent:
+    def test_assistant_text(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "thinking hard"}]},
+                }
+            )
+        assert "claude>" in caplog.text and "thinking hard" in caplog.text
+
+    def test_tool_use_command(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Bash",
+                                "input": {"command": "ls -la"},
+                            }
+                        ]
+                    },
+                }
+            )
+        assert "claude tool: Bash" in caplog.text and "ls -la" in caplog.text
+
+    def test_tool_use_file_path(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Read",
+                                "input": {"file_path": "/tmp/foo.py"},
+                            }
+                        ]
+                    },
+                }
+            )
+        assert "claude tool: Read" in caplog.text and "/tmp/foo.py" in caplog.text
+
+    def test_tool_use_fallback_first_value(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Thing",
+                                "input": {"other": "value-xyz"},
+                            }
+                        ]
+                    },
+                }
+            )
+        assert "claude tool: Thing" in caplog.text and "value-xyz" in caplog.text
+
+    def test_content_non_dict_skipped(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        # Must not raise
+        session._log_event(
+            {"type": "assistant", "message": {"content": ["not a dict"]}}
+        )
+
+    def test_user_tool_result(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [{"type": "tool_result", "content": "abcdefghij"}]
+                    },
+                }
+            )
+        assert "claude tool result" in caplog.text
+
+    def test_system_event(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event({"type": "system", "subtype": "init"})
+        assert "claude system: init" in caplog.text
+
+    def test_result_event(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.INFO, logger="kennel"):
+            session._log_event({"type": "result", "result": "all done"})
+        assert "claude result: all done" in caplog.text
+
+    def test_error_event(self, tmp_path: Path, caplog) -> None:
+        import logging as _l
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        with caplog.at_level(_l.WARNING, logger="kennel"):
+            session._log_event({"type": "error", "error": "kaboom"})
+        assert "claude error: kaboom" in caplog.text
+
+
 class TestClaudeSessionWaitForPendingPreempt:
     def test_returns_false_when_not_pending(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ class TestFromArgs:
             ]
         )
         assert cfg.port == 9000
-        assert cfg.log_level == "INFO"
+        assert cfg.log_level == "DEBUG"
         assert "copilot[bot]" in cfg.allowed_bots
 
     def test_custom_port(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Three fixes for the webhook responsiveness regression on PR #515:

1. **Reply-gen disallows tools.** Observed 2026-04-14: rhencke's review comment on PR #515 arrived at 23:36:15, reply posted at 23:41:32 — **4m 44s**. The JSONL showed Opus had fired `Bash`/`Read`/`Edit` calls on `test_status.py` inside the reply-gen turn, treating the review comment as a directive. `reply_system_prompt` now strictly forbids tool use and explains the worker will do the actual work later from the task queue.

2. **Fair preempt yield via `_preempt_pending` event.** Python's `RLock` isn't FIFO-fair under contention. A worker thread that released on `_cancel` could race back in and re-acquire before the waiting webhook thread got scheduled; `iter_events._cancel.clear()` at the next turn then wiped the webhook's signal, and the webhook waited a full worker turn to actually run. `session.prompt()` now sets `_preempt_pending` right after `_cancel.set()`, `__enter__` clears it on acquire, and the worker's retry loop calls `session.wait_for_pending_preempt()` between release and re-acquire.

3. **More ip-color style coverage.** Repo name `BOLD` + state word `GREEN`/`DIM` separately, Issue/PR/Worker labels `BOLD`, tree glyphs and claude pid suffix `DIM`, `kennel: UP` in `GREEN` and `DOWN` in `RED_BOLD`.

Logging added: `session.prompt` logs preempt request; `wait_for_pending_preempt` logs cede + acquire-latency or timeout warning.

## Test plan
- [x] 1823 tests, 100% coverage, ruff clean, pyright clean
- [ ] After merge: webhook review replies post in seconds, not minutes
- [ ] After merge: log shows `session: preempter acquired lock after <short>s yield` on webhook preempts