### PR TITLE
Introduce grouped infrastructure ports and composition roots (closes #398)

### DIFF
--- a/kennel/infra.py
+++ b/kennel/infra.py
@@ -1,0 +1,155 @@
+"""Infrastructure port protocols and real implementations.
+
+Each port groups one low-level concern — process execution, time/sleep,
+filesystem queries, or OS-level process control — so callers can accept
+a single typed collaborator instead of a bag of raw stdlib callables.
+
+Real implementations delegate directly to the stdlib with no added logic.
+Tests inject fakes or mocks constructed at the call site.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Protocol
+
+# ---------------------------------------------------------------------------
+# Process execution
+# ---------------------------------------------------------------------------
+
+
+class ProcessRunner(Protocol):
+    """Runs external processes.
+
+    Wraps :func:`subprocess.run` so callers can be tested without spawning
+    real subprocesses.
+    """
+
+    def run(
+        self,
+        cmd: Sequence[str],
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        """Execute *cmd*, forwarding all keyword arguments to :func:`subprocess.run`."""
+        ...
+
+
+class RealProcessRunner:
+    """Real :class:`ProcessRunner` that delegates to :func:`subprocess.run`."""
+
+    def run(
+        self,
+        cmd: Sequence[str],
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(cmd, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Clock / time
+# ---------------------------------------------------------------------------
+
+
+class Clock(Protocol):
+    """Time and sleep operations.
+
+    Wraps :func:`time.sleep` and :func:`time.monotonic` so callers can be
+    tested without real wall-clock delays.
+    """
+
+    def sleep(self, secs: float) -> None:
+        """Pause execution for *secs* seconds."""
+        ...
+
+    def monotonic(self) -> float:
+        """Return a monotonic clock value in fractional seconds."""
+        ...
+
+
+class RealClock:
+    """Real :class:`Clock` that delegates to :mod:`time`."""
+
+    def sleep(self, secs: float) -> None:
+        time.sleep(secs)
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem queries
+# ---------------------------------------------------------------------------
+
+
+class Filesystem(Protocol):
+    """Filesystem queries.
+
+    Wraps :func:`shutil.which` and :meth:`pathlib.Path.is_dir` so callers
+    can be tested against a fake filesystem.
+    """
+
+    def which(self, name: str) -> str | None:
+        """Return the full path to *name* on PATH, or ``None`` if not found."""
+        ...
+
+    def is_dir(self, path: Path) -> bool:
+        """Return ``True`` if *path* is an existing directory."""
+        ...
+
+
+class RealFilesystem:
+    """Real :class:`Filesystem` that delegates to :mod:`shutil` and :mod:`pathlib`."""
+
+    def which(self, name: str) -> str | None:
+        return shutil.which(name)
+
+    def is_dir(self, path: Path) -> bool:
+        return path.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# OS-level process control
+# ---------------------------------------------------------------------------
+
+
+class OsProcess(Protocol):
+    """OS-level process control.
+
+    Wraps :func:`os.execvp`, :func:`os.chdir`, and :func:`signal.signal`
+    so callers can be tested without replacing the running process or
+    mutating global OS state.
+    """
+
+    def execvp(self, file: str, args: list[str]) -> None:
+        """Replace the running process image — equivalent to :func:`os.execvp`."""
+        ...
+
+    def chdir(self, path: Path | str) -> None:
+        """Change the process working directory — equivalent to :func:`os.chdir`."""
+        ...
+
+    def install_signal(self, signum: int, handler: Any) -> Any:
+        """Install a signal handler — equivalent to :func:`signal.signal`.
+
+        Returns the previous handler.
+        """
+        ...
+
+
+class RealOsProcess:
+    """Real :class:`OsProcess` that delegates to :mod:`os` and :mod:`signal`."""
+
+    def execvp(self, file: str, args: list[str]) -> None:
+        os.execvp(file, args)
+
+    def chdir(self, path: Path | str) -> None:
+        os.chdir(path)
+
+    def install_signal(self, signum: int, handler: Any) -> Any:
+        return signal.signal(signum, handler)

--- a/kennel/infra.py
+++ b/kennel/infra.py
@@ -10,6 +10,7 @@ Tests inject fakes or mocks constructed at the call site.
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import shutil
 import signal
@@ -153,3 +154,33 @@ class RealOsProcess:
 
     def install_signal(self, signum: int, handler: Any) -> Any:
         return signal.signal(signum, handler)
+
+
+# ---------------------------------------------------------------------------
+# Grouped bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class Infra:
+    """All four infrastructure ports bundled as a single injectable collaborator.
+
+    Callers that need all ports accept one :class:`Infra` instead of four
+    separate arguments.  Tests construct an :class:`Infra` with fakes and
+    inject the whole bundle at the composition root.
+    """
+
+    proc: ProcessRunner
+    clock: Clock
+    fs: Filesystem
+    os_proc: OsProcess
+
+
+def real_infra() -> Infra:
+    """Construct an :class:`Infra` wired to the real stdlib implementations."""
+    return Infra(
+        proc=RealProcessRunner(),
+        clock=RealClock(),
+        fs=RealFilesystem(),
+        os_proc=RealOsProcess(),
+    )

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -33,12 +33,10 @@ from kennel.github import GitHub
 from kennel.infra import (
     Clock,
     Filesystem,
+    Infra,
     OsProcess,
     ProcessRunner,
-    RealClock,
-    RealFilesystem,
-    RealOsProcess,
-    RealProcessRunner,
+    real_infra,
 )
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.watchdog import (  # noqa: PLC2701
@@ -317,9 +315,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # can replace them without patching module-level names.
     gh: GitHub | None = None
     # Infrastructure ports — set by server.run() composition root.
-    proc: ProcessRunner = RealProcessRunner()
-    clock: Clock = RealClock()
-    os_proc: OsProcess = RealOsProcess()
+    infra: Infra = real_infra()
     _fn_dispatch = staticmethod(dispatch)
     _fn_reply_to_comment = staticmethod(reply_to_comment)
     _fn_reply_to_review = staticmethod(reply_to_review)
@@ -546,7 +542,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _self_restart(self, repo_name: str, *, reason: str = "") -> None:
         runner_dir = type(self)._fn_runner_dir()
-        self_repo = _get_self_repo(runner_dir, self.proc)
+        self_repo = _get_self_repo(runner_dir, self.infra.proc)
         if self_repo != repo_name:
             return  # Not our repo — nothing to do.
         log.info(
@@ -559,15 +555,15 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # log and return without touching the running workers — fido on the
         # kennel repo keeps running its old code rather than being silently
         # left without a worker thread.
-        if not _pull_with_backoff(runner_dir, self.proc, self.clock):
+        if not _pull_with_backoff(runner_dir, self.infra.proc, self.infra.clock):
             log.error("self-restart: gave up — running old version (%s)", reason)
             return
         log.info(
             "self-restart: runner synced — stopping workers and re-execing (%s)", reason
         )
         self.registry.stop_and_join(repo_name)
-        self.os_proc.chdir(runner_dir)
-        self.os_proc.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
+        self.infra.os_proc.chdir(runner_dir)
+        self.infra.os_proc.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
 
     def do_GET(self) -> None:
         if self.path == "/status":
@@ -741,22 +737,16 @@ def run(
     sys.excepthook = _log_uncaught
     threading.excepthook = _log_thread_exception
 
-    proc = RealProcessRunner()
-    fs = RealFilesystem()
-    clock = RealClock()
-    os_proc = RealOsProcess()
-
-    WebhookHandler.proc = proc
-    WebhookHandler.clock = clock
-    WebhookHandler.os_proc = os_proc
+    infra = real_infra()
+    WebhookHandler.infra = infra
 
     gh = _GitHub()
-    _startup_pull(proc, clock, os_proc)
+    _startup_pull(infra.proc, infra.clock, infra.os_proc)
     try:
-        _preflight_tools(fs)
-        _preflight_sub_dir(config, fs)
+        _preflight_tools(infra.fs)
+        _preflight_sub_dir(config, infra.fs)
         _preflight_gh_auth(gh)
-        _preflight_repo_identity(config.repos, proc)
+        _preflight_repo_identity(config.repos, infra.proc)
     except PreflightError as e:
         raise SystemExit(str(e)) from e
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -10,7 +10,6 @@ import signal
 import subprocess
 import sys
 import threading
-import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -31,7 +30,16 @@ from kennel.events import (
     reply_to_review,
 )
 from kennel.github import GitHub
-from kennel.infra import Filesystem, ProcessRunner, RealFilesystem, RealProcessRunner
+from kennel.infra import (
+    Clock,
+    Filesystem,
+    OsProcess,
+    ProcessRunner,
+    RealClock,
+    RealFilesystem,
+    RealOsProcess,
+    RealProcessRunner,
+)
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
@@ -97,18 +105,14 @@ def _parse_repo_from_url(url: str) -> str | None:
     return path if len(parts) == 2 and all(parts) else None
 
 
-def _get_self_repo(
-    runner_dir: Path,
-    *,
-    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str | None:
+def _get_self_repo(runner_dir: Path, proc: ProcessRunner) -> str | None:
     """Return 'owner/repo' from the runner clone's origin remote, or None on error.
 
     Handles both SSH (``git@github.com:owner/repo.git``) and HTTPS
     (``https://github.com/owner/repo.git``) remote URLs.
     """
     try:
-        result = _run(
+        result = proc.run(
             ["git", "remote", "get-url", "origin"],
             cwd=str(runner_dir),
             capture_output=True,
@@ -207,14 +211,10 @@ def preflight_gh_auth(gh: GitHub) -> None:
     log.info("preflight: gh auth confirmed — bot user is %r", bot_user)
 
 
-def _get_head(
-    runner_dir: Path,
-    *,
-    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str | None:
+def _get_head(runner_dir: Path, proc: ProcessRunner) -> str | None:
     """Return the current HEAD commit hash of the runner clone, or None on error."""
     try:
-        result = _run(
+        result = proc.run(
             ["git", "rev-parse", "HEAD"],
             cwd=str(runner_dir),
             capture_output=True,
@@ -228,10 +228,8 @@ def _get_head(
 
 def _pull_with_backoff(
     runner_dir: Path,
-    *,
-    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-    _sleep: Callable[[float], None] = time.sleep,
-    _monotonic: Callable[[], float] = time.monotonic,
+    proc: ProcessRunner,
+    clock: Clock,
 ) -> bool:
     """Sync the runner clone to ``origin/main`` with exponential backoff.
 
@@ -247,19 +245,19 @@ def _pull_with_backoff(
     each attempt and the elapsed time.  Returns ``True`` on success,
     ``False`` if every retry fails or the budget is exhausted.
     """
-    start = _monotonic()
+    start = clock.monotonic()
     attempt = 0
     while True:
         attempt += 1
         try:
-            _run(
+            proc.run(
                 ["git", "fetch", "origin", "main"],
                 cwd=str(runner_dir),
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            _run(
+            proc.run(
                 ["git", "reset", "--hard", "origin/main"],
                 cwd=str(runner_dir),
                 capture_output=True,
@@ -269,11 +267,11 @@ def _pull_with_backoff(
             log.info(
                 "self-restart: runner synced on attempt %d (%.1fs elapsed)",
                 attempt,
-                _monotonic() - start,
+                clock.monotonic() - start,
             )
             return True
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            elapsed = _monotonic() - start
+            elapsed = clock.monotonic() - start
             log.error(
                 "self-restart: runner sync attempt %d failed after %.1fs: %s",
                 attempt,
@@ -295,7 +293,7 @@ def _pull_with_backoff(
                 )
                 return False
             log.info("self-restart: sleeping %ds before retry", delay)
-            _sleep(delay)
+            clock.sleep(delay)
 
 
 def _spawn_bg(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
@@ -318,6 +316,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
+    # Infrastructure ports — set by server.run() composition root.
+    proc: ProcessRunner = RealProcessRunner()
+    clock: Clock = RealClock()
+    os_proc: OsProcess = RealOsProcess()
     _fn_dispatch = staticmethod(dispatch)
     _fn_reply_to_comment = staticmethod(reply_to_comment)
     _fn_reply_to_review = staticmethod(reply_to_review)
@@ -327,11 +329,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_spawn_bg = staticmethod(_spawn_bg)
     _fn_after_do_post = staticmethod(_noop_after_post)
     _fn_runner_dir = staticmethod(_runner_dir)
-    _fn_get_self_repo = staticmethod(_get_self_repo)
-    _fn_get_head = staticmethod(_get_head)
-    _fn_pull_with_backoff = staticmethod(_pull_with_backoff)
-    _fn_os_chdir = staticmethod(os.chdir)
-    _fn_os_execvp = staticmethod(os.execvp)
 
     def do_POST(self) -> None:
         try:
@@ -549,7 +546,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _self_restart(self, repo_name: str, *, reason: str = "") -> None:
         runner_dir = type(self)._fn_runner_dir()
-        self_repo = type(self)._fn_get_self_repo(runner_dir)
+        self_repo = _get_self_repo(runner_dir, self.proc)
         if self_repo != repo_name:
             return  # Not our repo — nothing to do.
         log.info(
@@ -562,15 +559,15 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # log and return without touching the running workers — fido on the
         # kennel repo keeps running its old code rather than being silently
         # left without a worker thread.
-        if not type(self)._fn_pull_with_backoff(runner_dir):
+        if not _pull_with_backoff(runner_dir, self.proc, self.clock):
             log.error("self-restart: gave up — running old version (%s)", reason)
             return
         log.info(
             "self-restart: runner synced — stopping workers and re-execing (%s)", reason
         )
         self.registry.stop_and_join(repo_name)
-        type(self)._fn_os_chdir(runner_dir)
-        type(self)._fn_os_execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
+        self.os_proc.chdir(runner_dir)
+        self.os_proc.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
 
     def do_GET(self) -> None:
         if self.path == "/status":
@@ -657,27 +654,21 @@ def populate_memberships(config: Config, gh: GitHub) -> None:
         )
 
 
-def _startup_pull(
-    *,
-    _runner_dir: Callable[[], Path] = _runner_dir,
-    _get_head: Callable[..., str | None] = _get_head,
-    _pull: Callable[..., bool] = _pull_with_backoff,
-    _execvp: Callable[..., None] = os.execvp,
-) -> None:
+def _startup_pull(proc: ProcessRunner, clock: Clock, os_proc: OsProcess) -> None:
     """Sync the runner clone on startup and re-exec if HEAD changed."""
     runner_dir = _runner_dir()
-    head_before = _get_head(runner_dir)
-    if not _pull(runner_dir):
+    head_before = _get_head(runner_dir, proc)
+    if not _pull_with_backoff(runner_dir, proc, clock):
         log.warning("startup: runner sync failed — continuing with current code")
         return
-    head_after = _get_head(runner_dir)
+    head_after = _get_head(runner_dir, proc)
     if head_before and head_after and head_before != head_after:
         log.info(
             "startup: runner updated %s → %s — re-execing",
             head_before[:12],
             head_after[:12],
         )
-        _execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
+        os_proc.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
     elif head_before and head_after:
         log.info("startup: runner already up to date at %s", head_before[:12])
     else:
@@ -752,9 +743,15 @@ def run(
 
     proc = RealProcessRunner()
     fs = RealFilesystem()
+    clock = RealClock()
+    os_proc = RealOsProcess()
+
+    WebhookHandler.proc = proc
+    WebhookHandler.clock = clock
+    WebhookHandler.os_proc = os_proc
 
     gh = _GitHub()
-    _startup_pull()
+    _startup_pull(proc, clock, os_proc)
     try:
         _preflight_tools(fs)
         _preflight_sub_dir(config, fs)

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -6,7 +6,6 @@ import hmac
 import json
 import logging
 import os
-import shutil
 import signal
 import subprocess
 import sys
@@ -32,6 +31,7 @@ from kennel.events import (
     reply_to_review,
 )
 from kennel.github import GitHub
+from kennel.infra import Filesystem, ProcessRunner, RealFilesystem, RealProcessRunner
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
@@ -128,8 +128,7 @@ def _get_self_repo(
 
 def preflight_repo_identity(
     repos: dict[str, RepoConfig],
-    *,
-    _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    proc: ProcessRunner,
 ) -> None:
     """Verify each configured work_dir is a git repo whose origin matches its name.
 
@@ -138,7 +137,7 @@ def preflight_repo_identity(
     """
     for name, repo_cfg in repos.items():
         try:
-            result = _run(
+            result = proc.run(
                 ["git", "remote", "get-url", "origin"],
                 cwd=str(repo_cfg.work_dir),
                 capture_output=True,
@@ -167,27 +166,20 @@ def preflight_repo_identity(
 _REQUIRED_TOOLS = ("git", "gh", "claude")
 
 
-def preflight_tools(
-    *,
-    _which: Callable[[str], str | None] = shutil.which,
-) -> None:
+def preflight_tools(fs: Filesystem) -> None:
     """Verify that all required CLI tools are on PATH.
 
     Raises :exc:`PreflightError` naming the first missing tool.
     """
     for tool in _REQUIRED_TOOLS:
-        if _which(tool) is None:
+        if fs.which(tool) is None:
             raise PreflightError(
                 f"preflight: required tool not found on PATH: {tool!r}"
             )
     log.info("preflight: all required tools found: %s", ", ".join(_REQUIRED_TOOLS))
 
 
-def preflight_sub_dir(
-    config: Config,
-    *,
-    _is_dir: Callable[[Path], bool] = Path.is_dir,
-) -> None:
+def preflight_sub_dir(config: Config, fs: Filesystem) -> None:
     """Verify that the skill-files directory exists.
 
     Raises :exc:`PreflightError` if ``config.sub_dir`` is not an existing
@@ -195,7 +187,7 @@ def preflight_sub_dir(
     every task run — a missing directory causes every worker invocation to fail
     with an obscure I/O error rather than a clear startup message.
     """
-    if not _is_dir(config.sub_dir):
+    if not fs.is_dir(config.sub_dir):
         raise PreflightError(
             f"preflight: skill-files directory not found: {config.sub_dir}"
         )
@@ -758,13 +750,16 @@ def run(
     sys.excepthook = _log_uncaught
     threading.excepthook = _log_thread_exception
 
+    proc = RealProcessRunner()
+    fs = RealFilesystem()
+
     gh = _GitHub()
     _startup_pull()
     try:
-        _preflight_tools()
-        _preflight_sub_dir(config)
+        _preflight_tools(fs)
+        _preflight_sub_dir(config, fs)
         _preflight_gh_auth(gh)
-        _preflight_repo_identity(config.repos)
+        _preflight_repo_identity(config.repos, proc)
     except PreflightError as e:
         raise SystemExit(str(e)) from e
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -1,0 +1,113 @@
+"""Tests for kennel.infra — infrastructure port protocols and real implementations."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kennel.infra import RealClock, RealFilesystem, RealOsProcess, RealProcessRunner
+
+
+class TestRealProcessRunner:
+    def test_run_delegates_to_subprocess_run(self) -> None:
+        mock_result = MagicMock(stdout="v2.43.0\n")
+        with patch("kennel.infra.subprocess.run", return_value=mock_result) as mock_run:
+            runner = RealProcessRunner()
+            result = runner.run(
+                ["git", "--version"],
+                cwd="/tmp",
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        mock_run.assert_called_once_with(
+            ["git", "--version"],
+            cwd="/tmp",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result is mock_result
+
+    def test_run_forwards_arbitrary_kwargs(self) -> None:
+        mock_result = MagicMock()
+        with patch("kennel.infra.subprocess.run", return_value=mock_result) as mock_run:
+            RealProcessRunner().run(["true"], env={"FOO": "bar"}, timeout=5)
+        mock_run.assert_called_once_with(["true"], env={"FOO": "bar"}, timeout=5)
+
+    def test_run_propagates_called_process_error(self) -> None:
+        with patch(
+            "kennel.infra.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, ["bad"]),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                RealProcessRunner().run(["bad"], check=True)
+
+
+class TestRealClock:
+    def test_sleep_delegates_to_time_sleep(self) -> None:
+        with patch("kennel.infra.time.sleep") as mock_sleep:
+            RealClock().sleep(2.5)
+        mock_sleep.assert_called_once_with(2.5)
+
+    def test_monotonic_delegates_to_time_monotonic(self) -> None:
+        with patch("kennel.infra.time.monotonic", return_value=123.456):
+            result = RealClock().monotonic()
+        assert result == 123.456
+
+    def test_monotonic_returns_float(self) -> None:
+        result = RealClock().monotonic()
+        assert isinstance(result, float)
+        assert result > 0
+
+
+class TestRealFilesystem:
+    def test_which_returns_path_when_tool_found(self) -> None:
+        with patch("kennel.infra.shutil.which", return_value="/usr/bin/git"):
+            result = RealFilesystem().which("git")
+        assert result == "/usr/bin/git"
+
+    def test_which_returns_none_when_tool_absent(self) -> None:
+        with patch("kennel.infra.shutil.which", return_value=None):
+            result = RealFilesystem().which("no-such-tool")
+        assert result is None
+
+    def test_is_dir_true_for_existing_directory(self, tmp_path: Path) -> None:
+        assert RealFilesystem().is_dir(tmp_path) is True
+
+    def test_is_dir_false_for_nonexistent_path(self, tmp_path: Path) -> None:
+        assert RealFilesystem().is_dir(tmp_path / "does-not-exist") is False
+
+    def test_is_dir_false_for_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.txt"
+        f.write_text("hello")
+        assert RealFilesystem().is_dir(f) is False
+
+
+class TestRealOsProcess:
+    def test_execvp_delegates_to_os_execvp(self) -> None:
+        with patch("kennel.infra.os.execvp") as mock_execvp:
+            RealOsProcess().execvp("uv", ["uv", "run", "kennel"])
+        mock_execvp.assert_called_once_with("uv", ["uv", "run", "kennel"])
+
+    def test_chdir_delegates_to_os_chdir(self, tmp_path: Path) -> None:
+        with patch("kennel.infra.os.chdir") as mock_chdir:
+            RealOsProcess().chdir(tmp_path)
+        mock_chdir.assert_called_once_with(tmp_path)
+
+    def test_chdir_accepts_string_path(self) -> None:
+        with patch("kennel.infra.os.chdir") as mock_chdir:
+            RealOsProcess().chdir("/tmp")
+        mock_chdir.assert_called_once_with("/tmp")
+
+    def test_install_signal_delegates_to_signal_signal(self) -> None:
+        old_handler = MagicMock()
+        handler = MagicMock()
+        with patch("kennel.infra.signal.signal", return_value=old_handler) as mock_sig:
+            result = RealOsProcess().install_signal(signal.SIGTERM, handler)
+        mock_sig.assert_called_once_with(signal.SIGTERM, handler)
+        assert result is old_handler

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from http.server import HTTPServer
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -1551,49 +1551,64 @@ class TestParseRepoFromUrl:
         assert _parse_repo_from_url("garbage") is None
 
 
+class _FakeProcessRunner:
+    """Minimal ProcessRunner fake for preflight tests."""
+
+    def __init__(
+        self, results: list[Any] | None = None, error: Exception | None = None
+    ) -> None:
+        self._results = list(results or [])
+        self._error = error
+        self.call_count = 0
+
+    def run(self, cmd: Any, **kwargs: Any) -> Any:
+        self.call_count += 1
+        if self._error is not None:
+            raise self._error
+        return self._results.pop(0)
+
+
 class TestPreflightRepoIdentity:
     def test_succeeds_when_remote_matches(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-        mock_run = MagicMock(
-            return_value=MagicMock(stdout="git@github.com:owner/repo.git\n")
-        )
-        preflight_repo_identity(repos, _run=mock_run)  # no exception
+        fake = _FakeProcessRunner([MagicMock(stdout="git@github.com:owner/repo.git\n")])
+        preflight_repo_identity(repos, fake)  # no exception
 
     def test_raises_on_remote_mismatch(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-        mock_run = MagicMock(
-            return_value=MagicMock(stdout="git@github.com:other/thing.git\n")
+        fake = _FakeProcessRunner(
+            [MagicMock(stdout="git@github.com:other/thing.git\n")]
         )
         with pytest.raises(PreflightError, match="other/thing"):
-            preflight_repo_identity(repos, _run=mock_run)
+            preflight_repo_identity(repos, fake)
 
     def test_raises_on_subprocess_error(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
+        fake = _FakeProcessRunner(error=subprocess.CalledProcessError(128, []))
         with pytest.raises(PreflightError):
-            preflight_repo_identity(repos, _run=mock_run)
+            preflight_repo_identity(repos, fake)
 
     def test_raises_when_git_not_found(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-        mock_run = MagicMock(side_effect=FileNotFoundError())
+        fake = _FakeProcessRunner(error=FileNotFoundError())
         with pytest.raises(PreflightError):
-            preflight_repo_identity(repos, _run=mock_run)
+            preflight_repo_identity(repos, fake)
 
     def test_raises_on_unparseable_url(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
 
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
-        mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n"))
+        fake = _FakeProcessRunner([MagicMock(stdout="garbage\n")])
         with pytest.raises(PreflightError):
-            preflight_repo_identity(repos, _run=mock_run)
+            preflight_repo_identity(repos, fake)
 
     def test_checks_all_repos(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
@@ -1602,14 +1617,14 @@ class TestPreflightRepoIdentity:
             "owner/repo1": RepoConfig(name="owner/repo1", work_dir=tmp_path),
             "owner/repo2": RepoConfig(name="owner/repo2", work_dir=tmp_path),
         }
-        mock_run = MagicMock(
-            side_effect=[
+        fake = _FakeProcessRunner(
+            [
                 MagicMock(stdout="git@github.com:owner/repo1.git\n"),
                 MagicMock(stdout="git@github.com:owner/repo2.git\n"),
             ]
         )
-        preflight_repo_identity(repos, _run=mock_run)  # no exception
-        assert mock_run.call_count == 2
+        preflight_repo_identity(repos, fake)  # no exception
+        assert fake.call_count == 2
 
     def test_raises_on_second_repo_mismatch(self, tmp_path: Path) -> None:
         from kennel.server import preflight_repo_identity
@@ -1618,14 +1633,14 @@ class TestPreflightRepoIdentity:
             "owner/repo1": RepoConfig(name="owner/repo1", work_dir=tmp_path),
             "owner/repo2": RepoConfig(name="owner/repo2", work_dir=tmp_path),
         }
-        mock_run = MagicMock(
-            side_effect=[
+        fake = _FakeProcessRunner(
+            [
                 MagicMock(stdout="git@github.com:owner/repo1.git\n"),
                 MagicMock(stdout="git@github.com:other/thing.git\n"),
             ]
         )
         with pytest.raises(PreflightError, match="other/thing"):
-            preflight_repo_identity(repos, _run=mock_run)
+            preflight_repo_identity(repos, fake)
 
     def test_run_calls_preflight_repo_identity(self, tmp_path: Path) -> None:
         from kennel.server import run
@@ -1657,7 +1672,7 @@ class TestPreflightRepoIdentity:
             _GitHub=MagicMock,
         )
 
-        mock_preflight.assert_called_once_with(fake_cfg.repos)
+        mock_preflight.assert_called_once_with(fake_cfg.repos, ANY)
 
     def test_run_calls_preflight_tools(self, tmp_path: Path) -> None:
         from kennel.server import run
@@ -1689,7 +1704,7 @@ class TestPreflightRepoIdentity:
             _GitHub=MagicMock,
         )
 
-        mock_preflight.assert_called_once_with()
+        mock_preflight.assert_called_once_with(ANY)
 
     def test_run_calls_preflight_gh_auth(self, tmp_path: Path) -> None:
         from kennel.server import run
@@ -1753,7 +1768,7 @@ class TestPreflightRepoIdentity:
             _GitHub=MagicMock,
         )
 
-        mock_preflight.assert_called_once_with(fake_cfg)
+        mock_preflight.assert_called_once_with(fake_cfg, ANY)
 
     def test_run_converts_preflight_error_to_system_exit(self, tmp_path: Path) -> None:
         from kennel.server import run
@@ -1787,32 +1802,48 @@ class TestPreflightRepoIdentity:
             )
 
 
+class _FakeFilesystem:
+    """Minimal Filesystem fake for preflight tests."""
+
+    def __init__(
+        self, missing: set[str] | None = None, dirs: set[Path] | None = None
+    ) -> None:
+        self._missing = missing or set()
+        self._dirs = dirs or set()
+
+    def which(self, name: str) -> str | None:
+        return None if name in self._missing else f"/usr/bin/{name}"
+
+    def is_dir(self, path: Path) -> bool:
+        return path in self._dirs
+
+
 class TestPreflightTools:
     def test_succeeds_when_all_tools_found(self) -> None:
         from kennel.server import preflight_tools
 
-        preflight_tools(_which=lambda _: "/usr/bin/git")  # no exception
+        preflight_tools(_FakeFilesystem())  # no exception
 
     def test_raises_when_git_missing(self) -> None:
         from kennel.server import preflight_tools
 
         missing = "git"
         with pytest.raises(PreflightError, match=repr(missing)):
-            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+            preflight_tools(_FakeFilesystem(missing={missing}))
 
     def test_raises_when_gh_missing(self) -> None:
         from kennel.server import preflight_tools
 
         missing = "gh"
         with pytest.raises(PreflightError, match=repr(missing)):
-            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+            preflight_tools(_FakeFilesystem(missing={missing}))
 
     def test_raises_when_claude_missing(self) -> None:
         from kennel.server import preflight_tools
 
         missing = "claude"
         with pytest.raises(PreflightError, match=repr(missing)):
-            preflight_tools(_which=lambda t: None if t == missing else f"/usr/bin/{t}")
+            preflight_tools(_FakeFilesystem(missing={missing}))
 
     def test_required_tools_constant(self) -> None:
         from kennel.server import _REQUIRED_TOOLS
@@ -1824,15 +1855,16 @@ class TestPreflightSubDir:
     def test_succeeds_when_sub_dir_exists(self, tmp_path: Path) -> None:
         from kennel.server import preflight_sub_dir
 
+        sub = tmp_path / "sub"
         cfg = Config(
             port=0,
             secret=b"s",
             repos={},
             allowed_bots=frozenset(),
             log_level="INFO",
-            sub_dir=tmp_path / "sub",
+            sub_dir=sub,
         )
-        preflight_sub_dir(cfg, _is_dir=lambda _: True)  # no exception
+        preflight_sub_dir(cfg, _FakeFilesystem(dirs={sub}))  # no exception
 
     def test_raises_when_sub_dir_missing(self, tmp_path: Path) -> None:
         from kennel.server import preflight_sub_dir
@@ -1846,7 +1878,7 @@ class TestPreflightSubDir:
             sub_dir=tmp_path / "sub",
         )
         with pytest.raises(PreflightError, match="skill-files directory not found"):
-            preflight_sub_dir(cfg, _is_dir=lambda _: False)
+            preflight_sub_dir(cfg, _FakeFilesystem())
 
     def test_error_message_includes_path(self, tmp_path: Path) -> None:
         from kennel.server import preflight_sub_dir
@@ -1861,7 +1893,7 @@ class TestPreflightSubDir:
             sub_dir=sub,
         )
         with pytest.raises(PreflightError, match=str(sub)):
-            preflight_sub_dir(cfg, _is_dir=lambda _: False)
+            preflight_sub_dir(cfg, _FakeFilesystem())
 
 
 class TestPreflightGhAuth:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -86,11 +86,9 @@ def _restore_handler_fns():
         "_fn_spawn_bg": WebhookHandler._fn_spawn_bg,
         "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
-        "_fn_get_self_repo": WebhookHandler._fn_get_self_repo,
-        "_fn_get_head": WebhookHandler._fn_get_head,
-        "_fn_pull_with_backoff": WebhookHandler._fn_pull_with_backoff,
-        "_fn_os_chdir": WebhookHandler._fn_os_chdir,
-        "_fn_os_execvp": WebhookHandler._fn_os_execvp,
+        "proc": WebhookHandler.proc,
+        "clock": WebhookHandler.clock,
+        "os_proc": WebhookHandler.os_proc,
     }
     # Override _fn_after_do_post for all tests so _post_webhook can wait for
     # do_POST to complete without sleeping (see module-level comment above).
@@ -1552,20 +1550,64 @@ class TestParseRepoFromUrl:
 
 
 class _FakeProcessRunner:
-    """Minimal ProcessRunner fake for preflight tests."""
+    """Minimal ProcessRunner fake.
+
+    Results are consumed in order.  Each item is either a return value or an
+    exception instance — exceptions are raised, everything else is returned.
+    The ``error`` parameter overrides the results list and raises the same
+    exception on every call (backward-compat shorthand for single-error tests).
+    """
 
     def __init__(
         self, results: list[Any] | None = None, error: Exception | None = None
     ) -> None:
         self._results = list(results or [])
         self._error = error
-        self.call_count = 0
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
 
     def run(self, cmd: Any, **kwargs: Any) -> Any:
-        self.call_count += 1
+        self.calls.append((cmd, kwargs))
         if self._error is not None:
             raise self._error
-        return self._results.pop(0)
+        result = self._results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+class _FakeClock:
+    """Minimal Clock fake: returns pre-configured monotonic values, records sleeps."""
+
+    def __init__(self, times: list[float] | None = None) -> None:
+        self._times = iter(times or [])
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return next(self._times)
+
+    def sleep(self, secs: float) -> None:
+        self.slept.append(secs)
+
+
+class _FakeOsProcess:
+    """Minimal OsProcess fake: captures execvp and chdir calls."""
+
+    def __init__(self) -> None:
+        self.execvp_calls: list[tuple[str, list[str]]] = []
+        self.chdir_calls: list[Any] = []
+
+    def execvp(self, file: str, args: list[str]) -> None:
+        self.execvp_calls.append((file, args))
+
+    def chdir(self, path: Any) -> None:
+        self.chdir_calls.append(path)
+
+    def install_signal(self, signum: Any, handler: Any) -> Any:
+        return None
 
 
 class TestPreflightRepoIdentity:
@@ -1925,70 +1967,64 @@ class TestGetSelfRepo:
     def test_parses_ssh_remote(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(
-            return_value=MagicMock(
-                stdout="git@github.com:owner/kennel.git\n", returncode=0
-            )
+        proc = _FakeProcessRunner(
+            [MagicMock(stdout="git@github.com:owner/kennel.git\n")]
         )
-        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+        assert _get_self_repo(tmp_path, proc) == "owner/kennel"
 
     def test_parses_https_remote(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(
-            return_value=MagicMock(
-                stdout="https://github.com/owner/kennel.git\n", returncode=0
-            )
+        proc = _FakeProcessRunner(
+            [MagicMock(stdout="https://github.com/owner/kennel.git\n")]
         )
-        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+        assert _get_self_repo(tmp_path, proc) == "owner/kennel"
 
     def test_parses_remote_without_git_suffix(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(
-            return_value=MagicMock(
-                stdout="https://github.com/owner/kennel\n", returncode=0
-            )
+        proc = _FakeProcessRunner(
+            [MagicMock(stdout="https://github.com/owner/kennel\n")]
         )
-        assert _get_self_repo(tmp_path, _run=mock_run) == "owner/kennel"
+        assert _get_self_repo(tmp_path, proc) == "owner/kennel"
 
     def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
-        assert _get_self_repo(tmp_path, _run=mock_run) is None
+        proc = _FakeProcessRunner([subprocess.CalledProcessError(128, [])])
+        assert _get_self_repo(tmp_path, proc) is None
 
     def test_returns_none_on_file_not_found(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(side_effect=FileNotFoundError())
-        assert _get_self_repo(tmp_path, _run=mock_run) is None
+        proc = _FakeProcessRunner([FileNotFoundError()])
+        assert _get_self_repo(tmp_path, proc) is None
 
     def test_returns_none_on_unparseable_url(self, tmp_path: Path) -> None:
         from kennel.server import _get_self_repo
 
-        mock_run = MagicMock(return_value=MagicMock(stdout="garbage\n", returncode=0))
-        assert _get_self_repo(tmp_path, _run=mock_run) is None
+        proc = _FakeProcessRunner([MagicMock(stdout="garbage\n")])
+        assert _get_self_repo(tmp_path, proc) is None
 
 
 class TestGetHead:
     def test_returns_sha(self, tmp_path: Path) -> None:
         from kennel.server import _get_head
 
-        run = MagicMock(return_value=MagicMock(stdout="abc123def456\n"))
-        assert _get_head(tmp_path, _run=run) == "abc123def456"
+        proc = _FakeProcessRunner([MagicMock(stdout="abc123def456\n")])
+        assert _get_head(tmp_path, proc) == "abc123def456"
 
     def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
         from kennel.server import _get_head
 
-        run = MagicMock(side_effect=subprocess.CalledProcessError(128, []))
-        assert _get_head(tmp_path, _run=run) is None
+        proc = _FakeProcessRunner([subprocess.CalledProcessError(128, [])])
+        assert _get_head(tmp_path, proc) is None
 
     def test_returns_none_on_file_not_found(self, tmp_path: Path) -> None:
         from kennel.server import _get_head
 
-        run = MagicMock(side_effect=FileNotFoundError())
-        assert _get_head(tmp_path, _run=run) is None
+        proc = _FakeProcessRunner([FileNotFoundError()])
+        assert _get_head(tmp_path, proc) is None
 
 
 class TestRunnerDir:
@@ -2003,39 +2039,27 @@ class TestPullWithBackoff:
     def test_success_on_first_try(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
-        mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        mock_sleep = MagicMock()
-        assert _pull_with_backoff(
-            tmp_path, _run=mock_run, _sleep=mock_sleep, _monotonic=lambda: 0.0
-        )
+        proc = _FakeProcessRunner([MagicMock(), MagicMock()])  # fetch + reset
+        clock = _FakeClock(times=[0.0, 0.0])  # start + success log
+        assert _pull_with_backoff(tmp_path, proc, clock)
         # Each sync attempt runs two git commands: fetch + reset.
-        assert mock_run.call_count == 2
-        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert proc.call_count == 2
+        cmds = [c[0] for c in proc.calls]
         assert cmds[0] == ["git", "fetch", "origin", "main"]
         assert cmds[1] == ["git", "reset", "--hard", "origin/main"]
-        mock_sleep.assert_not_called()
+        assert clock.slept == []
 
     def test_success_after_retry(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
         # First attempt: fetch fails.  Second attempt: fetch + reset both succeed.
-        mock_run = MagicMock(
-            side_effect=[
-                subprocess.CalledProcessError(1, []),
-                MagicMock(returncode=0),
-                MagicMock(returncode=0),
-            ]
+        proc = _FakeProcessRunner(
+            [subprocess.CalledProcessError(1, []), MagicMock(), MagicMock()]
         )
-        mock_sleep = MagicMock()
-        times = iter([0.0, 1.0, 1.0])
-        assert _pull_with_backoff(
-            tmp_path,
-            _run=mock_run,
-            _sleep=mock_sleep,
-            _monotonic=lambda: next(times),
-        )
-        assert mock_run.call_count == 3
-        mock_sleep.assert_called_once_with(10)
+        clock = _FakeClock(times=[0.0, 1.0, 1.0])  # start, fail-elapsed, success-log
+        assert _pull_with_backoff(tmp_path, proc, clock)
+        assert proc.call_count == 3
+        assert clock.slept == [10]
 
     def test_recovers_from_divergent_local(self, tmp_path: Path) -> None:
         """The whole point of using fetch+reset: divergent local branch is fine.
@@ -2047,138 +2071,119 @@ class TestPullWithBackoff:
         """
         from kennel.server import _pull_with_backoff
 
-        mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        mock_sleep = MagicMock()
-        assert _pull_with_backoff(
-            tmp_path, _run=mock_run, _sleep=mock_sleep, _monotonic=lambda: 0.0
-        )
-        assert ["git", "reset", "--hard", "origin/main"] in [
-            c.args[0] for c in mock_run.call_args_list
-        ]
-        mock_sleep.assert_not_called()
+        proc = _FakeProcessRunner([MagicMock(), MagicMock()])  # fetch + reset
+        clock = _FakeClock(times=[0.0, 0.0])
+        assert _pull_with_backoff(tmp_path, proc, clock)
+        assert ["git", "reset", "--hard", "origin/main"] in [c[0] for c in proc.calls]
+        assert clock.slept == []
 
     def test_gives_up_after_all_retries_fail(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
         # Fetch fails on every attempt — 4 attempts total.
-        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
-        mock_sleep = MagicMock()
-        times = iter([0.0, 1.0, 1.0, 12.0, 12.0, 43.0, 43.0, 104.0])
-        assert not _pull_with_backoff(
-            tmp_path,
-            _run=mock_run,
-            _sleep=mock_sleep,
-            _monotonic=lambda: next(times),
-        )
+        proc = _FakeProcessRunner(error=subprocess.CalledProcessError(1, []))
+        # start + one elapsed read per failed attempt (4 total)
+        clock = _FakeClock(times=[0.0, 1.0, 12.0, 43.0, 104.0])
+        assert not _pull_with_backoff(tmp_path, proc, clock)
         # 4 attempts × 1 failing fetch each = 4 calls.
-        assert mock_run.call_count == 4
+        assert proc.call_count == 4
         # 3 sleeps at 10s, 30s, 60s between retries.
-        assert [c.args[0] for c in mock_sleep.call_args_list] == [10, 30, 60]
+        assert clock.slept == [10, 30, 60]
 
     def test_reset_failure_retries(self, tmp_path: Path) -> None:
         """Fetch succeeds but reset fails — both commands matter for the result."""
         from kennel.server import _pull_with_backoff
 
-        mock_run = MagicMock(
-            side_effect=[
-                MagicMock(returncode=0),  # fetch
+        proc = _FakeProcessRunner(
+            [
+                MagicMock(),  # fetch
                 subprocess.CalledProcessError(1, []),  # reset
-                MagicMock(returncode=0),  # fetch retry
-                MagicMock(returncode=0),  # reset retry
+                MagicMock(),  # fetch retry
+                MagicMock(),  # reset retry
             ]
         )
-        mock_sleep = MagicMock()
-        times = iter([0.0, 1.0, 1.0])
-        assert _pull_with_backoff(
-            tmp_path,
-            _run=mock_run,
-            _sleep=mock_sleep,
-            _monotonic=lambda: next(times),
-        )
-        assert mock_run.call_count == 4
-        mock_sleep.assert_called_once_with(10)
+        clock = _FakeClock(times=[0.0, 1.0, 1.0])  # start, fail-elapsed, success-log
+        assert _pull_with_backoff(tmp_path, proc, clock)
+        assert proc.call_count == 4
+        assert clock.slept == [10]
 
     def test_gives_up_when_budget_exhausted(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
-        mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, []))
-        mock_sleep = MagicMock()
+        proc = _FakeProcessRunner(error=subprocess.CalledProcessError(1, []))
         # First attempt at t=0, elapsed=595; next delay of 10s would exceed 600s budget.
-        times = iter([0.0, 595.0, 595.0])
-        assert not _pull_with_backoff(
-            tmp_path,
-            _run=mock_run,
-            _sleep=mock_sleep,
-            _monotonic=lambda: next(times),
-        )
+        clock = _FakeClock(times=[0.0, 595.0])
+        assert not _pull_with_backoff(tmp_path, proc, clock)
         # Slept zero times because budget was exhausted before any sleep.
-        mock_sleep.assert_not_called()
+        assert clock.slept == []
 
     def test_returns_false_on_file_not_found(self, tmp_path: Path) -> None:
         from kennel.server import _pull_with_backoff
 
-        mock_run = MagicMock(side_effect=FileNotFoundError())
-        mock_sleep = MagicMock()
-        times = iter([0.0, 1.0, 1.0, 12.0, 12.0, 43.0, 43.0, 104.0])
-        assert not _pull_with_backoff(
-            tmp_path,
-            _run=mock_run,
-            _sleep=mock_sleep,
-            _monotonic=lambda: next(times),
-        )
+        proc = _FakeProcessRunner(error=FileNotFoundError())
+        clock = _FakeClock(times=[0.0, 1.0, 12.0, 43.0, 104.0])
+        assert not _pull_with_backoff(tmp_path, proc, clock)
 
 
 class TestStartupPull:
     def test_reexecs_when_head_changes(self) -> None:
         from kennel.server import _startup_pull
 
-        heads = iter(["aaa", "bbb"])
-        mock_exec = MagicMock()
-        _startup_pull(
-            _runner_dir=lambda: Path("/fake"),
-            _get_head=lambda _d: next(heads),
-            _pull=lambda _d: True,
-            _execvp=mock_exec,
+        # rev-parse before, fetch, reset, rev-parse after — different SHAs
+        proc = _FakeProcessRunner(
+            [
+                MagicMock(stdout="sha1\n"),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(stdout="sha2\n"),
+            ]
         )
-        mock_exec.assert_called_once()
-        assert mock_exec.call_args.args[0] == "uv"
+        clock = _FakeClock(times=[0.0, 0.0])  # start + success log
+        os_proc = _FakeOsProcess()
+        _startup_pull(proc, clock, os_proc)
+        assert len(os_proc.execvp_calls) == 1
+        assert os_proc.execvp_calls[0][0] == "uv"
 
     def test_skips_exec_when_head_unchanged(self) -> None:
         from kennel.server import _startup_pull
 
-        mock_exec = MagicMock()
-        _startup_pull(
-            _runner_dir=lambda: Path("/fake"),
-            _get_head=lambda _d: "same_sha",
-            _pull=lambda _d: True,
-            _execvp=mock_exec,
+        proc = _FakeProcessRunner(
+            [
+                MagicMock(stdout="same\n"),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(stdout="same\n"),
+            ]
         )
-        mock_exec.assert_not_called()
+        clock = _FakeClock(times=[0.0, 0.0])
+        os_proc = _FakeOsProcess()
+        _startup_pull(proc, clock, os_proc)
+        assert os_proc.execvp_calls == []
 
     def test_continues_on_pull_failure(self) -> None:
         from kennel.server import _startup_pull
 
-        mock_exec = MagicMock()
-        _startup_pull(
-            _runner_dir=lambda: Path("/fake"),
-            _get_head=lambda _d: "aaa",
-            _pull=lambda _d: False,
-            _execvp=mock_exec,
+        # get_head fails → None; fetch fails with budget exhausted immediately
+        proc = _FakeProcessRunner(
+            [FileNotFoundError(), subprocess.CalledProcessError(1, [])]
         )
-        mock_exec.assert_not_called()
+        clock = _FakeClock(times=[0.0, 601.0])  # budget exhausted on first attempt
+        os_proc = _FakeOsProcess()
+        _startup_pull(proc, clock, os_proc)
+        assert os_proc.execvp_calls == []
 
     def test_execs_when_head_unknown(self) -> None:
         from kennel.server import _startup_pull
 
-        mock_exec = MagicMock()
-        _startup_pull(
-            _runner_dir=lambda: Path("/fake"),
-            _get_head=lambda _d: None,
-            _pull=lambda _d: True,
-            _execvp=mock_exec,
+        # Both rev-parse calls fail → head_before and head_after are None
+        proc = _FakeProcessRunner(
+            [FileNotFoundError(), MagicMock(), MagicMock(), FileNotFoundError()]
         )
-        # Can't compare HEAD — but pull succeeded, so log and continue
-        mock_exec.assert_not_called()
+        clock = _FakeClock(times=[0.0, 0.0])
+        os_proc = _FakeOsProcess()
+        _startup_pull(proc, clock, os_proc)
+        # Can't compare HEAD — pull succeeded, log and continue without exec
+        assert os_proc.execvp_calls == []
 
 
 class TestSelfRestart:
@@ -2200,50 +2205,56 @@ class TestSelfRestart:
     def test_triggers_exec_on_matching_repo(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-            WebhookHandler._fn_pull_with_backoff = lambda _d: True
-            mock_chdir = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_chdir = mock_chdir
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    MagicMock(),  # fetch
+                    MagicMock(),  # reset
+                ]
+            )
+            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
-            mock_chdir.assert_called_once_with(tmp_path)
-            mock_exec.assert_called_once()
-            args = mock_exec.call_args.args
-            assert args[0] == "uv"
-            assert args[1][:3] == ["uv", "run", "kennel"]
+            assert os_proc.chdir_calls == [tmp_path]
+            assert len(os_proc.execvp_calls) == 1
+            assert os_proc.execvp_calls[0][0] == "uv"
+            assert os_proc.execvp_calls[0][1][:3] == ["uv", "run", "kennel"]
         finally:
             srv.shutdown()
 
     def test_skips_when_self_repo_mismatch(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "other/repo"
-            mock_pull = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_pull_with_backoff = mock_pull
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            proc = _FakeProcessRunner(
+                [MagicMock(stdout="git@github.com:other/repo.git\n")]
+            )
+            WebhookHandler.proc = proc
+            WebhookHandler.clock = _FakeClock()
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
-            mock_pull.assert_not_called()
-            mock_exec.assert_not_called()
+            assert proc.call_count == 1  # only the get-url call; no pull attempted
+            assert os_proc.execvp_calls == []
         finally:
             srv.shutdown()
 
     def test_skips_when_self_repo_unknown(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: None
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner([FileNotFoundError()])
+            WebhookHandler.clock = _FakeClock()
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
-            mock_exec.assert_not_called()
+            assert os_proc.execvp_calls == []
         finally:
             srv.shutdown()
 
@@ -2257,69 +2268,81 @@ class TestSelfRestart:
         """
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-            WebhookHandler._fn_pull_with_backoff = lambda _d: False
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    subprocess.CalledProcessError(
+                        1, []
+                    ),  # fetch fails; budget exhausted
+                ]
+            )
+            WebhookHandler.clock = _FakeClock(times=[0.0, 601.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
-            mock_exec.assert_not_called()
+            assert os_proc.execvp_calls == []
         finally:
             srv.shutdown()
 
     def test_pull_precedes_stop_and_join(self, tmp_path: Path) -> None:
-        """Pull MUST run before stop_and_join, so a failed pull leaves the
+        """Pull MUST complete before stop_and_join so a failed pull leaves the
         worker intact."""
-        call_order: list[str] = []
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
-        mock_registry.stop_and_join.side_effect = lambda *_a, **_kw: call_order.append(
-            "stop_and_join"
-        )
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-
-            def fake_pull(_d):
-                call_order.append("pull")
-                return True
-
-            WebhookHandler._fn_pull_with_backoff = fake_pull
-            WebhookHandler._fn_os_chdir = MagicMock()
-            WebhookHandler._fn_os_execvp = MagicMock()
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    MagicMock(),  # fetch
+                    MagicMock(),  # reset
+                ]
+            )
+            WebhookHandler.proc = proc
+            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            # All 3 proc calls (get-url + fetch + reset) happened before stop_and_join.
+            assert proc.call_count == 3
+            mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
         finally:
             srv.shutdown()
-        assert call_order == ["pull", "stop_and_join"]
 
     def test_push_to_default_branch_triggers_restart(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-            WebhookHandler._fn_pull_with_backoff = lambda _d: True
-            mock_chdir = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_chdir = mock_chdir
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    MagicMock(),  # fetch
+                    MagicMock(),  # reset
+                ]
+            )
+            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
-            mock_exec.assert_called_once()
+            assert len(os_proc.execvp_calls) == 1
         finally:
             srv.shutdown()
 
     def test_push_to_non_default_branch_ignored(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            mock_pull = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_pull_with_backoff = mock_pull
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            proc = _FakeProcessRunner([])
+            WebhookHandler.proc = proc
+            WebhookHandler.clock = _FakeClock()
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             payload = {**_PUSH_PAYLOAD, "ref": "refs/heads/feature-branch"}
             _post_webhook(url, cfg, "push", payload)
-            mock_pull.assert_not_called()
-            mock_exec.assert_not_called()
+            assert proc.calls == []
+            assert os_proc.execvp_calls == []
         finally:
             srv.shutdown()
 
@@ -2358,16 +2381,20 @@ class TestSelfRestart:
         """Self-restart fires for merged PR even when the repo is not registered."""
         srv, url, cfg = self._make_unregistered_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-            WebhookHandler._fn_pull_with_backoff = lambda _d: True
-            mock_chdir = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_chdir = mock_chdir
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    MagicMock(),  # fetch
+                    MagicMock(),  # reset
+                ]
+            )
+            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
-            mock_exec.assert_called_once()
+            assert len(os_proc.execvp_calls) == 1
         finally:
             srv.shutdown()
 
@@ -2377,15 +2404,19 @@ class TestSelfRestart:
         """Self-restart fires for push to default branch even when repo is not registered."""
         srv, url, cfg = self._make_unregistered_server(tmp_path)
         try:
-            WebhookHandler._fn_runner_dir = lambda: tmp_path
-            WebhookHandler._fn_get_self_repo = lambda _d: "owner/kennel"
-            WebhookHandler._fn_pull_with_backoff = lambda _d: True
-            mock_chdir = MagicMock()
-            mock_exec = MagicMock()
-            WebhookHandler._fn_os_chdir = mock_chdir
-            WebhookHandler._fn_os_execvp = mock_exec
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            WebhookHandler.proc = _FakeProcessRunner(
+                [
+                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                    MagicMock(),  # fetch
+                    MagicMock(),  # reset
+                ]
+            )
+            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
+            os_proc = _FakeOsProcess()
+            WebhookHandler.os_proc = os_proc
             status = _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
             assert status == 200
-            mock_exec.assert_called_once()
+            assert len(os_proc.execvp_calls) == 1
         finally:
             srv.shutdown()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from kennel.config import Config, RepoConfig
+from kennel.infra import Infra
 from kennel.server import PreflightError, WebhookHandler
 
 # Thread-capture and do_POST synchronisation helpers ---------------------------
@@ -86,9 +87,7 @@ def _restore_handler_fns():
         "_fn_spawn_bg": WebhookHandler._fn_spawn_bg,
         "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
-        "proc": WebhookHandler.proc,
-        "clock": WebhookHandler.clock,
-        "os_proc": WebhookHandler.os_proc,
+        "infra": WebhookHandler.infra,
     }
     # Override _fn_after_do_post for all tests so _post_webhook can wait for
     # do_POST to complete without sleeping (see module-level comment above).
@@ -2206,16 +2205,19 @@ class TestSelfRestart:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner(
-                [
-                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
-                    MagicMock(),  # fetch
-                    MagicMock(),  # reset
-                ]
-            )
-            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        MagicMock(),  # fetch
+                        MagicMock(),  # reset
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
@@ -2233,10 +2235,13 @@ class TestSelfRestart:
             proc = _FakeProcessRunner(
                 [MagicMock(stdout="git@github.com:other/repo.git\n")]
             )
-            WebhookHandler.proc = proc
-            WebhookHandler.clock = _FakeClock()
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=proc,
+                clock=_FakeClock(),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
             assert proc.call_count == 1  # only the get-url call; no pull attempted
@@ -2248,10 +2253,13 @@ class TestSelfRestart:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner([FileNotFoundError()])
-            WebhookHandler.clock = _FakeClock()
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner([FileNotFoundError()]),
+                clock=_FakeClock(),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
             assert os_proc.execvp_calls == []
@@ -2269,17 +2277,20 @@ class TestSelfRestart:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner(
-                [
-                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
-                    subprocess.CalledProcessError(
-                        1, []
-                    ),  # fetch fails; budget exhausted
-                ]
-            )
-            WebhookHandler.clock = _FakeClock(times=[0.0, 601.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        subprocess.CalledProcessError(
+                            1, []
+                        ),  # fetch fails; budget exhausted
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 601.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             mock_registry.stop_and_join.assert_not_called()
             assert os_proc.execvp_calls == []
@@ -2299,10 +2310,13 @@ class TestSelfRestart:
                     MagicMock(),  # reset
                 ]
             )
-            WebhookHandler.proc = proc
-            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=proc,
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             # All 3 proc calls (get-url + fetch + reset) happened before stop_and_join.
             assert proc.call_count == 3
@@ -2314,16 +2328,19 @@ class TestSelfRestart:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner(
-                [
-                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
-                    MagicMock(),  # fetch
-                    MagicMock(),  # reset
-                ]
-            )
-            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        MagicMock(),  # fetch
+                        MagicMock(),  # reset
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
             mock_registry.stop_and_join.assert_called_once_with("owner/kennel")
             assert len(os_proc.execvp_calls) == 1
@@ -2335,10 +2352,13 @@ class TestSelfRestart:
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
             proc = _FakeProcessRunner([])
-            WebhookHandler.proc = proc
-            WebhookHandler.clock = _FakeClock()
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=proc,
+                clock=_FakeClock(),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             payload = {**_PUSH_PAYLOAD, "ref": "refs/heads/feature-branch"}
             _post_webhook(url, cfg, "push", payload)
             assert proc.calls == []
@@ -2382,16 +2402,19 @@ class TestSelfRestart:
         srv, url, cfg = self._make_unregistered_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner(
-                [
-                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
-                    MagicMock(),  # fetch
-                    MagicMock(),  # reset
-                ]
-            )
-            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        MagicMock(),  # fetch
+                        MagicMock(),  # reset
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
             assert status == 200
             assert len(os_proc.execvp_calls) == 1
@@ -2405,16 +2428,19 @@ class TestSelfRestart:
         srv, url, cfg = self._make_unregistered_server(tmp_path)
         try:
             WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
-            WebhookHandler.proc = _FakeProcessRunner(
-                [
-                    MagicMock(stdout="git@github.com:owner/kennel.git\n"),
-                    MagicMock(),  # fetch
-                    MagicMock(),  # reset
-                ]
-            )
-            WebhookHandler.clock = _FakeClock(times=[0.0, 0.0])
             os_proc = _FakeOsProcess()
-            WebhookHandler.os_proc = os_proc
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        MagicMock(),  # fetch
+                        MagicMock(),  # reset
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
             status = _post_webhook(url, cfg, "push", _PUSH_PAYLOAD)
             assert status == 200
             assert len(os_proc.execvp_calls) == 1


### PR DESCRIPTION
Fixes #398.

Introduces grouped infrastructure port protocols (subprocess, clock, filesystem, OS/process) with real implementations, then migrates server.py's preflight functions, self-restart flow, and WebhookHandler infrastructure slots to use them. The server composition root assembles and threads the grouped ports instead of raw callable parameters.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add infrastructure port protocols and real implementations <!-- type:spec -->
- [x] Migrate server preflight functions to grouped ports <!-- type:spec -->
- [x] Migrate server self-restart flow to grouped ports <!-- type:spec -->
- [x] Migrate WebhookHandler infrastructure slots to grouped ports <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->