### PR TITLE
Webhook reply hardening: dedup review fan-out, kill late thread tasks, instrument silent paths (closes #518, #520, #524)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -843,7 +843,7 @@ class ClaudeSession:
         self._proc = self._spawn()
         _register_child(self._proc)
 
-    def wait_for_pending_preempt(self, timeout: float = 2.0) -> bool:
+    def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
         """Block for up to *timeout* seconds while a preempter holds the
         lock queue.  Returns ``True`` if the preemption completed within the
         window, ``False`` on timeout (no preempter pending in the first place

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -438,61 +438,29 @@ def reply_to_review(
     *,
     _print_prompt: _PrintPrompt | None = None,
 ) -> None:
-    """Fetch inline comments from a review and reply to each."""
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
-    info = action.review_comments
-    if not info:
-        return
+    """No-op for inline comments — they are handled per-comment.
 
-    log.info(
-        "fetching review comments for PR #%s review %s", info["pr"], info["review_id"]
+    GitHub fires both ``pull_request_review`` (this handler) and a separate
+    ``pull_request_review_comment`` for each inline comment within the
+    review.  Iterating the inline comments here too caused two independent
+    handlers to triage and post against the same comment in parallel — the
+    per-comment lock didn't serialize them because triage takes the lock
+    only after a long pre-flight, so both posted clarification replies on
+    the same thread.  Closes #518.
+
+    Inline comments are now exclusively handled by the per-comment
+    webhook.  This handler is left as a stub so the dispatcher can still
+    register it for the event type (and so future top-level review-body
+    handling has a place to live).
+
+    Note: the review's *top-level* body text (the box at the bottom of
+    \"Submit review\") still arrives only through this event and is not
+    yet handled.  Tracked separately — out of scope for the dedup fix.
+    """
+    _ = (action, config, repo_cfg, gh, already_replied, _print_prompt)
+    log.debug(
+        "reply_to_review: skipping inline comments — handled per-comment (closes #518)"
     )
-    try:
-        comments = gh.get_review_comments(info["repo"], info["pr"], info["review_id"])
-    except Exception:
-        log.exception("failed to fetch review comments")
-        return
-
-    if not comments:
-        log.info("no inline comments in review")
-        return
-
-    skipped = [
-        cid for cid, _body in comments if already_replied and cid in already_replied
-    ]
-    todo = [
-        (cid, body)
-        for cid, body in comments
-        if not already_replied or cid not in already_replied
-    ]
-    if skipped:
-        log.info("skipping %d already-replied comments", len(skipped))
-    if not todo:
-        return
-    log.info("replying to %d review comments", len(todo))
-    for cid, body in todo:
-        try:
-            reply_to_comment(
-                Action(
-                    prompt=action.prompt,
-                    reply_to={
-                        "repo": info["repo"],
-                        "pr": info["pr"],
-                        "comment_id": cid,
-                    },
-                    comment_body=body,
-                ),
-                config,
-                repo_cfg,
-                gh,
-                _print_prompt=_print_prompt,
-            )
-        except Exception:
-            log.exception("failed to reply to review comment %s — skipping", cid)
-            continue
-        if already_replied is not None:
-            already_replied.add(cid)
 
 
 def needs_more_context(
@@ -566,7 +534,13 @@ def _triage(
     if _print_prompt is None:
         _print_prompt = claude.print_prompt
     prompt = triage_prompt(comment_body, is_bot, context)
+    log.info("triage classifier: requesting category from opus")
     text = _print_prompt(prompt, "claude-opus-4-6")
+    log.info(
+        "triage classifier: returned %d chars (preview=%r)",
+        len(text or ""),
+        (text or "")[:80],
+    )
     category: str | None = None
     titles: list[str] = []
     for line in text.splitlines() if text else []:
@@ -583,6 +557,10 @@ def _triage(
             titles.append(title)
     if category is not None and titles:
         return category, titles
+    log.warning(
+        "triage classifier: unparseable response, falling back to %s + summarize",
+        "DO" if is_bot else "ACT",
+    )
     # Fallback: ACT for humans, DO for bots; summarize comment into action item
     category = "DO" if is_bot else "ACT"
     title = _summarize_as_action_item(comment_body, _print_prompt=_print_prompt)
@@ -1056,6 +1034,41 @@ def create_task(
     """
     if _tasks is None:
         _tasks = Tasks(repo_cfg.work_dir)
+    # Race guard for thread tasks (#520): if the originating review thread
+    # has already been resolved on GitHub (most often because fido completed
+    # an earlier task in the same thread and auto-resolved it before this
+    # late-arriving triage queued the new task), don't queue.  Without this
+    # check the worker re-does work that's already shipped (#521), or
+    # rejects the resolved-thread state and reopens it.
+    if thread and thread.get("repo") and thread.get("pr") and thread.get("comment_id"):
+        try:
+            already = gh.is_thread_resolved_for_comment(
+                thread["repo"], int(thread["pr"]), int(thread["comment_id"])
+            )
+        except Exception:
+            log.exception(
+                "create_task: thread-resolved check failed for comment %s; queuing anyway",
+                thread.get("comment_id"),
+            )
+            already = False
+        # Strict ``is True`` so MagicMock test gh stubs (whose method calls
+        # return another MagicMock — truthy by default) don't cause this
+        # guard to swallow every test-level task creation.  Real GitHub
+        # always returns a real bool from ``is_thread_resolved_for_comment``.
+        if already is True:
+            log.info(
+                "create_task: thread for comment %s already resolved on GitHub — "
+                "skipping queue (closes #520)",
+                thread["comment_id"],
+            )
+            # Return a synthetic task-shaped dict so callers that don't check
+            # status don't choke; callers that DO walk tasks.json won't see it.
+            return {
+                "title": prompt,
+                "type": (TaskType.THREAD if thread else TaskType.SPEC).value,
+                "status": "skipped_resolved",
+                "thread": thread,
+            }
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -746,6 +746,24 @@ class GitHub:
         )
         self._graphql(query, id=thread_id)
 
+    def is_thread_resolved_for_comment(
+        self, repo: str, pr: int | str, comment_id: int
+    ) -> bool:
+        """Return True if the review thread containing *comment_id* is
+        already resolved on GitHub.
+
+        Used by webhook task creation to skip queuing late-arriving thread
+        tasks for threads fido has already auto-resolved (closes #520 race
+        / #521 redo loop).  Returns False when the comment isn't found in
+        any thread (treat as "go ahead and queue").
+        """
+        owner, name = repo.split("/", 1)
+        for node in self.get_review_threads(owner, name, pr):
+            for c in node.get("comments", {}).get("nodes", []):
+                if c.get("databaseId") == comment_id:
+                    return bool(node.get("isResolved"))
+        return False
+
     def get_required_checks(self, repo: str, branch: str) -> list[str]:
         """Return required status check names for branch, or [] if unprotected."""
         try:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1120,81 +1120,29 @@ class TestReplyToReview:
     def _repo_cfg(self, tmp_path: Path) -> RepoConfig:
         return RepoConfig(name="owner/repo", work_dir=tmp_path)
 
-    def test_no_review_comments_returns_early(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        action = Action(prompt="review", review_comments=None)
-        # should return without error
-        reply_to_review(action, cfg, self._repo_cfg(tmp_path), MagicMock())
-
-    def test_fetches_and_replies(self, tmp_path: Path) -> None:
+    def test_is_a_no_op_for_inline_comments(self, tmp_path: Path) -> None:
+        """Inline comments are now exclusively handled by the per-comment
+        webhook (``pull_request_review_comment``).  ``reply_to_review`` no
+        longer iterates the inline comments — closes #518 (double-reply on
+        review submission)."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="review",
             review_comments={"repo": "owner/repo", "pr": 5, "review_id": 777},
         )
-
-        def fake_pp(prompt, model, **kwargs):
-            if model == "claude-haiku-4-5":
-                return "NO"
-            if "Triage" in prompt:
-                return "ACT: fix it"
-            return "Will fix."
-
         mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = [(100, "fix this"), (200, "nit")]
         reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), mock_gh, _print_prompt=fake_pp
+            action, cfg, self._repo_cfg(tmp_path), mock_gh, _print_prompt=MagicMock()
         )
+        # Doesn't fetch, doesn't post — no GitHub side effects at all.
+        mock_gh.get_review_comments.assert_not_called()
+        mock_gh.reply_to_review_comment.assert_not_called()
 
-    def test_skips_already_replied(self, tmp_path: Path) -> None:
+    def test_no_op_with_no_review_comments(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="review",
-            review_comments={"repo": "owner/repo", "pr": 5, "review_id": 778},
-        )
-        already = {100, 200}
-        calls = []
-
-        def fake_pp(prompt, model, **kwargs):
-            calls.append((prompt, model))
-            return ""
-
-        mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = [(100, "fix this"), (200, "nit")]
-        reply_to_review(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            mock_gh,
-            already_replied=already,
-            _print_prompt=fake_pp,
-        )
-        # no claude calls since all comments already replied
-        assert not calls
-
-    def test_fetch_exception_returns_early(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="review",
-            review_comments={"repo": "owner/repo", "pr": 5, "review_id": 779},
-        )
-        mock_gh = MagicMock()
-        mock_gh.get_review_comments.side_effect = Exception("network fail")
-        reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), mock_gh
-        )  # should not raise
-
-    def test_no_inline_comments(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="review",
-            review_comments={"repo": "owner/repo", "pr": 5, "review_id": 780},
-        )
-        mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = []
-        reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), mock_gh
-        )  # empty → no replies
+        action = Action(prompt="review", review_comments=None)
+        # should return without error
+        reply_to_review(action, cfg, self._repo_cfg(tmp_path), MagicMock())
 
 
 class TestReplyToIssueComment:
@@ -1547,6 +1495,49 @@ class TestCreateTask:
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
         )
+
+    def test_skips_when_thread_already_resolved(self, tmp_path: Path) -> None:
+        """Late-arriving triage for a thread fido has already auto-resolved
+        is dropped on the floor (closes #520)."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 5, "comment_id": 999}
+        mock_tasks = self._mock_tasks()
+        mock_gh = MagicMock()
+        mock_gh.is_thread_resolved_for_comment.return_value = True
+        with patch("kennel.events.launch_sync"):
+            result = create_task(
+                "do something",
+                cfg,
+                repo_cfg,
+                mock_gh,
+                thread=thread,
+                _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
+            )
+        mock_tasks.add.assert_not_called()
+        assert result["status"] == "skipped_resolved"
+
+    def test_queues_when_thread_resolved_check_raises(self, tmp_path: Path) -> None:
+        """If the GitHub thread-resolved check fails, fail open and queue
+        the task — better to dedup later than drop work."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 5, "comment_id": 999}
+        mock_tasks = self._mock_tasks()
+        mock_gh = MagicMock()
+        mock_gh.is_thread_resolved_for_comment.side_effect = RuntimeError("api down")
+        with patch("kennel.events.launch_sync"):
+            create_task(
+                "do something",
+                cfg,
+                repo_cfg,
+                mock_gh,
+                thread=thread,
+                _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
+            )
+        mock_tasks.add.assert_called_once()
 
     def test_returns_created_task(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2943,88 +2934,6 @@ class TestReplyToCommentElseBranch:
                 mock_gh,
                 _print_prompt=fake_pp,
             )
-
-
-class TestReplyToReviewAlreadyRepliedTracking:
-    def _cfg(self, tmp_path: Path) -> Config:
-        return Config(
-            port=9000,
-            secret=b"test",
-            repos={},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-
-    def _repo_cfg(self, tmp_path: Path) -> RepoConfig:
-        return RepoConfig(name="owner/repo", work_dir=tmp_path)
-
-    def test_adds_to_already_replied_set(self, tmp_path: Path) -> None:
-        """When already_replied set is passed, processed comment ids are added (line 452)."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="review",
-            review_comments={"repo": "owner/repo", "pr": 5, "review_id": 900},
-        )
-        already: set[int] = set()
-
-        def fake_pp(prompt, model, **kwargs):
-            if model == "claude-haiku-4-5":
-                return "NO"
-            if "Triage" in prompt:
-                return "ACT: fix it"
-            return "Will fix."
-
-        mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = [(500, "please fix")]
-        reply_to_review(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            mock_gh,
-            already_replied=already,
-            _print_prompt=fake_pp,
-        )
-        assert 500 in already
-
-    def test_does_not_add_to_already_replied_on_post_failure(
-        self, tmp_path: Path
-    ) -> None:
-        """Failed comment is not added to already_replied; loop continues for others."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="review",
-            review_comments={"repo": "owner/repo", "pr": 5, "review_id": 901},
-        )
-        already: set[int] = set()
-
-        def fake_pp(prompt, model, **kwargs):
-            if model == "claude-haiku-4-5":
-                return "NO"
-            if "Triage" in prompt:
-                return "ACT: fix it"
-            return "Will fix."
-
-        mock_gh = MagicMock()
-        mock_gh.get_review_comments.return_value = [
-            (501, "please fix"),
-            (502, "also fix this"),
-        ]
-        # First comment fails, second succeeds
-        mock_gh.reply_to_review_comment.side_effect = [
-            RuntimeError("network down"),
-            None,
-        ]
-        reply_to_review(
-            action,
-            cfg,
-            self._repo_cfg(tmp_path),
-            mock_gh,
-            already_replied=already,
-            _print_prompt=fake_pp,
-        )
-        assert 501 not in already  # post failed — should not be marked as replied
-        assert 502 in already  # second comment still processed
 
 
 class TestReplyToCommentTerseEnrichment:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1496,6 +1496,50 @@ class TestGitHubClass:
         assert "resolveReviewThread" in body["query"]
         assert body["variables"] == {"id": "T_abc"}
 
+    def test_is_thread_resolved_for_comment_resolved(self) -> None:
+        gh, mock_s = self._gh()
+        nodes = [
+            {
+                "isResolved": True,
+                "comments": {"nodes": [{"databaseId": 42}, {"databaseId": 43}]},
+            },
+            {
+                "isResolved": False,
+                "comments": {"nodes": [{"databaseId": 99}]},
+            },
+        ]
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
+        mock_s.post.return_value = resp
+        assert gh.is_thread_resolved_for_comment("o/r", 10, 43) is True
+
+    def test_is_thread_resolved_for_comment_unresolved(self) -> None:
+        gh, mock_s = self._gh()
+        nodes = [
+            {
+                "isResolved": False,
+                "comments": {"nodes": [{"databaseId": 99}]},
+            },
+        ]
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
+        mock_s.post.return_value = resp
+        assert gh.is_thread_resolved_for_comment("o/r", 10, 99) is False
+
+    def test_is_thread_resolved_for_comment_not_found(self) -> None:
+        gh, mock_s = self._gh()
+        nodes: list[dict[str, object]] = []
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}
+        }
+        mock_s.post.return_value = resp
+        assert gh.is_thread_resolved_for_comment("o/r", 10, 7777) is False
+
     def test_get_reviews_returns_dict(self) -> None:
         gh, mock_s = self._gh()
         pr_resp = MagicMock()


### PR DESCRIPTION
## Summary
- **#518 dedup review fan-out**: `reply_to_review` no longer iterates inline comments — the per-comment webhook (`pull_request_review_comment`) handles each one. Both used to fire in parallel and post duplicate clarification replies on the same thread (observed twice on rhencke/orly PR #3).
- **#520 kill late-arriving thread tasks**: `create_task` calls new `GitHub.is_thread_resolved_for_comment` and drops the task if the thread is already resolved. Stops fido from re-doing already-shipped work (#521 race) when triage queues a follow-up after auto-resolve.
- **#524 instrument silent triage + bump yield timeout**: `_triage` now logs request + return preview and warns on unparseable category. `wait_for_pending_preempt` timeout 2s → 30s so a webhook waiting on a slow yielding worker doesn't bail and lose the preempt.

## Test plan
- [x] 1832 tests, 100% coverage, ruff clean, pyright clean
- [ ] After merge: rhencke/orly PR #3-style review threads get exactly one fido reply per inline comment, no duplicates
- [ ] After merge: late-arriving triage logs `thread for comment N already resolved on GitHub — skipping queue` instead of queuing
- [ ] After merge: `wait_for_pending_preempt` yield timing visible in log; if any timeout, `session: preempter still pending after 30.0s` warning surfaces

Closes #518, #520, #524. Related to (but does not fix): #521 (which becomes a no-op once #520 lands).