### PR TITLE
Finish unifying task and state file access behind coherent storage APIs (closes #393)

### DIFF
--- a/kennel/state.py
+++ b/kennel/state.py
@@ -46,6 +46,14 @@ class JsonFileStore(ABC):
         """Value yielded when the data file is absent or empty."""
         return {}
 
+    def _validate(self, data: Any) -> None:
+        """Validate loaded data.  Raise :exc:`ValueError` if invalid.
+
+        Called by :meth:`modify` after deserialising the JSON and before
+        yielding to the caller.  The default implementation is a no-op;
+        override in subclasses to add schema checks.
+        """
+
     @contextmanager
     def modify(self) -> Generator[Any, None, None]:
         """Atomic read-modify-write: hold the exclusive flock for the entire block.
@@ -54,6 +62,9 @@ class JsonFileStore(ABC):
         the file is absent or empty).  Any mutations are written back when the
         ``with`` block exits, while the exclusive lock is still held —
         preventing interleaved concurrent modifications.
+
+        Raises :exc:`ValueError` if the file contains invalid JSON or if
+        :meth:`_validate` rejects the loaded data.
         """
         lock_path = self._lock_path
         data_path = self._data_path
@@ -62,7 +73,14 @@ class JsonFileStore(ABC):
         with open(lock_path) as lock_fd:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             text = data_path.read_text() if data_path.exists() else ""
-            data = json.loads(text) if text.strip() else self._default()
+            if text.strip():
+                try:
+                    data = json.loads(text)
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"corrupt {data_path.name}: {e}") from e
+            else:
+                data = self._default()
+            self._validate(data)
             yield data
             data_path.write_text(json.dumps(data))
 

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -6,10 +6,10 @@ import fcntl
 import json
 import subprocess
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import IO, Any, Generator
+from typing import Any
 
 
 class JsonFileStore(ABC):
@@ -67,36 +67,6 @@ class JsonFileStore(ABC):
             data_path.write_text(json.dumps(data))
 
 
-def _state_lock(fido_dir: Path, exclusive: bool = False) -> IO[str]:
-    """Open and flock state.lock in fido_dir. Caller must close the returned fd."""
-    lock_path = fido_dir / "state.lock"
-    lock_path.touch(exist_ok=True)
-    lock_fd = open(lock_path)  # noqa: SIM115
-    fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
-    return lock_fd
-
-
-def load_state(fido_dir: Path) -> dict[str, Any]:
-    """Load state.json from fido_dir, returning an empty dict if absent."""
-    with _state_lock(fido_dir):
-        state_path = fido_dir / "state.json"
-        if not state_path.exists():
-            return {}
-        return json.loads(state_path.read_text())
-
-
-def save_state(fido_dir: Path, state: dict[str, Any]) -> None:
-    """Write state to state.json in fido_dir."""
-    with _state_lock(fido_dir, exclusive=True):
-        (fido_dir / "state.json").write_text(json.dumps(state))
-
-
-def clear_state(fido_dir: Path) -> None:
-    """Remove state.json from fido_dir (no-op if absent)."""
-    with _state_lock(fido_dir, exclusive=True):
-        (fido_dir / "state.json").unlink(missing_ok=True)
-
-
 class State(JsonFileStore):
     """Encapsulates fido state.json operations for a single worker directory.
 
@@ -105,7 +75,7 @@ class State(JsonFileStore):
 
     Inherits :meth:`~JsonFileStore.modify` for atomic read-modify-write.
     The lock is held on ``state.lock`` (separate from the data file) so that
-    shared reads via :func:`load_state` are not blocked by concurrent
+    shared reads via :meth:`load` are not blocked by concurrent
     ``modify`` calls.
     """
 
@@ -120,19 +90,52 @@ class State(JsonFileStore):
     def _lock_path(self) -> Path:
         return self._fido_dir / "state.lock"
 
+    @contextmanager
+    def _flock(self, exclusive: bool = False) -> Generator[None, None, None]:
+        """Hold a flock on ``state.lock`` for the duration of the block."""
+        lock_path = self._lock_path
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.touch(exist_ok=True)
+        with open(lock_path) as lock_fd:  # noqa: SIM115
+            fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+            yield
+
     def load(self) -> dict[str, Any]:
         """Return state dict, or {} when the directory or state file is absent."""
         if not self._fido_dir.exists():
             return {}
-        return load_state(self._fido_dir)
+        with self._flock():
+            if not self._data_path.exists():
+                return {}
+            return json.loads(self._data_path.read_text())
 
     def save(self, data: dict[str, Any]) -> None:
         """Write *data* to state.json."""
-        save_state(self._fido_dir, data)
+        with self._flock(exclusive=True):
+            self._data_path.write_text(json.dumps(data))
 
     def clear(self) -> None:
         """Remove state.json."""
-        clear_state(self._fido_dir)
+        with self._flock(exclusive=True):
+            self._data_path.unlink(missing_ok=True)
+
+
+# Compatibility shims — callers are migrated to State in subsequent commits.
+
+
+def load_state(fido_dir: Path) -> dict[str, Any]:
+    """Load state.json from fido_dir, returning an empty dict if absent."""
+    return State(fido_dir).load()
+
+
+def save_state(fido_dir: Path, state: dict[str, Any]) -> None:
+    """Write state to state.json in fido_dir."""
+    State(fido_dir).save(state)
+
+
+def clear_state(fido_dir: Path) -> None:
+    """Remove state.json from fido_dir (no-op if absent)."""
+    State(fido_dir).clear()
 
 
 def _resolve_git_dir(  # pyright: ignore[reportUnusedFunction]  # imported by tasks/worker

--- a/kennel/state.py
+++ b/kennel/state.py
@@ -120,24 +120,6 @@ class State(JsonFileStore):
             self._data_path.unlink(missing_ok=True)
 
 
-# Compatibility shims — callers are migrated to State in subsequent commits.
-
-
-def load_state(fido_dir: Path) -> dict[str, Any]:
-    """Load state.json from fido_dir, returning an empty dict if absent."""
-    return State(fido_dir).load()
-
-
-def save_state(fido_dir: Path, state: dict[str, Any]) -> None:
-    """Write state to state.json in fido_dir."""
-    State(fido_dir).save(state)
-
-
-def clear_state(fido_dir: Path) -> None:
-    """Remove state.json from fido_dir (no-op if absent)."""
-    State(fido_dir).clear()
-
-
 def _resolve_git_dir(  # pyright: ignore[reportUnusedFunction]  # imported by tasks/worker
     work_dir: Path,
     *,

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -15,6 +15,7 @@ from typing import Any
 from kennel.color import BOLD, CYAN, DIM, GREEN, MAGENTA, RED, RED_BOLD, YELLOW, color
 from kennel.config import RepoConfig
 from kennel.state import State
+from kennel.tasks import Tasks
 
 
 @dataclass
@@ -282,18 +283,6 @@ def _read_state(fido_dir: Path) -> dict[str, Any]:  # pyright: ignore[reportUnus
         return {}
 
 
-def _read_tasks(fido_dir: Path) -> list[dict[str, Any]]:
-    """Read tasks.json from fido_dir, returning [] if absent or unreadable."""
-    path = fido_dir / "tasks.json"
-    if not path.exists():
-        return []
-    try:
-        data = json.loads(path.read_text())
-        return data if isinstance(data, list) else []
-    except (json.JSONDecodeError, OSError):  # fmt: skip
-        return []
-
-
 def _current_task(task_list: list[dict[str, Any]]) -> str | None:
     """Return the title of the first in_progress task, then the first pending task."""
     for t in task_list:
@@ -388,7 +377,7 @@ def repo_status(
     pr_number = state.get("pr_number")
     pr_title = state.get("pr_title")
 
-    task_list = _read_tasks(fido_dir)
+    task_list = Tasks(repo_config.work_dir).list()
     pending = sum(1 for t in task_list if t["status"] == "pending")
     completed = sum(1 for t in task_list if t["status"] == "completed")
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -81,6 +81,9 @@ def _locked(path: Path, write: bool = False):
     return Lock()
 
 
+# Compatibility shims — callers are migrated to Tasks in subsequent commits.
+
+
 def add_task(
     work_dir: Path,
     title: str,
@@ -89,108 +92,35 @@ def add_task(
     status: TaskStatus = TaskStatus.PENDING,
     thread: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Add a task to the shared task file. Returns the new task.
-
-    task_type: mandatory — one of TaskType.CI, TaskType.THREAD, TaskType.SPEC.
-    thread: optional {repo, pr, comment_id, review_id} for comment/review tasks.
-    """
-    if not isinstance(task_type, TaskType):  # pyright: ignore[reportUnnecessaryIsInstance]
-        raise TypeError(f"task_type must be TaskType, got {type(task_type).__name__}")
-    title = " ".join(title.split())
-    task: dict[str, Any] = {
-        "id": f"{int(time.time() * 1000)}-{random.randint(0, 9999):04d}",
-        "title": title,
-        "type": str(task_type),
-        "description": description,
-        "status": str(status),
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    }
-    if thread:
-        task["thread"] = thread
-    comment_id = (thread or {}).get("comment_id")
-    path = _task_file(work_dir)
-    with _locked(path, write=True) as lock:
-        existing = lock.read()
-        for t in existing:
-            if comment_id is not None:
-                # Never re-create a task for the same comment, regardless of status.
-                if (t.get("thread") or {}).get("comment_id") == comment_id:
-                    log.info(
-                        "task already exists for comment_id %s (status: %s)",
-                        comment_id,
-                        t["status"],
-                    )
-                    return t
-            elif t["status"] == TaskStatus.PENDING and t["title"] == title:
-                log.info("task already exists: %s", title[:80])
-                return t
-        existing.append(task)
-        lock.write(existing)
-    log.info("task added: %s", title[:80])
-    return task
+    """Add a task.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).add(
+        title, task_type, description=description, status=status, thread=thread
+    )
 
 
 def update_task(work_dir: Path, task_id: str, status: TaskStatus) -> bool:
-    """Update a task's status. Returns True if found."""
-    path = _task_file(work_dir)
-    with _locked(path, write=True) as lock:
-        tasks = lock.read()
-        for t in tasks:
-            if t["id"] == task_id:
-                t["status"] = str(status)
-                lock.write(tasks)
-                log.info("task %s → %s", task_id, status)
-                return True
-    return False
+    """Update a task's status.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).update(task_id, status)
 
 
 def list_tasks(work_dir: Path) -> list[dict[str, Any]]:
-    """Read all tasks."""
-    path = _task_file(work_dir)
-    with _locked(path) as lock:
-        return lock.read()
+    """Read all tasks.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).list()
 
 
 def complete_by_id(work_dir: Path, task_id: str) -> dict[str, Any] | None:
-    """Mark the task with the given ID as completed.
-
-    Returns the task's thread dict if it had one, else None.
-    Returns None silently if no matching task is found.
-    """
-    path = _task_file(work_dir)
-    with _locked(path, write=True) as lock:
-        tasks = lock.read()
-        for t in tasks:
-            if t["id"] == task_id and t["status"] != TaskStatus.COMPLETED:
-                t["status"] = str(TaskStatus.COMPLETED)
-                lock.write(tasks)
-                log.info("task completed (id=%s): %s", task_id, t["title"][:80])
-                return t.get("thread")
-    return None
+    """Mark a task completed.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).complete_by_id(task_id)
 
 
 def has_pending_tasks_for_comment(work_dir: Path, comment_id: int | str) -> bool:
-    """Return True if any pending task references the given comment_id."""
-    cid = int(comment_id)
-    path = _task_file(work_dir)
-    with _locked(path) as lock:
-        for t in lock.read():
-            if t.get("status") == TaskStatus.PENDING:
-                if int((t.get("thread") or {}).get("comment_id", -1)) == cid:
-                    return True
-    return False
+    """Check pending tasks for comment.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).has_pending_for_comment(comment_id)
 
 
 def remove_task(work_dir: Path, task_id: str) -> bool:
-    """Remove a task. Returns True if found."""
-    path = _task_file(work_dir)
-    with _locked(path, write=True) as lock:
-        tasks = lock.read()
-        new_tasks = [t for t in tasks if t["id"] != task_id]
-        if len(new_tasks) < len(tasks):
-            lock.write(new_tasks)
-            return True
-    return False
+    """Remove a task.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).remove(task_id)
 
 
 def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
@@ -641,7 +571,8 @@ class Tasks(JsonFileStore):
 
     def list(self) -> list[dict[str, Any]]:
         """Return all tasks."""
-        return list_tasks(self._work_dir)
+        with _locked(self._data_path) as lock:
+            return lock.read()
 
     def add(
         self,
@@ -652,27 +583,85 @@ class Tasks(JsonFileStore):
         thread: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Add a task. Returns the new (or existing duplicate) task."""
-        return add_task(
-            self._work_dir,
-            title,
-            task_type,
-            description=description,
-            status=status,
-            thread=thread,
-        )
+        if not isinstance(task_type, TaskType):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError(
+                f"task_type must be TaskType, got {type(task_type).__name__}"
+            )
+        title = " ".join(title.split())
+        task: dict[str, Any] = {
+            "id": f"{int(time.time() * 1000)}-{random.randint(0, 9999):04d}",
+            "title": title,
+            "type": str(task_type),
+            "description": description,
+            "status": str(status),
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        if thread:
+            task["thread"] = thread
+        comment_id = (thread or {}).get("comment_id")
+        with _locked(self._data_path, write=True) as lock:
+            existing = lock.read()
+            for t in existing:
+                if comment_id is not None:
+                    # Never re-create a task for the same comment, regardless of status.
+                    if (t.get("thread") or {}).get("comment_id") == comment_id:
+                        log.info(
+                            "task already exists for comment_id %s (status: %s)",
+                            comment_id,
+                            t["status"],
+                        )
+                        return t
+                elif t["status"] == TaskStatus.PENDING and t["title"] == title:
+                    log.info("task already exists: %s", title[:80])
+                    return t
+            existing.append(task)
+            lock.write(existing)
+        log.info("task added: %s", title[:80])
+        return task
 
     def complete_by_id(self, task_id: str) -> dict[str, Any] | None:
-        """Mark a task completed. Returns its thread dict or None."""
-        return complete_by_id(self._work_dir, task_id)
+        """Mark a task completed. Returns its thread dict or None.
+
+        Returns ``None`` silently if no matching task is found.
+        """
+        with _locked(self._data_path, write=True) as lock:
+            tasks = lock.read()
+            for t in tasks:
+                if t["id"] == task_id and t["status"] != TaskStatus.COMPLETED:
+                    t["status"] = str(TaskStatus.COMPLETED)
+                    lock.write(tasks)
+                    log.info("task completed (id=%s): %s", task_id, t["title"][:80])
+                    return t.get("thread")
+        return None
 
     def has_pending_for_comment(self, comment_id: int | str) -> bool:
         """Return True if any pending task references *comment_id*."""
-        return has_pending_tasks_for_comment(self._work_dir, comment_id)
+        cid = int(comment_id)
+        with _locked(self._data_path) as lock:
+            for t in lock.read():
+                if t.get("status") == TaskStatus.PENDING:
+                    if int((t.get("thread") or {}).get("comment_id", -1)) == cid:
+                        return True
+        return False
 
     def remove(self, task_id: str) -> bool:
         """Remove a task. Returns True if found."""
-        return remove_task(self._work_dir, task_id)
+        with _locked(self._data_path, write=True) as lock:
+            tasks = lock.read()
+            new_tasks = [t for t in tasks if t["id"] != task_id]
+            if len(new_tasks) < len(tasks):
+                lock.write(new_tasks)
+                return True
+        return False
 
     def update(self, task_id: str, status: TaskStatus) -> bool:
         """Update a task's status. Returns True if found."""
-        return update_task(self._work_dir, task_id, status)
+        with _locked(self._data_path, write=True) as lock:
+            tasks = lock.read()
+            for t in tasks:
+                if t["id"] == task_id:
+                    t["status"] = str(status)
+                    lock.write(tasks)
+                    log.info("task %s → %s", task_id, status)
+                    return True
+        return False

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -460,7 +460,7 @@ def reorder_tasks(
     If *_on_done* is provided, it is called after a successful reorder write so
     callers can trigger follow-up work (e.g. rewriting the PR description).
     """
-    task_list = list_tasks(work_dir)
+    task_list = Tasks(work_dir).list()
     if not task_list:
         log.info("reorder_tasks: no tasks — skipping")
         return

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -189,12 +189,10 @@ def _auto_complete_ask_tasks(
     gh: GitHub,
     repo: str,
     pr_number: int | str,
-    *,
-    _list_tasks: Callable[[Path], list[dict[str, Any]]] = list_tasks,
-    _complete_by_id: Callable[[Path, str], dict[str, Any] | None] = complete_by_id,
 ) -> None:
     """Mark pending ASK tasks complete when their review thread is resolved."""
-    task_list = _list_tasks(work_dir)
+    tasks = Tasks(work_dir)
+    task_list = tasks.list()
     ask_tasks = [
         t
         for t in task_list
@@ -221,7 +219,7 @@ def _auto_complete_ask_tasks(
             log.info(
                 "sync_tasks: ASK task thread resolved — completing: %s", task["title"]
             )
-            _complete_by_id(work_dir, task["id"])
+            tasks.complete_by_id(task["id"])
 
 
 def sync_tasks(
@@ -229,7 +227,6 @@ def sync_tasks(
     gh: GitHub,
     *,
     _resolve_git_dir_fn: Callable[[Path], Path] = _resolve_git_dir,
-    _list_tasks: Callable[[Path], list[dict[str, Any]]] = list_tasks,
     _auto_complete_ask_tasks_fn: Callable[..., None] = _auto_complete_ask_tasks,
 ) -> None:
     """Sync tasks.json → PR body work queue.
@@ -273,7 +270,7 @@ def sync_tasks(
         pr_number = pr_data["number"]
         _auto_complete_ask_tasks_fn(work_dir, gh, repo, pr_number)
 
-        task_list = _list_tasks(work_dir)
+        task_list = Tasks(work_dir).list()
         if not task_list:
             log.info("sync_tasks: no tasks — nothing to sync")
             return

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -633,6 +633,12 @@ class Tasks(JsonFileStore):
     def _default(self) -> list[dict[str, Any]]:
         return []
 
+    def _validate(self, data: Any) -> None:
+        """Ensure every task has a ``type`` field."""
+        for t in data:
+            if "type" not in t:
+                raise ValueError(f"task {t.get('id', '?')} missing required type field")
+
     def list(self) -> list[dict[str, Any]]:
         """Return all tasks."""
         return list_tasks(self._work_dir)

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -19,8 +19,8 @@ from kennel.github import GitHub
 from kennel.prompts import rescope_prompt as _rescope_prompt_default
 from kennel.state import (
     JsonFileStore,
+    State,
     _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
-    load_state,
 )
 from kennel.types import TaskStatus, TaskType
 
@@ -326,7 +326,7 @@ def sync_tasks(
         return
 
     try:
-        state = load_state(fido_dir)
+        state = State(fido_dir).load()
         issue = state.get("issue")
         if issue is None:
             log.info("sync_tasks: no current issue — nothing to sync")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ class TestMain:
             "type": "spec",
             "status": "pending",
         }
-        with patch("kennel.tasks.add_task", return_value=fake_task) as mock_add:
+        with patch("kennel.tasks.Tasks.add", return_value=fake_task) as mock_add:
             main(["task", str(tmp_path), "add", "spec", "my task"], _GitHub=MagicMock())
 
         mock_add.assert_called_once()
@@ -55,7 +55,7 @@ class TestMain:
 
         with (
             patch("sys.argv", ["kennel", "task", str(tmp_path), "list"]),
-            patch("kennel.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
         ):
             main(_GitHub=MagicMock())  # should not raise
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -26,7 +26,6 @@ from kennel.status import (
     _port_from_pid,
     _process_uptime_seconds,
     _read_state,
-    _read_tasks,
     _repos_from_pid,
     collect,
     format_status,
@@ -617,39 +616,6 @@ class TestReadState:
             assert _read_state(fido_dir) == {}
 
 
-class TestReadTasks:
-    def test_absent_returns_empty(self, tmp_path: Path) -> None:
-        fido_dir = tmp_path / "fido"
-        fido_dir.mkdir()
-        assert _read_tasks(fido_dir) == []
-
-    def test_reads_tasks(self, tmp_path: Path) -> None:
-        fido_dir = tmp_path / "fido"
-        fido_dir.mkdir()
-        tasks = [{"id": "1", "title": "do thing", "status": "pending"}]
-        (fido_dir / "tasks.json").write_text(json.dumps(tasks))
-        assert _read_tasks(fido_dir) == tasks
-
-    def test_corrupt_json_returns_empty(self, tmp_path: Path) -> None:
-        fido_dir = tmp_path / "fido"
-        fido_dir.mkdir()
-        (fido_dir / "tasks.json").write_text("not json")
-        assert _read_tasks(fido_dir) == []
-
-    def test_non_list_returns_empty(self, tmp_path: Path) -> None:
-        fido_dir = tmp_path / "fido"
-        fido_dir.mkdir()
-        (fido_dir / "tasks.json").write_text('{"not": "a list"}')
-        assert _read_tasks(fido_dir) == []
-
-    def test_oserror_returns_empty(self, tmp_path: Path) -> None:
-        fido_dir = tmp_path / "fido"
-        fido_dir.mkdir()
-        (fido_dir / "tasks.json").touch()
-        with patch.object(Path, "read_text", side_effect=OSError("oops")):
-            assert _read_tasks(fido_dir) == []
-
-
 class TestCurrentTask:
     def test_empty_list(self) -> None:
         assert _current_task([]) is None
@@ -729,8 +695,8 @@ class TestRepoStatus:
         fido_dir.mkdir(parents=True)
         (fido_dir / "state.json").write_text('{"issue": 7}')
         tasks = [
-            {"status": "completed", "title": "done task"},
-            {"status": "pending", "title": "next task"},
+            {"status": "completed", "title": "done task", "type": "spec"},
+            {"status": "pending", "title": "next task", "type": "spec"},
         ]
         (fido_dir / "tasks.json").write_text(json.dumps(tasks))
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -968,3 +968,21 @@ class TestTasks:
         with Tasks(work_dir).modify() as tasks:
             tasks[0]["title"] = "Modified task"
         assert list_tasks(work_dir)[0]["title"] == "Modified task"
+
+    def test_modify_raises_on_corrupt_json(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        _task_file(work_dir).write_text("not json")
+        with pytest.raises(ValueError, match="corrupt tasks.json"):
+            with Tasks(work_dir).modify() as _:
+                pass
+
+    def test_modify_raises_on_missing_type_field(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        _task_file(work_dir).write_text(
+            '[{"id": "bad", "title": "no type", "status": "pending"}]'
+        )
+        with pytest.raises(ValueError, match="missing required type field"):
+            with Tasks(work_dir).modify() as _:
+                pass

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -898,7 +898,7 @@ class TestComputeThreadChanges:
 
 
 class TestTasks:
-    def test_list_delegates_to_list_tasks(self, tmp_path: Path) -> None:
+    def test_list_returns_all_tasks(self, tmp_path: Path) -> None:
         from kennel.types import TaskType
 
         work_dir = tmp_path / "work"
@@ -908,7 +908,7 @@ class TestTasks:
         assert len(result) == 1
         assert result[0]["title"] == "Task A"
 
-    def test_add_delegates_to_add_task(self, tmp_path: Path) -> None:
+    def test_add_creates_task(self, tmp_path: Path) -> None:
         from kennel.types import TaskType
 
         work_dir = tmp_path / "work"
@@ -917,7 +917,7 @@ class TestTasks:
         assert task["title"] == "Task B"
         assert task["type"] == "ci"
 
-    def test_complete_by_id_delegates(self, tmp_path: Path) -> None:
+    def test_complete_by_id_marks_task_completed(self, tmp_path: Path) -> None:
         from kennel.types import TaskType
 
         work_dir = tmp_path / "work"
@@ -926,7 +926,7 @@ class TestTasks:
         Tasks(work_dir).complete_by_id(task["id"])
         assert list_tasks(work_dir)[0]["status"] == "completed"
 
-    def test_has_pending_for_comment_delegates(self, tmp_path: Path) -> None:
+    def test_has_pending_for_comment_returns_bool(self, tmp_path: Path) -> None:
         from kennel.types import TaskType
 
         work_dir = tmp_path / "work"
@@ -935,7 +935,7 @@ class TestTasks:
         assert Tasks(work_dir).has_pending_for_comment(7) is True
         assert Tasks(work_dir).has_pending_for_comment(99) is False
 
-    def test_remove_delegates(self, tmp_path: Path) -> None:
+    def test_remove_deletes_task(self, tmp_path: Path) -> None:
         from kennel.types import TaskType
 
         work_dir = tmp_path / "work"
@@ -944,7 +944,7 @@ class TestTasks:
         assert Tasks(work_dir).remove(task["id"]) is True
         assert list_tasks(work_dir) == []
 
-    def test_update_delegates(self, tmp_path: Path) -> None:
+    def test_update_changes_status(self, tmp_path: Path) -> None:
         from kennel.types import TaskStatus, TaskType
 
         work_dir = tmp_path / "work"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3111,7 +3111,7 @@ class TestFindOrCreatePr:
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", return_value=["a task"]),
+            patch("kennel.tasks.Tasks.list", return_value=["a task"]),
         ):
             result = worker.find_or_create_pr(
                 fido_dir, self._make_repo_ctx(), 5, "title"
@@ -3126,7 +3126,7 @@ class TestFindOrCreatePr:
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", return_value=["a task"]),
+            patch("kennel.tasks.Tasks.list", return_value=["a task"]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -3140,7 +3140,7 @@ class TestFindOrCreatePr:
         mock_start = MagicMock(return_value="sess-1")
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", mock_start),
@@ -3157,7 +3157,7 @@ class TestFindOrCreatePr:
         mock_build = MagicMock()
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", return_value="sess"),
@@ -3173,7 +3173,7 @@ class TestFindOrCreatePr:
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
@@ -3189,14 +3189,14 @@ class TestFindOrCreatePr:
         task = {"title": "t", "status": "pending"}
         call_count = 0
 
-        def list_tasks_side_effect(_work_dir):
+        def list_tasks_side_effect():
             nonlocal call_count
             call_count += 1
             return [] if call_count <= 2 else [task]
 
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", side_effect=list_tasks_side_effect),
+            patch("kennel.tasks.Tasks.list", side_effect=list_tasks_side_effect),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
@@ -3212,7 +3212,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 side_effect=[[], [{"id": "1", "title": "t", "status": "pending"}]],
             ),
             patch.object(
@@ -3238,14 +3238,14 @@ class TestFindOrCreatePr:
         task = {"title": "t", "status": "pending"}
         call_count = 0
 
-        def list_tasks_side_effect(_work_dir):
+        def list_tasks_side_effect():
             nonlocal call_count
             call_count += 1
             return [] if call_count == 1 else [task]
 
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.tasks.list_tasks", side_effect=list_tasks_side_effect),
+            patch("kennel.tasks.Tasks.list", side_effect=list_tasks_side_effect),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
         ):
@@ -3260,7 +3260,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=[{"title": "t", "status": "pending"}],
             ),
             patch("kennel.worker.build_prompt", mock_build),
@@ -3283,7 +3283,7 @@ class TestFindOrCreatePr:
 
         with (
             patch.object(worker, "_git", side_effect=side_effect),
-            patch("kennel.worker.tasks.list_tasks", return_value=["t"]),
+            patch("kennel.tasks.Tasks.list", return_value=["t"]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert ["checkout", "-b", "br", "--track", "origin/br"] in git_calls
@@ -3300,7 +3300,7 @@ class TestFindOrCreatePr:
 
         with (
             patch.object(worker, "_git", side_effect=side_effect),
-            patch("kennel.worker.tasks.list_tasks", return_value=["t"]),
+            patch("kennel.tasks.Tasks.list", return_value=["t"]),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert git_calls[0] == ["fetch", "origin"]
@@ -3319,7 +3319,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude_start", return_value="sess"),
             patch("kennel.worker._write_pr_description"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=[{"title": "Do thing", "status": "pending"}],
             ),
         ):
@@ -3344,7 +3344,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
             pytest.raises(RuntimeError),
         ):
@@ -3364,7 +3364,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", mock_start),
             patch("kennel.worker._write_pr_description"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -3383,7 +3383,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", return_value="s"),
             patch("kennel.worker._write_pr_description"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -3403,7 +3403,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=[{"title": "t", "status": "pending"}],
             ),
         ):
@@ -3433,7 +3433,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -3461,7 +3461,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -3489,7 +3489,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=[{"title": "t", "status": "pending"}],
             ),
         ):
@@ -3509,7 +3509,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             pytest.raises(RuntimeError, match="setup produced no tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
@@ -3529,7 +3529,7 @@ class TestFindOrCreatePr:
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=[{"title": "t", "status": "pending"}],
             ),
             caplog.at_level(logging.INFO, logger="kennel"),
@@ -3555,14 +3555,14 @@ class TestSeedTasksFromPrBody:
 
     def test_noop_when_tasks_exist(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        with patch("kennel.worker.tasks.list_tasks", return_value=[{"title": "t"}]):
+        with patch("kennel.tasks.Tasks.list", return_value=[{"title": "t"}]):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         gh.get_pr.assert_not_called()
 
     def test_fetches_pr_body_when_no_tasks(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {"body": ""}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.seed_tasks_from_pr_body("owner/repo", 42)
         gh.get_pr.assert_called_once_with("owner/repo", 42)
 
@@ -3570,8 +3570,8 @@ class TestSeedTasksFromPrBody:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {"body": "No markers here."}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_not_called()
@@ -3586,8 +3586,8 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_not_called()
@@ -3598,18 +3598,11 @@ class TestSeedTasksFromPrBody:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = self._pr_with_queue("Fix the bug")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
-        mock_add.assert_called_once_with(
-            tmp_path,
-            "Fix the bug",
-            TaskType.SPEC,
-            description=ANY,
-            status=ANY,
-            thread=ANY,
-        )
+        mock_add.assert_called_once_with("Fix the bug", TaskType.SPEC)
 
     def test_adds_multiple_tasks(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3617,8 +3610,8 @@ class TestSeedTasksFromPrBody:
             "Task one", "Task two", "Task three"
         )
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         assert mock_add.call_count == 3
@@ -3635,13 +3628,13 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         # Only the unchecked task should have been added
         assert mock_add.call_count == 1
-        assert mock_add.call_args.args[1] == "Still pending"
+        assert mock_add.call_args.args[0] == "Still pending"
 
     def test_skips_all_when_only_completed(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3654,8 +3647,8 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_not_called()
@@ -3671,11 +3664,11 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
-        titles = [call.args[1] for call in mock_add.call_args_list]
+        titles = [call.args[0] for call in mock_add.call_args_list]
         assert titles[0] == "First task"
         assert "**→ next**" not in titles[0]
 
@@ -3684,10 +3677,10 @@ class TestSeedTasksFromPrBody:
         gh.get_pr.return_value = self._pr_with_queue("Write the tests", "Fix the lint")
         received: list[str] = []
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch(
-                "kennel.worker.tasks.add_task",
-                side_effect=lambda wd, t, tt, **kw: received.append(t),
+                "kennel.tasks.Tasks.add",
+                side_effect=lambda t, tt, **kw: received.append(t),
             ),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 5)
@@ -3697,8 +3690,8 @@ class TestSeedTasksFromPrBody:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {"body": None}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         mock_add.assert_not_called()
@@ -3716,8 +3709,8 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
             caplog.at_level(logging.WARNING, logger="kennel"),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
@@ -3730,8 +3723,8 @@ class TestSeedTasksFromPrBody:
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = self._pr_with_queue("T1", "T2")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task"),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
@@ -3746,7 +3739,7 @@ class TestSeedTasksFromPrBody:
             "body": "<!-- WORK_QUEUE_START -->\n<!-- WORK_QUEUE_END -->"
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
@@ -3763,8 +3756,8 @@ class TestSeedTasksFromPrBody:
             )
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
-            patch("kennel.worker.tasks.add_task") as mock_add,
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         assert mock_add.call_count == 1
@@ -4090,7 +4083,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4108,7 +4101,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4126,7 +4119,7 @@ class TestHandleCi:
             patch.object(worker, "set_status") as mock_status,
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 7, "branch")
@@ -4148,7 +4141,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4165,7 +4158,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4188,7 +4181,7 @@ class TestHandleCi:
                 side_effect=lambda fd, sk, ctx: captured_context.update({"ctx": ctx}),
             ),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4208,7 +4201,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 42, "branch")
@@ -4226,7 +4219,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 5, "fix-branch")
@@ -4249,7 +4242,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess-1", "")) as mock_cr,
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4268,7 +4261,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4286,7 +4279,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4306,7 +4299,7 @@ class TestHandleCi:
             patch.object(worker, "set_status") as mock_status,
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4327,7 +4320,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -5549,7 +5542,7 @@ class TestExecuteTask:
     def test_returns_false_when_no_tasks(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is False
 
@@ -5558,13 +5551,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Implement feature")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
@@ -5575,13 +5568,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Write the tests")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status") as mock_status,
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "my-branch")
@@ -5592,13 +5585,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Fix the bug")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "fix-branch")
@@ -5610,13 +5603,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Do work")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "my-slug")
@@ -5631,13 +5624,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("The special task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5659,13 +5652,13 @@ class TestExecuteTask:
             },
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
@@ -5679,13 +5672,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Plain task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5698,13 +5691,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess", "")) as mock_run,
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5715,13 +5708,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True) as mock_push,
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "my-slug")
@@ -5732,30 +5725,30 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("My task title")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_complete.assert_called_once_with(tmp_path, task["id"])
+        mock_complete.assert_called_once_with(task["id"])
 
     def test_skips_complete_when_push_fails(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5766,13 +5759,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5783,13 +5776,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5800,30 +5793,30 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_complete.assert_called_once_with(tmp_path, task["id"])
+        mock_complete.assert_called_once_with(task["id"])
 
     def test_returns_true_when_already_in_sync(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5834,13 +5827,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5851,13 +5844,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5870,13 +5863,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Log me please")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -5890,13 +5883,13 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("my-session", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -5917,7 +5910,7 @@ class TestExecuteTask:
             )
         )
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch(
@@ -5926,7 +5919,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5947,7 +5940,7 @@ class TestExecuteTask:
             )
         )
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch(
@@ -5956,7 +5949,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -5981,7 +5974,7 @@ class TestExecuteTask:
             )
         )
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch(
@@ -5995,7 +5988,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6023,7 +6016,7 @@ class TestExecuteTask:
         list_tasks_calls = iter([[task], [completed_task]])
         with (
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 side_effect=lambda *a, **kw: next(list_tasks_calls),
             ),
             patch.object(worker, "set_status"),
@@ -6033,14 +6026,14 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         # claude_run called exactly once (initial dispatch), not again after break
         mock_run.assert_called_once()
         # complete_by_id still called (idempotent — task already completed externally)
-        mock_complete.assert_called_once_with(tmp_path, task["id"])
+        mock_complete.assert_called_once_with(task["id"])
 
     def test_saves_current_task_id_to_state_before_claude_run(
         self, tmp_path: Path
@@ -6056,13 +6049,13 @@ class TestExecuteTask:
             return ("sess", "")
 
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", side_effect=capture),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6074,13 +6067,13 @@ class TestExecuteTask:
         State(fido_dir).save({"issue": 1})
         task = {"id": "task-77", "title": "Complete me", "status": "pending"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6100,13 +6093,13 @@ class TestExecuteTask:
             return ("sess", "")
 
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", side_effect=capture),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "br")
@@ -6119,13 +6112,13 @@ class TestExecuteTask:
         State(fido_dir).save({"issue": 1})
         task = {"id": "task-push-fail", "title": "Push me", "status": "pending"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sess", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6155,19 +6148,19 @@ class TestExecuteTask:
         task = {"id": "t-abort", "title": "Abort me", "status": "pending"}
         worker._abort_task.set()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
-            patch("kennel.worker.tasks.remove_task") as mock_remove,
+            patch("kennel.tasks.Tasks.remove") as mock_remove,
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
         mock_clean.assert_called_once()
-        mock_remove.assert_called_once_with(tmp_path, "t-abort")
+        mock_remove.assert_called_once_with("t-abort")
         assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
@@ -6189,19 +6182,19 @@ class TestExecuteTask:
             return ("sid", "")
 
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", side_effect=set_abort_on_second),
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
-            patch("kennel.worker.tasks.remove_task") as mock_remove,
+            patch("kennel.tasks.Tasks.remove") as mock_remove,
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
         mock_clean.assert_called_once()
-        mock_remove.assert_called_once_with(tmp_path, "t-resume-abort")
+        mock_remove.assert_called_once_with("t-resume-abort")
         assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
@@ -6213,14 +6206,14 @@ class TestExecuteTask:
         task = {"id": "t-no-complete", "title": "No complete", "status": "pending"}
         worker._abort_task.set()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean"),
-            patch("kennel.worker.tasks.remove_task"),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.remove"),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6231,7 +6224,7 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("Do work")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
@@ -6240,7 +6233,7 @@ class TestExecuteTask:
                 worker, "_squash_wip_commit", return_value=False
             ) as mock_squash,
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "feat-branch")
@@ -6254,7 +6247,7 @@ class TestExecuteTask:
         task = self._pending_task("Do work")
         call_order: list[str] = []
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
@@ -6269,7 +6262,7 @@ class TestExecuteTask:
                 "ensure_pushed",
                 side_effect=lambda *a: call_order.append("push") or True,
             ),
-            patch("kennel.worker.tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_by_id"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6280,14 +6273,14 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("First task")
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[task]),
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "_squash_wip_commit", return_value=True),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.worker.tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6608,7 +6601,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 7, "my-branch", 3)
@@ -6622,7 +6615,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6635,7 +6628,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6652,7 +6645,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6666,7 +6659,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6682,7 +6675,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -6699,7 +6692,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -6716,7 +6709,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -6733,7 +6726,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -6750,7 +6743,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_status = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status", mock_status),
         ):
@@ -6766,7 +6759,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6782,7 +6775,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_merge.assert_called_once_with("rhencke/myrepo", 9, squash=True, auto=True)
 
@@ -6793,7 +6786,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -6805,7 +6798,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         pending = [{"id": "t1", "title": "Do work", "status": "pending"}]
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=pending),
+            patch("kennel.tasks.Tasks.list", return_value=pending),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -6817,7 +6810,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=True)
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=completed),
+            patch("kennel.tasks.Tasks.list", return_value=completed),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -6828,7 +6821,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._reviews(state="COMMENTED", is_draft=False)
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -6844,7 +6837,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -6857,7 +6850,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = [{"name": "ci", "state": "FAILURE"}]
         gh.get_required_checks.return_value = ["ci"]
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -6870,7 +6863,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = [{"name": "ci", "state": "FAILURE"}]
         gh.get_required_checks.return_value = ["ci"]
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -6884,7 +6877,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -6898,7 +6891,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_merge.assert_not_called()
 
@@ -6916,7 +6909,7 @@ class TestHandlePromoteMerge:
         }
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6944,7 +6937,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6957,7 +6950,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6972,7 +6965,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -6986,7 +6979,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -7002,7 +6995,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -7017,7 +7010,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -7032,7 +7025,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -7049,7 +7042,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_git = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git", mock_git),
             patch.object(worker, "set_status"),
         ):
@@ -7064,7 +7057,7 @@ class TestHandlePromoteMerge:
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         mock_status = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status", mock_status),
         ):
@@ -7080,7 +7073,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -7096,7 +7089,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_merge.assert_called_once_with("rhencke/myrepo", 9, squash=True, auto=True)
 
@@ -7105,7 +7098,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7133,7 +7126,7 @@ class TestHandlePromoteMerge:
             "commits": [{"committedDate": "2024-01-01T08:00:00Z"}],
             "isDraft": False,
         }
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         # CHANGES_REQUESTED is latest — must not merge
         gh.pr_merge.assert_not_called()
@@ -7155,7 +7148,7 @@ class TestHandlePromoteMerge:
             "commits": [{"committedDate": "2024-01-01T10:00:00Z"}],
             "isDraft": False,
         }
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7175,7 +7168,7 @@ class TestHandlePromoteMerge:
             "commits": [{"committedDate": "2024-01-01T10:00:00Z"}],
             "isDraft": False,
         }
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7200,7 +7193,7 @@ class TestHandlePromoteMerge:
         }
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7224,7 +7217,7 @@ class TestHandlePromoteMerge:
         }
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7241,7 +7234,7 @@ class TestHandlePromoteMerge:
         )
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once()
 
@@ -7262,7 +7255,7 @@ class TestHandlePromoteMerge:
         }
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once()
 
@@ -7285,7 +7278,7 @@ class TestHandlePromoteMerge:
             "isDraft": False,
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7309,7 +7302,7 @@ class TestHandlePromoteMerge:
             "isDraft": False,
             "requestedReviewers": ["rhencke"],
         }
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7329,7 +7322,7 @@ class TestHandlePromoteMerge:
         }
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -7350,7 +7343,7 @@ class TestHandlePromoteMerge:
         }
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
         ):
@@ -7372,7 +7365,7 @@ class TestHandlePromoteMerge:
         }
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7390,7 +7383,7 @@ class TestHandlePromoteMerge:
             "commits": [],
             "isDraft": False,
         }
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_merge.assert_not_called()
 
@@ -7400,7 +7393,7 @@ class TestHandlePromoteMerge:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7410,7 +7403,7 @@ class TestHandlePromoteMerge:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_not_called()
 
@@ -7422,7 +7415,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
-        with patch("kennel.worker.tasks.list_tasks", return_value=completed):
+        with patch("kennel.tasks.Tasks.list", return_value=completed):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
 
@@ -7434,7 +7427,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
-        with patch("kennel.worker.tasks.list_tasks", return_value=completed):
+        with patch("kennel.tasks.Tasks.list", return_value=completed):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7446,7 +7439,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
-        with patch("kennel.worker.tasks.list_tasks", return_value=completed):
+        with patch("kennel.tasks.Tasks.list", return_value=completed):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7466,7 +7459,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
-        with patch("kennel.worker.tasks.list_tasks", return_value=completed):
+        with patch("kennel.tasks.Tasks.list", return_value=completed):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7479,7 +7472,7 @@ class TestHandlePromoteMerge:
             {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
             {"id": "t2", "title": "Next", "status": "pending", "type": "spec"},
         ]
-        with patch("kennel.worker.tasks.list_tasks", return_value=tasks_list):
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7501,9 +7494,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = self._passing_checks()
         gh.get_required_checks.return_value = ["ci / test"]
         gh.get_review_threads.return_value = []
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7515,9 +7506,7 @@ class TestHandlePromoteMerge:
             {"name": "ci / test", "state": "IN_PROGRESS", "link": "http://..."}
         ]
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7531,9 +7520,7 @@ class TestHandlePromoteMerge:
             {"name": "ci / test", "state": "FAILURE", "link": "http://..."}
         ]
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_not_called()
 
@@ -7545,9 +7532,7 @@ class TestHandlePromoteMerge:
             {"name": "ci / test", "state": "IN_PROGRESS", "link": "http://..."}
         ]
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7562,9 +7547,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7577,9 +7560,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.get_required_checks.assert_called_once_with("rhencke/myrepo", "main")
 
@@ -7600,9 +7581,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = [self._unresolved_thread()]
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7616,9 +7595,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = [self._resolved_thread()]
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
 
@@ -7635,7 +7612,7 @@ class TestHandlePromoteMerge:
         gh.get_review_threads.return_value = [self._unresolved_thread()]
         with (
             patch(
-                "kennel.worker.tasks.list_tasks",
+                "kennel.tasks.Tasks.list",
                 return_value=self._completed_tasks(),
             ),
             caplog.at_level(logging.INFO, logger="kennel"),
@@ -7650,9 +7627,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
-        with patch(
-            "kennel.worker.tasks.list_tasks", return_value=self._completed_tasks()
-        ):
+        with patch("kennel.tasks.Tasks.list", return_value=self._completed_tasks()):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.get_review_threads.assert_called_once_with("rhencke", "myrepo", 9)
 
@@ -7666,7 +7641,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
         gh.pr_checks.return_value = self._passing_checks()
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
 
@@ -7680,7 +7655,7 @@ class TestHandlePromoteMerge:
             {"name": "ci / test", "state": "IN_PROGRESS", "link": "http://..."}
         ]
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7690,7 +7665,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
         gh.pr_checks.return_value = self._passing_checks()
         gh.get_required_checks.return_value = ["ci / test"]
-        with patch("kennel.worker.tasks.list_tasks", return_value=[]):
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7709,7 +7684,7 @@ class TestHandlePromoteMerge:
             "requestedReviewers": ["rhencke"],
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7724,7 +7699,7 @@ class TestHandlePromoteMerge:
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7744,7 +7719,7 @@ class TestHandlePromoteMerge:
         }
         mock_status = MagicMock()
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status", mock_status),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7761,7 +7736,7 @@ class TestHandlePromoteMerge:
             "requestedReviewers": ["rhencke"],
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
         ):
             result = worker.handle_promote_merge(
@@ -7778,7 +7753,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -7793,7 +7768,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_git"),
             patch.object(worker, "set_status"),
             caplog.at_level(logging.INFO, logger="kennel"),
@@ -7809,7 +7784,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7824,7 +7799,7 @@ class TestHandlePromoteMerge:
             state="CHANGES_REQUESTED", is_draft=False
         )
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7837,7 +7812,7 @@ class TestHandlePromoteMerge:
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7854,7 +7829,7 @@ class TestHandlePromoteMerge:
         gh.get_review_threads.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=completed),
+            patch("kennel.tasks.Tasks.list", return_value=completed),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7872,7 +7847,7 @@ class TestHandlePromoteMerge:
             "requestedReviewers": ["rhencke"],
         }
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=[]),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "set_status"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -7896,7 +7871,7 @@ class TestHandlePromoteMerge:
             {"id": "t1", "title": "Done", "status": "completed"},
             self._ask_task(),
         ]
-        with patch("kennel.worker.tasks.list_tasks", return_value=tasks_list):
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_not_called()
 
@@ -7908,7 +7883,7 @@ class TestHandlePromoteMerge:
             {"id": "t1", "title": "Done", "status": "completed"},
             self._ask_task(),
         ]
-        with patch("kennel.worker.tasks.list_tasks", return_value=tasks_list):
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7916,7 +7891,7 @@ class TestHandlePromoteMerge:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": False}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[self._ask_task()]):
+        with patch("kennel.tasks.Tasks.list", return_value=[self._ask_task()]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7928,7 +7903,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(
             state="CHANGES_REQUESTED", is_draft=False
         )
-        with patch("kennel.worker.tasks.list_tasks", return_value=[self._ask_task()]):
+        with patch("kennel.tasks.Tasks.list", return_value=[self._ask_task()]):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.add_pr_reviewers.assert_not_called()
 
@@ -7940,7 +7915,7 @@ class TestHandlePromoteMerge:
             {"id": "t1", "title": "Done", "status": "completed"},
             self._ask_task(),
         ]
-        with patch("kennel.worker.tasks.list_tasks", return_value=tasks_list):
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
@@ -7957,7 +7932,7 @@ class TestHandlePromoteMerge:
             self._ask_task(),
         ]
         with (
-            patch("kennel.worker.tasks.list_tasks", return_value=tasks_list),
+            patch("kennel.tasks.Tasks.list", return_value=tasks_list),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
@@ -7971,7 +7946,7 @@ class TestHandlePromoteMerge:
         gh.get_reviews.return_value = self._reviews(is_draft=True, state="NONE")
         completed = {"id": "t1", "title": "Done", "status": "completed", "type": "spec"}
         pending = {"id": "t2", "title": "Not done", "status": "pending", "type": "spec"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[completed, pending]):
+        with patch("kennel.tasks.Tasks.list", return_value=[completed, pending]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 1, "branch", 1
             )
@@ -7986,7 +7961,7 @@ class TestHandlePromoteMerge:
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
         completed = {"id": "t1", "title": "Done", "status": "completed", "type": "spec"}
-        with patch("kennel.worker.tasks.list_tasks", return_value=[completed]):
+        with patch("kennel.tasks.Tasks.list", return_value=[completed]):
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 1, "branch", 1
             )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8250,25 +8250,20 @@ class TestAutoCompleteAskTasks:
 
     def test_no_ask_tasks_does_nothing(self, tmp_path: Path) -> None:
         gh = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path, gh, "owner/repo", 1, _list_tasks=MagicMock(return_value=[])
-        )
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         gh.get_review_threads.assert_not_called()
 
     def test_completes_ask_task_when_thread_resolved(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = self._ask_task(42)
         gh.get_review_threads.return_value = [self._resolved_node(42)]
-        mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
-        mock_complete.assert_called_once_with(tmp_path, "ask-1")
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
+        mock_complete.assert_called_once_with("ask-1")
 
     def test_does_not_complete_ask_task_when_thread_not_resolved(
         self, tmp_path: Path
@@ -8278,31 +8273,23 @@ class TestAutoCompleteAskTasks:
         gh.get_review_threads.return_value = [
             {"isResolved": False, "comments": {"nodes": [{"databaseId": 42}]}}
         ]
-        mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         mock_complete.assert_not_called()
 
     def test_get_review_threads_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = self._ask_task(1)
         gh.get_review_threads.side_effect = RuntimeError("api fail")
-        mock_complete = MagicMock()
-        with pytest.raises(RuntimeError, match="api fail"):
-            _auto_complete_ask_tasks(
-                tmp_path,
-                gh,
-                "owner/repo",
-                1,
-                _list_tasks=MagicMock(return_value=[task]),
-                _complete_by_id=mock_complete,
-            )
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            pytest.raises(RuntimeError, match="api fail"),
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         mock_complete.assert_not_called()
 
     def test_non_ask_tasks_ignored(self, tmp_path: Path) -> None:
@@ -8313,29 +8300,21 @@ class TestAutoCompleteAskTasks:
             "thread": {"comment_id": 1},
         }
         gh.get_review_threads.return_value = [self._resolved_node(1)]
-        mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         mock_complete.assert_not_called()
 
     def test_ask_task_without_thread_ignored(self, tmp_path: Path) -> None:
         gh = MagicMock()
         task = {"title": "ASK: question", "status": "pending"}
-        mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         mock_complete.assert_not_called()
         gh.get_review_threads.assert_not_called()
 
@@ -8345,15 +8324,11 @@ class TestAutoCompleteAskTasks:
         gh.get_review_threads.return_value = [
             {"isResolved": True, "comments": {"nodes": [{}]}}
         ]
-        mock_complete = MagicMock()
-        _auto_complete_ask_tasks(
-            tmp_path,
-            gh,
-            "owner/repo",
-            1,
-            _list_tasks=MagicMock(return_value=[task]),
-            _complete_by_id=mock_complete,
-        )
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+        ):
+            _auto_complete_ask_tasks(tmp_path, gh, "owner/repo", 1)
         mock_complete.assert_not_called()
 
 
@@ -8366,15 +8341,10 @@ class TestSyncTasks:
     def _state_with_issue(self, fido_dir: Path, issue: int = 1) -> None:
         (fido_dir / "state.json").write_text(f'{{"issue": {issue}}}')
 
-    def _sync_kwargs(
-        self,
-        fido_dir: Path,
-        task_list: list | None = None,
-    ) -> dict:
+    def _sync_kwargs(self, fido_dir: Path) -> dict:
         """Return injection kwargs for sync_tasks pointing _resolve_git_dir at fido_dir.parent."""
         return {
             "_resolve_git_dir_fn": MagicMock(return_value=fido_dir.parent),
-            "_list_tasks": MagicMock(return_value=task_list or []),
             "_auto_complete_ask_tasks_fn": MagicMock(),
         }
 
@@ -8437,7 +8407,8 @@ class TestSyncTasks:
         gh.get_repo_info.return_value = "owner/repo"
         gh.get_user.return_value = "fido-bot"
         gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[]))
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.get_pr_body.assert_not_called()
 
     def test_syncs_pr_body_when_queue_markers_present(self, tmp_path: Path) -> None:
@@ -8450,7 +8421,8 @@ class TestSyncTasks:
         body = "desc\n<!-- WORK_QUEUE_START -->\nold\n<!-- WORK_QUEUE_END -->\nfooter"
         gh.get_pr_body.return_value = body
         task = {"title": "Do it", "status": "pending"}
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with patch("kennel.tasks.Tasks.list", return_value=[task]):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_called_once()
         new_body = gh.edit_pr_body.call_args[0][2]
         assert "Do it" in new_body
@@ -8470,7 +8442,8 @@ class TestSyncTasks:
         )
         gh.get_pr_body.return_value = body
         task = {"title": "Do it", "status": "pending", "type": "spec"}
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with patch("kennel.tasks.Tasks.list", return_value=[task]):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_called_once()
         new_body = gh.edit_pr_body.call_args[0][2]
         assert "My PR description." in new_body
@@ -8485,7 +8458,8 @@ class TestSyncTasks:
         gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
         gh.get_pr_body.return_value = "no markers here"
         task = {"title": "Do it", "status": "pending"}
-        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with patch("kennel.tasks.Tasks.list", return_value=[task]):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_not_called()
 
     def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
@@ -8506,8 +8480,11 @@ class TestSyncTasks:
         gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
         gh.get_pr_body.side_effect = RuntimeError("api down")
         task = {"title": "Do it", "status": "pending"}
-        with pytest.raises(RuntimeError, match="api down"):
-            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            pytest.raises(RuntimeError, match="api down"),
+        ):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_not_called()
 
     def test_edit_pr_body_exception_propagates(self, tmp_path: Path) -> None:
@@ -8521,8 +8498,11 @@ class TestSyncTasks:
         gh.get_pr_body.return_value = body
         gh.edit_pr_body.side_effect = RuntimeError("api down")
         task = {"title": "Do it", "status": "pending"}
-        with pytest.raises(RuntimeError, match="api down"):
-            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir, task_list=[task]))
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            pytest.raises(RuntimeError, match="api down"),
+        ):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
 
 
 class TestSyncTasksBackground:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -16,9 +16,6 @@ from kennel.config import RepoMembership
 from kennel.state import (
     State,
     _resolve_git_dir,
-    clear_state,
-    load_state,
-    save_state,
 )
 from kennel.tasks import (
     _apply_queue_to_body,
@@ -600,14 +597,14 @@ class TestWorker:
     def test_get_issue_returns_issue_number_when_open(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 7})
+        State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
         assert Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo") == 7
 
     def test_get_issue_returns_int_type(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 7})
+        State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
         result = Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
         assert isinstance(result, int)
@@ -615,17 +612,17 @@ class TestWorker:
     def test_get_issue_returns_none_when_closed(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 4})
+        State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
         assert Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo") is None
 
     def test_get_issue_clears_state_when_closed(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 4})
+        State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
         Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
-        assert load_state(fido_dir) == {}
+        assert State(fido_dir).load() == {}
 
     def test_get_issue_does_not_call_view_issue_when_no_state(
         self, tmp_path: Path
@@ -639,7 +636,7 @@ class TestWorker:
     def test_get_issue_calls_view_issue_with_correct_args(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 12})
+        State(fido_dir).save({"issue": 12})
         gh = self._make_issue_gh(state="OPEN")
         Worker(tmp_path, gh).get_current_issue(fido_dir, "alice/proj")
         gh.view_issue.assert_called_once_with("alice/proj", 12)
@@ -649,7 +646,7 @@ class TestWorker:
 
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 9})
+        State(fido_dir).save({"issue": 9})
         gh = self._make_issue_gh(state="CLOSED")
         with caplog.at_level(logging.INFO, logger="kennel"):
             Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
@@ -658,10 +655,10 @@ class TestWorker:
     def test_get_issue_state_preserved_when_open(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         gh = self._make_issue_gh(state="OPEN")
         Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
-        assert load_state(fido_dir) == {"issue": 5}
+        assert State(fido_dir).load() == {"issue": 5}
 
     # --- run ---
 
@@ -1360,7 +1357,7 @@ class TestWorkerFindNextIssue:
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
             worker.find_next_issue(fido_dir, self._make_repo_ctx())
-        state = load_state(fido_dir)
+        state = State(fido_dir).load()
         assert state["issue"] == 7
         assert state["issue_title"] == "Fetch!"
         assert "issue_started_at" in state
@@ -1371,7 +1368,7 @@ class TestWorkerFindNextIssue:
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
             worker.find_next_issue(fido_dir, self._make_repo_ctx())
-        assert load_state(fido_dir) == {}
+        assert State(fido_dir).load() == {}
 
     def test_calls_set_status_with_issue_info_when_found(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -2120,7 +2117,7 @@ class TestLoadState:
     def test_returns_empty_dict_when_absent(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        assert load_state(fido_dir) == {}
+        assert State(fido_dir).load() == {}
 
     def test_returns_state_when_present(self, tmp_path: Path) -> None:
         import json
@@ -2128,7 +2125,7 @@ class TestLoadState:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (fido_dir / "state.json").write_text(json.dumps({"issue": 42}))
-        assert load_state(fido_dir) == {"issue": 42}
+        assert State(fido_dir).load() == {"issue": 42}
 
     def test_returns_dict_with_arbitrary_keys(self, tmp_path: Path) -> None:
         import json
@@ -2136,7 +2133,7 @@ class TestLoadState:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (fido_dir / "state.json").write_text(json.dumps({"issue": 7, "extra": "val"}))
-        result = load_state(fido_dir)
+        result = State(fido_dir).load()
         assert result["issue"] == 7
         assert result["extra"] == "val"
 
@@ -2145,43 +2142,43 @@ class TestSaveState:
     def test_creates_state_file(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         assert (fido_dir / "state.json").exists()
 
     def test_roundtrips_with_load_state(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 99})
-        assert load_state(fido_dir) == {"issue": 99}
+        State(fido_dir).save({"issue": 99})
+        assert State(fido_dir).load() == {"issue": 99}
 
     def test_overwrites_existing_state(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 1})
-        save_state(fido_dir, {"issue": 2})
-        assert load_state(fido_dir) == {"issue": 2}
+        State(fido_dir).save({"issue": 1})
+        State(fido_dir).save({"issue": 2})
+        assert State(fido_dir).load() == {"issue": 2}
 
 
 class TestClearState:
     def test_removes_state_file(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 3})
-        clear_state(fido_dir)
+        State(fido_dir).save({"issue": 3})
+        State(fido_dir).clear()
         assert not (fido_dir / "state.json").exists()
 
     def test_noop_when_absent(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         # Should not raise
-        clear_state(fido_dir)
+        State(fido_dir).clear()
 
     def test_load_returns_empty_after_clear(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 10})
-        clear_state(fido_dir)
-        assert load_state(fido_dir) == {}
+        State(fido_dir).save({"issue": 10})
+        State(fido_dir).clear()
+        assert State(fido_dir).load() == {}
 
 
 class TestState:
@@ -2201,12 +2198,12 @@ class TestState:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 42})
-        assert load_state(fido_dir) == {"issue": 42}
+        assert State(fido_dir).load() == {"issue": 42}
 
     def test_clear_removes_state_file(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         State(fido_dir).clear()
         assert not (fido_dir / "state.json").exists()
 
@@ -3188,7 +3185,7 @@ class TestFindOrCreatePr:
         worker, gh = self._make_worker(tmp_path)
         gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         task = {"title": "t", "status": "pending"}
         call_count = 0
 
@@ -6050,12 +6047,12 @@ class TestExecuteTask:
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         task = {"id": "task-99", "title": "Do stuff", "status": "pending"}
         captured: dict = {}
 
         def capture(fd, *args, **kwargs):
-            captured.update(load_state(fd))
+            captured.update(State(fd).load())
             return ("sess", "")
 
         with (
@@ -6074,7 +6071,7 @@ class TestExecuteTask:
     def test_clears_current_task_id_after_completion(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         task = {"id": "task-77", "title": "Complete me", "status": "pending"}
         with (
             patch("kennel.worker.tasks.list_tasks", return_value=[task]),
@@ -6087,19 +6084,19 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        assert "current_task_id" not in load_state(fido_dir)
+        assert "current_task_id" not in State(fido_dir).load()
 
     def test_preserves_other_state_keys_when_saving_current_task_id(
         self, tmp_path: Path
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         task = {"id": "t-111", "title": "Preserve", "status": "pending"}
         captured: dict = {}
 
         def capture(fd, *args, **kwargs):
-            captured.update(load_state(fd))
+            captured.update(State(fd).load())
             return ("sess", "")
 
         with (
@@ -6119,7 +6116,7 @@ class TestExecuteTask:
     def test_current_task_id_not_cleared_when_push_fails(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         task = {"id": "task-push-fail", "title": "Push me", "status": "pending"}
         with (
             patch("kennel.worker.tasks.list_tasks", return_value=[task]),
@@ -6132,7 +6129,7 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        assert load_state(fido_dir).get("current_task_id") == "task-push-fail"
+        assert State(fido_dir).load().get("current_task_id") == "task-push-fail"
 
     @staticmethod
     def _git_same_sha():
@@ -6154,7 +6151,7 @@ class TestExecuteTask:
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1, "current_task_id": "t-abort"})
+        State(fido_dir).save({"issue": 1, "current_task_id": "t-abort"})
         task = {"id": "t-abort", "title": "Abort me", "status": "pending"}
         worker._abort_task.set()
         with (
@@ -6171,7 +6168,7 @@ class TestExecuteTask:
         assert result is True
         mock_clean.assert_called_once()
         mock_remove.assert_called_once_with(tmp_path, "t-abort")
-        assert "current_task_id" not in load_state(fido_dir)
+        assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
 
@@ -6180,7 +6177,7 @@ class TestExecuteTask:
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         task = {"id": "t-resume-abort", "title": "Resume abort", "status": "pending"}
         call_count = 0
 
@@ -6205,14 +6202,14 @@ class TestExecuteTask:
         assert result is True
         mock_clean.assert_called_once()
         mock_remove.assert_called_once_with(tmp_path, "t-resume-abort")
-        assert "current_task_id" not in load_state(fido_dir)
+        assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
 
     def test_abort_does_not_call_complete_by_id(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 1})
+        State(fido_dir).save({"issue": 1})
         task = {"id": "t-no-complete", "title": "No complete", "status": "pending"}
         worker._abort_task.set()
         with (
@@ -6665,7 +6662,7 @@ class TestHandlePromoteMerge:
     def test_approved_not_draft_no_pending_clears_state(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         gh.get_reviews.return_value = self._reviews(is_draft=False)
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
@@ -6674,7 +6671,7 @@ class TestHandlePromoteMerge:
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        assert load_state(fido_dir) == {}
+        assert State(fido_dir).load() == {}
 
     def test_approved_not_draft_no_pending_git_checkout_default(
         self, tmp_path: Path
@@ -6985,7 +6982,7 @@ class TestHandlePromoteMerge:
     def test_changes_req_then_approved_clears_state(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
-        save_state(fido_dir, {"issue": 5})
+        State(fido_dir).save({"issue": 5})
         gh.get_reviews.return_value = self._changes_requested_then_approved_reviews()
         gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
         with (
@@ -6994,7 +6991,7 @@ class TestHandlePromoteMerge:
             patch.object(worker, "set_status"),
         ):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        assert load_state(fido_dir) == {}
+        assert State(fido_dir).load() == {}
 
     def test_changes_req_then_approved_git_checkout_default(
         self, tmp_path: Path


### PR DESCRIPTION
Fixes #393.

Unifies task and state file access behind coherent storage APIs. State free functions get internalized into the State class, Tasks locking and validation get consolidated with JsonFileStore, and all call sites get routed through the OO boundaries instead of bypassing them with free functions or direct file access.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Internalize State free functions into the State class <!-- type:spec -->
- [x] Route all external state access through State <!-- type:spec -->
- [x] Unify Tasks locking and validation with JsonFileStore <!-- type:spec -->
- [x] Move task CRUD free functions into Tasks class <!-- type:spec -->
- [x] Route remaining task access through Tasks <!-- type:spec -->
- [x] Move task orchestration functions to use Tasks internally <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->