### PR TITLE
Convert Claude and prompt assembly into injectable collaborators (closes #399)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1459,3 +1459,313 @@ def resume_status(
         return extract_result_text(result.stdout.strip())
     except subprocess.TimeoutExpired, FileNotFoundError:
         return ""
+
+
+# ── Injectable one-shot collaborator ─────────────────────────────────────────
+
+
+class ClaudeClient:
+    """Injectable collaborator for one-shot Claude CLI interactions.
+
+    Wraps subprocess-based, session-based, and streaming Claude helpers
+    so callers can depend on an explicit boundary instead of module-level
+    functions.  Constructor-injected dependencies replace the per-call
+    ``runner=`` / ``streaming_runner=`` overrides used by the free functions.
+
+    The class does not own the persistent :class:`ClaudeSession` — it
+    receives a *session_fn* callback that resolves the session for the
+    calling context (thread-local repo in production, a test fake in
+    tests).
+    """
+
+    def __init__(
+        self,
+        runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        session_fn: Callable[[], "ClaudeSession"] = _session_for_current_repo,
+        streaming_runner: Callable[..., Iterator[str]] = _run_streaming,
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._runner = runner
+        self._session_fn = session_fn
+        self._streaming_runner = streaming_runner
+        self._sleep_fn = sleep_fn
+
+    # ── Session-based helpers ────────────────────────────────────────────
+
+    def print_prompt(
+        self,
+        prompt: str,
+        model: str,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run a prompt turn on the persistent session, returning the result text."""
+        session = self._session_fn()
+        return session.prompt(prompt, model=model, system_prompt=system_prompt)
+
+    def print_prompt_json(
+        self,
+        prompt: str,
+        key: str,
+        model: str,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run a prompt turn and parse JSON from the response at *key*."""
+        json_instruction = (
+            f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
+            " No other text before or after the JSON."
+        )
+        full_system = (
+            f"{system_prompt}\n\n{json_instruction}"
+            if system_prompt
+            else json_instruction
+        )
+        raw = self.print_prompt(prompt, model, system_prompt=full_system)
+        if not raw:
+            return ""
+        candidates = [raw] + [
+            m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)
+        ]
+        for candidate in candidates:
+            try:
+                obj = json.loads(candidate)
+                if isinstance(obj.get(key), str):
+                    return obj[key]
+            except json.JSONDecodeError, AttributeError:
+                continue
+        return ""
+
+    def generate_status(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: str = "claude-opus-4-6",
+    ) -> str:
+        """Ask claude to generate a GitHub status (two lines: emoji + text)."""
+        return self.print_prompt(
+            prompt=prompt, model=model, system_prompt=system_prompt
+        )
+
+    def generate_status_emoji(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: str = "claude-opus-4-6",
+    ) -> str:
+        """Ask claude to choose a single emoji for a GitHub status."""
+        return self.print_prompt(
+            prompt=prompt, model=model, system_prompt=system_prompt
+        )
+
+    # ── Streaming file-based helpers ─────────────────────────────────────
+
+    def print_prompt_from_file(
+        self,
+        system_file: Path,
+        prompt_file: Path,
+        model: str,
+        timeout: int = 30,
+        idle_timeout: float = 1800.0,
+        cwd: Path | str | None = None,
+    ) -> str:
+        """Run claude --print reading system prompt and user prompt from files."""
+        cmd = [
+            "claude",
+            "--model",
+            model,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+            "--system-prompt-file",
+            str(system_file),
+            "--print",
+        ]
+        return "".join(
+            self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
+        ).strip()
+
+    def resume_session(
+        self,
+        session_id: str,
+        prompt_file: Path,
+        model: str,
+        timeout: int = 300,
+        idle_timeout: float = 1800.0,
+        cwd: Path | str | None = None,
+    ) -> str:
+        """Continue an existing claude session by ID, feeding prompt_file on stdin."""
+        cmd = [
+            "claude",
+            "--model",
+            model,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+            "--resume",
+            session_id,
+            "--print",
+        ]
+        return "".join(
+            self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
+        ).strip()
+
+    # ── Subprocess one-shot helpers ──────────────────────────────────────
+
+    def triage_comment(
+        self,
+        prompt: str,
+        model: str = "claude-opus-4-6",
+        timeout: int = 15,
+    ) -> str:
+        """Ask claude to triage a PR comment. Returns the raw first line of output."""
+        try:
+            result = _claude(
+                "--model",
+                model,
+                "--print",
+                "-p",
+                prompt,
+                timeout=timeout,
+                runner=self._runner,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip().splitlines()[0]
+            return ""
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            return ""
+
+    def generate_reply(
+        self,
+        prompt: str,
+        model: str = "claude-opus-4-6",
+        timeout: int = 30,
+    ) -> str:
+        """Ask claude to generate a short reply. Returns stripped output or empty string."""
+        try:
+            result = _claude(
+                "--model",
+                model,
+                "--print",
+                "-p",
+                prompt,
+                timeout=timeout,
+                runner=self._runner,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            return ""
+
+    def generate_branch_name(
+        self,
+        prompt: str,
+        model: str = "claude-haiku-4-5-20251001",
+        timeout: int = 15,
+    ) -> str:
+        """Ask claude to generate a git branch name slug. Returns first line of output."""
+        try:
+            result = _claude(
+                "--model",
+                model,
+                "--print",
+                "-p",
+                prompt,
+                timeout=timeout,
+                runner=self._runner,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip().splitlines()[0]
+            return ""
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            return ""
+
+    def generate_status_with_session(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: str = "claude-opus-4-6",
+        timeout: int = 15,
+    ) -> tuple[str, str]:
+        """Generate a GitHub status, returning (status_text, session_id)."""
+        for attempt in range(_EMPTY_RETRY_COUNT + 1):
+            try:
+                result = _claude(
+                    "--model",
+                    model,
+                    "--output-format",
+                    "stream-json",
+                    "--verbose",
+                    "--dangerously-skip-permissions",
+                    "--system-prompt",
+                    system_prompt,
+                    "--print",
+                    "-p",
+                    prompt,
+                    timeout=timeout,
+                    runner=self._runner,
+                )
+                if result.returncode != 0:
+                    log.warning(
+                        "generate_status_with_session: claude exited %d",
+                        result.returncode,
+                    )
+                    return "", ""
+                raw = result.stdout.strip()
+                text = extract_result_text(raw)
+                sid = extract_session_id(raw)
+                if text:
+                    return text, sid
+                if result.stderr:
+                    log.warning(
+                        "generate_status_with_session: stderr=%r",
+                        _Trunc(result.stderr),
+                    )
+                log.debug(
+                    "generate_status_with_session: stdout=%r",
+                    _Trunc(result.stdout),
+                )
+                if attempt < _EMPTY_RETRY_COUNT:
+                    log.warning(
+                        "generate_status_with_session: empty output on attempt %d"
+                        " — retrying",
+                        attempt + 1,
+                    )
+                    self._sleep_fn(_EMPTY_RETRY_DELAY)
+            except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+                log.warning("generate_status_with_session: %s", exc)
+                return "", ""
+        log.warning(
+            "generate_status_with_session: empty output after %d attempts",
+            _EMPTY_RETRY_COUNT + 1,
+        )
+        return "", ""
+
+    def resume_status(
+        self,
+        session_id: str,
+        prompt: str,
+        model: str = "claude-opus-4-6",
+        timeout: int = 15,
+    ) -> str:
+        """Resume an existing claude session to refine a status response."""
+        try:
+            result = _claude(
+                "--model",
+                model,
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--dangerously-skip-permissions",
+                "--resume",
+                session_id,
+                "--print",
+                "-p",
+                prompt,
+                timeout=timeout,
+                runner=self._runner,
+            )
+            if result.returncode != 0:
+                return ""
+            return extract_result_text(result.stdout.strip())
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            return ""

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -209,13 +209,13 @@ def _session_for_current_repo() -> "ClaudeSession":
     repo = current_repo()
     if repo is None:
         raise RuntimeError(
-            "claude.print_prompt called without a thread-local repo_name — "
-            "server.WebhookHandler._process_action and WorkerThread.run both "
-            "set it; this caller is missing the install."
+            "ClaudeClient.print_prompt called without a thread-local repo_name"
+            " — server.WebhookHandler._process_action and WorkerThread.run"
+            " both set it; this caller is missing the install."
         )
     if _session_resolver is None:
         raise RuntimeError(
-            "claude.print_prompt called before set_session_resolver — "
+            "ClaudeClient.print_prompt called before set_session_resolver — "
             "server._run() installs it at startup; nothing should run before."
         )
     session = _session_resolver(repo)
@@ -393,63 +393,8 @@ def extract_result_text(output: str) -> str:
     return result
 
 
-# ── Simple print calls (no tool use) ─────────────────────────────────────────
-
-
 _EMPTY_RETRY_COUNT = 2
 _EMPTY_RETRY_DELAY = 1.0
-
-
-def print_prompt(
-    prompt: str,
-    model: str,
-    system_prompt: str | None = None,
-) -> str:
-    """Run a prompt turn on this thread's persistent :class:`ClaudeSession`,
-    returning the result text.
-
-    Always routes through the session resolved via :func:`set_session_resolver`
-    — production has one claude subprocess per repo, and every prompt call
-    shares it.  Errors propagate (we fail open, not silently masked).
-    """
-    session = _session_for_current_repo()
-    return session.prompt(prompt, model=model, system_prompt=system_prompt)
-
-
-def print_prompt_json(
-    prompt: str,
-    key: str,
-    model: str,
-    system_prompt: str | None = None,
-) -> str:
-    """Run a prompt turn and parse JSON from the response at *key*.
-
-    Appends a JSON-format instruction to *system_prompt* so Claude outputs
-    ``{"key": "..."}``.  Scans the raw response for a JSON object so
-    preamble or trailing text from Opus does not corrupt the result.
-    Returns ``""`` if the JSON parse fails (but claude errors propagate
-    from :func:`print_prompt` — we fail open on infrastructure failure).
-    """
-    json_instruction = (
-        f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
-        " No other text before or after the JSON."
-    )
-    full_system = (
-        f"{system_prompt}\n\n{json_instruction}" if system_prompt else json_instruction
-    )
-    raw = print_prompt(prompt, model, system_prompt=full_system)
-    if not raw:
-        return ""
-    # Try parsing whole output, then scan for JSON objects (handles preamble).
-    candidates = [raw] + [m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)]
-    for candidate in candidates:
-        try:
-            obj = json.loads(candidate)
-            if isinstance(obj.get(key), str):
-                return obj[key]
-        except json.JSONDecodeError, AttributeError:
-            continue
-    return ""
 
 
 def _run_streaming(
@@ -527,230 +472,6 @@ def _run_streaming(
         if talker_registered and repo_name is not None:
             unregister_talker(repo_name, thread_id)
         _unregister_child(proc)
-
-
-def print_prompt_from_file(
-    system_file: Path,
-    prompt_file: Path,
-    model: str,
-    timeout: int = 30,
-    idle_timeout: float = 1800.0,
-    cwd: Path | str | None = None,
-    streaming_runner: Callable[..., Iterator[str]] = _run_streaming,
-) -> str:
-    """Run claude --print reading system prompt and user prompt from files.
-
-    Returns the full stdout on success.  Kills the process if no output
-    is produced for *idle_timeout* seconds (default 30 min).
-
-    Raises ``ClaudeStreamError`` on nonzero exit or idle timeout.
-    ``FileNotFoundError`` propagates if the claude CLI is not installed.
-    Both are authoritative failures — callers should not silently ignore them.
-    """
-    cmd = [
-        "claude",
-        "--model",
-        model,
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--dangerously-skip-permissions",
-        "--system-prompt-file",
-        str(system_file),
-        "--print",
-    ]
-    return "".join(streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)).strip()
-
-
-def resume_session(
-    session_id: str,
-    prompt_file: Path,
-    model: str,
-    timeout: int = 300,
-    idle_timeout: float = 1800.0,
-    cwd: Path | str | None = None,
-    streaming_runner: Callable[..., Iterator[str]] = _run_streaming,
-) -> str:
-    """Continue an existing claude session by ID, feeding prompt_file on stdin.
-
-    Returns the full stdout on success.  Kills the process if no output
-    is produced for *idle_timeout* seconds (default 30 min).
-
-    Raises ``ClaudeStreamError`` on nonzero exit or idle timeout.
-    ``FileNotFoundError`` propagates if the claude CLI is not installed.
-    Both are authoritative failures — callers should not silently ignore them.
-    """
-    cmd = [
-        "claude",
-        "--model",
-        model,
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--dangerously-skip-permissions",
-        "--resume",
-        session_id,
-        "--print",
-    ]
-    return "".join(streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)).strip()
-
-
-# ── Specialised wrappers used by events.py ───────────────────────────────────
-
-
-def triage_comment(
-    prompt: str,
-    model: str = "claude-opus-4-6",
-    timeout: int = 15,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str:
-    """Ask claude to triage a PR comment. Returns the raw first line of output.
-
-    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
-    CLI — callers must treat an empty result as "unable to triage".
-    """
-    try:
-        result = _claude(
-            "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip().splitlines()[0]
-        return ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
-
-
-def generate_reply(
-    prompt: str,
-    model: str = "claude-opus-4-6",
-    timeout: int = 30,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str:
-    """Ask claude to generate a short reply. Returns stripped output or empty string.
-
-    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
-    CLI — callers must treat an empty result as "no reply generated".
-    """
-    try:
-        result = _claude(
-            "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
-        )
-        return result.stdout.strip() if result.returncode == 0 else ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
-
-
-def generate_branch_name(
-    prompt: str,
-    model: str = "claude-haiku-4-5-20251001",
-    timeout: int = 15,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str:
-    """Ask claude to generate a git branch name slug. Returns first line of output.
-
-    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
-    CLI — callers must treat an empty result as "use a fallback branch name".
-    """
-    try:
-        result = _claude(
-            "--model", model, "--print", "-p", prompt, timeout=timeout, runner=runner
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip().splitlines()[0]
-        return ""
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
-
-
-def generate_status(
-    prompt: str,
-    system_prompt: str,
-    model: str = "claude-opus-4-6",
-) -> str:
-    """Ask claude to generate a GitHub status (two lines: emoji + text)."""
-    return print_prompt(
-        prompt=prompt,
-        model=model,
-        system_prompt=system_prompt,
-    )
-
-
-def generate_status_emoji(
-    prompt: str,
-    system_prompt: str,
-    model: str = "claude-opus-4-6",
-) -> str:
-    """Ask claude to choose a single emoji for a GitHub status."""
-    return print_prompt(
-        prompt=prompt,
-        model=model,
-        system_prompt=system_prompt,
-    )
-
-
-def generate_status_with_session(
-    prompt: str,
-    system_prompt: str,
-    model: str = "claude-opus-4-6",
-    timeout: int = 15,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-    _sleep: Callable[[float], None] = time.sleep,
-) -> tuple[str, str]:
-    """Generate a GitHub status, returning (status_text, session_id).
-
-    Best-effort enrichment: returns ``("", "")`` on any failure — callers must
-    treat an all-empty tuple as "status unavailable".  Uses stream-json output
-    format to capture the session_id alongside the response text, enabling
-    follow-up calls (e.g., ``resume_status`` to shorten a long response).
-    Retries up to ``_EMPTY_RETRY_COUNT`` times when Claude exits 0 but
-    produces no output.
-    """
-    for attempt in range(_EMPTY_RETRY_COUNT + 1):
-        try:
-            result = _claude(
-                "--model",
-                model,
-                "--output-format",
-                "stream-json",
-                "--verbose",
-                "--dangerously-skip-permissions",
-                "--system-prompt",
-                system_prompt,
-                "--print",
-                "-p",
-                prompt,
-                timeout=timeout,
-                runner=runner,
-            )
-            if result.returncode != 0:
-                log.warning(
-                    "generate_status_with_session: claude exited %d", result.returncode
-                )
-                return "", ""
-            raw = result.stdout.strip()
-            text = extract_result_text(raw)
-            sid = extract_session_id(raw)
-            if text:
-                return text, sid
-            if result.stderr:
-                log.warning(
-                    "generate_status_with_session: stderr=%r", _Trunc(result.stderr)
-                )
-            log.debug("generate_status_with_session: stdout=%r", _Trunc(result.stdout))
-            if attempt < _EMPTY_RETRY_COUNT:
-                log.warning(
-                    "generate_status_with_session: empty output on attempt %d — retrying",
-                    attempt + 1,
-                )
-                _sleep(_EMPTY_RETRY_DELAY)
-        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-            log.warning("generate_status_with_session: %s", exc)
-            return "", ""
-    log.warning(
-        "generate_status_with_session: empty output after %d attempts",
-        _EMPTY_RETRY_COUNT + 1,
-    )
-    return "", ""
 
 
 # ── Persistent bidirectional session ─────────────────────────────────────────
@@ -1423,42 +1144,6 @@ class ClaudeSession:
                 log.debug("ClaudeSession.stop: wait failed: %s", exc)
         finally:
             _unregister_child(self._proc)
-
-
-def resume_status(
-    session_id: str,
-    prompt: str,
-    model: str = "claude-opus-4-6",
-    timeout: int = 15,
-    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-) -> str:
-    """Resume an existing claude session to refine a status response.
-
-    Best-effort enrichment: returns ``""`` on nonzero exit, timeout, or missing
-    CLI — callers must treat an empty result as "refinement unavailable".
-    Passes *prompt* as a positional argument (``-p``), so no file is needed.
-    """
-    try:
-        result = _claude(
-            "--model",
-            model,
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions",
-            "--resume",
-            session_id,
-            "--print",
-            "-p",
-            prompt,
-            timeout=timeout,
-            runner=runner,
-        )
-        if result.returncode != 0:
-            return ""
-        return extract_result_text(result.stdout.strip())
-    except subprocess.TimeoutExpired, FileNotFoundError:
-        return ""
 
 
 # ── Injectable one-shot collaborator ─────────────────────────────────────────

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -933,7 +933,12 @@ def _make_reorder_kwargs(
     def on_done() -> None:
         rewrite_fn(work_dir, gh, claude_client=claude_client)
 
-    kwargs: dict[str, Any] = {"_on_changes": on_changes, "_on_done": on_done}
+    kwargs: dict[str, Any] = {
+        "_on_changes": on_changes,
+        "_on_done": on_done,
+        "claude_client": claude_client,
+        "prompts": prompts,
+    }
     if registry is not None and repo_cfg is not None:
 
         def on_inprogress_affected() -> None:

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -10,24 +10,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from kennel import claude
+from kennel.claude import ClaudeClient
 from kennel.config import Config, RepoConfig
 from kennel.github import GitHub
-from kennel.prompts import (
-    Prompts,
-    issue_reply_instruction,
-    reply_instruction,
-    triage_prompt,
-)
+from kennel.prompts import Prompts
 from kennel.registry import WorkerRegistry
 from kennel.tasks import Tasks
 from kennel.types import TaskType
 
 log = logging.getLogger(__name__)
-
-# Type alias for the claude.print_prompt DI callback.
-# Uses Callable[..., str] because some callsites pass system_prompt= as a kwarg.
-_PrintPrompt = Callable[..., str]
 
 # Per-work_dir coalescing state for _reorder_tasks_background.
 # Ensures at most one Opus call in-flight + one pending per repo.
@@ -238,17 +229,21 @@ def maybe_react(
     config: Config,
     gh: GitHub,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> None:
     """Let Fido decide whether to react to a comment with an emoji.
 
     comment_type: 'pulls' for review comments, 'issues' for issue comments.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
-    prompts = Prompts(_load_persona(config))
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
     reaction = (
-        _print_prompt(prompts.react_prompt(comment_body), "claude-opus-4-6")
+        claude_client.print_prompt(
+            prompts.react_prompt(comment_body), "claude-opus-4-6"
+        )
         .lower()
         .split("\n")[0]
         .strip()
@@ -272,7 +267,8 @@ def reply_to_comment(
     repo_cfg: RepoConfig,
     gh: GitHub,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> tuple[str, list[str]]:
     """Triage a comment via Opus, generate a reply via Opus, post it.
 
@@ -282,8 +278,10 @@ def reply_to_comment(
     Uses a per-comment lockfile to prevent concurrent replies.
     Raises on reply-post failure so callers fail closed.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
     info = action.reply_to
     if not info or not action.comment_body:
         return ("ACT", [action.comment_body or action.prompt])
@@ -302,7 +300,6 @@ def reply_to_comment(
     else:
         lock_fd = None
 
-    prompts = Prompts(_load_persona(config))
     comment = action.comment_body
 
     context: dict[str, Any] = dict(action.context) if action.context else {}
@@ -326,7 +323,7 @@ def reply_to_comment(
 
     # Enrich context with sibling threads when the comment needs more context
     if (
-        needs_more_context(comment, _print_prompt=_print_prompt)
+        needs_more_context(comment, claude_client=claude_client)
         and info.get("repo")
         and info.get("pr")
     ):
@@ -340,7 +337,7 @@ def reply_to_comment(
 
     # Step 1: Haiku triage (on the triggering comment to determine category)
     category, titles = _triage(
-        comment, action.is_bot, context, _print_prompt=_print_prompt
+        comment, action.is_bot, context, claude_client=claude_client, prompts=prompts
     )
     log.info("triage: %s — %s", category, titles)
 
@@ -351,7 +348,7 @@ def reply_to_comment(
     # reflects what the reviewer originally asked.
     if category in ("ACT", "DO"):
         log.info("deriving task title from root comment")
-        titles = [_summarize_as_action_item(root_body, _print_prompt=_print_prompt)]
+        titles = [_summarize_as_action_item(root_body, claude_client=claude_client)]
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply.
     # Raises on failure so we don't craft a reply referencing a missing issue.
@@ -361,7 +358,7 @@ def reply_to_comment(
         issue_url = _open_defer_issue(gh, info["repo"], pr_url, titles[0], comment)
 
     # Step 3: Opus reply based on triage
-    instr = reply_instruction(
+    instr = prompts.reply_instruction(
         category, comment, ", ".join(titles), context, issue_url=issue_url
     )
 
@@ -371,7 +368,7 @@ def reply_to_comment(
         info["pr"],
         info["comment_id"],
     )
-    body = _print_prompt(
+    body = claude_client.print_prompt(
         prompts.persona_wrap(instr),
         "claude-opus-4-6",
         system_prompt=prompts.reply_system_prompt(),
@@ -409,7 +406,8 @@ def reply_to_comment(
         info.get("repo", ""),
         config,
         gh,
-        _print_prompt=_print_prompt,
+        claude_client=claude_client,
+        prompts=prompts,
     )
 
     # For DUMP: also resolve the thread
@@ -436,7 +434,8 @@ def reply_to_review(
     gh: GitHub,
     already_replied: set[int] | None = None,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> None:
     """No-op for inline comments — they are handled per-comment.
 
@@ -457,14 +456,14 @@ def reply_to_review(
     \"Submit review\") still arrives only through this event and is not
     yet handled.  Tracked separately — out of scope for the dedup fix.
     """
-    _ = (action, config, repo_cfg, gh, already_replied, _print_prompt)
+    _ = (action, config, repo_cfg, gh, already_replied, claude_client, prompts)
     log.debug(
         "reply_to_review: skipping inline comments — handled per-comment (closes #518)"
     )
 
 
 def needs_more_context(
-    comment_body: str, *, _print_prompt: _PrintPrompt | None = None
+    comment_body: str, *, claude_client: ClaudeClient | None = None
 ) -> bool:
     """Ask Haiku whether this comment needs sibling thread context to act on.
 
@@ -472,8 +471,8 @@ def needs_more_context(
     to act on alone (e.g. "same", "ditto", "^"), False otherwise.
     Falls back to False on any error.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
     prompt = (
         "A reviewer left this comment on a pull request:\n\n"
         f"{comment_body!r}\n\n"
@@ -482,7 +481,7 @@ def needs_more_context(
         "to act on alone)?\n\n"
         "Reply with exactly YES or NO."
     )
-    answer = _print_prompt(prompt, "claude-haiku-4-5").upper()
+    answer = claude_client.print_prompt(prompt, "claude-haiku-4-5").upper()
     return answer.startswith("YES")
 
 
@@ -490,25 +489,25 @@ _MAX_TITLE_LEN = 80
 
 
 def _summarize_as_action_item(
-    comment_body: str, *, _print_prompt: _PrintPrompt | None = None
+    comment_body: str, *, claude_client: ClaudeClient | None = None
 ) -> str:
     """Ask Opus to convert a comment into a short imperative action-item title.
 
     If the result is too long, asks Claude to shorten it up to 3 times before
     falling back to hard truncation.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
     prompt = (
         "Convert this PR review comment into a short, imperative task title starting with a verb. "
         "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
         f"Comment: {comment_body}"
     )
-    result = _print_prompt(prompt, "claude-opus-4-6").strip()
+    result = claude_client.print_prompt(prompt, "claude-opus-4-6").strip()
     for _ in range(3):
         if not result or len(result) <= _MAX_TITLE_LEN:
             break
-        result = _print_prompt(
+        result = claude_client.print_prompt(
             f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
             f"Reply with ONLY the shortened title.\n\nTitle: {result}",
             "claude-opus-4-6",
@@ -523,7 +522,8 @@ def _triage(
     is_bot: bool,
     context: dict[str, Any] | None = None,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> tuple[str, list[str]]:
     """Ask Opus to triage a comment. Returns (category, titles).
 
@@ -531,11 +531,13 @@ def _triage(
     for ANSWER/ASK/DEFER/DUMP (used as reply context), or one or more entries
     for ACT/DO (each becomes a separate work-queue task).
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
-    prompt = triage_prompt(comment_body, is_bot, context)
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts("")
+    prompt = prompts.triage_prompt(comment_body, is_bot, context)
     log.info("triage classifier: requesting category from opus")
-    text = _print_prompt(prompt, "claude-opus-4-6")
+    text = claude_client.print_prompt(prompt, "claude-opus-4-6")
     log.info(
         "triage classifier: returned %d chars (preview=%r)",
         len(text or ""),
@@ -563,7 +565,7 @@ def _triage(
     )
     # Fallback: ACT for humans, DO for bots; summarize comment into action item
     category = "DO" if is_bot else "ACT"
-    title = _summarize_as_action_item(comment_body, _print_prompt=_print_prompt)
+    title = _summarize_as_action_item(comment_body, claude_client=claude_client)
     return category, [title]
 
 
@@ -573,14 +575,17 @@ def reply_to_issue_comment(
     repo_cfg: RepoConfig,
     gh: GitHub,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> tuple[str, list[str]]:
     """Triage and reply to a top-level PR comment (issue_comment event).
 
     Raises on reply-post failure so callers fail closed.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
     comment = action.comment_body or ""
 
     # Extract PR number from prompt
@@ -611,9 +616,12 @@ def reply_to_issue_comment(
     if conversation_context:
         context["conversation"] = conversation_context
 
-    prompts = Prompts(_load_persona(config))
     category, titles = _triage(
-        comment, action.is_bot, context or None, _print_prompt=_print_prompt
+        comment,
+        action.is_bot,
+        context or None,
+        claude_client=claude_client,
+        prompts=prompts,
     )
     log.info("issue comment triage: %s — %s", category, titles)
 
@@ -624,12 +632,12 @@ def reply_to_issue_comment(
         pr_url = f"https://github.com/{repo_full}/pull/{number}" if number else ""
         issue_url = _open_defer_issue(gh, repo_full, pr_url, titles[0], comment)
 
-    instr = issue_reply_instruction(
+    instr = prompts.issue_reply_instruction(
         category, comment, ", ".join(titles), action.context, issue_url=issue_url
     )
 
     log.info("generating %s reply for issue comment on PR #%s", category, number)
-    body = _print_prompt(
+    body = claude_client.print_prompt(
         prompts.persona_wrap(instr),
         "claude-opus-4-6",
         system_prompt=prompts.reply_system_prompt(),
@@ -653,7 +661,8 @@ def reply_to_issue_comment(
             repo_full,
             config,
             gh,
-            _print_prompt=_print_prompt,
+            claude_client=claude_client,
+            prompts=prompts,
         )
 
     return (category, titles)
@@ -736,7 +745,8 @@ def _notify_thread_change(
     config: Config,
     gh: GitHub,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
 ) -> None:
     """Post a brief comment notifying a commenter that their task was rescoped.
 
@@ -748,8 +758,10 @@ def _notify_thread_change(
     review comment API; for issue comments (comment_type='issues') posts via
     the issue comments API.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
 
     task = change["task"]
     thread = task.get("thread") or {}
@@ -764,7 +776,6 @@ def _notify_thread_change(
 
     kind = change["kind"]
     original_title = task.get("title", "")
-    prompts = Prompts(_load_persona(config))
 
     if kind == "completed":
         instruction = (
@@ -789,7 +800,7 @@ def _notify_thread_change(
             "has been updated. Reference the comment URL."
         )
 
-    body = _print_prompt(
+    body = claude_client.print_prompt(
         prompts.persona_wrap(instruction),
         "claude-opus-4-6",
         system_prompt=prompts.reply_system_prompt(),
@@ -822,7 +833,7 @@ def _rewrite_pr_description(
     work_dir: Path,
     gh: Any,
     *,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
     _state: Any = None,
     _tasks: Any = None,
     _max_retries: int = 3,
@@ -874,7 +885,15 @@ def _rewrite_pr_description(
 
         body = gh.get_pr_body(repo, pr_number)
         _write_pr_description(
-            gh, repo, pr_number, issue, task_list, body, _print_prompt=_print_prompt
+            gh,
+            repo,
+            pr_number,
+            issue,
+            task_list,
+            body,
+            _print_prompt=claude_client.print_prompt
+            if claude_client is not None
+            else None,
         )
 
         snapshot_after = _task_snapshot(_tasks.list())
@@ -901,17 +920,20 @@ def _make_reorder_kwargs(
     repo_cfg: RepoConfig | None,
     registry: WorkerRegistry | None,
     gh: Any,
-    print_prompt: Any,
+    claude_client: ClaudeClient | None,
+    prompts: Prompts | None,
     rewrite_fn: Any,
 ) -> dict[str, Any]:
     """Build the kwargs dict for a :func:`~kennel.tasks.reorder_tasks` call."""
 
     def on_changes(changes: list[dict[str, Any]]) -> None:
         for change in changes:
-            _notify_thread_change(change, config, gh)
+            _notify_thread_change(
+                change, config, gh, claude_client=claude_client, prompts=prompts
+            )
 
     def on_done() -> None:
-        rewrite_fn(work_dir, gh, _print_prompt=print_prompt)
+        rewrite_fn(work_dir, gh, claude_client=claude_client)
 
     kwargs: dict[str, Any] = {"_on_changes": on_changes, "_on_done": on_done}
     if registry is not None and repo_cfg is not None:
@@ -936,7 +958,8 @@ def _reorder_tasks_background(
     registry: WorkerRegistry | None = None,
     *,
     _start: Callable[[threading.Thread], None] = threading.Thread.start,
-    _print_prompt: _PrintPrompt | None = None,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
     _rewrite_fn: Callable[..., None] | None = None,
     _reorder_fn: Callable[..., None] | None = None,
     _coalesce_state: dict[str, Any] | None = None,
@@ -970,7 +993,7 @@ def _reorder_tasks_background(
 
     key = str(work_dir)
     kwargs = _make_reorder_kwargs(
-        work_dir, config, repo_cfg, registry, gh, _print_prompt, rewrite_fn
+        work_dir, config, repo_cfg, registry, gh, claude_client, prompts, rewrite_fn
     )
 
     with _reorder_coalesce_lock:

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -891,9 +891,7 @@ def _rewrite_pr_description(
             issue,
             task_list,
             body,
-            _print_prompt=claude_client.print_prompt
-            if claude_client is not None
-            else None,
+            claude_client=claude_client,
         )
 
         snapshot_after = _task_snapshot(_tasks.list())

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
 from pathlib import Path
 
-from kennel import claude
+from kennel.claude import ClaudeClient
 from kennel.github import GitHub
 
 _SUB_DIR = Path(__file__).resolve().parent.parent / "sub"
@@ -28,10 +27,12 @@ def generate_persona_status(
     message: str,
     persona: str,
     *,
-    _print_prompt: Callable[..., str] = claude.print_prompt,
+    claude_client: ClaudeClient | None = None,
 ) -> str:
+    if claude_client is None:
+        claude_client = ClaudeClient()
     system = f"{persona}\n\n{_STATUS_SYSTEM}" if persona else _STATUS_SYSTEM
-    result = _print_prompt(
+    result = claude_client.print_prompt(
         prompt=f"Rewrite this status in Fido's voice: {message}",
         model="claude-opus-4-6",
         system_prompt=system,
@@ -45,10 +46,12 @@ def generate_persona_emoji(
     status_text: str,
     persona: str,
     *,
-    _print_prompt_json: Callable[..., str] = claude.print_prompt_json,
+    claude_client: ClaudeClient | None = None,
 ) -> str:
+    if claude_client is None:
+        claude_client = ClaudeClient()
     system = f"{persona}\n\n{_EMOJI_SYSTEM}" if persona else _EMOJI_SYSTEM
-    result = _print_prompt_json(
+    result = claude_client.print_prompt_json(
         prompt=f"Pick an emoji for this status: {status_text}",
         key="emoji",
         model="claude-opus-4-6",
@@ -63,16 +66,17 @@ def set_gh_status(
     message: str,
     *,
     persona_path: Path = _PERSONA_PATH,
-    _generate_persona_status: Callable[..., str] = generate_persona_status,
-    _generate_persona_emoji: Callable[..., str] = generate_persona_emoji,
+    claude_client: ClaudeClient | None = None,
     _gh: GitHub,
 ) -> None:
+    if claude_client is None:
+        claude_client = ClaudeClient()
     try:
         persona = persona_path.read_text()
     except FileNotFoundError:
         persona = ""
-    text = _generate_persona_status(message, persona)
-    emoji = _generate_persona_emoji(text, persona)
+    text = generate_persona_status(message, persona, claude_client=claude_client)
+    emoji = generate_persona_emoji(text, persona, claude_client=claude_client)
     _gh.set_user_status(text, emoji, busy=True)
 
 

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -60,30 +60,6 @@ def triage_context_block(context: dict[str, Any] | None) -> str:
     return "\n".join(parts)
 
 
-def triage_prompt(
-    comment_body: str,
-    is_bot: bool,
-    context: dict[str, Any] | None = None,
-) -> str:
-    """Build a triage prompt for Haiku/Opus.
-
-    Returns a prompt that asks the model to classify the comment and return one
-    or more ``CATEGORY: title`` lines.  A single comment may produce zero tasks
-    (ANSWER/ASK/DEFER/DUMP) or multiple tasks (multiple ACT/DO lines).
-    """
-    categories = triage_categories(is_bot)
-    ctx_str = triage_context_block(context)
-    return (
-        f"Triage this PR comment into one or more categories: {categories}\n\n"
-        f"{ctx_str}\n\nComment: {comment_body}\n\n"
-        "Reply with one line per task: category word, colon, short imperative task title. "
-        "For ACT/DO, list each distinct required change on its own line. "
-        "Task titles must start with a verb — never quote or paraphrase the comment text. "
-        "Example (one task): ACT: add unit tests for parser\n"
-        "Example (two tasks): ACT: add unit tests for parser\nACT: update documentation"
-    )
-
-
 # ── Reply instructions ────────────────────────────────────────────────────────
 
 
@@ -117,223 +93,6 @@ def reply_context_block(
     parts.append(f"Comment: {comment}")
     parts.append(f"Your plan: {title}")
     return "\n\n".join(parts)
-
-
-def reply_instruction(
-    category: str,
-    comment_body: str,
-    title: str,
-    context: dict[str, Any] | None = None,
-    issue_url: str | None = None,
-) -> str:
-    """Build the instruction text for a review-comment reply.
-
-    Used by ``reply_to_comment`` in events.py.  Returns a plain instruction
-    string (no persona wrapper) so the caller can compose it with
-    :meth:`Prompts.persona_wrap`.
-    """
-    ctx = reply_context_block(context, comment_body, title)
-    match category:
-        case "ACT" | "DO":
-            return (
-                f"Write a short GitHub PR reply to this comment. Acknowledge what they're asking for "
-                f"and briefly explain your approach. "
-                f"Do NOT promise to open issues or do anything outside of code changes in this PR.\n\n{ctx}"
-            )
-        case "ASK":
-            return (
-                f"Write a short GitHub PR reply asking a focused clarifying question. "
-                f"You need more information before you can act.\n\n{ctx}"
-            )
-        case "ANSWER":
-            return (
-                f"Write a short GitHub PR reply directly answering this question. "
-                f"Be helpful and specific. Do NOT say you'll make code changes.\n\nQuestion: {comment_body}"
-            )
-        case "DEFER":
-            issue_line = (
-                f"An issue has been opened to track this: {issue_url}"
-                if issue_url
-                else "An issue will be opened to track this"
-            )
-            return (
-                f"Write a short GitHub PR reply acknowledging this suggestion but explaining it's "
-                f"out of scope for this PR. "
-                f"{issue_line} — mention it in your reply.\n\n{ctx}"
-            )
-        case "DUMP":
-            return (
-                f"Write a short GitHub PR reply politely declining this suggestion and briefly "
-                f"explaining why it's not applicable.\n\n{ctx}"
-            )
-        case _:
-            return f"Write a short GitHub PR reply to this comment.\n\n{ctx}"
-
-
-def issue_reply_instruction(
-    category: str,
-    comment_body: str,
-    title: str,
-    context: dict[str, Any] | None = None,
-    issue_url: str | None = None,
-) -> str:
-    """Build the instruction text for a top-level issue/PR comment reply.
-
-    Used by ``reply_to_issue_comment`` in events.py.
-    """
-    ctx = context or {}
-    parts: list[str] = []
-    if ctx.get("pr_title"):
-        parts.append(f"PR: {ctx['pr_title']}")
-    parts.append(f"Comment: {comment_body}")
-    parts.append(f"Your plan: {title}")
-    context_str = "\n\n".join(parts)
-
-    match category:
-        case "ACT" | "DO":
-            return (
-                f"Write a short GitHub PR reply acknowledging and explaining your approach. "
-                f"Do NOT promise to open issues or do anything outside of code changes in this PR.\n\n{context_str}"
-            )
-        case "ASK":
-            return f"Write a short GitHub PR reply asking a clarifying question.\n\n{context_str}"
-        case "ANSWER":
-            return f"Write a short GitHub PR reply directly answering the question.\n\nQuestion: {comment_body}"
-        case "DEFER":
-            issue_line = (
-                f"An issue has been opened to track this: {issue_url}"
-                if issue_url
-                else "An issue will be opened to track this"
-            )
-            return (
-                f"Write a short GitHub PR reply acknowledging this suggestion but explaining it's "
-                f"out of scope for this PR. "
-                f"{issue_line} — mention it in your reply.\n\n{context_str}"
-            )
-        case "DUMP":
-            return f"Write a short polite decline.\n\n{context_str}"
-        case _:
-            return f"Write a short GitHub PR reply.\n\n{context_str}"
-
-
-# ── Rescoping ────────────────────────────────────────────────────────────────
-
-
-def rescope_prompt(
-    task_list: list[dict[str, Any]],
-    commit_summary: str,
-) -> str:
-    """Build an Opus prompt for dependency-aware task reordering.
-
-    Presents the full task list and a summary of commits already made, then
-    asks Opus to return a JSON array of the reordered pending tasks.
-
-    Rules enforced in the prompt:
-    - CI tasks (type "ci") must remain first.
-    - Completed tasks are excluded from the output.
-    - Task IDs must be preserved exactly.
-    - Tasks already covered by a commit should be omitted — they will be marked
-      completed automatically by the caller.
-    - Thread-task requirements that conflict with a spec task should cause
-      the spec task title/description to be updated.
-
-    The caller is responsible for parsing the returned JSON and applying it.
-    """
-    pending = [t for t in task_list if t.get("status") != "completed"]
-    completed = [t for t in task_list if t.get("status") == "completed"]
-
-    def _fmt(t: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "id": t.get("id", ""),
-            "type": t.get("type", "spec"),
-            "status": t.get("status", "pending"),
-            "title": t.get("title", ""),
-            "description": t.get("description", ""),
-        }
-
-    pending_json = json.dumps([_fmt(t) for t in pending], indent=2)
-    completed_titles = [t.get("title", "") for t in completed]
-    completed_block = (
-        "\n".join(f"- {title}" for title in completed_titles)
-        if completed_titles
-        else "(none)"
-    )
-
-    return (
-        "You are reviewing the pending work queue for a pull request in progress.\n\n"
-        "Already completed tasks:\n"
-        f"{completed_block}\n\n"
-        "Recent commits (already implemented):\n"
-        f"{commit_summary or '(none)'}\n\n"
-        "Pending tasks (current order):\n"
-        f"{pending_json}\n\n"
-        "Reorder these tasks for the optimal implementation sequence based on "
-        "dependency analysis. Apply these rules:\n"
-        '1. Tasks with type "ci" must come first — do not move them.\n'
-        "2. Reorder remaining tasks so each task builds on what comes before it.\n"
-        "3. If a task is already covered by a recent commit, omit it from the output — it will be marked done.\n"
-        "4. If a thread task changes the requirements of an existing spec task, "
-        "rewrite that spec task's title and/or description to reflect the updated "
-        "requirements.\n"
-        "5. Preserve every task ID exactly — never change or drop IDs.\n"
-        "6. Include only pending and in_progress tasks in the output — omit completed.\n\n"
-        'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
-        'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
-        "No other text before or after the JSON."
-    )
-
-
-# ── PR description rewrite ───────────────────────────────────────────────────
-
-
-def rewrite_description_prompt(
-    pr_body: str,
-    task_list: list[dict[str, Any]],
-) -> str:
-    """Build an Opus prompt to rewrite the PR description after rescoping.
-
-    Presents the current PR description section and the updated task list,
-    then asks Opus to rewrite only the descriptive summary while preserving
-    required structural lines like ``Fixes #N``.
-
-    The caller is responsible for substituting the result back into the PR
-    body, keeping the work-queue section intact.
-    """
-    divider = "\n\n---\n\n"
-    if divider in pr_body:
-        description_section = pr_body.split(divider)[0]
-    elif "<!-- WORK_QUEUE_START -->" in pr_body:
-        description_section = pr_body.split("<!-- WORK_QUEUE_START -->")[0].strip()
-    else:
-        description_section = pr_body
-
-    pending = [t for t in task_list if t.get("status") != "completed"]
-
-    def _fmt(t: dict[str, Any]) -> str:
-        title = t.get("title", "")
-        desc = t.get("description", "")
-        return f"- {title}" + (f": {desc}" if desc else "")
-
-    task_block = "\n".join(_fmt(t) for t in pending) if pending else "(none)"
-
-    return (
-        "You are rewriting the description section of a pull request after the plan changed.\n\n"
-        "Current PR description section:\n"
-        f"{description_section.strip()}\n\n"
-        "Updated task list (pending work):\n"
-        f"{task_block}\n\n"
-        "Rewrite the descriptive summary to match the updated plan. Rules:\n"
-        "1. Keep it to 2-3 sentences.\n"
-        "2. Preserve any 'Fixes #N.' lines exactly as they appear — do not add, remove, or modify them.\n"
-        "3. Do not include work queue content, markdown headers, or HTML comments.\n"
-        "4. Wrap your final output in <body>...</body> tags. Only text between the tags is used.\n"
-        "5. Do not add any text before the opening <body> tag or after the closing </body> tag.\n\n"
-        "Example output:\n"
-        "<body>\n"
-        "Fixes #123.\n\n"
-        "Refactors the foo module to use bar so we can add baz support later.\n"
-        "</body>"
-    )
 
 
 # ── Prompts DI class ──────────────────────────────────────────────────────────
@@ -479,11 +238,22 @@ class Prompts:
     ) -> str:
         """Build a triage prompt for Haiku/Opus.
 
-        Delegates to the module-level helper functions
-        :func:`triage_categories` and :func:`triage_context_block` for the
-        subcomponents.
+        Returns a prompt that asks the model to classify the comment and return
+        one or more ``CATEGORY: title`` lines.  A single comment may produce
+        zero tasks (ANSWER/ASK/DEFER/DUMP) or multiple tasks (multiple
+        ACT/DO lines).
         """
-        return triage_prompt(comment_body, is_bot, context)
+        categories = triage_categories(is_bot)
+        ctx_str = triage_context_block(context)
+        return (
+            f"Triage this PR comment into one or more categories: {categories}\n\n"
+            f"{ctx_str}\n\nComment: {comment_body}\n\n"
+            "Reply with one line per task: category word, colon, short imperative task title. "
+            "For ACT/DO, list each distinct required change on its own line. "
+            "Task titles must start with a verb — never quote or paraphrase the comment text. "
+            "Example (one task): ACT: add unit tests for parser\n"
+            "Example (two tasks): ACT: add unit tests for parser\nACT: update documentation"
+        )
 
     def reply_instruction(
         self,
@@ -493,8 +263,47 @@ class Prompts:
         context: dict[str, Any] | None = None,
         issue_url: str | None = None,
     ) -> str:
-        """Build the instruction text for a review-comment reply."""
-        return reply_instruction(category, comment_body, title, context, issue_url)
+        """Build the instruction text for a review-comment reply.
+
+        Returns a plain instruction string (no persona wrapper) so the caller
+        can compose it with :meth:`persona_wrap`.
+        """
+        ctx = reply_context_block(context, comment_body, title)
+        match category:
+            case "ACT" | "DO":
+                return (
+                    f"Write a short GitHub PR reply to this comment. Acknowledge what they're asking for "
+                    f"and briefly explain your approach. "
+                    f"Do NOT promise to open issues or do anything outside of code changes in this PR.\n\n{ctx}"
+                )
+            case "ASK":
+                return (
+                    f"Write a short GitHub PR reply asking a focused clarifying question. "
+                    f"You need more information before you can act.\n\n{ctx}"
+                )
+            case "ANSWER":
+                return (
+                    f"Write a short GitHub PR reply directly answering this question. "
+                    f"Be helpful and specific. Do NOT say you'll make code changes.\n\nQuestion: {comment_body}"
+                )
+            case "DEFER":
+                issue_line = (
+                    f"An issue has been opened to track this: {issue_url}"
+                    if issue_url
+                    else "An issue will be opened to track this"
+                )
+                return (
+                    f"Write a short GitHub PR reply acknowledging this suggestion but explaining it's "
+                    f"out of scope for this PR. "
+                    f"{issue_line} — mention it in your reply.\n\n{ctx}"
+                )
+            case "DUMP":
+                return (
+                    f"Write a short GitHub PR reply politely declining this suggestion and briefly "
+                    f"explaining why it's not applicable.\n\n{ctx}"
+                )
+            case _:
+                return f"Write a short GitHub PR reply to this comment.\n\n{ctx}"
 
     def issue_reply_instruction(
         self,
@@ -505,22 +314,150 @@ class Prompts:
         issue_url: str | None = None,
     ) -> str:
         """Build the instruction text for a top-level issue/PR comment reply."""
-        return issue_reply_instruction(
-            category, comment_body, title, context, issue_url
-        )
+        ctx = context or {}
+        parts: list[str] = []
+        if ctx.get("pr_title"):
+            parts.append(f"PR: {ctx['pr_title']}")
+        parts.append(f"Comment: {comment_body}")
+        parts.append(f"Your plan: {title}")
+        context_str = "\n\n".join(parts)
+
+        match category:
+            case "ACT" | "DO":
+                return (
+                    f"Write a short GitHub PR reply acknowledging and explaining your approach. "
+                    f"Do NOT promise to open issues or do anything outside of code changes in this PR.\n\n{context_str}"
+                )
+            case "ASK":
+                return f"Write a short GitHub PR reply asking a clarifying question.\n\n{context_str}"
+            case "ANSWER":
+                return f"Write a short GitHub PR reply directly answering the question.\n\nQuestion: {comment_body}"
+            case "DEFER":
+                issue_line = (
+                    f"An issue has been opened to track this: {issue_url}"
+                    if issue_url
+                    else "An issue will be opened to track this"
+                )
+                return (
+                    f"Write a short GitHub PR reply acknowledging this suggestion but explaining it's "
+                    f"out of scope for this PR. "
+                    f"{issue_line} — mention it in your reply.\n\n{context_str}"
+                )
+            case "DUMP":
+                return f"Write a short polite decline.\n\n{context_str}"
+            case _:
+                return f"Write a short GitHub PR reply.\n\n{context_str}"
 
     def rescope_prompt(
         self,
         task_list: list[dict[str, Any]],
         commit_summary: str,
     ) -> str:
-        """Build an Opus prompt for dependency-aware task reordering."""
-        return rescope_prompt(task_list, commit_summary)
+        """Build an Opus prompt for dependency-aware task reordering.
+
+        Presents the full task list and a summary of commits already made, then
+        asks Opus to return a JSON array of the reordered pending tasks.
+
+        Rules enforced in the prompt:
+        - CI tasks (type "ci") must remain first.
+        - Completed tasks are excluded from the output.
+        - Task IDs must be preserved exactly.
+        - Tasks already covered by a commit should be omitted -- they will be
+          marked completed automatically by the caller.
+        - Thread-task requirements that conflict with a spec task should cause
+          the spec task title/description to be updated.
+
+        The caller is responsible for parsing the returned JSON and applying it.
+        """
+        pending = [t for t in task_list if t.get("status") != "completed"]
+        completed = [t for t in task_list if t.get("status") == "completed"]
+
+        def _fmt(t: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "id": t.get("id", ""),
+                "type": t.get("type", "spec"),
+                "status": t.get("status", "pending"),
+                "title": t.get("title", ""),
+                "description": t.get("description", ""),
+            }
+
+        pending_json = json.dumps([_fmt(t) for t in pending], indent=2)
+        completed_titles = [t.get("title", "") for t in completed]
+        completed_block = (
+            "\n".join(f"- {title}" for title in completed_titles)
+            if completed_titles
+            else "(none)"
+        )
+
+        return (
+            "You are reviewing the pending work queue for a pull request in progress.\n\n"
+            "Already completed tasks:\n"
+            f"{completed_block}\n\n"
+            "Recent commits (already implemented):\n"
+            f"{commit_summary or '(none)'}\n\n"
+            "Pending tasks (current order):\n"
+            f"{pending_json}\n\n"
+            "Reorder these tasks for the optimal implementation sequence based on "
+            "dependency analysis. Apply these rules:\n"
+            '1. Tasks with type "ci" must come first — do not move them.\n'
+            "2. Reorder remaining tasks so each task builds on what comes before it.\n"
+            "3. If a task is already covered by a recent commit, omit it from the output — it will be marked done.\n"
+            "4. If a thread task changes the requirements of an existing spec task, "
+            "rewrite that spec task's title and/or description to reflect the updated "
+            "requirements.\n"
+            "5. Preserve every task ID exactly — never change or drop IDs.\n"
+            "6. Include only pending and in_progress tasks in the output — omit completed.\n\n"
+            'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
+            'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
+            "No other text before or after the JSON."
+        )
 
     def rewrite_description_prompt(
         self,
         pr_body: str,
         task_list: list[dict[str, Any]],
     ) -> str:
-        """Build an Opus prompt to rewrite the PR description after rescoping."""
-        return rewrite_description_prompt(pr_body, task_list)
+        """Build an Opus prompt to rewrite the PR description after rescoping.
+
+        Presents the current PR description section and the updated task list,
+        then asks Opus to rewrite only the descriptive summary while preserving
+        required structural lines like ``Fixes #N``.
+
+        The caller is responsible for substituting the result back into the PR
+        body, keeping the work-queue section intact.
+        """
+        divider = "\n\n---\n\n"
+        if divider in pr_body:
+            description_section = pr_body.split(divider)[0]
+        elif "<!-- WORK_QUEUE_START -->" in pr_body:
+            description_section = pr_body.split("<!-- WORK_QUEUE_START -->")[0].strip()
+        else:
+            description_section = pr_body
+
+        pending = [t for t in task_list if t.get("status") != "completed"]
+
+        def _fmt(t: dict[str, Any]) -> str:
+            title = t.get("title", "")
+            desc = t.get("description", "")
+            return f"- {title}" + (f": {desc}" if desc else "")
+
+        task_block = "\n".join(_fmt(t) for t in pending) if pending else "(none)"
+
+        return (
+            "You are rewriting the description section of a pull request after the plan changed.\n\n"
+            "Current PR description section:\n"
+            f"{description_section.strip()}\n\n"
+            "Updated task list (pending work):\n"
+            f"{task_block}\n\n"
+            "Rewrite the descriptive summary to match the updated plan. Rules:\n"
+            "1. Keep it to 2-3 sentences.\n"
+            "2. Preserve any 'Fixes #N.' lines exactly as they appear — do not add, remove, or modify them.\n"
+            "3. Do not include work queue content, markdown headers, or HTML comments.\n"
+            "4. Wrap your final output in <body>...</body> tags. Only text between the tags is used.\n"
+            "5. Do not add any text before the opening <body> tag or after the closing </body> tag.\n\n"
+            "Example output:\n"
+            "<body>\n"
+            "Fixes #123.\n\n"
+            "Refactors the foo module to use bar so we can add baz support later.\n"
+            "</body>"
+        )

--- a/kennel/prompts.py
+++ b/kennel/prompts.py
@@ -340,15 +340,19 @@ def rewrite_description_prompt(
 
 
 class Prompts:
-    """Persona-aware prompt builder.
+    """Persona-aware prompt builder and one-stop prompt collaborator.
 
     Accepts a ``persona`` string via the constructor so callers need only read
     the persona file once and inject it — rather than re-reading it inside
     every prompt function.  Follows the dependency injection pattern described
     in CLAUDE.md.
 
-    Stateless helpers that do not depend on the persona remain as module-level
-    functions above (e.g. :func:`triage_prompt`, :func:`reply_instruction`).
+    Prompt builders that do not depend on the persona are also methods here
+    so callers can depend on a single injected collaborator rather than a mix
+    of the class and bare module-level functions.  Value-only helpers
+    (e.g. :func:`triage_categories`, :func:`triage_context_block`,
+    :func:`reply_context_block`) remain module-level since they only
+    transform data.
 
     Usage::
 
@@ -356,8 +360,9 @@ class Prompts:
         prompt = p.persona_wrap(instruction)
         prompt = p.react_prompt(comment_body)
         prompt = p.pickup_comment_prompt(issue_title)
-        prompt = p.status_text_prompt(what)
-        prompt = p.status_emoji_prompt(text)
+        prompt = p.triage_prompt(comment_body, is_bot)
+        prompt = p.reply_instruction(category, comment_body, title)
+        prompt = p.rescope_prompt(task_list, commit_summary)
     """
 
     def __init__(self, persona: str) -> None:
@@ -463,3 +468,59 @@ class Prompts:
             "Reply with JUST the reaction keyword (e.g. heart, rocket, eyes). "
             "If you wouldn't react, reply NONE."
         )
+
+    # ── Prompt builders (persona-independent) ────────────────────────────
+
+    def triage_prompt(
+        self,
+        comment_body: str,
+        is_bot: bool,
+        context: dict[str, Any] | None = None,
+    ) -> str:
+        """Build a triage prompt for Haiku/Opus.
+
+        Delegates to the module-level helper functions
+        :func:`triage_categories` and :func:`triage_context_block` for the
+        subcomponents.
+        """
+        return triage_prompt(comment_body, is_bot, context)
+
+    def reply_instruction(
+        self,
+        category: str,
+        comment_body: str,
+        title: str,
+        context: dict[str, Any] | None = None,
+        issue_url: str | None = None,
+    ) -> str:
+        """Build the instruction text for a review-comment reply."""
+        return reply_instruction(category, comment_body, title, context, issue_url)
+
+    def issue_reply_instruction(
+        self,
+        category: str,
+        comment_body: str,
+        title: str,
+        context: dict[str, Any] | None = None,
+        issue_url: str | None = None,
+    ) -> str:
+        """Build the instruction text for a top-level issue/PR comment reply."""
+        return issue_reply_instruction(
+            category, comment_body, title, context, issue_url
+        )
+
+    def rescope_prompt(
+        self,
+        task_list: list[dict[str, Any]],
+        commit_summary: str,
+    ) -> str:
+        """Build an Opus prompt for dependency-aware task reordering."""
+        return rescope_prompt(task_list, commit_summary)
+
+    def rewrite_description_prompt(
+        self,
+        pr_body: str,
+        task_list: list[dict[str, Any]],
+    ) -> str:
+        """Build an Opus prompt to rewrite the PR description after rescoping."""
+        return rewrite_description_prompt(pr_body, task_list)

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -14,9 +14,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import IO, Any
 
-from kennel.claude import print_prompt as _claude_print_prompt
+from kennel.claude import ClaudeClient
 from kennel.github import GitHub
-from kennel.prompts import rescope_prompt as _rescope_prompt_default
+from kennel.prompts import Prompts
 from kennel.state import (
     JsonFileStore,
     State,
@@ -426,8 +426,8 @@ def reorder_tasks(
     work_dir: Path,
     commit_summary: str,
     *,
-    _print_prompt: Callable[..., str] = _claude_print_prompt,
-    _rescope_prompt_fn: Callable[..., str] = _rescope_prompt_default,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
     _on_inprogress_affected: Callable[[], None] | None = None,
     _on_done: Callable[[], None] | None = None,
@@ -462,9 +462,14 @@ def reorder_tasks(
         log.info("reorder_tasks: no tasks — skipping")
         return
 
+    if claude_client is None:
+        claude_client = ClaudeClient()
+    if prompts is None:
+        prompts = Prompts("")
+
     original_ids = frozenset(t["id"] for t in task_list)
-    prompt = _rescope_prompt_fn(task_list, commit_summary)
-    raw = _print_prompt(prompt, "claude-opus-4-6")
+    prompt = prompts.rescope_prompt(task_list, commit_summary)
+    raw = claude_client.print_prompt(prompt, "claude-opus-4-6")
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -20,7 +20,7 @@ from kennel import claude, hooks, tasks
 from kennel.claude import ClaudeClient
 from kennel.config import RepoMembership
 from kennel.github import GitHub
-from kennel.prompts import Prompts, rewrite_description_prompt
+from kennel.prompts import Prompts
 from kennel.state import (
     State,
     _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
@@ -720,7 +720,7 @@ def _write_pr_description(
             queue = "<!-- no tasks yet -->"
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
-    prompt = rewrite_description_prompt(existing_body, task_list)
+    prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
     raw = claude_client.print_prompt(prompt, "claude-opus-4-6")
     new_desc = _extract_body(raw)
     if not new_desc:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import IO, Any, Protocol
 
 from kennel import claude, hooks, tasks
+from kennel.claude import ClaudeClient
 from kennel.config import RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts, rewrite_description_prompt
@@ -229,6 +230,7 @@ def claude_start(
     timeout: int = 300,
     cwd: Path | str | None = None,
     session: claude.ClaudeSession | None = None,
+    claude_client: ClaudeClient | None = None,
 ) -> str:
     """Start a new sub-Claude session from fido_dir/system and fido_dir/prompt.
 
@@ -238,17 +240,19 @@ def claude_start(
     is returned — there is no subprocess session_id to track.
 
     When *session* is ``None`` a fresh subprocess is spawned via
-    ``claude.print_prompt_from_file`` and the session_id extracted from its
-    stream-json output is returned.  Raises ``ClaudeStreamError`` or
+    :meth:`~ClaudeClient.print_prompt_from_file` and the session_id extracted
+    from its stream-json output is returned.  Raises ``ClaudeStreamError`` or
     ``FileNotFoundError`` on subprocess failure — these propagate to the
     worker's crash handler.
     """
     if session is not None:
         _run_session_turn(session, _session_turn_prompt(fido_dir))
         return ""
+    if claude_client is None:
+        claude_client = ClaudeClient()
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
-    output = claude.print_prompt_from_file(
+    output = claude_client.print_prompt_from_file(
         system_file, prompt_file, model, timeout, cwd=cwd
     )
     return claude.extract_session_id(output)
@@ -307,6 +311,7 @@ def claude_run(
     timeout: int = 300,
     cwd: Path | str | None = None,
     session: claude.ClaudeSession | None = None,
+    claude_client: ClaudeClient | None = None,
 ) -> tuple[str, str]:
     """Continue or start a sub-Claude session, streaming progress as JSON.
 
@@ -324,9 +329,11 @@ def claude_run(
     if session is not None:
         _run_session_turn(session, _session_turn_prompt(fido_dir))
         return "", ""
+    if claude_client is None:
+        claude_client = ClaudeClient()
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
-    output = claude.print_prompt_from_file(
+    output = claude_client.print_prompt_from_file(
         system_file, prompt_file, model, timeout, cwd=cwd
     )
     new_session_id = claude.extract_session_id(output)
@@ -670,7 +677,7 @@ def _write_pr_description(
     task_list: list[dict[str, Any]],
     existing_body: str = "",
     *,
-    _print_prompt: Callable[..., str] | None = None,
+    claude_client: ClaudeClient | None = None,
 ) -> None:
     """Write or rewrite the PR description.
 
@@ -684,8 +691,8 @@ def _write_pr_description(
     ``---`` divider (rewrite precondition) or when Opus returns no
     ``<body>``-tagged content.
     """
-    if _print_prompt is None:
-        _print_prompt = claude.print_prompt
+    if claude_client is None:
+        claude_client = ClaudeClient()
 
     divider = "\n\n---\n\n"
 
@@ -714,7 +721,7 @@ def _write_pr_description(
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
     prompt = rewrite_description_prompt(existing_body, task_list)
-    raw = _print_prompt(prompt, "claude-opus-4-6")
+    raw = claude_client.print_prompt(prompt, "claude-opus-4-6")
     new_desc = _extract_body(raw)
     if not new_desc:
         raise ValueError(
@@ -751,6 +758,8 @@ class Worker:
         session: claude.ClaudeSession | None = None,
         session_issue: int | None = None,
         _tasks: Tasks | None = None,
+        claude_client: ClaudeClient | None = None,
+        prompts: Prompts | None = None,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
@@ -761,6 +770,21 @@ class Worker:
         self._session: claude.ClaudeSession | None = session
         self._session_issue: int | None = session_issue
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
+        self._claude_client = (
+            claude_client if claude_client is not None else ClaudeClient()
+        )
+        self._prompts = prompts
+
+    def _get_prompts(self, *, _sub_dir_fn: Callable[..., Path] = _sub_dir) -> Prompts:
+        """Return the injected Prompts or build one from the persona file."""
+        if self._prompts is not None:
+            return self._prompts
+        persona_path = _sub_dir_fn() / "persona.md"
+        try:
+            persona = persona_path.read_text()
+        except OSError:
+            persona = ""
+        return Prompts(persona)
 
     def resolve_git_dir(
         self, *, _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
@@ -906,13 +930,7 @@ class Worker:
         session), logs and returns — status is best-effort and callers should
         not block on it.
         """
-        persona_path = _sub_dir_fn() / "persona.md"
-        try:
-            persona = persona_path.read_text()
-        except OSError:
-            persona = ""
-
-        prompts = Prompts(persona)
+        prompts = self._get_prompts(_sub_dir_fn=_sub_dir_fn)
 
         ctx = (
             self._registry.status_update()
@@ -1095,7 +1113,12 @@ class Worker:
                     f"Work dir: {self.work_dir}"
                 )
                 build_prompt(fido_dir, "setup", context)
-                claude_start(fido_dir, cwd=self.work_dir, session=self._session)
+                claude_start(
+                    fido_dir,
+                    cwd=self.work_dir,
+                    session=self._session,
+                    claude_client=self._claude_client,
+                )
                 if not self._tasks.list():
                     raise RuntimeError(f"setup produced no tasks for PR #{pr_number}")
             log.info(
@@ -1107,7 +1130,7 @@ class Worker:
             return pr_number, slug
 
         # Generate branch slug via Haiku
-        raw_slug = claude.generate_branch_name(
+        raw_slug = self._claude_client.generate_branch_name(
             "Output ONLY a git branch name: 2-4 lowercase words separated by"
             " hyphens, no issue numbers, summarising this request."
             " No explanation, no punctuation, just the branch name."
@@ -1137,7 +1160,12 @@ class Worker:
             f"Work dir: {self.work_dir}"
         )
         build_prompt(fido_dir, "setup", context)
-        claude_start(fido_dir, cwd=self.work_dir, session=self._session)
+        claude_start(
+            fido_dir,
+            cwd=self.work_dir,
+            session=self._session,
+            claude_client=self._claude_client,
+        )
 
         if not self._tasks.list():
             raise RuntimeError("setup produced no tasks")
@@ -1156,7 +1184,12 @@ class Worker:
             state["pr_number"] = pr_number
             state["pr_title"] = request
         _write_pr_description(
-            self.gh, repo_ctx.repo, pr_number, issue, self._tasks.list()
+            self.gh,
+            repo_ctx.repo,
+            pr_number,
+            issue,
+            self._tasks.list(),
+            claude_client=self._claude_client,
         )
         task_count = len(
             [t for t in self._tasks.list() if t.get("status") == "pending"]
@@ -1278,7 +1311,12 @@ class Worker:
             f" (JSON — may be empty):\n{json.dumps(ci_threads)}"
         )
         build_prompt(fido_dir, "ci", context)
-        session_id, _ = claude_run(fido_dir, cwd=self.work_dir, session=self._session)
+        session_id, _ = claude_run(
+            fido_dir,
+            cwd=self.work_dir,
+            session=self._session,
+            claude_client=self._claude_client,
+        )
         log.info("CI fix done (session=%s)", session_id)
 
         # CI failures have no task entry — no complete call needed
@@ -1402,7 +1440,12 @@ class Worker:
             f"\nUnresolved threads (JSON):\n{json.dumps({'threads': threads})}"
         )
         build_prompt(fido_dir, "comments", context)
-        session_id, _ = claude_run(fido_dir, cwd=self.work_dir, session=self._session)
+        session_id, _ = claude_run(
+            fido_dir,
+            cwd=self.work_dir,
+            session=self._session,
+            claude_client=self._claude_client,
+        )
         log.info("threads done (session=%s)", session_id)
         tasks.sync_tasks_background(self.work_dir, self.gh)
         return True
@@ -1548,6 +1591,7 @@ class Worker:
             fido_dir,
             cwd=self.work_dir,
             session=self._session,
+            claude_client=self._claude_client,
         )
         log.info("task done (session=%s)", session_id)
         head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
@@ -1584,6 +1628,7 @@ class Worker:
                 fido_dir,
                 cwd=self.work_dir,
                 session=self._session,
+                claude_client=self._claude_client,
             )
             log.info("task resume done (session=%s)", session_id)
             head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
@@ -1678,15 +1723,9 @@ class Worker:
             log.info("issue #%s: pickup comment already exists — skipping", issue)
             return
 
-        persona_path = _sub_dir() / "persona.md"
-        try:
-            persona = persona_path.read_text()
-        except OSError:
-            persona = ""
-
-        prompts = Prompts(persona)
+        prompts = self._get_prompts()
         prompt = prompts.pickup_comment_prompt(issue_title)
-        msg = claude.generate_reply(prompt)
+        msg = self._claude_client.generate_reply(prompt)
         if not msg:
             msg = f"Picking up issue: {issue_title}"
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -10,6 +10,7 @@ import pytest
 from kennel.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
+    ClaudeClient,
     ClaudeSession,
     ClaudeStreamError,
     _active_children,
@@ -2521,3 +2522,530 @@ class TestClaudeSessionInterrupt:
 
         assert proc.stdin.write.call_count > 0
         session.stop()
+
+
+# ── ClaudeClient ─────────────────────────────────────────────────────────────
+
+
+class TestClaudeClientPrintPrompt:
+    def test_delegates_to_session_prompt(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "hello"
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt("hi", "claude-opus-4-6") == "hello"
+        session.prompt.assert_called_once_with(
+            "hi", model="claude-opus-4-6", system_prompt=None
+        )
+
+    def test_passes_system_prompt(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "ok"
+        client = ClaudeClient(session_fn=lambda: session)
+        client.print_prompt("q", "claude-opus-4-6", system_prompt="be fido")
+        assert session.prompt.call_args.kwargs["system_prompt"] == "be fido"
+
+    def test_session_errors_propagate(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = ClaudeStreamError(1)
+        client = ClaudeClient(session_fn=lambda: session)
+        with pytest.raises(ClaudeStreamError):
+            client.print_prompt("q", "claude-opus-4-6")
+
+
+class TestClaudeClientPrintPromptJson:
+    def test_extracts_json_value(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = '{"answer": "42"}'
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == "42"
+
+    def test_returns_empty_on_empty_response(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = ""
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == ""
+
+    def test_returns_empty_on_malformed_json(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "not json"
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == ""
+
+    def test_scans_for_json_in_preamble(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = 'Here is the answer: {"answer": "yes"}'
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == "yes"
+
+    def test_appends_json_instruction_to_system(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = '{"k": "v"}'
+        client = ClaudeClient(session_fn=lambda: session)
+        client.print_prompt_json("q", "k", "claude-opus-4-6", system_prompt="sys")
+        sp = session.prompt.call_args.kwargs["system_prompt"]
+        assert sp.startswith("sys\n\n")
+        assert '"k"' in sp
+
+    def test_json_instruction_only_when_no_system(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = '{"k": "v"}'
+        client = ClaudeClient(session_fn=lambda: session)
+        client.print_prompt_json("q", "k", "claude-opus-4-6")
+        sp = session.prompt.call_args.kwargs["system_prompt"]
+        assert "Respond with ONLY" in sp
+
+    def test_returns_empty_when_key_missing(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = '{"other": "val"}'
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == ""
+
+    def test_returns_empty_when_value_not_string(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = '{"answer": 42}'
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.print_prompt_json("q", "answer", "claude-opus-4-6") == ""
+
+
+class TestClaudeClientGenerateStatus:
+    def test_delegates_to_print_prompt(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "🐶\ncoding up a storm"
+        client = ClaudeClient(session_fn=lambda: session)
+        assert (
+            client.generate_status("working on #42", "be fido")
+            == "🐶\ncoding up a storm"
+        )
+        session.prompt.assert_called_once_with(
+            "working on #42", model="claude-opus-4-6", system_prompt="be fido"
+        )
+
+    def test_custom_model(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "🐶\nwoof"
+        client = ClaudeClient(session_fn=lambda: session)
+        client.generate_status("working", "sys", model="claude-sonnet-4-6")
+        assert session.prompt.call_args.kwargs["model"] == "claude-sonnet-4-6"
+
+
+class TestClaudeClientGenerateStatusEmoji:
+    def test_delegates_to_print_prompt(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "🐕"
+        client = ClaudeClient(session_fn=lambda: session)
+        assert client.generate_status_emoji("pick emoji", "be fido") == "🐕"
+        session.prompt.assert_called_once_with(
+            "pick emoji", model="claude-opus-4-6", system_prompt="be fido"
+        )
+
+    def test_custom_model(self) -> None:
+        session = MagicMock()
+        session.prompt.return_value = "🐕"
+        client = ClaudeClient(session_fn=lambda: session)
+        client.generate_status_emoji("pick", "sys", model="claude-sonnet-4-6")
+        assert session.prompt.call_args.kwargs["model"] == "claude-sonnet-4-6"
+
+
+class TestClaudeClientPrintPromptFromFile:
+    def _files(self, tmp_path: Path) -> tuple[Path, Path]:
+        sys = tmp_path / "system.md"
+        sys.write_text("sys")
+        prompt = tmp_path / "prompt.txt"
+        prompt.write_text("p")
+        return sys, prompt
+
+    def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(return_value=iter(["session output"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        result = client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+        assert result == "session output"
+
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeStreamError):
+            client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+
+    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeStreamError):
+            client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(FileNotFoundError):
+            client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+
+    def test_passes_correct_cmd(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--system-prompt-file" in cmd
+        assert str(sys) in cmd
+        assert "--print" in cmd
+
+    def test_passes_idle_timeout(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.print_prompt_from_file(
+            sys, prompt, "claude-sonnet-4-6", idle_timeout=600.0
+        )
+        assert mock_stream.call_args[0][2] == 600.0
+
+    def test_passes_cwd(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6", cwd="/some/dir")
+        assert mock_stream.call_args[1]["cwd"] == "/some/dir"
+
+
+class TestClaudeClientResumeSession:
+    def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(return_value=iter(["resumed output"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        result = client.resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
+        assert result == "resumed output"
+
+    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeStreamError):
+            client.resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
+
+    def test_passes_correct_cmd(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--resume" in cmd
+        assert "sess-123" in cmd
+        assert "--print" in cmd
+
+    def test_passes_idle_timeout(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.resume_session(
+            "sess-123", prompt_file, "claude-sonnet-4-6", idle_timeout=600.0
+        )
+        assert mock_stream.call_args[0][2] == 600.0
+
+
+class TestClaudeClientTriageComment:
+    def test_returns_first_line(self) -> None:
+        mock_run = MagicMock(return_value=_completed("ACT: fix the thing\nextra"))
+        client = ClaudeClient(runner=mock_run)
+        assert client.triage_comment("triage this") == "ACT: fix the thing"
+
+    def test_returns_empty_on_nonzero(self) -> None:
+        mock_run = MagicMock(return_value=_completed("ACT", returncode=1))
+        client = ClaudeClient(runner=mock_run)
+        assert client.triage_comment("triage this") == ""
+
+    def test_returns_empty_on_empty_output(self) -> None:
+        mock_run = MagicMock(return_value=_completed(""))
+        client = ClaudeClient(runner=mock_run)
+        assert client.triage_comment("triage this") == ""
+
+    def test_returns_empty_on_timeout(self) -> None:
+        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
+        client = ClaudeClient(runner=mock_run)
+        assert client.triage_comment("triage") == ""
+
+    def test_returns_empty_on_file_not_found(self) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(runner=mock_run)
+        assert client.triage_comment("triage") == ""
+
+    def test_default_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("ACT: thing"))
+        client = ClaudeClient(runner=mock_run)
+        client.triage_comment("triage this")
+        cmd = mock_run.call_args.args[0]
+        assert "claude-opus-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 15
+
+    def test_custom_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("DO: fix"))
+        client = ClaudeClient(runner=mock_run)
+        client.triage_comment("triage", model="claude-haiku-4-5-20251001", timeout=5)
+        cmd = mock_run.call_args.args[0]
+        assert "claude-haiku-4-5-20251001" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 5
+
+
+class TestClaudeClientGenerateReply:
+    def test_returns_stripped_output(self) -> None:
+        mock_run = MagicMock(return_value=_completed("  woof!  \n"))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_reply("write a reply") == "woof!"
+
+    def test_returns_empty_on_nonzero(self) -> None:
+        mock_run = MagicMock(return_value=_completed("err", returncode=1))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_reply("write") == ""
+
+    def test_returns_empty_on_timeout(self) -> None:
+        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_reply("write") == ""
+
+    def test_returns_empty_on_file_not_found(self) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_reply("write") == ""
+
+    def test_default_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("ok"))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_reply("write a reply")
+        cmd = mock_run.call_args.args[0]
+        assert "claude-opus-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 30
+
+    def test_custom_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("ok"))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_reply("write", model="claude-sonnet-4-6", timeout=10)
+        cmd = mock_run.call_args.args[0]
+        assert "claude-sonnet-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 10
+
+
+class TestClaudeClientGenerateBranchName:
+    def test_returns_first_line(self) -> None:
+        mock_run = MagicMock(return_value=_completed("fix-the-bug\nextra"))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_branch_name("name this") == "fix-the-bug"
+
+    def test_returns_empty_on_nonzero(self) -> None:
+        mock_run = MagicMock(return_value=_completed("slug", returncode=1))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_branch_name("name this") == ""
+
+    def test_returns_empty_on_empty_output(self) -> None:
+        mock_run = MagicMock(return_value=_completed(""))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_branch_name("name this") == ""
+
+    def test_returns_empty_on_timeout(self) -> None:
+        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_branch_name("name") == ""
+
+    def test_returns_empty_on_file_not_found(self) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(runner=mock_run)
+        assert client.generate_branch_name("name") == ""
+
+    def test_default_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("slug"))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_branch_name("name this")
+        cmd = mock_run.call_args.args[0]
+        assert "claude-haiku-4-5-20251001" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 15
+
+    def test_custom_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed("slug"))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_branch_name("name", model="claude-opus-4-6", timeout=5)
+        cmd = mock_run.call_args.args[0]
+        assert "claude-opus-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 5
+
+
+class TestClaudeClientGenerateStatusWithSession:
+    _RESULT_LINE = '{"type":"result","result":"🐶\\ncoding","session_id":"sess-42"}'
+
+    def test_returns_text_and_session_id_on_success(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        text, sid = client.generate_status_with_session("doing stuff", "be fido")
+        assert text == "🐶\ncoding"
+        assert sid == "sess-42"
+
+    def test_returns_empty_pair_on_nonzero(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
+        mock_run.assert_called_once()
+
+    def test_returns_empty_pair_on_timeout(self) -> None:
+        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
+        mock_run.assert_called_once()
+
+    def test_returns_empty_pair_on_file_not_found(self) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
+        mock_run.assert_called_once()
+
+    def test_passes_correct_flags(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_status_with_session(
+            "working on #42", "be a dog", model="claude-sonnet-4-6", timeout=10
+        )
+        cmd = mock_run.call_args.args[0]
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+        assert "--verbose" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--system-prompt" in cmd
+        assert "be a dog" in cmd
+        assert "--print" in cmd
+        assert "-p" in cmd
+        assert "working on #42" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 10
+
+    def test_default_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        client.generate_status_with_session("working", "sys")
+        cmd = mock_run.call_args.args[0]
+        assert "claude-opus-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 15
+
+    def test_retries_on_empty_output_then_succeeds(self) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(
+            side_effect=[
+                _completed(empty_line),
+                _completed(empty_line),
+                _completed(self._RESULT_LINE),
+            ]
+        )
+        mock_sleep = MagicMock()
+        client = ClaudeClient(runner=mock_run, sleep_fn=mock_sleep)
+        text, sid = client.generate_status_with_session("working", "sys")
+        assert text == "🐶\ncoding"
+        assert sid == "sess-42"
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_returns_empty_pair_after_all_retries_exhausted(self) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        mock_sleep = MagicMock()
+        client = ClaudeClient(runner=mock_run, sleep_fn=mock_sleep)
+        assert client.generate_status_with_session("working", "sys") == ("", "")
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    def test_returns_empty_session_when_no_session_id(self) -> None:
+        no_sid = '{"type":"result","result":"🐶\\nwoof"}'
+        mock_run = MagicMock(return_value=_completed(no_sid))
+        client = ClaudeClient(runner=mock_run)
+        text, sid = client.generate_status_with_session("working", "sys")
+        assert text == "🐶\nwoof"
+        assert sid == ""
+
+    def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(
+            return_value=_completed(empty_line, stderr="Rate limit exceeded")
+        )
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            client.generate_status_with_session("working", "sys")
+        assert "Rate limit exceeded" in caplog.text
+
+    def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
+            client.generate_status_with_session("working", "sys")
+        assert "stdout=" in caplog.text
+
+    def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
+        empty_line = '{"type":"result","session_id":"s1"}'
+        mock_run = MagicMock(return_value=_completed(empty_line))
+        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
+        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
+            client.generate_status_with_session("working", "sys")
+        assert "stderr=" not in caplog.text
+
+
+class TestClaudeClientResumeStatus:
+    _RESULT_LINE = '{"type":"result","result":"🐕\\nfetching","session_id":"s-1"}'
+
+    def test_returns_text_on_success(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        assert client.resume_status("s-1", "please shorten") == "🐕\nfetching"
+
+    def test_returns_empty_on_nonzero(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
+        client = ClaudeClient(runner=mock_run)
+        assert client.resume_status("s-1", "shorten") == ""
+
+    def test_returns_empty_on_timeout(self) -> None:
+        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
+        client = ClaudeClient(runner=mock_run)
+        assert client.resume_status("s-1", "shorten") == ""
+
+    def test_returns_empty_on_file_not_found(self) -> None:
+        mock_run = MagicMock(side_effect=FileNotFoundError)
+        client = ClaudeClient(runner=mock_run)
+        assert client.resume_status("s-1", "shorten") == ""
+
+    def test_passes_correct_flags(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        client.resume_status(
+            "my-session", "shorten to 80 chars", model="claude-sonnet-4-6", timeout=20
+        )
+        cmd = mock_run.call_args.args[0]
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+        assert "--verbose" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--resume" in cmd
+        assert "my-session" in cmd
+        assert "--print" in cmd
+        assert "-p" in cmd
+        assert "shorten to 80 chars" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 20
+
+    def test_default_model_and_timeout(self) -> None:
+        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
+        client = ClaudeClient(runner=mock_run)
+        client.resume_status("s-1", "shorten")
+        cmd = mock_run.call_args.args[0]
+        assert "claude-opus-4-6" in cmd
+        assert mock_run.call_args.kwargs["timeout"] == 15
+
+    def test_returns_empty_when_no_result_field(self) -> None:
+        no_result = '{"type":"result","session_id":"s-1"}'
+        mock_run = MagicMock(return_value=_completed(no_result))
+        client = ClaudeClient(runner=mock_run)
+        assert client.resume_status("s-1", "shorten") == ""

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -20,18 +20,7 @@ from kennel.claude import (
     _unregister_child,
     extract_result_text,
     extract_session_id,
-    generate_branch_name,
-    generate_reply,
-    generate_status,
-    generate_status_emoji,
-    generate_status_with_session,
     kill_active_children,
-    print_prompt,
-    print_prompt_from_file,
-    print_prompt_json,
-    resume_session,
-    resume_status,
-    triage_comment,
 )
 
 
@@ -183,114 +172,6 @@ def session_resolver():
         claude_module.set_thread_repo(None)
 
 
-class TestPrintPrompt:
-    def test_delegates_to_session_prompt(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "hello"
-        assert print_prompt("hi", "claude-opus-4-6") == "hello"
-        session_resolver.prompt.assert_called_once_with(
-            "hi", model="claude-opus-4-6", system_prompt=None
-        )
-
-    def test_passes_system_prompt(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "ok"
-        print_prompt("q", "claude-opus-4-6", system_prompt="be fido")
-        assert session_resolver.prompt.call_args.kwargs["system_prompt"] == "be fido"
-
-    def test_raises_without_repo_set(self) -> None:
-        """No thread_repo → wiring bug, raise loud."""
-        with pytest.raises(RuntimeError, match="without a thread-local repo_name"):
-            print_prompt("q", "claude-opus-4-6")
-
-    def test_raises_without_resolver_installed(self) -> None:
-        from kennel import claude as claude_module
-
-        claude_module.set_thread_repo("owner/repo")
-        try:
-            with pytest.raises(RuntimeError, match="before set_session_resolver"):
-                print_prompt("q", "claude-opus-4-6")
-        finally:
-            claude_module.set_thread_repo(None)
-
-    def test_raises_when_session_missing(self) -> None:
-        from kennel import claude as claude_module
-
-        claude_module.set_session_resolver(lambda repo: None)
-        claude_module.set_thread_repo("owner/repo")
-        try:
-            with pytest.raises(RuntimeError, match="no ClaudeSession registered"):
-                print_prompt("q", "claude-opus-4-6")
-        finally:
-            claude_module.set_session_resolver(None)
-            claude_module.set_thread_repo(None)
-
-    def test_raises_when_session_not_alive(self) -> None:
-        from kennel import claude as claude_module
-
-        dead = MagicMock()
-        dead.is_alive.return_value = False
-        claude_module.set_session_resolver(lambda repo: dead)
-        claude_module.set_thread_repo("owner/repo")
-        try:
-            with pytest.raises(RuntimeError, match="is not alive"):
-                print_prompt("q", "claude-opus-4-6")
-        finally:
-            claude_module.set_session_resolver(None)
-            claude_module.set_thread_repo(None)
-
-    def test_session_errors_propagate(self, session_resolver) -> None:
-        """Session errors must not be masked — fail open, not silently."""
-        session_resolver.prompt.side_effect = ClaudeStreamError(1)
-        with pytest.raises(ClaudeStreamError):
-            print_prompt("q", "claude-opus-4-6")
-
-
-class TestPrintPromptJson:
-    def test_extracts_key_from_clean_json(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = '{"description": "Fixes bug."}'
-        assert print_prompt_json("q", "description", "claude-opus-4-6") == "Fixes bug."
-
-    def test_extracts_key_when_preamble_present(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = (
-            'Sure! Here: {"description": "Adds feature."} Done.'
-        )
-        assert (
-            print_prompt_json("q", "description", "claude-opus-4-6") == "Adds feature."
-        )
-
-    def test_returns_empty_when_key_missing(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = '{"other": "value"}'
-        assert print_prompt_json("q", "description", "claude-opus-4-6") == ""
-
-    def test_returns_empty_on_no_json(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "just plain text"
-        assert print_prompt_json("q", "description", "claude-opus-4-6") == ""
-
-    def test_returns_empty_on_empty_output(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = ""
-        assert print_prompt_json("q", "description", "claude-opus-4-6") == ""
-
-    def test_non_string_value_is_ignored(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = '{"description": 42}'
-        assert print_prompt_json("q", "description", "claude-opus-4-6") == ""
-
-    def test_appends_json_instruction_to_system_prompt(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = '{"description": "x"}'
-        print_prompt_json(
-            "q", "description", "claude-opus-4-6", system_prompt="be helpful"
-        )
-        sent_system = session_resolver.prompt.call_args.kwargs["system_prompt"]
-        assert "be helpful" in sent_system
-        assert "description" in sent_system
-
-    def test_uses_json_instruction_as_only_system_prompt_when_none_given(
-        self, session_resolver
-    ) -> None:
-        session_resolver.prompt.return_value = '{"description": "x"}'
-        print_prompt_json("q", "description", "claude-opus-4-6", system_prompt=None)
-        sent_system = session_resolver.prompt.call_args.kwargs["system_prompt"]
-        assert "description" in sent_system
-
-
 class TestRunStreaming:
     def test_yields_output_lines(self, tmp_path: Path) -> None:
         from kennel.claude import _run_streaming
@@ -426,277 +307,6 @@ class TestRunStreaming:
         assert "extra" in result
 
 
-class TestPrintPromptFromFile:
-    def _files(self, tmp_path: Path) -> tuple[Path, Path]:
-        sys = tmp_path / "system.md"
-        sys.write_text("sys")
-        prompt = tmp_path / "prompt.txt"
-        prompt.write_text("p")
-        return sys, prompt
-
-    def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(return_value=iter(["session output"]))
-        result = print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == "session output"
-
-    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        with pytest.raises(ClaudeStreamError):
-            print_prompt_from_file(
-                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-            )
-
-    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT))
-        with pytest.raises(ClaudeStreamError):
-            print_prompt_from_file(
-                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-            )
-
-    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(side_effect=FileNotFoundError)
-        with pytest.raises(FileNotFoundError):
-            print_prompt_from_file(
-                sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-            )
-
-    def test_passes_correct_cmd(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(return_value=iter(["out"]))
-        print_prompt_from_file(
-            sys, prompt, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        cmd = mock_stream.call_args[0][0]
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
-        assert "--system-prompt-file" in cmd
-        assert str(sys) in cmd
-        assert "--print" in cmd
-
-    def test_passes_idle_timeout(self, tmp_path: Path) -> None:
-        sys, prompt = self._files(tmp_path)
-        mock_stream = MagicMock(return_value=iter(["out"]))
-        print_prompt_from_file(
-            sys,
-            prompt,
-            "claude-sonnet-4-6",
-            idle_timeout=600.0,
-            streaming_runner=mock_stream,
-        )
-        assert mock_stream.call_args[0][2] == 600.0
-
-
-class TestResumeSession:
-    def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("continue")
-        mock_stream = MagicMock(return_value=iter(["continued"]))
-        result = resume_session(
-            "sess-123", prompt_file, "claude-sonnet-4-6", streaming_runner=mock_stream
-        )
-        assert result == "continued"
-
-    def test_raises_on_nonzero(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("p")
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
-        with pytest.raises(ClaudeStreamError):
-            resume_session(
-                "sess-123",
-                prompt_file,
-                "claude-sonnet-4-6",
-                streaming_runner=mock_stream,
-            )
-
-    def test_raises_on_idle_timeout(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("p")
-        mock_stream = MagicMock(side_effect=ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT))
-        with pytest.raises(ClaudeStreamError):
-            resume_session(
-                "sess-123",
-                prompt_file,
-                "claude-sonnet-4-6",
-                streaming_runner=mock_stream,
-            )
-
-    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("p")
-        mock_stream = MagicMock(side_effect=FileNotFoundError)
-        with pytest.raises(FileNotFoundError):
-            resume_session(
-                "sess-123",
-                prompt_file,
-                "claude-sonnet-4-6",
-                streaming_runner=mock_stream,
-            )
-
-    def test_passes_correct_cmd(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("p")
-        mock_stream = MagicMock(return_value=iter(["out"]))
-        resume_session(
-            "my-session-id",
-            prompt_file,
-            "claude-sonnet-4-6",
-            streaming_runner=mock_stream,
-        )
-        cmd = mock_stream.call_args[0][0]
-        assert "--resume" in cmd
-        assert "my-session-id" in cmd
-        assert "--print" in cmd
-
-    def test_passes_idle_timeout(self, tmp_path: Path) -> None:
-        prompt_file = tmp_path / "prompt.txt"
-        prompt_file.write_text("p")
-        mock_stream = MagicMock(return_value=iter(["out"]))
-        resume_session(
-            "sess-1",
-            prompt_file,
-            "claude-sonnet-4-6",
-            idle_timeout=900.0,
-            streaming_runner=mock_stream,
-        )
-        assert mock_stream.call_args[0][2] == 900.0
-
-
-class TestTriageComment:
-    def test_returns_first_line(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ACT: fix the thing\nextra"))
-        assert triage_comment("triage this", runner=mock_run) == "ACT: fix the thing"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ACT", returncode=1))
-        assert triage_comment("triage this", runner=mock_run) == ""
-
-    def test_returns_empty_on_empty_output(self) -> None:
-        mock_run = MagicMock(return_value=_completed(""))
-        assert triage_comment("triage this", runner=mock_run) == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert triage_comment("triage", runner=mock_run) == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert triage_comment("triage", runner=mock_run) == ""
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ACT: thing"))
-        triage_comment("triage this", runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_custom_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("DO: fix"))
-        triage_comment(
-            "triage", model="claude-haiku-4-5-20251001", timeout=5, runner=mock_run
-        )
-        cmd = mock_run.call_args.args[0]
-        assert "claude-haiku-4-5-20251001" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 5
-
-
-class TestGenerateReply:
-    def test_returns_stripped_output(self) -> None:
-        mock_run = MagicMock(return_value=_completed("  woof!  \n"))
-        assert generate_reply("write a reply", runner=mock_run) == "woof!"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed("err", returncode=1))
-        assert generate_reply("write", runner=mock_run) == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
-        assert generate_reply("write", runner=mock_run) == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert generate_reply("write", runner=mock_run) == ""
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ok"))
-        generate_reply("write a reply", runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 30
-
-    def test_custom_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ok"))
-        generate_reply("write", model="claude-sonnet-4-6", timeout=10, runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-sonnet-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 10
-
-
-class TestGenerateBranchName:
-    def test_returns_first_line(self) -> None:
-        mock_run = MagicMock(return_value=_completed("add-tests\nextra line"))
-        assert (
-            generate_branch_name("make branch for: add tests", runner=mock_run)
-            == "add-tests"
-        )
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed("slug", returncode=1))
-        assert generate_branch_name("make branch", runner=mock_run) == ""
-
-    def test_returns_empty_on_empty_output(self) -> None:
-        mock_run = MagicMock(return_value=_completed(""))
-        assert generate_branch_name("make branch", runner=mock_run) == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert generate_branch_name("make branch", runner=mock_run) == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert generate_branch_name("make branch", runner=mock_run) == ""
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("fix-bug"))
-        generate_branch_name("fix bug in parser", runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-haiku-4-5-20251001" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_custom_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("fix-bug"))
-        generate_branch_name(
-            "fix bug", model="claude-opus-4-6", timeout=20, runner=mock_run
-        )
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 20
-
-
-class TestGenerateStatus:
-    def test_delegates_to_session_prompt(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "🐶\ncoding up a storm"
-        assert generate_status("working on #42", "be fido") == "🐶\ncoding up a storm"
-        session_resolver.prompt.assert_called_once_with(
-            "working on #42", model="claude-opus-4-6", system_prompt="be fido"
-        )
-
-    def test_default_model(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "🐶\nwoof"
-        generate_status("working", "sys")
-        assert session_resolver.prompt.call_args.kwargs["model"] == "claude-opus-4-6"
-
-    def test_custom_model(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "🐶\nwoof"
-        generate_status("working", "sys", model="claude-sonnet-4-6")
-        assert session_resolver.prompt.call_args.kwargs["model"] == "claude-sonnet-4-6"
-
-
 class TestExtractSessionId:
     def test_returns_session_id_from_result_line(self) -> None:
         output = '{"type":"result","session_id":"abc-123"}'
@@ -800,221 +410,6 @@ class TestExtractResultText:
             '{"type":"result","result":"🐕\\nworking","session_id":"sid"}\n'
         )
         assert extract_result_text(output) == "🐕\nworking"
-
-
-class TestGenerateStatusWithSession:
-    _RESULT_LINE = '{"type":"result","result":"🐶\\ncoding","session_id":"sess-42"}'
-
-    def test_returns_text_and_session_id_on_success(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        text, sid = generate_status_with_session(
-            "doing stuff", "be fido", runner=mock_run
-        )
-        assert text == "🐶\ncoding"
-        assert sid == "sess-42"
-
-    def test_returns_empty_pair_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
-        mock_run.assert_called_once()
-        mock_sleep.assert_not_called()
-
-    def test_returns_empty_pair_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
-        mock_run.assert_called_once()
-        mock_sleep.assert_not_called()
-
-    def test_returns_empty_pair_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "doing stuff", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
-        mock_run.assert_called_once()
-        mock_sleep.assert_not_called()
-
-    def test_passes_correct_flags(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        generate_status_with_session(
-            "working on #42",
-            "be a dog",
-            model="claude-sonnet-4-6",
-            timeout=10,
-            runner=mock_run,
-        )
-        cmd = mock_run.call_args.args[0]
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
-        assert "--output-format" in cmd
-        assert "stream-json" in cmd
-        assert "--verbose" in cmd
-        assert "--dangerously-skip-permissions" in cmd
-        assert "--system-prompt" in cmd
-        assert "be a dog" in cmd
-        assert "--print" in cmd
-        assert "-p" in cmd
-        assert "working on #42" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 10
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        generate_status_with_session("working", "sys", runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_returns_empty_pair_when_no_result_field_after_retries(self) -> None:
-        no_result = '{"type":"result","session_id":"sid"}'
-        mock_run = MagicMock(return_value=_completed(no_result))
-        mock_sleep = MagicMock()
-        text, sid = generate_status_with_session(
-            "working", "sys", runner=mock_run, _sleep=mock_sleep
-        )
-        assert text == ""
-        assert sid == ""
-        assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    def test_returns_empty_session_when_no_session_id(self) -> None:
-        no_sid = '{"type":"result","result":"🐶\\nwoof"}'
-        mock_run = MagicMock(return_value=_completed(no_sid))
-        text, sid = generate_status_with_session("working", "sys", runner=mock_run)
-        assert text == "🐶\nwoof"
-        assert sid == ""
-
-    def test_retries_on_empty_output_then_succeeds(self) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(
-            side_effect=[
-                _completed(empty_line),
-                _completed(empty_line),
-                _completed(self._RESULT_LINE),
-            ]
-        )
-        mock_sleep = MagicMock()
-        text, sid = generate_status_with_session(
-            "working", "sys", runner=mock_run, _sleep=mock_sleep
-        )
-        assert text == "🐶\ncoding"
-        assert sid == "sess-42"
-        assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    def test_returns_empty_pair_after_all_retries_exhausted(self) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        mock_sleep = MagicMock()
-        assert generate_status_with_session(
-            "working", "sys", runner=mock_run, _sleep=mock_sleep
-        ) == ("", "")
-        assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(
-            return_value=_completed(empty_line, stderr="Rate limit exceeded")
-        )
-        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
-        assert "Rate limit exceeded" in caplog.text
-
-    def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
-        assert "stdout=" in caplog.text
-
-    def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            generate_status_with_session(
-                "working", "sys", runner=mock_run, _sleep=MagicMock()
-            )
-        assert "stderr=" not in caplog.text
-
-
-class TestGenerateStatusEmoji:
-    def test_delegates_to_session_prompt(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "🐕"
-        assert generate_status_emoji("pick emoji", "be fido") == "🐕"
-        session_resolver.prompt.assert_called_once_with(
-            "pick emoji", model="claude-opus-4-6", system_prompt="be fido"
-        )
-
-    def test_custom_model(self, session_resolver) -> None:
-        session_resolver.prompt.return_value = "🐕"
-        generate_status_emoji("pick emoji", "be fido", model="claude-sonnet-4-6")
-        assert session_resolver.prompt.call_args.kwargs["model"] == "claude-sonnet-4-6"
-
-
-class TestResumeStatus:
-    _RESULT_LINE = '{"type":"result","result":"🐕\\nfetching","session_id":"s-1"}'
-
-    def test_returns_text_on_success(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        result = resume_status("s-1", "please shorten", runner=mock_run)
-        assert result == "🐕\nfetching"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
-
-    def test_passes_correct_flags(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        resume_status(
-            "my-session",
-            "shorten to 80 chars",
-            model="claude-sonnet-4-6",
-            timeout=20,
-            runner=mock_run,
-        )
-        cmd = mock_run.call_args.args[0]
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
-        assert "--output-format" in cmd
-        assert "stream-json" in cmd
-        assert "--verbose" in cmd
-        assert "--dangerously-skip-permissions" in cmd
-        assert "--resume" in cmd
-        assert "my-session" in cmd
-        assert "--print" in cmd
-        assert "-p" in cmd
-        assert "shorten to 80 chars" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 20
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        resume_status("s-1", "shorten", runner=mock_run)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_returns_empty_when_no_result_field(self) -> None:
-        no_result = '{"type":"result","session_id":"s-1"}'
-        mock_run = MagicMock(return_value=_completed(no_result))
-        assert resume_status("s-1", "shorten", runner=mock_run) == ""
 
 
 class TestKillActiveChildren:
@@ -1145,6 +540,54 @@ class TestRunStreamingTracksChildren:
             assert _session_for_current_repo() is live
         finally:
             set_thread_repo(None)
+            claude_module.set_session_resolver(None)
+
+    def test_session_for_current_repo_raises_without_repo(self) -> None:
+        from kennel import claude as claude_module
+        from kennel.claude import _session_for_current_repo
+
+        claude_module.set_thread_repo(None)
+        with pytest.raises(RuntimeError, match="thread-local repo_name"):
+            _session_for_current_repo()
+
+    def test_session_for_current_repo_raises_without_resolver(self) -> None:
+        from kennel import claude as claude_module
+        from kennel.claude import _session_for_current_repo
+
+        claude_module.set_session_resolver(None)
+        claude_module.set_thread_repo("owner/repo")
+        try:
+            with pytest.raises(RuntimeError, match="set_session_resolver"):
+                _session_for_current_repo()
+        finally:
+            claude_module.set_thread_repo(None)
+
+    def test_session_for_current_repo_raises_when_no_session(self) -> None:
+        from kennel import claude as claude_module
+        from kennel.claude import _session_for_current_repo
+
+        claude_module.set_session_resolver(lambda repo: None)
+        claude_module.set_thread_repo("owner/repo")
+        try:
+            with pytest.raises(RuntimeError, match="no ClaudeSession registered"):
+                _session_for_current_repo()
+        finally:
+            claude_module.set_thread_repo(None)
+            claude_module.set_session_resolver(None)
+
+    def test_session_for_current_repo_raises_when_not_alive(self) -> None:
+        from kennel import claude as claude_module
+        from kennel.claude import _session_for_current_repo
+
+        dead = MagicMock()
+        dead.is_alive.return_value = False
+        claude_module.set_session_resolver(lambda repo: dead)
+        claude_module.set_thread_repo("owner/repo")
+        try:
+            with pytest.raises(RuntimeError, match="not alive"):
+                _session_for_current_repo()
+        finally:
+            claude_module.set_thread_repo(None)
             claude_module.set_session_resolver(None)
 
     def test_thread_name_for_id_returns_none_when_not_found(self) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from kennel.claude import ClaudeClient
 from kennel.config import Config, RepoConfig
 from kennel.events import (
     Action,
@@ -59,47 +60,54 @@ def _payload(repo_owner: str = "owner") -> dict:
     }
 
 
+def _client(return_value: str = "", *, side_effect=None) -> MagicMock:
+    """Build a mock ClaudeClient with print_prompt configured."""
+    client = MagicMock(spec=ClaudeClient)
+    if side_effect is not None:
+        client.print_prompt.side_effect = side_effect
+    else:
+        client.print_prompt.return_value = return_value
+    return client
+
+
 class TestNeedsMoreContext:
     def test_haiku_yes_returns_true(self) -> None:
-        assert needs_more_context("same", _print_prompt=MagicMock(return_value="YES"))
+        assert needs_more_context("same", claude_client=_client("YES"))
 
     def test_haiku_yes_with_explanation_returns_true(self) -> None:
-        assert needs_more_context(
-            "^", _print_prompt=MagicMock(return_value="YES, this is vague")
-        )
+        assert needs_more_context("^", claude_client=_client("YES, this is vague"))
 
     def test_haiku_no_returns_false(self) -> None:
         assert not needs_more_context(
             "This is a detailed review comment.",
-            _print_prompt=MagicMock(return_value="NO"),
+            claude_client=_client("NO"),
         )
 
     def test_haiku_no_with_explanation_returns_false(self) -> None:
         assert not needs_more_context(
             "Please rename this variable to be more descriptive.",
-            _print_prompt=MagicMock(return_value="NO, it's clear"),
+            claude_client=_client("NO, it's clear"),
         )
 
     def test_subprocess_exception_returns_false(self) -> None:
-        assert not needs_more_context("ditto", _print_prompt=MagicMock(return_value=""))
+        assert not needs_more_context("ditto", claude_client=_client(""))
 
     def test_timeout_returns_false(self) -> None:
-        assert not needs_more_context("same", _print_prompt=MagicMock(return_value=""))
+        assert not needs_more_context("same", claude_client=_client(""))
 
     def test_empty_output_returns_false(self) -> None:
-        assert not needs_more_context(
-            "here too", _print_prompt=MagicMock(return_value="")
-        )
+        assert not needs_more_context("here too", claude_client=_client(""))
 
     def test_uses_haiku_model(self) -> None:
-        mock_pp = MagicMock(return_value="YES")
-        needs_more_context("same", _print_prompt=mock_pp)
-        assert mock_pp.call_args.args[1] == "claude-haiku-4-5"
+        client = _client("YES")
+        needs_more_context("same", claude_client=client)
+        assert client.print_prompt.call_args.args[1] == "claude-haiku-4-5"
 
-    def test_defaults_to_claude_print_prompt(self) -> None:
-        with patch("kennel.claude.print_prompt", return_value="NO") as mock_pp:
+    def test_defaults_to_claude_client(self) -> None:
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = "NO"
             result = needs_more_context("some comment")
-        mock_pp.assert_called_once()
+        MockCls.assert_called_once_with()
         assert result is False
 
 
@@ -368,56 +376,57 @@ class TestCommentLock:
 
 class TestSummarizeAsActionItem:
     def test_returns_model_result(self) -> None:
-        pp = MagicMock(return_value="add logging to streamed sub-Claude output")
+        client = _client("add logging to streamed sub-Claude output")
         result = _summarize_as_action_item(
-            "Ensure we log at that level too.", _print_prompt=pp
+            "Ensure we log at that level too.", claude_client=client
         )
         assert result == "add logging to streamed sub-Claude output"
 
     def test_empty_result_raises(self) -> None:
-        pp = MagicMock(return_value="")
+        client = _client("")
         with pytest.raises(ValueError, match="_summarize_as_action_item"):
-            _summarize_as_action_item("short comment", _print_prompt=pp)
+            _summarize_as_action_item("short comment", claude_client=client)
 
     def test_strips_whitespace_from_result(self) -> None:
-        pp = MagicMock(return_value="  add tests  ")
-        result = _summarize_as_action_item("add tests please", _print_prompt=pp)
+        client = _client("  add tests  ")
+        result = _summarize_as_action_item("add tests please", claude_client=client)
         assert result == "add tests"
 
-    def test_defaults_to_claude_print_prompt(self) -> None:
-        with patch("kennel.claude.print_prompt", return_value="add tests") as mock_pp:
+    def test_defaults_to_claude_client(self) -> None:
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = "add tests"
             result = _summarize_as_action_item("add some tests")
-        mock_pp.assert_called_once()
+        MockCls.assert_called_once_with()
         assert result == "add tests"
 
     def test_short_result_returned_without_retry(self) -> None:
         short_title = "add unit tests"
-        pp = MagicMock(return_value=short_title)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        client = _client(short_title)
+        result = _summarize_as_action_item("add some tests", claude_client=client)
         assert result == short_title
-        pp.assert_called_once()  # no retry needed
+        client.print_prompt.assert_called_once()  # no retry needed
 
     def test_retries_when_result_too_long(self) -> None:
         long_title = "a" * 81
         short_title = "add tests"
-        pp = MagicMock(side_effect=[long_title, short_title])
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        client = _client(side_effect=[long_title, short_title])
+        result = _summarize_as_action_item("add some tests", claude_client=client)
         assert result == short_title
-        assert pp.call_count == 2
+        assert client.print_prompt.call_count == 2
 
     def test_retries_up_to_three_times_then_truncates(self) -> None:
         long_title = "a" * 81
-        pp = MagicMock(return_value=long_title)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        client = _client(long_title)
+        result = _summarize_as_action_item("add some tests", claude_client=client)
         assert result == long_title[:80]
-        assert pp.call_count == 4  # 1 initial + 3 retries
+        assert client.print_prompt.call_count == 4  # 1 initial + 3 retries
 
     def test_stops_retrying_once_short_enough(self) -> None:
         titles = ["a" * 81, "b" * 81, "short title"]
-        pp = MagicMock(side_effect=titles)
-        result = _summarize_as_action_item("add some tests", _print_prompt=pp)
+        client = _client(side_effect=titles)
+        result = _summarize_as_action_item("add some tests", claude_client=client)
         assert result == "short title"
-        assert pp.call_count == 3  # 1 initial + 2 retries
+        assert client.print_prompt.call_count == 3  # 1 initial + 2 retries
 
 
 class TestTriage:
@@ -425,20 +434,20 @@ class TestTriage:
         cat, titles = _triage(
             "please add tests",
             is_bot=False,
-            _print_prompt=MagicMock(return_value="ACT: add tests"),
+            claude_client=_client("ACT: add tests"),
         )
         assert cat == "ACT"
         assert titles == ["add tests"]
 
     def test_fallback_on_bad_response(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, titles = _triage("do stuff", is_bot=False, _print_prompt=pp)
+        client = _client(side_effect=["", "implement the thing"])
+        cat, titles = _triage("do stuff", is_bot=False, claude_client=client)
         assert cat == "ACT"
         assert titles == ["implement the thing"]
 
     def test_fallback_for_bot(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "implement the thing"])
-        cat, titles = _triage("do stuff", is_bot=True, _print_prompt=pp)
+        client = _client(side_effect=["", "implement the thing"])
+        cat, titles = _triage("do stuff", is_bot=True, claude_client=client)
         assert cat == "DO"
         assert titles == ["implement the thing"]
 
@@ -448,25 +457,25 @@ class TestTriage:
             "nit comment",
             is_bot=False,
             context=ctx,
-            _print_prompt=MagicMock(return_value="DEFER: out of scope"),
+            claude_client=_client("DEFER: out of scope"),
         )
         assert cat == "DEFER"
 
     def test_unrecognized_category_falls_back(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["WEIRD: something", "do the thing"])
-        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
+        client = _client(side_effect=["WEIRD: something", "do the thing"])
+        cat, titles = _triage("hi", is_bot=False, claude_client=client)
         assert cat == "ACT"
         assert titles == ["do the thing"]
 
     def test_timeout_falls_back(self, tmp_path: Path) -> None:
-        pp = MagicMock(side_effect=["", "do the thing"])
-        cat, titles = _triage("hi", is_bot=True, _print_prompt=pp)
+        client = _client(side_effect=["", "do the thing"])
+        cat, titles = _triage("hi", is_bot=True, claude_client=client)
         assert cat == "DO"
 
     def test_task_category_falls_back(self, tmp_path: Path) -> None:
         """TASK is no longer a valid bot category — falls back to DO."""
-        pp = MagicMock(side_effect=["TASK: add caching", "add result caching"])
-        cat, titles = _triage("cache results", is_bot=True, _print_prompt=pp)
+        client = _client(side_effect=["TASK: add caching", "add result caching"])
+        cat, titles = _triage("cache results", is_bot=True, claude_client=client)
         assert cat == "DO"
         assert titles == ["add result caching"]
 
@@ -478,15 +487,18 @@ class TestTriage:
             captured["prompt"] = prompt
             return "DO: implement feature"
 
-        cat, _ = _triage("implement feature", is_bot=True, _print_prompt=fake_pp)
+        cat, _ = _triage(
+            "implement feature", is_bot=True, claude_client=_client(side_effect=fake_pp)
+        )
         assert cat == "DO"
         assert "DO" in captured["prompt"]
         assert "TASK" not in captured["prompt"]
 
-    def test_defaults_to_claude_print_prompt(self) -> None:
-        with patch("kennel.claude.print_prompt", return_value="ACT: do it") as mock_pp:
+    def test_defaults_to_claude_client(self) -> None:
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = "ACT: do it"
             cat, titles = _triage("do it", is_bot=False)
-        mock_pp.assert_called_once()
+        MockCls.assert_called_once_with()
         assert cat == "ACT"
 
     def test_multiple_act_lines_returns_all_titles(self) -> None:
@@ -494,7 +506,7 @@ class TestTriage:
         cat, titles = _triage(
             "please add tests and docs",
             is_bot=False,
-            _print_prompt=MagicMock(return_value=response),
+            claude_client=_client(response),
         )
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
@@ -505,15 +517,15 @@ class TestTriage:
         cat, titles = _triage(
             "comment",
             is_bot=False,
-            _print_prompt=MagicMock(return_value=response),
+            claude_client=_client(response),
         )
         assert cat == "ACT"
         assert titles == ["add tests"]
 
     def test_zero_act_tasks_falls_back(self) -> None:
         """ACT with empty title is treated as parse failure → fallback."""
-        pp = MagicMock(side_effect=["ACT: ", "do the thing"])
-        cat, titles = _triage("hi", is_bot=False, _print_prompt=pp)
+        client = _client(side_effect=["ACT: ", "do the thing"])
+        cat, titles = _triage("hi", is_bot=False, claude_client=client)
         # empty title → stripped to "" → falsy → no titles collected → fallback
         assert cat == "ACT"
         assert titles == ["do the thing"]
@@ -524,7 +536,7 @@ class TestTriage:
         cat, titles = _triage(
             "add tests",
             is_bot=False,
-            _print_prompt=MagicMock(return_value=response),
+            claude_client=_client(response),
         )
         assert cat == "ACT"
         assert titles == ["add unit tests"]
@@ -551,7 +563,7 @@ class TestMaybeReact:
             "owner/repo",
             cfg,
             mock_gh,
-            _print_prompt=MagicMock(return_value="heart"),
+            claude_client=_client("heart"),
         )
         mock_gh.add_reaction.assert_called_once_with("owner/repo", "pulls", 99, "heart")
 
@@ -565,7 +577,7 @@ class TestMaybeReact:
             "owner/repo",
             cfg,
             mock_gh,
-            _print_prompt=MagicMock(return_value="NONE"),
+            claude_client=_client("NONE"),
         )
         mock_gh.add_reaction.assert_not_called()
 
@@ -578,7 +590,7 @@ class TestMaybeReact:
             "owner/repo",
             cfg,
             MagicMock(),
-            _print_prompt=MagicMock(return_value=""),
+            claude_client=_client(""),
         )
 
     def test_file_not_found_warns_and_returns(self, tmp_path: Path) -> None:
@@ -590,7 +602,7 @@ class TestMaybeReact:
             "owner/repo",
             cfg,
             MagicMock(),
-            _print_prompt=MagicMock(return_value=""),
+            claude_client=_client(""),
         )
 
     def test_reads_persona_if_present(self, tmp_path: Path) -> None:
@@ -618,15 +630,16 @@ class TestMaybeReact:
             "owner/repo",
             cfg,
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert "you are fido" in captured.get("prompt", "")
 
-    def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
+    def test_defaults_to_claude_client(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
-        with patch("kennel.claude.print_prompt", return_value="NONE") as mock_pp:
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = "NONE"
             maybe_react("hi", 1, "pulls", "owner/repo", cfg, MagicMock())
-        mock_pp.assert_called_once()
+        MockCls.assert_called_once_with()
 
 
 class TestReplyToComment:
@@ -689,7 +702,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
         assert "logging" in titles[0].lower()
@@ -715,7 +728,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ASK"
 
@@ -740,7 +753,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ANSWER"
 
@@ -768,7 +781,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "DO"
         assert titles == ["Cache results for performance"]
@@ -797,7 +810,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "DEFER"
         mock_gh.create_issue.assert_called_once_with(
@@ -827,7 +840,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "DUMP"
 
@@ -858,7 +871,7 @@ class TestReplyToComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
         mock_gh.reply_to_review_comment.assert_not_called()
 
@@ -886,7 +899,7 @@ class TestReplyToComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 MagicMock(),
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
     def test_lock_race_returns_act(self, tmp_path: Path) -> None:
@@ -935,7 +948,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
 
@@ -963,7 +976,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
         # Title comes from _summarize_as_action_item(root_body), not multi-item triage
@@ -1006,7 +1019,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
         # Title derived from root comment, not the "Woof" reply
@@ -1052,7 +1065,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
         # Title always comes from _summarize_as_action_item(root_body), even when
@@ -1094,7 +1107,7 @@ class TestReplyToComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ASK"
         # _summarize_as_action_item must not be called for non-task categories
@@ -1132,7 +1145,7 @@ class TestReplyToReview:
         )
         mock_gh = MagicMock()
         reply_to_review(
-            action, cfg, self._repo_cfg(tmp_path), mock_gh, _print_prompt=MagicMock()
+            action, cfg, self._repo_cfg(tmp_path), mock_gh, claude_client=_client()
         )
         # Doesn't fetch, doesn't post — no GitHub side effects at all.
         mock_gh.get_review_comments.assert_not_called()
@@ -1180,7 +1193,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
 
@@ -1197,7 +1210,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ASK"
 
@@ -1214,7 +1227,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ANSWER"
 
@@ -1231,7 +1244,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "DUMP"
 
@@ -1251,7 +1264,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "DEFER"
         mock_gh.create_issue.assert_called_once_with(
@@ -1280,7 +1293,7 @@ class TestReplyToIssueComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
         mock_gh.comment_issue.assert_not_called()
 
@@ -1298,7 +1311,7 @@ class TestReplyToIssueComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 MagicMock(),
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
     def test_post_exception_propagates(self, tmp_path: Path) -> None:
@@ -1324,7 +1337,7 @@ class TestReplyToIssueComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
     def test_no_comment_id_skips_react(self, tmp_path: Path) -> None:
@@ -1346,11 +1359,11 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
 
-    def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
+    def test_defaults_to_claude_client(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = self._action()
 
@@ -1359,11 +1372,12 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return "ok"
 
-        with patch("kennel.claude.print_prompt", side_effect=fake_pp) as mock_pp:
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.side_effect = fake_pp
             cat, titles = reply_to_issue_comment(
                 action, cfg, self._repo_cfg(tmp_path), MagicMock()
             )
-        assert mock_pp.called
+        MockCls.assert_called_once_with()
         assert cat == "ACT"
 
     def test_includes_conversation_context_in_triage(self, tmp_path: Path) -> None:
@@ -1389,7 +1403,7 @@ class TestReplyToIssueComment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
         assert cat == "ACT"
         mock_gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
@@ -1415,7 +1429,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             mock_gh,
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
 
@@ -1433,7 +1447,7 @@ class TestReplyToIssueComment:
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            _print_prompt=fake_pp,
+            claude_client=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
@@ -2267,7 +2281,9 @@ class TestReorderTasksBackground:
         }
         with patch("kennel.events._notify_thread_change") as mock_notify:
             on_changes([change])
-        mock_notify.assert_called_once_with(change, self._cfg(tmp_path), mock_gh)
+        mock_notify.assert_called_once_with(
+            change, self._cfg(tmp_path), mock_gh, claude_client=None, prompts=None
+        )
 
     def test_on_inprogress_affected_aborts_worker_via_registry(
         self, tmp_path: Path
@@ -2334,10 +2350,10 @@ class TestReorderTasksBackground:
         args, kwargs = rewrite_calls[0]
         assert args[0] == tmp_path
 
-    def test_on_done_passes_print_prompt_to_rewrite_fn(self, tmp_path: Path) -> None:
+    def test_on_done_passes_claude_client_to_rewrite_fn(self, tmp_path: Path) -> None:
         started: list = []
         rewrite_calls: list = []
-        fake_pp = MagicMock()
+        fake_client = MagicMock()
         calls, mock_reorder = self._capture_reorder_calls()
 
         def mock_rewrite(*a, **kw):
@@ -2350,14 +2366,14 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
-            _print_prompt=fake_pp,
+            claude_client=fake_client,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
         on_done()
-        assert rewrite_calls[0].get("_print_prompt") is fake_pp
+        assert rewrite_calls[0].get("claude_client") is fake_client
 
     def test_coalesces_when_already_running(self, tmp_path: Path) -> None:
         """Second call while first is running marks pending, does not spawn thread."""
@@ -2559,9 +2575,7 @@ class TestNotifyThreadChange:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
-        _notify_thread_change(
-            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Noted!")
-        )
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client("Noted!"))
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Noted!")
 
     def test_modified_posts_comment(self, tmp_path: Path) -> None:
@@ -2573,9 +2587,7 @@ class TestNotifyThreadChange:
             "new_title": "Updated title",
             "new_description": "",
         }
-        _notify_thread_change(
-            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Updated!")
-        )
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client("Updated!"))
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Updated!")
 
     def test_missing_thread_skips_comment(self, tmp_path: Path) -> None:
@@ -2584,7 +2596,7 @@ class TestNotifyThreadChange:
         task = self._task()
         task["thread"] = {}
         change = {"task": task, "kind": "completed"}
-        _notify_thread_change(change, cfg, mock_gh, _print_prompt=MagicMock())
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client())
         mock_gh.comment_issue.assert_not_called()
 
     def test_empty_opus_raises_for_completed(self, tmp_path: Path) -> None:
@@ -2592,9 +2604,7 @@ class TestNotifyThreadChange:
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
         with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(
-                change, cfg, mock_gh, _print_prompt=MagicMock(return_value="")
-            )
+            _notify_thread_change(change, cfg, mock_gh, claude_client=_client(""))
 
     def test_empty_opus_raises_for_modified(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2606,9 +2616,7 @@ class TestNotifyThreadChange:
             "new_description": "",
         }
         with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(
-                change, cfg, mock_gh, _print_prompt=MagicMock(return_value="")
-            )
+            _notify_thread_change(change, cfg, mock_gh, claude_client=_client(""))
 
     def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2620,7 +2628,7 @@ class TestNotifyThreadChange:
             change,
             cfg,
             mock_gh,
-            _print_prompt=MagicMock(return_value="In-thread reply"),
+            claude_client=_client("In-thread reply"),
         )
         mock_gh.reply_to_review_comment.assert_called_once_with(
             "owner/repo", 42, "In-thread reply", 999
@@ -2635,9 +2643,7 @@ class TestNotifyThreadChange:
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
         # Should not raise
-        _notify_thread_change(
-            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="ok")
-        )
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client("ok"))
 
     def test_no_comment_type_defaults_to_issue_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -2645,9 +2651,7 @@ class TestNotifyThreadChange:
         task = self._task()
         del task["thread"]["comment_type"]
         change = {"task": task, "kind": "completed"}
-        _notify_thread_change(
-            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="Fallback")
-        )
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client("Fallback"))
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Fallback")
         mock_gh.reply_to_review_comment.assert_not_called()
 
@@ -2660,7 +2664,9 @@ class TestNotifyThreadChange:
             return "ok"
 
         change = {"task": self._task(), "kind": "completed"}
-        _notify_thread_change(change, cfg, MagicMock(), _print_prompt=fake_pp)
+        _notify_thread_change(
+            change, cfg, MagicMock(), claude_client=_client(side_effect=fake_pp)
+        )
         assert "alice" in captured_prompt[0]
 
     def test_comment_issue_exception_does_not_raise(self, tmp_path: Path) -> None:
@@ -2669,16 +2675,16 @@ class TestNotifyThreadChange:
         mock_gh.comment_issue.side_effect = RuntimeError("api error")
         change = {"task": self._task(), "kind": "completed"}
         # Should not raise
-        _notify_thread_change(
-            change, cfg, mock_gh, _print_prompt=MagicMock(return_value="ok")
-        )
+        _notify_thread_change(change, cfg, mock_gh, claude_client=_client("ok"))
 
-    def test_default_print_prompt_uses_claude(self, tmp_path: Path) -> None:
+    def test_default_claude_client_used(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
-        with patch("kennel.events.claude.print_prompt", return_value="Auto reply"):
+        with patch("kennel.events.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = "Auto reply"
             _notify_thread_change(change, cfg, mock_gh)
+        MockCls.assert_called_once_with()
         mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Auto reply")
 
 
@@ -2862,7 +2868,7 @@ class TestMaybeReactGhException:
             "owner/repo",
             cfg,
             mock_gh,
-            _print_prompt=MagicMock(return_value="heart"),
+            claude_client=_client("heart"),
         )  # must not raise
 
 
@@ -2903,7 +2909,7 @@ class TestReplyToCommentElseBranch:
                 cfg,
                 self._repo_cfg(tmp_path),
                 MagicMock(),
-                _print_prompt=MagicMock(return_value="I'll look into this."),
+                claude_client=_client("I'll look into this."),
             )
         assert cat == "UNKNOWN_CAT"
 
@@ -2932,7 +2938,7 @@ class TestReplyToCommentElseBranch:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
 
@@ -2964,7 +2970,9 @@ class TestReplyToCommentTerseEnrichment:
         )
         captured_context: dict = {}
 
-        def fake_triage(body, is_bot, context=None, *, _print_prompt=None):
+        def fake_triage(
+            body, is_bot, context=None, *, claude_client=None, prompts=None
+        ):
             if context is not None:
                 captured_context.update(context)
             return ("ACT", ["handle same comment"])
@@ -2987,7 +2995,7 @@ class TestReplyToCommentTerseEnrichment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=MagicMock(return_value="On it!"),
+                claude_client=_client("On it!"),
             )
 
         mock_gh.fetch_sibling_threads.assert_called_once_with("owner/repo", 5)
@@ -3016,7 +3024,7 @@ class TestReplyToCommentTerseEnrichment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
         mock_gh.fetch_sibling_threads.assert_not_called()
@@ -3044,7 +3052,7 @@ class TestReplyToCommentTerseEnrichment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=fake_pp,
+                claude_client=_client(side_effect=fake_pp),
             )
 
         assert cat == "ACT"
@@ -3061,7 +3069,9 @@ class TestReplyToCommentTerseEnrichment:
         )
         captured_context: dict = {}
 
-        def fake_triage(body, is_bot, context=None, *, _print_prompt=None):
+        def fake_triage(
+            body, is_bot, context=None, *, claude_client=None, prompts=None
+        ):
             if context is not None:
                 captured_context.update(context)
             return ("ACT", ["check caret comment"])
@@ -3078,7 +3088,7 @@ class TestReplyToCommentTerseEnrichment:
                 cfg,
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                _print_prompt=MagicMock(return_value="On it!"),
+                claude_client=_client("On it!"),
             )
 
         assert "sibling_threads" not in captured_context
@@ -3117,7 +3127,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(),
+            claude_client=_client(),
             _state=self._mock_state(issue=None),
         )
         mock_gh.edit_pr_body.assert_not_called()
@@ -3129,7 +3139,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(),
+                claude_client=_client(),
                 _state=self._mock_state(),
             )
         mock_gh.edit_pr_body.assert_not_called()
@@ -3140,7 +3150,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(),
+            claude_client=_client(),
             _state=self._mock_state(),
         )
         mock_gh.edit_pr_body.assert_not_called()
@@ -3151,7 +3161,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(),
+            claude_client=_client(),
             _state=self._mock_state(),
         )
         mock_gh.edit_pr_body.assert_not_called()
@@ -3163,7 +3173,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(),
+                claude_client=_client(),
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
@@ -3177,7 +3187,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(),
+                claude_client=_client(),
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
@@ -3189,7 +3199,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(return_value=""),
+                claude_client=_client(""),
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
@@ -3200,9 +3210,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New description.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>New description.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3215,9 +3223,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>Updated description.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>Updated description.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3231,9 +3237,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>Fresh desc.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>Fresh desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=self._mock_tasks(),
         )
@@ -3249,26 +3253,22 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(
-                    return_value="<body>New desc.\n\nFixes #42.</body>"
-                ),
+                claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
 
-    def test_defaults_to_claude_print_prompt(self, tmp_path: Path) -> None:
+    def test_defaults_to_none_claude_client(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
-        with patch(
-            "kennel.claude.print_prompt",
-            return_value="<body>Desc.\n\nFixes #42.</body>",
-        ) as mock_pp:
+        with patch("kennel.worker._write_pr_description") as mock_write:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
-        mock_pp.assert_called_once()
+        mock_write.assert_called_once()
+        assert mock_write.call_args.kwargs.get("_print_prompt") is None
 
     def test_defaults_to_state(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
@@ -3277,7 +3277,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(),
+                claude_client=_client(),
                 _tasks=self._mock_tasks(),
             )
         mock_state_cls.assert_called_once_with(tmp_path / ".git" / "fido")
@@ -3292,9 +3292,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New desc.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=tasks,
         )
@@ -3316,9 +3314,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New desc.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=tasks,
         )
@@ -3339,9 +3335,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New desc.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=tasks,
             _max_retries=3,
@@ -3355,9 +3349,7 @@ class TestRewritePrDescription:
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,
-                _print_prompt=MagicMock(
-                    return_value="<body>New desc.\n\nFixes #42.</body>"
-                ),
+                claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
                 _state=self._mock_state(),
                 _tasks=self._mock_tasks(),
             )
@@ -3378,9 +3370,7 @@ class TestRewritePrDescription:
         _rewrite_pr_description(
             tmp_path,
             mock_gh,
-            _print_prompt=MagicMock(
-                return_value="<body>New desc.\n\nFixes #42.</body>"
-            ),
+            claude_client=_client("<body>New desc.\n\nFixes #42.</body>"),
             _state=self._mock_state(),
             _tasks=tasks,
         )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3268,7 +3268,7 @@ class TestRewritePrDescription:
                 _tasks=self._mock_tasks(),
             )
         mock_write.assert_called_once()
-        assert mock_write.call_args.kwargs.get("_print_prompt") is None
+        assert mock_write.call_args.kwargs.get("claude_client") is None
 
     def test_defaults_to_state(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kennel.claude import ClaudeClient
 from kennel.gh_status import (
     generate_persona_emoji,
     generate_persona_status,
@@ -14,82 +15,130 @@ from kennel.gh_status import (
 )
 
 
+def _client(**overrides: object) -> MagicMock:
+    """Create a mock ClaudeClient with optional attribute overrides."""
+    client = MagicMock(spec=ClaudeClient)
+    for k, v in overrides.items():
+        setattr(client, k, v)
+    return client
+
+
 class TestGeneratePersonaStatus:
     def test_happy_path(self) -> None:
+        mock_client = _client()
+        mock_client.print_prompt.return_value = "sniffing out a bug *tail wag*"
         result = generate_persona_status(
             "fixing a bug",
             "You are Fido",
-            _print_prompt=lambda **kw: "sniffing out a bug *tail wag*",
+            claude_client=mock_client,
         )
         assert result == "sniffing out a bug *tail wag*"
 
     def test_empty_response_raises(self) -> None:
+        mock_client = _client()
+        mock_client.print_prompt.return_value = ""
         with pytest.raises(ValueError, match="humanify_status"):
-            generate_persona_status(
-                "at the vet", "persona", _print_prompt=lambda **kw: ""
-            )
+            generate_persona_status("at the vet", "persona", claude_client=mock_client)
 
     def test_empty_persona(self) -> None:
-        result = generate_persona_status("test", "", _print_prompt=lambda **kw: "woof")
+        mock_client = _client()
+        mock_client.print_prompt.return_value = "woof"
+        result = generate_persona_status("test", "", claude_client=mock_client)
         assert result == "woof"
+
+    def test_creates_default_client_when_none(self) -> None:
+        with patch(
+            "kennel.gh_status.ClaudeClient",
+            return_value=_client(),
+        ) as mock_cls:
+            mock_cls.return_value.print_prompt.return_value = "woof"
+            generate_persona_status("test", "persona")
+            mock_cls.assert_called_once_with()
 
 
 class TestGeneratePersonaEmoji:
     def test_happy_path(self) -> None:
+        mock_client = _client()
+        mock_client.print_prompt_json.return_value = ":wrench:"
         result = generate_persona_emoji(
             "fixing bugs",
             "persona",
-            _print_prompt_json=lambda **kw: ":wrench:",
+            claude_client=mock_client,
         )
         assert result == ":wrench:"
 
     def test_empty_response_raises(self) -> None:
+        mock_client = _client()
+        mock_client.print_prompt_json.return_value = ""
         with pytest.raises(ValueError, match="generate_persona_emoji"):
-            generate_persona_emoji(
-                "test", "persona", _print_prompt_json=lambda **kw: ""
-            )
+            generate_persona_emoji("test", "persona", claude_client=mock_client)
 
     def test_empty_persona(self) -> None:
-        result = generate_persona_emoji(
-            "test", "", _print_prompt_json=lambda **kw: ":rocket:"
-        )
+        mock_client = _client()
+        mock_client.print_prompt_json.return_value = ":rocket:"
+        result = generate_persona_emoji("test", "", claude_client=mock_client)
         assert result == ":rocket:"
+
+    def test_creates_default_client_when_none(self) -> None:
+        with patch(
+            "kennel.gh_status.ClaudeClient",
+            return_value=_client(),
+        ) as mock_cls:
+            mock_cls.return_value.print_prompt_json.return_value = ":dog:"
+            generate_persona_emoji("test", "persona")
+            mock_cls.assert_called_once_with()
 
 
 class TestSetGhStatus:
-    def test_happy_path(self, tmp_path) -> None:
+    def test_happy_path(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("You are Fido")
         mock_gh = MagicMock()
+        mock_client = _client()
+        mock_client.print_prompt.return_value = "sniffing around"
+        mock_client.print_prompt_json.return_value = ":dog2:"
 
         set_gh_status(
             "diagnosing issue",
             persona_path=persona_file,
-            _generate_persona_status=lambda msg, p: "sniffing around",
-            _generate_persona_emoji=lambda txt, p: ":dog2:",
+            claude_client=mock_client,
             _gh=mock_gh,
         )
         mock_gh.set_user_status.assert_called_once_with(
             "sniffing around", ":dog2:", busy=True
         )
 
-    def test_missing_persona_file(self, tmp_path) -> None:
+    def test_missing_persona_file(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         mock_gh = MagicMock()
-        calls: list[str] = []
-
-        def track_status(msg: str, persona: str) -> str:
-            calls.append(persona)
-            return "woof"
+        mock_client = _client()
+        mock_client.print_prompt.return_value = "woof"
+        mock_client.print_prompt_json.return_value = ":dog:"
 
         set_gh_status(
             "test",
             persona_path=tmp_path / "nonexistent.md",
-            _generate_persona_status=track_status,
-            _generate_persona_emoji=lambda txt, p: ":dog:",
+            claude_client=mock_client,
             _gh=mock_gh,
         )
-        assert calls == [""]
+        # Verify empty persona was passed through
+        call_kwargs = mock_client.print_prompt.call_args
+        assert call_kwargs is not None
+        system = call_kwargs.kwargs.get("system_prompt", "")
+        assert system.startswith("\n\n") or "rewriting a status" in system
         mock_gh.set_user_status.assert_called_once()
+
+    def test_creates_default_client_when_none(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        persona_file = tmp_path / "persona.md"
+        persona_file.write_text("persona")
+        mock_gh = MagicMock()
+        with patch(
+            "kennel.gh_status.ClaudeClient",
+            return_value=_client(),
+        ) as mock_cls:
+            mock_cls.return_value.print_prompt.return_value = "woof"
+            mock_cls.return_value.print_prompt_json.return_value = ":dog:"
+            set_gh_status("test", persona_path=persona_file, _gh=mock_gh)
+            mock_cls.assert_called_once_with()
 
 
 class TestMain:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,14 +6,9 @@ import pytest
 
 from kennel.prompts import (
     Prompts,
-    issue_reply_instruction,
     reply_context_block,
-    reply_instruction,
-    rescope_prompt,
-    rewrite_description_prompt,
     triage_categories,
     triage_context_block,
-    triage_prompt,
 )
 
 # ── triage_categories ─────────────────────────────────────────────────────────
@@ -174,42 +169,50 @@ class TestTriageContextBlock:
         assert "alice: hi" in result
 
 
-# ── triage_prompt ─────────────────────────────────────────────────────────────
+# ── Prompts.triage_prompt ────────────────────────────────────────────────────
 
 
 class TestTriagePrompt:
     def test_includes_comment(self) -> None:
-        result = triage_prompt("please fix the bug", is_bot=False)
+        result = Prompts("").triage_prompt("please fix the bug", is_bot=False)
         assert "please fix the bug" in result
 
     def test_includes_categories(self) -> None:
-        result = triage_prompt("fix this", is_bot=False)
+        result = Prompts("").triage_prompt("fix this", is_bot=False)
         assert "ACT" in result
         assert "DEFER" in result
 
     def test_includes_bot_categories(self) -> None:
-        result = triage_prompt("suggestion", is_bot=True)
+        result = Prompts("").triage_prompt("suggestion", is_bot=True)
         assert "DO" in result
         assert "DEFER" in result
 
     def test_includes_context(self) -> None:
-        result = triage_prompt("comment", is_bot=False, context={"pr_title": "My PR"})
+        result = Prompts("").triage_prompt(
+            "comment", is_bot=False, context={"pr_title": "My PR"}
+        )
         assert "PR: My PR" in result
 
     def test_includes_example(self) -> None:
-        result = triage_prompt("x", is_bot=False)
+        result = Prompts("").triage_prompt("x", is_bot=False)
         assert "Example" in result
 
     def test_requires_imperative_action_item_title(self) -> None:
-        result = triage_prompt("x", is_bot=False)
+        result = Prompts("").triage_prompt("x", is_bot=False)
         assert "imperative" in result
         assert "verb" in result
         assert "never quote" in result.lower()
 
     def test_no_context(self) -> None:
         # Prompt with empty context still works — just has an empty ctx_str
-        result = triage_prompt("hello", is_bot=False, context=None)
+        result = Prompts("").triage_prompt("hello", is_bot=False, context=None)
         assert "hello" in result
+
+    def test_with_context(self) -> None:
+        p = Prompts("")
+        ctx = {"pr_title": "Refactor"}
+        result = p.triage_prompt("x", is_bot=True, context=ctx)
+        assert "Refactor" in result
 
 
 # ── reply_context_block ───────────────────────────────────────────────────────
@@ -247,13 +250,13 @@ class TestReplyContextBlock:
         assert "Your plan: p" in result
 
 
-# ── reply_instruction ─────────────────────────────────────────────────────────
+# ── Prompts.reply_instruction ────────────────────────────────────────────────
 
 
 class TestReplyInstruction:
     @pytest.mark.parametrize("category", ["ACT", "DO"])
     def test_act_do_acknowledges(self, category: str) -> None:
-        result = reply_instruction(category, "fix this", "will fix", {})
+        result = Prompts("").reply_instruction(category, "fix this", "will fix", {})
         assert "Acknowledge" in result or "acknowledge" in result
         assert "approach" in result
         assert "Do NOT promise" in result
@@ -268,25 +271,27 @@ class TestReplyInstruction:
         the constraint must not say 'create tasks' or it would misrepresent
         what the system actually does.
         """
-        result = reply_instruction(category, "please fix this", "fix: edge case", {})
+        result = Prompts("").reply_instruction(
+            category, "please fix this", "fix: edge case", {}
+        )
         assert "Do NOT promise" in result
         assert "create tasks" not in result
 
     def test_ask_asks_question(self) -> None:
-        result = reply_instruction("ASK", "unclear", "need info", {})
+        result = Prompts("").reply_instruction("ASK", "unclear", "need info", {})
         assert "clarifying question" in result
 
     def test_answer_no_code_changes(self) -> None:
-        result = reply_instruction("ANSWER", "what is X?", "explain X", {})
+        result = Prompts("").reply_instruction("ANSWER", "what is X?", "explain X", {})
         assert "Do NOT say you'll make code changes" in result
         assert "Question: what is X?" in result
 
     def test_defer_out_of_scope(self) -> None:
-        result = reply_instruction("DEFER", "big refactor", "defer", {})
+        result = Prompts("").reply_instruction("DEFER", "big refactor", "defer", {})
         assert "out of scope" in result
 
     def test_defer_issue_opened_with_url(self) -> None:
-        result = reply_instruction(
+        result = Prompts("").reply_instruction(
             "DEFER",
             "big refactor",
             "defer",
@@ -297,35 +302,44 @@ class TestReplyInstruction:
         assert "https://github.com/x/y/issues/1" in result
 
     def test_defer_issue_will_be_opened_without_url(self) -> None:
-        result = reply_instruction("DEFER", "big refactor", "defer", {})
+        result = Prompts("").reply_instruction("DEFER", "big refactor", "defer", {})
         assert "An issue will be opened" in result
 
     def test_dump_politely_declines(self) -> None:
-        result = reply_instruction("DUMP", "bad idea", "decline", {})
+        result = Prompts("").reply_instruction("DUMP", "bad idea", "decline", {})
         assert "politely declining" in result or "politely" in result
 
     def test_unknown_category_fallback(self) -> None:
-        result = reply_instruction("UNKNOWN", "comment", "title", {})
+        result = Prompts("").reply_instruction("UNKNOWN", "comment", "title", {})
         assert "Write a short GitHub PR reply" in result
         assert "Comment: comment" in result
 
     def test_passes_context_to_act(self) -> None:
-        result = reply_instruction("ACT", "fix it", "patch", {"pr_title": "Bugfix PR"})
+        result = Prompts("").reply_instruction(
+            "ACT", "fix it", "patch", {"pr_title": "Bugfix PR"}
+        )
         assert "PR: Bugfix PR" in result
 
+    def test_with_issue_url(self) -> None:
+        url = "https://github.com/x/y/issues/1"
+        result = Prompts("").reply_instruction(
+            "DEFER", "big refactor", "defer", {}, issue_url=url
+        )
+        assert url in result
 
-# ── issue_reply_instruction ───────────────────────────────────────────────────
+
+# ── Prompts.issue_reply_instruction ──────────────────────────────────────────
 
 
 class TestIssueReplyInstruction:
     @pytest.mark.parametrize("category", ["ACT", "DO"])
     def test_act_do_acknowledging(self, category: str) -> None:
-        result = issue_reply_instruction(category, "fix it", "will fix", {})
+        result = Prompts("").issue_reply_instruction(category, "fix it", "will fix", {})
         assert "acknowledging" in result
 
     @pytest.mark.parametrize("category", ["ACT", "DO"])
     def test_act_do_no_promises(self, category: str) -> None:
-        result = issue_reply_instruction(category, "fix it", "will fix", {})
+        result = Prompts("").issue_reply_instruction(category, "fix it", "will fix", {})
         assert "Do NOT promise to open issues" in result
 
     @pytest.mark.parametrize("category", ["ACT", "DO"])
@@ -338,26 +352,32 @@ class TestIssueReplyInstruction:
         the constraint must not say 'create tasks' or it would misrepresent
         what the system actually does.
         """
-        result = issue_reply_instruction(
+        result = Prompts("").issue_reply_instruction(
             category, "please fix this", "fix: edge case", {}
         )
         assert "Do NOT promise" in result
         assert "create tasks" not in result
 
     def test_ask_clarifying(self) -> None:
-        result = issue_reply_instruction("ASK", "unclear", "need more info", {})
+        result = Prompts("").issue_reply_instruction(
+            "ASK", "unclear", "need more info", {}
+        )
         assert "clarifying question" in result
 
     def test_answer_direct(self) -> None:
-        result = issue_reply_instruction("ANSWER", "what is X?", "explain", {})
+        result = Prompts("").issue_reply_instruction(
+            "ANSWER", "what is X?", "explain", {}
+        )
         assert "Question: what is X?" in result
 
     def test_defer_out_of_scope(self) -> None:
-        result = issue_reply_instruction("DEFER", "add feature", "defer", {})
+        result = Prompts("").issue_reply_instruction(
+            "DEFER", "add feature", "defer", {}
+        )
         assert "out of scope" in result
 
     def test_defer_issue_opened_with_url(self) -> None:
-        result = issue_reply_instruction(
+        result = Prompts("").issue_reply_instruction(
             "DEFER",
             "add feature",
             "defer",
@@ -368,24 +388,35 @@ class TestIssueReplyInstruction:
         assert "https://github.com/x/y/issues/2" in result
 
     def test_defer_issue_will_be_opened_without_url(self) -> None:
-        result = issue_reply_instruction("DEFER", "add feature", "defer", {})
+        result = Prompts("").issue_reply_instruction(
+            "DEFER", "add feature", "defer", {}
+        )
         assert "An issue will be opened" in result
 
     def test_dump_decline(self) -> None:
-        result = issue_reply_instruction("DUMP", "bad idea", "decline", {})
+        result = Prompts("").issue_reply_instruction("DUMP", "bad idea", "decline", {})
         assert "decline" in result
 
     def test_unknown_fallback(self) -> None:
-        result = issue_reply_instruction("MYSTERY", "hello", "hmm", {})
+        result = Prompts("").issue_reply_instruction("MYSTERY", "hello", "hmm", {})
         assert "short GitHub PR reply" in result
 
     def test_includes_pr_title_in_context(self) -> None:
-        result = issue_reply_instruction("ACT", "fix it", "fix", {"pr_title": "My PR"})
+        result = Prompts("").issue_reply_instruction(
+            "ACT", "fix it", "fix", {"pr_title": "My PR"}
+        )
         assert "PR: My PR" in result
 
     def test_no_context(self) -> None:
-        result = issue_reply_instruction("ACT", "do something", "will do")
+        result = Prompts("").issue_reply_instruction("ACT", "do something", "will do")
         assert "Comment: do something" in result
+
+    def test_with_issue_url(self) -> None:
+        url = "https://github.com/x/y/issues/2"
+        result = Prompts("").issue_reply_instruction(
+            "DEFER", "feature", "defer", {}, issue_url=url
+        )
+        assert url in result
 
 
 # ── Prompts.status_system_prompt ─────────────────────────────────────────────
@@ -567,7 +598,7 @@ class TestPromptsPickupCommentPrompt:
         assert isinstance(Prompts("persona").pickup_comment_prompt("title"), str)
 
 
-# ── rescope_prompt ────────────────────────────────────────────────────────────
+# ── Prompts.rescope_prompt ───────────────────────────────────────────────────
 
 
 class TestRescopePrompt:
@@ -589,7 +620,7 @@ class TestRescopePrompt:
 
     def test_includes_pending_tasks_json(self) -> None:
         tasks = [self._task("Add feature", task_id="1")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "Add feature" in result
         assert '"id": "1"' in result
 
@@ -598,7 +629,7 @@ class TestRescopePrompt:
             self._task("Done task", task_id="1", status="completed"),
             self._task("Todo task", task_id="2"),
         ]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         # Completed appears in the completed block, not the pending JSON
         assert '"id": "2"' in result
         assert '"id": "1"' not in result.split("Pending tasks")[1]
@@ -608,44 +639,44 @@ class TestRescopePrompt:
             self._task("Already done", task_id="1", status="completed"),
             self._task("Still pending", task_id="2"),
         ]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "Already done" in result.split("Pending tasks")[0]
 
     def test_no_completed_tasks_shows_none(self) -> None:
         tasks = [self._task("Only pending", task_id="1")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "(none)" in result.split("Pending tasks")[0]
 
     def test_commit_summary_included(self) -> None:
         tasks = [self._task("Add tests", task_id="1")]
-        result = rescope_prompt(tasks, "feat: add parser method")
+        result = Prompts("").rescope_prompt(tasks, "feat: add parser method")
         assert "feat: add parser method" in result
 
     def test_empty_commit_summary_shows_none(self) -> None:
         tasks = [self._task("Add tests", task_id="1")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "(none)" in result
 
     def test_ci_tasks_must_come_first_rule_stated(self) -> None:
         tasks = [self._task("Fix CI", task_id="1", task_type="ci")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "ci" in result.lower()
         assert "first" in result
 
     def test_json_output_format_instructed(self) -> None:
         tasks = [self._task("Do something", task_id="1")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert '{"tasks": [...]}' in result
 
     def test_preserve_ids_rule_stated(self) -> None:
         tasks = [self._task("Task A", task_id="abc-123")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "ID" in result or "id" in result
         assert "preserve" in result.lower() or "never change" in result.lower()
 
     def test_remove_covered_tasks_rule_stated(self) -> None:
         tasks = [self._task("Task A", task_id="1")]
-        result = rescope_prompt(tasks, "commit covering this")
+        result = Prompts("").rescope_prompt(tasks, "commit covering this")
         assert "commit" in result.lower() or "covered" in result.lower()
 
     def test_rewrite_spec_on_thread_conflict_rule_stated(self) -> None:
@@ -653,28 +684,28 @@ class TestRescopePrompt:
             self._task("Old spec title", task_id="1", task_type="spec"),
             self._task("New comment task", task_id="2", task_type="thread"),
         ]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "thread" in result.lower() or "rewrite" in result.lower()
 
     def test_no_other_text_instruction_present(self) -> None:
         tasks = [self._task("X", task_id="1")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "No other text" in result
 
     def test_in_progress_tasks_included_in_pending(self) -> None:
         tasks = [
             self._task("Running task", task_id="1", status="in_progress"),
         ]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert '"id": "1"' in result
 
     def test_description_included_in_task_json(self) -> None:
         tasks = [self._task("X", task_id="1", description="important details")]
-        result = rescope_prompt(tasks, "")
+        result = Prompts("").rescope_prompt(tasks, "")
         assert "important details" in result
 
     def test_empty_task_list(self) -> None:
-        result = rescope_prompt([], "")
+        result = Prompts("").rescope_prompt([], "")
         assert isinstance(result, str)
         assert "(none)" in result  # both completed and commit summary
 
@@ -696,7 +727,7 @@ class TestPromptsStoresPersona:
         assert "persona A" not in p2.status_prompt(activities)
 
 
-# ── rewrite_description_prompt ────────────────────────────────────────────────
+# ── Prompts.rewrite_description_prompt ───────────────────────────────────────
 
 
 class TestRewriteDescriptionPrompt:
@@ -721,26 +752,28 @@ class TestRewriteDescriptionPrompt:
         )
 
     def test_includes_current_description(self) -> None:
-        result = rewrite_description_prompt(
+        result = Prompts("").rewrite_description_prompt(
             self._body("Implements the feature.\n\nFixes #7."),
             [self._task("New task")],
         )
         assert "Implements the feature." in result
 
     def test_excludes_work_queue_section_from_context(self) -> None:
-        result = rewrite_description_prompt(self._body(), [self._task("A task")])
+        result = Prompts("").rewrite_description_prompt(
+            self._body(), [self._task("A task")]
+        )
         assert "WORK_QUEUE_START" not in result
         assert "do a thing" not in result
 
     def test_includes_pending_tasks(self) -> None:
-        result = rewrite_description_prompt(
+        result = Prompts("").rewrite_description_prompt(
             self._body(),
             [self._task("Add caching layer")],
         )
         assert "Add caching layer" in result
 
     def test_excludes_completed_tasks(self) -> None:
-        result = rewrite_description_prompt(
+        result = Prompts("").rewrite_description_prompt(
             self._body(),
             [
                 self._task("Done already", status="completed"),
@@ -750,171 +783,56 @@ class TestRewriteDescriptionPrompt:
         assert "Done already" not in result
 
     def test_empty_pending_shows_none(self) -> None:
-        result = rewrite_description_prompt(
+        result = Prompts("").rewrite_description_prompt(
             self._body(),
             [self._task("Finished", status="completed")],
         )
         assert "(none)" in result
 
     def test_task_description_included(self) -> None:
-        result = rewrite_description_prompt(
+        result = Prompts("").rewrite_description_prompt(
             self._body(),
             [self._task("Cache results", description="use Redis")],
         )
         assert "use Redis" in result
 
     def test_fixes_line_preservation_rule_stated(self) -> None:
-        result = rewrite_description_prompt(self._body(), [])
+        result = Prompts("").rewrite_description_prompt(self._body(), [])
         assert "Fixes #N" in result or "Fixes #" in result
         assert "preserve" in result.lower() or "exactly" in result.lower()
 
     def test_no_work_queue_content_rule_stated(self) -> None:
-        result = rewrite_description_prompt(self._body(), [])
+        result = Prompts("").rewrite_description_prompt(self._body(), [])
         assert "work queue" in result.lower()
 
     def test_body_tag_contract_stated(self) -> None:
         """Prompt must instruct Opus to wrap output in <body> tags so we can
         reliably strip preamble and trailing chatter."""
-        result = rewrite_description_prompt(self._body(), [])
+        result = Prompts("").rewrite_description_prompt(self._body(), [])
         assert "<body>" in result
         assert "</body>" in result
 
     def test_extracts_description_at_divider(self) -> None:
         body = "My description.\n\nFixes #3.\n\n---\n\nStuff below divider."
-        result = rewrite_description_prompt(body, [])
+        result = Prompts("").rewrite_description_prompt(body, [])
         assert "My description." in result
         assert "Stuff below divider." not in result
 
     def test_fallback_to_wq_marker_when_no_divider(self) -> None:
-        body = "Short desc.\n<!-- WORK_QUEUE_START -->\n- [ ] task\n<!-- WORK_QUEUE_END -->"
-        result = rewrite_description_prompt(body, [])
+        body = (
+            "Short desc.\n<!-- WORK_QUEUE_START -->"
+            "\n- [ ] task\n<!-- WORK_QUEUE_END -->"
+        )
+        result = Prompts("").rewrite_description_prompt(body, [])
         assert "Short desc." in result
         assert "WORK_QUEUE_START" not in result
 
     def test_fallback_to_full_body_when_no_markers(self) -> None:
         body = "Plain description with no markers."
-        result = rewrite_description_prompt(body, [])
+        result = Prompts("").rewrite_description_prompt(body, [])
         assert "Plain description with no markers." in result
 
     def test_empty_task_list(self) -> None:
-        result = rewrite_description_prompt(self._body(), [])
+        result = Prompts("").rewrite_description_prompt(self._body(), [])
         assert isinstance(result, str)
         assert "(none)" in result
-
-
-# ── Prompts method delegates ─────────────────────────────────────────────────
-# Each method on the class delegates to its module-level counterpart.  These
-# tests verify that the method produces the same output as the free function.
-
-
-class TestPromptsTriagePrompt:
-    def test_matches_free_function(self) -> None:
-        p = Prompts("persona")
-        assert p.triage_prompt("fix bug", is_bot=False) == triage_prompt(
-            "fix bug", is_bot=False
-        )
-
-    def test_with_context(self) -> None:
-        p = Prompts("")
-        ctx = {"pr_title": "Refactor"}
-        assert p.triage_prompt("x", is_bot=True, context=ctx) == triage_prompt(
-            "x", is_bot=True, context=ctx
-        )
-
-    def test_includes_comment(self) -> None:
-        result = Prompts("").triage_prompt("please fix the bug", is_bot=False)
-        assert "please fix the bug" in result
-
-    def test_includes_categories(self) -> None:
-        result = Prompts("").triage_prompt("fix this", is_bot=False)
-        assert "ACT" in result
-
-
-class TestPromptsReplyInstruction:
-    def test_matches_free_function(self) -> None:
-        p = Prompts("persona")
-        assert p.reply_instruction(
-            "ACT", "fix it", "will fix", {}
-        ) == reply_instruction("ACT", "fix it", "will fix", {})
-
-    def test_with_issue_url(self) -> None:
-        p = Prompts("")
-        url = "https://github.com/x/y/issues/1"
-        assert p.reply_instruction(
-            "DEFER", "big refactor", "defer", {}, issue_url=url
-        ) == reply_instruction("DEFER", "big refactor", "defer", {}, issue_url=url)
-
-    def test_act_includes_acknowledge(self) -> None:
-        result = Prompts("").reply_instruction("ACT", "fix this", "will fix", {})
-        assert "acknowledge" in result.lower() or "Acknowledge" in result
-
-
-class TestPromptsIssueReplyInstruction:
-    def test_matches_free_function(self) -> None:
-        p = Prompts("persona")
-        assert p.issue_reply_instruction(
-            "ACT", "fix it", "will fix", {}
-        ) == issue_reply_instruction("ACT", "fix it", "will fix", {})
-
-    def test_with_issue_url(self) -> None:
-        p = Prompts("")
-        url = "https://github.com/x/y/issues/2"
-        assert p.issue_reply_instruction(
-            "DEFER", "feature", "defer", {}, issue_url=url
-        ) == issue_reply_instruction("DEFER", "feature", "defer", {}, issue_url=url)
-
-    def test_answer_includes_question(self) -> None:
-        result = Prompts("").issue_reply_instruction(
-            "ANSWER", "what is X?", "explain", {}
-        )
-        assert "Question: what is X?" in result
-
-
-class TestPromptsRescopePrompt:
-    def _task(self, title: str, task_id: str = "1", status: str = "pending") -> dict:
-        return {"id": task_id, "title": title, "status": status}
-
-    def test_matches_free_function(self) -> None:
-        p = Prompts("persona")
-        tasks = [self._task("Add feature")]
-        assert p.rescope_prompt(tasks, "commit msg") == rescope_prompt(
-            tasks, "commit msg"
-        )
-
-    def test_includes_task_title(self) -> None:
-        p = Prompts("")
-        result = p.rescope_prompt([self._task("Add caching")], "")
-        assert "Add caching" in result
-
-    def test_includes_commit_summary(self) -> None:
-        p = Prompts("")
-        result = p.rescope_prompt([self._task("X")], "feat: add parser")
-        assert "feat: add parser" in result
-
-
-class TestPromptsRewriteDescriptionPrompt:
-    def _task(self, title: str, status: str = "pending") -> dict:
-        return {"id": "1", "title": title, "status": status}
-
-    def _body(self) -> str:
-        return "Does stuff.\n\nFixes #5.\n\n---\n\n## Work queue\n<!-- WORK_QUEUE_START -->\n- [ ] task\n<!-- WORK_QUEUE_END -->"
-
-    def test_matches_free_function(self) -> None:
-        p = Prompts("persona")
-        body = self._body()
-        tasks = [self._task("New task")]
-        assert p.rewrite_description_prompt(body, tasks) == rewrite_description_prompt(
-            body, tasks
-        )
-
-    def test_includes_pending_task(self) -> None:
-        p = Prompts("")
-        result = p.rewrite_description_prompt(self._body(), [self._task("Add caching")])
-        assert "Add caching" in result
-
-    def test_excludes_completed(self) -> None:
-        p = Prompts("")
-        result = p.rewrite_description_prompt(
-            self._body(), [self._task("Done", status="completed")]
-        )
-        assert "Done" not in result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -800,3 +800,121 @@ class TestRewriteDescriptionPrompt:
         result = rewrite_description_prompt(self._body(), [])
         assert isinstance(result, str)
         assert "(none)" in result
+
+
+# ── Prompts method delegates ─────────────────────────────────────────────────
+# Each method on the class delegates to its module-level counterpart.  These
+# tests verify that the method produces the same output as the free function.
+
+
+class TestPromptsTriagePrompt:
+    def test_matches_free_function(self) -> None:
+        p = Prompts("persona")
+        assert p.triage_prompt("fix bug", is_bot=False) == triage_prompt(
+            "fix bug", is_bot=False
+        )
+
+    def test_with_context(self) -> None:
+        p = Prompts("")
+        ctx = {"pr_title": "Refactor"}
+        assert p.triage_prompt("x", is_bot=True, context=ctx) == triage_prompt(
+            "x", is_bot=True, context=ctx
+        )
+
+    def test_includes_comment(self) -> None:
+        result = Prompts("").triage_prompt("please fix the bug", is_bot=False)
+        assert "please fix the bug" in result
+
+    def test_includes_categories(self) -> None:
+        result = Prompts("").triage_prompt("fix this", is_bot=False)
+        assert "ACT" in result
+
+
+class TestPromptsReplyInstruction:
+    def test_matches_free_function(self) -> None:
+        p = Prompts("persona")
+        assert p.reply_instruction(
+            "ACT", "fix it", "will fix", {}
+        ) == reply_instruction("ACT", "fix it", "will fix", {})
+
+    def test_with_issue_url(self) -> None:
+        p = Prompts("")
+        url = "https://github.com/x/y/issues/1"
+        assert p.reply_instruction(
+            "DEFER", "big refactor", "defer", {}, issue_url=url
+        ) == reply_instruction("DEFER", "big refactor", "defer", {}, issue_url=url)
+
+    def test_act_includes_acknowledge(self) -> None:
+        result = Prompts("").reply_instruction("ACT", "fix this", "will fix", {})
+        assert "acknowledge" in result.lower() or "Acknowledge" in result
+
+
+class TestPromptsIssueReplyInstruction:
+    def test_matches_free_function(self) -> None:
+        p = Prompts("persona")
+        assert p.issue_reply_instruction(
+            "ACT", "fix it", "will fix", {}
+        ) == issue_reply_instruction("ACT", "fix it", "will fix", {})
+
+    def test_with_issue_url(self) -> None:
+        p = Prompts("")
+        url = "https://github.com/x/y/issues/2"
+        assert p.issue_reply_instruction(
+            "DEFER", "feature", "defer", {}, issue_url=url
+        ) == issue_reply_instruction("DEFER", "feature", "defer", {}, issue_url=url)
+
+    def test_answer_includes_question(self) -> None:
+        result = Prompts("").issue_reply_instruction(
+            "ANSWER", "what is X?", "explain", {}
+        )
+        assert "Question: what is X?" in result
+
+
+class TestPromptsRescopePrompt:
+    def _task(self, title: str, task_id: str = "1", status: str = "pending") -> dict:
+        return {"id": task_id, "title": title, "status": status}
+
+    def test_matches_free_function(self) -> None:
+        p = Prompts("persona")
+        tasks = [self._task("Add feature")]
+        assert p.rescope_prompt(tasks, "commit msg") == rescope_prompt(
+            tasks, "commit msg"
+        )
+
+    def test_includes_task_title(self) -> None:
+        p = Prompts("")
+        result = p.rescope_prompt([self._task("Add caching")], "")
+        assert "Add caching" in result
+
+    def test_includes_commit_summary(self) -> None:
+        p = Prompts("")
+        result = p.rescope_prompt([self._task("X")], "feat: add parser")
+        assert "feat: add parser" in result
+
+
+class TestPromptsRewriteDescriptionPrompt:
+    def _task(self, title: str, status: str = "pending") -> dict:
+        return {"id": "1", "title": title, "status": status}
+
+    def _body(self) -> str:
+        return "Does stuff.\n\nFixes #5.\n\n---\n\n## Work queue\n<!-- WORK_QUEUE_START -->\n- [ ] task\n<!-- WORK_QUEUE_END -->"
+
+    def test_matches_free_function(self) -> None:
+        p = Prompts("persona")
+        body = self._body()
+        tasks = [self._task("New task")]
+        assert p.rewrite_description_prompt(body, tasks) == rewrite_description_prompt(
+            body, tasks
+        )
+
+    def test_includes_pending_task(self) -> None:
+        p = Prompts("")
+        result = p.rewrite_description_prompt(self._body(), [self._task("Add caching")])
+        assert "Add caching" in result
+
+    def test_excludes_completed(self) -> None:
+        p = Prompts("")
+        result = p.rewrite_description_prompt(
+            self._body(), [self._task("Done", status="completed")]
+        )
+        assert "Done" not in result

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+from kennel.claude import ClaudeClient
+from kennel.prompts import Prompts
 from kennel.tasks import (
     Tasks,
     _apply_reorder,
@@ -19,6 +22,13 @@ from kennel.tasks import (
     update_task,
 )
 from kennel.types import TaskStatus, TaskType
+
+
+def _client(print_prompt_return: str = "") -> MagicMock:
+    """Create a mock ClaudeClient with a configurable print_prompt return."""
+    client = MagicMock(spec=ClaudeClient)
+    client.print_prompt.return_value = print_prompt_return
+    return client
 
 
 def _task_file(tmp_path: Path) -> Path:
@@ -492,22 +502,31 @@ class TestReorderTasks:
         return json.dumps({"tasks": items})
 
     def test_skips_when_no_tasks(self, tmp_path: Path) -> None:
-        called = []
-        reorder_tasks(
-            tmp_path, "", _print_prompt=lambda *a, **k: called.append(1) or ""
-        )
-        assert called == []
+        client = _client("")
+        reorder_tasks(tmp_path, "", claude_client=client)
+        client.print_prompt.assert_not_called()
+
+    def test_creates_default_client_when_none(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        self._add(tmp_path, "Task A")
+        with patch(
+            "kennel.tasks.ClaudeClient",
+            return_value=_client(""),
+        ) as mock_cls:
+            reorder_tasks(tmp_path, "")
+            mock_cls.assert_called_once_with()
 
     def test_skips_on_empty_opus_response(self, tmp_path: Path) -> None:
         self._add(tmp_path, "Task A")
         result_before = list_tasks(tmp_path)
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: "")
+        reorder_tasks(tmp_path, "", claude_client=_client(""))
         assert list_tasks(tmp_path) == result_before
 
     def test_skips_on_unparseable_response(self, tmp_path: Path) -> None:
         self._add(tmp_path, "Task A")
         result_before = list_tasks(tmp_path)
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: "not json")
+        reorder_tasks(tmp_path, "", claude_client=_client("not json"))
         assert list_tasks(tmp_path) == result_before
 
     def test_reorders_tasks(self, tmp_path: Path) -> None:
@@ -520,7 +539,7 @@ class TestReorderTasks:
                 {"id": t1["id"], "title": "First", "description": ""},
             ]
         )
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        reorder_tasks(tmp_path, "", claude_client=_client(raw))
         result = list_tasks(tmp_path)
         assert result[0]["id"] == t2["id"]
         assert result[1]["id"] == t1["id"]
@@ -530,14 +549,14 @@ class TestReorderTasks:
         raw = self._response(
             [{"id": t1["id"], "title": "New title", "description": ""}]
         )
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        reorder_tasks(tmp_path, "", claude_client=_client(raw))
         assert list_tasks(tmp_path)[0]["title"] == "New title"
 
     def test_marks_completed_task_opus_excludes(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Keep")
         t2 = self._add(tmp_path, "No longer needed")
         raw = self._response([{"id": t1["id"], "title": "Keep", "description": ""}])
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        reorder_tasks(tmp_path, "", claude_client=_client(raw))
         result = list_tasks(tmp_path)
         task2 = next(t for t in result if t["id"] == t2["id"])
         assert task2["status"] == "completed"
@@ -547,7 +566,7 @@ class TestReorderTasks:
         complete_by_id(tmp_path, t1["id"])
         t2 = self._add(tmp_path, "Pending")
         raw = self._response([{"id": t2["id"], "title": "Pending", "description": ""}])
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw)
+        reorder_tasks(tmp_path, "", claude_client=_client(raw))
         result = list_tasks(tmp_path)
         statuses = {t["id"]: t["status"] for t in result}
         assert statuses[t1["id"]] == "completed"
@@ -556,21 +575,18 @@ class TestReorderTasks:
         self, tmp_path: Path
     ) -> None:
         self._add(tmp_path, "Task A")
-        captured = {}
-
-        def fake_rescope(task_list, commit_summary):
-            captured["task_list"] = task_list
-            captured["commit_summary"] = commit_summary
-            return "prompt text"
-
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt text"
         reorder_tasks(
             tmp_path,
             "feat: added thing",
-            _print_prompt=lambda *a, **k: "",
-            _rescope_prompt_fn=fake_rescope,
+            claude_client=_client(""),
+            prompts=mock_prompts,
         )
-        assert captured["commit_summary"] == "feat: added thing"
-        assert len(captured["task_list"]) == 1
+        mock_prompts.rescope_prompt.assert_called_once()
+        call_kwargs = mock_prompts.rescope_prompt.call_args
+        assert call_kwargs[0][1] == "feat: added thing"
+        assert len(call_kwargs[0][0]) == 1
 
     def test_picks_up_task_added_while_opus_was_thinking(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Original task")
@@ -590,7 +606,9 @@ class TestReorderTasks:
                 }
             )
 
-        reorder_tasks(tmp_path, "", _print_prompt=slow_print_prompt)
+        client = _client()
+        client.print_prompt.side_effect = slow_print_prompt
+        reorder_tasks(tmp_path, "", claude_client=client)
         result = list_tasks(tmp_path)
         ids = [t["id"] for t in result]
         assert new_task_id[0] in ids  # not silently dropped
@@ -615,7 +633,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_changes=lambda changes: received.extend(changes),
         )
         assert len(received) == 1
@@ -639,7 +657,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_changes=lambda changes: received.extend(changes),
         )
         assert len(received) == 1
@@ -657,7 +675,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_changes=lambda changes: received.extend(changes),
         )
         assert received == []
@@ -670,7 +688,7 @@ class TestReorderTasks:
         t2 = self._add(tmp_path, "Keep")
         raw = self._response([{"id": t2["id"], "title": "Keep", "description": ""}])
         # Should not raise even though t1 is completed and _on_changes is None
-        reorder_tasks(tmp_path, "", _print_prompt=lambda *a, **k: raw, _on_changes=None)
+        reorder_tasks(tmp_path, "", claude_client=_client(raw), _on_changes=None)
         # t1 should be marked completed
         task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
         assert task1["status"] == "completed"
@@ -688,7 +706,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_inprogress_affected=lambda: affected.append(1),
         )
         assert affected == [1]
@@ -708,7 +726,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_inprogress_affected=lambda: affected.append(1),
         )
         assert affected == [1]
@@ -729,7 +747,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_inprogress_affected=lambda: affected.append(1),
         )
         assert affected == []
@@ -749,7 +767,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_inprogress_affected=lambda: affected.append(1),
         )
         assert affected == []
@@ -765,7 +783,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_inprogress_affected=None,
         )
         task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
@@ -778,7 +796,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: raw,
+            claude_client=_client(raw),
             _on_done=lambda: done_calls.append(1),
         )
         assert done_calls == [1]
@@ -788,7 +806,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: "{}",
+            claude_client=_client("{}"),
             _on_done=lambda: done_calls.append(1),
         )
         assert done_calls == []
@@ -799,7 +817,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: "",
+            claude_client=_client(""),
             _on_done=lambda: done_calls.append(1),
         )
         assert done_calls == []
@@ -810,7 +828,7 @@ class TestReorderTasks:
         reorder_tasks(
             tmp_path,
             "",
-            _print_prompt=lambda *a, **k: "not json at all",
+            claude_client=_client("not json at all"),
             _on_done=lambda: done_calls.append(1),
         )
         assert done_calls == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12,7 +12,9 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
+from kennel.claude import ClaudeClient
 from kennel.config import RepoMembership
+from kennel.prompts import Prompts
 from kennel.state import (
     State,
     _resolve_git_dir,
@@ -61,6 +63,16 @@ def _no_claude_session_spawn(monkeypatch):
     from kennel import claude
 
     monkeypatch.setattr(claude, "ClaudeSession", MagicMock(return_value=MagicMock()))
+
+
+def _client(return_value: str = "", *, side_effect=None) -> MagicMock:
+    """Build a mock ClaudeClient with print_prompt configured."""
+    client = MagicMock(spec=ClaudeClient)
+    if side_effect is not None:
+        client.print_prompt.side_effect = side_effect
+    else:
+        client.print_prompt.return_value = return_value
+    return client
 
 
 class TestRepoContextFilter:
@@ -1800,11 +1812,13 @@ class TestPickNextIssue:
 class TestWorkerPostPickupComment:
     """Tests for Worker.post_pickup_comment."""
 
-    def _make_worker(self, tmp_path: Path) -> tuple["Worker", MagicMock]:
+    def _make_worker(
+        self, tmp_path: Path, claude_client: MagicMock | None = None
+    ) -> tuple["Worker", MagicMock]:
         gh = MagicMock()
         gh.view_issue.return_value = {"created_at": "2024-01-01T00:00:00Z"}
         gh.get_issue_events.return_value = []
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, claude_client=claude_client), gh
 
     def test_skips_when_already_commented(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -1819,101 +1833,83 @@ class TestWorkerPostPickupComment:
         gh.comment_issue.assert_not_called()
 
     def test_posts_comment_when_no_previous_comment(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Woof! On it!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("I am Fido.")
         gh.get_issue_comments.return_value = [
             {"user": {"login": "other-user"}, "body": "Hi"}
         ]
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value="Woof! On it!"),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
+        worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
         gh.comment_issue.assert_called_once_with("owner/repo", 1, "Woof! On it!")
 
     def test_posts_comment_when_no_existing_comments(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "I am on it!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("I am Fido.")
         gh.get_issue_comments.return_value = []
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value="I am on it!"),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            worker.post_pickup_comment("owner/repo", 3, "Some task", "fido-bot")
+        worker.post_pickup_comment("owner/repo", 3, "Some task", "fido-bot")
         gh.comment_issue.assert_called_once()
 
     def test_falls_back_to_plain_text_when_claude_returns_empty(
         self, tmp_path: Path
     ) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = ""
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("I am Fido.")
         gh.get_issue_comments.return_value = []
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value=""),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            worker.post_pickup_comment("owner/repo", 5, "A task", "fido-bot")
+        worker.post_pickup_comment("owner/repo", 5, "A task", "fido-bot")
         gh.comment_issue.assert_called_once_with(
             "owner/repo", 5, "Picking up issue: A task"
         )
 
     def test_uses_persona_from_sub_dir(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Fetched!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("I am a very good dog.")
         gh.get_issue_comments.return_value = []
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch(
-                "kennel.worker.claude.generate_reply", return_value="Fetched!"
-            ) as mock_gen,
-        ):
-            (tmp_path / "persona.md").write_text("I am a very good dog.")
-            worker.post_pickup_comment("owner/repo", 2, "Some work", "fido-bot")
-        prompt_arg = mock_gen.call_args[0][0]
+        worker.post_pickup_comment("owner/repo", 2, "Some work", "fido-bot")
+        prompt_arg = mock_client.generate_reply.call_args[0][0]
         assert "I am a very good dog." in prompt_arg
 
     def test_falls_back_to_empty_persona_on_oserror(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "On it!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("")
         gh.get_issue_comments.return_value = []
-        missing = tmp_path / "no_such_dir"
-        with (
-            patch("kennel.worker._sub_dir", return_value=missing),
-            patch(
-                "kennel.worker.claude.generate_reply", return_value="On it!"
-            ) as mock_gen,
-        ):
-            worker.post_pickup_comment("owner/repo", 2, "Work item", "fido-bot")
-        prompt_arg = mock_gen.call_args[0][0]
+        worker.post_pickup_comment("owner/repo", 2, "Work item", "fido-bot")
+        prompt_arg = mock_client.generate_reply.call_args[0][0]
         assert "Picking up issue: Work item" in prompt_arg
 
     def test_prompt_includes_issue_title(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "On it!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("")
         gh.get_issue_comments.return_value = []
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch(
-                "kennel.worker.claude.generate_reply", return_value="On it!"
-            ) as mock_gen,
-        ):
-            (tmp_path / "persona.md").write_text("")
-            worker.post_pickup_comment("owner/repo", 4, "Refactor auth", "fido-bot")
-        prompt_arg = mock_gen.call_args[0][0]
+        worker.post_pickup_comment("owner/repo", 4, "Refactor auth", "fido-bot")
+        prompt_arg = mock_client.generate_reply.call_args[0][0]
         assert "Refactor auth" in prompt_arg
 
     def test_checks_comments_for_correct_repo_and_issue(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Arf!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
+        worker._prompts = Prompts("")
         gh.get_issue_comments.return_value = []
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value="Arf!"),
-        ):
-            (tmp_path / "persona.md").write_text("")
-            worker.post_pickup_comment("org/myrepo", 99, "Title", "fido-bot")
+        worker.post_pickup_comment("org/myrepo", 99, "Title", "fido-bot")
         gh.get_issue_comments.assert_called_once_with("org/myrepo", 99)
 
     def test_logs_info_when_skipping(self, tmp_path: Path, caplog) -> None:
         import logging
 
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Woof!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.get_issue_comments.return_value = [
             {
                 "user": {"login": "fido-bot"},
@@ -1921,17 +1917,15 @@ class TestWorkerPostPickupComment:
                 "created_at": "2024-02-01T00:00:00Z",
             }
         ]
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value="Woof!"),
-        ):
-            with caplog.at_level(logging.INFO, logger="kennel"):
-                worker.post_pickup_comment("owner/repo", 7, "Title", "fido-bot")
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            worker.post_pickup_comment("owner/repo", 7, "Title", "fido-bot")
         assert "already exists" in caplog.text
 
     def test_posts_comment_on_reopened_issue(self, tmp_path: Path) -> None:
         """Old comment predates reopen, so a new pickup comment is posted."""
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Back on it!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.get_issue_events.return_value = [
             {"event": "reopened", "created_at": "2024-06-01T00:00:00Z"}
         ]
@@ -1942,12 +1936,8 @@ class TestWorkerPostPickupComment:
                 "created_at": "2024-02-01T00:00:00Z",
             }
         ]
-        with (
-            patch("kennel.worker._sub_dir", return_value=tmp_path),
-            patch("kennel.worker.claude.generate_reply", return_value="Back on it!"),
-        ):
-            (tmp_path / "persona.md").write_text("I am Fido.")
-            worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
+        worker._prompts = Prompts("I am Fido.")
+        worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
         gh.comment_issue.assert_called_once_with("owner/repo", 1, "Back on it!")
 
 
@@ -2312,37 +2302,32 @@ class TestClaudeStart:
     def test_returns_session_id_on_success(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         output = '{"type":"result","session_id":"sess-abc"}'
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=output),
-            patch(
-                "kennel.claude.extract_session_id",
-                return_value="sess-abc",
-            ),
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = output
+        with patch(
+            "kennel.claude.extract_session_id",
+            return_value="sess-abc",
         ):
-            result = claude_start(fido_dir)
+            result = claude_start(fido_dir, claude_client=mock_client)
         assert result == "sess-abc"
 
     def test_returns_empty_when_extract_fails(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=""),
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            result = claude_start(fido_dir)
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            result = claude_start(fido_dir, claude_client=mock_client)
         assert result == ""
 
     def test_calls_print_prompt_from_file_with_correct_files(
         self, tmp_path: Path
     ) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_start(fido_dir)
-        mock_ppf.assert_called_once_with(
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_start(fido_dir, claude_client=mock_client)
+        mock_client.print_prompt_from_file.assert_called_once_with(
             fido_dir / "system",
             fido_dir / "prompt",
             "claude-opus-4-6",
@@ -2352,56 +2337,43 @@ class TestClaudeStart:
 
     def test_passes_custom_model(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_start(fido_dir, model="claude-sonnet-4-6")
-        assert mock_ppf.call_args[0][2] == "claude-sonnet-4-6"
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_start(fido_dir, model="claude-sonnet-4-6", claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][2] == "claude-sonnet-4-6"
 
     def test_passes_custom_timeout(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_start(fido_dir, timeout=600)
-        assert mock_ppf.call_args[0][3] == 600
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_start(fido_dir, timeout=600, claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][3] == 600
 
     def test_default_model_is_opus(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_start(fido_dir)
-        assert mock_ppf.call_args[0][2] == "claude-opus-4-6"
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_start(fido_dir, claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][2] == "claude-opus-4-6"
 
     def test_default_timeout_is_300(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_start(fido_dir)
-        assert mock_ppf.call_args[0][3] == 300
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_start(fido_dir, claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][3] == 300
 
     def test_passes_output_to_extract_session_id(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         raw = '{"type":"result","session_id":"xyz"}'
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=raw),
-            patch("kennel.claude.extract_session_id", return_value="xyz") as mock_ext,
-        ):
-            claude_start(fido_dir)
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = raw
+        with patch("kennel.claude.extract_session_id", return_value="xyz") as mock_ext:
+            claude_start(fido_dir, claude_client=mock_client)
         mock_ext.assert_called_once_with(raw)
 
     # ── Session path ──────────────────────────────────────────────────────
@@ -2459,9 +2431,9 @@ class TestClaudeStart:
     def test_session_path_does_not_call_subprocess(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         session = self._mock_session()
-        with patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf:
-            claude_start(fido_dir, session=session)
-        mock_ppf.assert_not_called()
+        mock_client = _client()
+        claude_start(fido_dir, session=session, claude_client=mock_client)
+        mock_client.print_prompt_from_file.assert_not_called()
 
     def test_session_path_uses_context_manager(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -2469,6 +2441,17 @@ class TestClaudeStart:
         claude_start(fido_dir, session=session)
         session.__enter__.assert_called_once()
         session.__exit__.assert_called_once()
+
+    def test_creates_default_client_when_none(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        with patch(
+            "kennel.worker.ClaudeClient",
+            return_value=_client(),
+        ) as mock_cls:
+            mock_cls.return_value.print_prompt_from_file.return_value = ""
+            with patch("kennel.claude.extract_session_id", return_value=""):
+                claude_start(fido_dir)
+            mock_cls.assert_called_once_with()
 
 
 class TestClaudeRun:
@@ -2487,36 +2470,31 @@ class TestClaudeRun:
     def test_start_returns_new_session_id(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         raw = '{"type":"result","session_id":"new-sess"}'
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=raw),
-            patch(
-                "kennel.claude.extract_session_id",
-                return_value="new-sess",
-            ),
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = raw
+        with patch(
+            "kennel.claude.extract_session_id",
+            return_value="new-sess",
         ):
-            session_id, _ = claude_run(fido_dir)
+            session_id, _ = claude_run(fido_dir, claude_client=mock_client)
         assert session_id == "new-sess"
 
     def test_start_returns_raw_output(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         raw = '{"type":"result","session_id":"s"}'
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=raw),
-            patch("kennel.claude.extract_session_id", return_value="s"),
-        ):
-            _, output = claude_run(fido_dir)
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = raw
+        with patch("kennel.claude.extract_session_id", return_value="s"):
+            _, output = claude_run(fido_dir, claude_client=mock_client)
         assert output == raw
 
     def test_start_calls_print_prompt_from_file(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_run(fido_dir)
-        mock_ppf.assert_called_once_with(
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_run(fido_dir, claude_client=mock_client)
+        mock_client.print_prompt_from_file.assert_called_once_with(
             fido_dir / "system",
             fido_dir / "prompt",
             "claude-sonnet-4-6",
@@ -2526,34 +2504,27 @@ class TestClaudeRun:
 
     def test_start_returns_empty_session_id_on_failure(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch("kennel.worker.claude.print_prompt_from_file", return_value=""),
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            session_id, _ = claude_run(fido_dir)
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            session_id, _ = claude_run(fido_dir, claude_client=mock_client)
         assert session_id == ""
 
     def test_default_model_is_sonnet(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_run(fido_dir)
-        assert mock_ppf.call_args[0][2] == "claude-sonnet-4-6"
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_run(fido_dir, claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][2] == "claude-sonnet-4-6"
 
     def test_default_timeout_is_300(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
-        with (
-            patch(
-                "kennel.worker.claude.print_prompt_from_file", return_value=""
-            ) as mock_ppf,
-            patch("kennel.claude.extract_session_id", return_value=""),
-        ):
-            claude_run(fido_dir)
-        assert mock_ppf.call_args[0][3] == 300
+        mock_client = _client()
+        mock_client.print_prompt_from_file.return_value = ""
+        with patch("kennel.claude.extract_session_id", return_value=""):
+            claude_run(fido_dir, claude_client=mock_client)
+        assert mock_client.print_prompt_from_file.call_args[0][3] == 300
 
     # ── Session path ──────────────────────────────────────────────────────
 
@@ -2589,9 +2560,9 @@ class TestClaudeRun:
     def test_session_path_does_not_call_subprocess(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         session = self._mock_session()
-        with patch("kennel.worker.claude.print_prompt_from_file") as mock_ppf:
-            claude_run(fido_dir, session=session)
-        mock_ppf.assert_not_called()
+        mock_client = _client()
+        claude_run(fido_dir, session=session, claude_client=mock_client)
+        mock_client.print_prompt_from_file.assert_not_called()
 
     def test_session_path_uses_context_manager(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -2599,6 +2570,17 @@ class TestClaudeRun:
         claude_run(fido_dir, session=session)
         session.__enter__.assert_called_once()
         session.__exit__.assert_called_once()
+
+    def test_creates_default_client_when_none(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        with patch(
+            "kennel.worker.ClaudeClient",
+            return_value=_client(),
+        ) as mock_cls:
+            mock_cls.return_value.print_prompt_from_file.return_value = ""
+            with patch("kennel.claude.extract_session_id", return_value=""):
+                claude_run(fido_dir)
+            mock_cls.assert_called_once_with()
 
 
 class TestSanitizeSlug:
@@ -2893,7 +2875,7 @@ class TestWritePrDescription:
         issue=1,
         pr_number=42,
     ):
-        mock_pp = MagicMock(return_value=print_return)
+        mock_cc = _client(print_return)
         return (
             _write_pr_description(
                 gh,
@@ -2902,9 +2884,9 @@ class TestWritePrDescription:
                 issue,
                 task_list or [],
                 existing_body,
-                _print_prompt=mock_pp,
+                claude_client=mock_cc,
             ),
-            mock_pp,
+            mock_cc,
         )
 
     def test_writes_to_github(self) -> None:
@@ -3059,22 +3041,24 @@ class TestWritePrDescription:
             self._call(gh, existing_body="no divider here")
         gh.edit_pr_body.assert_not_called()
 
-    def test_defaults_to_claude_print_prompt(self) -> None:
+    def test_defaults_to_claude_client(self) -> None:
         gh = MagicMock()
-        with patch(
-            "kennel.claude.print_prompt",
-            return_value="<body>Desc.\n\nFixes #1.</body>",
-        ) as mock_pp:
-            _write_pr_description(gh, "owner/repo", 1, 1, [])
-        mock_pp.assert_called_once()
+        with patch("kennel.worker.ClaudeClient") as MockCls:
+            MockCls.return_value.print_prompt.return_value = (
+                "<body>Desc.\n\nFixes #42.</body>"
+            )
+            _write_pr_description(gh, "owner/repo", 99, 42, [])
+        MockCls.assert_called_once_with()
 
 
 class TestFindOrCreatePr:
     """Tests for Worker.find_or_create_pr."""
 
-    def _make_worker(self, tmp_path: Path) -> tuple["Worker", MagicMock]:
+    def _make_worker(
+        self, tmp_path: Path, claude_client: MagicMock | None = None
+    ) -> tuple["Worker", MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, claude_client=claude_client), gh
 
     def _make_repo_ctx(
         self,
@@ -3133,7 +3117,8 @@ class TestFindOrCreatePr:
         assert "resuming" in caplog.text
 
     def test_open_pr_runs_setup_when_no_tasks(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
@@ -3148,7 +3133,9 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY)
-        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
+        mock_start.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=mock_client
+        )
 
     def test_open_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3308,13 +3295,14 @@ class TestFindOrCreatePr:
     # --- No PR (new branch) path ---
 
     def test_no_pr_returns_pr_number_and_slug(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "fix-bug"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/55"
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
             patch("kennel.worker._write_pr_description"),
@@ -3334,13 +3322,14 @@ class TestFindOrCreatePr:
     def test_no_pr_logs_new_branch(self, tmp_path: Path, caplog) -> None:
         import logging
 
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -3352,7 +3341,9 @@ class TestFindOrCreatePr:
         assert "new branch" in caplog.text
 
     def test_no_pr_calls_setup(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
@@ -3360,7 +3351,6 @@ class TestFindOrCreatePr:
         mock_start = MagicMock(return_value="s")
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", mock_start),
             patch("kennel.worker._write_pr_description"),
@@ -3369,17 +3359,20 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY)
-        mock_start.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
+        mock_start.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=mock_client
+        )
 
     def test_no_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt", mock_build),
             patch("kennel.worker.claude_start", return_value="s"),
             patch("kennel.worker._write_pr_description"),
@@ -3391,14 +3384,15 @@ class TestFindOrCreatePr:
         assert f"Work dir: {tmp_path}" in context
 
     def test_no_pr_creates_pr_with_correct_params(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/99"
         fido_dir = self._fido_dir(tmp_path)
         repo_ctx = self._make_repo_ctx(repo="owner/proj", default_branch="main")
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -3417,7 +3411,9 @@ class TestFindOrCreatePr:
         )
 
     def test_no_pr_git_operations_in_order(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
@@ -3429,7 +3425,6 @@ class TestFindOrCreatePr:
 
         with (
             patch.object(worker, "_git", side_effect=side_effect),
-            patch("kennel.worker.claude.generate_branch_name", return_value="do-work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -3445,7 +3440,9 @@ class TestFindOrCreatePr:
         self, tmp_path: Path
     ) -> None:
         """Always start fresh — delete existing branch before checkout -b."""
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "slug"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
@@ -3457,7 +3454,6 @@ class TestFindOrCreatePr:
 
         with (
             patch.object(worker, "_git", side_effect=side_effect),
-            patch("kennel.worker.claude.generate_branch_name", return_value="slug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -3469,7 +3465,9 @@ class TestFindOrCreatePr:
         assert ["checkout", "-b", "slug", "origin/main"] in git_calls
 
     def test_no_pr_slug_sanitized(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "Add New Feature!"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
@@ -3481,10 +3479,6 @@ class TestFindOrCreatePr:
 
         with (
             patch.object(worker, "_git", side_effect=side_effect),
-            patch(
-                "kennel.worker.claude.generate_branch_name",
-                return_value="Add New Feature!",
-            ),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -3501,12 +3495,13 @@ class TestFindOrCreatePr:
 
     def test_no_pr_setup_no_tasks_raises(self, tmp_path: Path) -> None:
         """New-PR path: setup produces no tasks → raises RuntimeError, skips PR creation."""
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "fix-bug"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="fix-bug"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value="sess"),
             patch("kennel.tasks.Tasks.list", return_value=[]),
@@ -3518,13 +3513,14 @@ class TestFindOrCreatePr:
     def test_no_pr_logs_pr_number(self, tmp_path: Path, caplog) -> None:
         import logging
 
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "work"
+        worker, gh = self._make_worker(tmp_path, claude_client=mock_client)
         gh.find_pr.return_value = None
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/42"
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
-            patch("kennel.worker.claude.generate_branch_name", return_value="work"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.claude_start", return_value=""),
             patch("kennel.worker._write_pr_description"),
@@ -4246,7 +4242,9 @@ class TestHandleCi:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
-        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
+        mock_cr.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=ANY
+        )
 
     def test_does_not_complete_ci_task(self, tmp_path: Path) -> None:
         """CI failures have no task entry — no complete call needed."""
@@ -4939,7 +4937,9 @@ class TestHandleThreads:
             patch("kennel.tasks.sync_tasks_background"),
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
-        mock_cr.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
+        mock_cr.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=ANY
+        )
 
     def test_spawns_sync_script(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -5701,7 +5701,9 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_run.assert_called_once_with(fido_dir, cwd=tmp_path, session=None)
+        mock_run.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=ANY
+        )
 
     def test_calls_ensure_pushed_with_origin_and_slug(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)


### PR DESCRIPTION
Fixes #399.

Extracts one-shot Claude helpers into an injectable `ClaudeClient` class and consolidates module-level prompt builders onto `Prompts`, then migrates `events.py`, `worker.py`, `gh_status.py`, and `tasks.py` to accept these collaborators instead of threading `_print_prompt` callable slots. Finishes by removing the deprecated module-level wrappers so both modules' public surfaces shrink to their collaborator boundaries.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (7)</summary>

- [x] Extract one-shot Claude helpers into a ClaudeClient collaborator class <!-- type:spec -->
- [x] Move module-level prompt builders onto the Prompts class <!-- type:spec -->
- [x] Migrate events.py to accept ClaudeClient and Prompts as injected collaborators <!-- type:spec -->
- [x] Migrate worker.py to accept ClaudeClient and Prompts as injected collaborators <!-- type:spec -->
- [x] Migrate gh_status.py and tasks.py to use injected collaborators <!-- type:spec -->
- [x] Remove deprecated module-level wrappers from claude.py and prompts.py <!-- type:spec -->
- [x] [resolve merge conflict](https://github.com/FidoCanCode/home/pull/527#issuecomment-4252610810) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->