### PR TITLE
Detect Claude provider failures and recover webhook replies

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -346,6 +346,23 @@ class ClaudeStreamError(Exception):
         super().__init__(f"claude exited with code {returncode}")
 
 
+class ClaudeProviderError(RuntimeError):
+    """Raised when Claude reports an API/provider failure for a turn."""
+
+    def __init__(
+        self,
+        *,
+        message: str,
+        status_code: int | None = None,
+        request_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.request_id = request_id
+        self.payload = payload or {}
+        super().__init__(message)
+
+
 # ── Stream-JSON helpers ───────────────────────────────────────────────────────
 
 
@@ -391,6 +408,74 @@ def extract_result_text(output: str) -> str:
             if text:
                 result = text
     return result
+
+
+def _provider_error_from_result_text(text: str) -> ClaudeProviderError | None:
+    """Parse a Claude CLI API error string from ``type=result`` text."""
+    match = re.match(r"^API Error:\s*(\d+)\s+(.*)$", text.strip(), re.DOTALL)
+    if not match:
+        return None
+    status_code = int(match.group(1))
+    tail = match.group(2).strip()
+    payload: dict[str, Any] = {}
+    message = tail
+    request_id = None
+    try:
+        parsed = json.loads(tail)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        payload = parsed
+        error = parsed.get("error")
+        if isinstance(error, dict):
+            message = str(error.get("message") or tail)
+        request_id_value = parsed.get("request_id")
+        if isinstance(request_id_value, str) and request_id_value:
+            request_id = request_id_value
+    return ClaudeProviderError(
+        message=f"Claude API error {status_code}: {message}",
+        status_code=status_code,
+        request_id=request_id,
+        payload=payload,
+    )
+
+
+def _provider_error_from_event(obj: dict[str, Any]) -> ClaudeProviderError | None:
+    """Return a provider error for a stream-json event when it encodes one."""
+    event_type = obj.get("type")
+    if event_type == "result" and isinstance(obj.get("result"), str):
+        return _provider_error_from_result_text(obj["result"])
+    if event_type != "error":
+        return None
+    error_obj = obj.get("error")
+    if isinstance(error_obj, dict):
+        message = str(error_obj.get("message") or error_obj)
+    else:
+        message = str(error_obj or obj)
+    request_id = obj.get("request_id")
+    return ClaudeProviderError(
+        message=f"Claude API error: {message}",
+        request_id=request_id if isinstance(request_id, str) else None,
+        payload=obj,
+    )
+
+
+def raise_for_provider_error_output(output: str) -> None:
+    """Raise the first provider error encoded in stream-json *output*."""
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError:
+            provider_error = _provider_error_from_result_text(stripped)
+            if provider_error is not None:
+                raise provider_error
+            continue
+        provider_error = _provider_error_from_event(obj)
+        if provider_error is not None:
+            raise provider_error
 
 
 _EMPTY_RETRY_COUNT = 2
@@ -1114,6 +1199,17 @@ class ClaudeSession:
         """
         result_text = ""
         for event in self.iter_events():
+            provider_error = _provider_error_from_event(event)
+            if provider_error is not None:
+                log.error(
+                    "ClaudeSession: provider failure during turn: %s"
+                    " (status=%s, request_id=%s)",
+                    provider_error,
+                    provider_error.status_code,
+                    provider_error.request_id or "—",
+                )
+                self.restart()
+                raise provider_error
             if event.get("type") == "result" and isinstance(event.get("result"), str):
                 result_text = event["result"]
         return result_text
@@ -1265,9 +1361,11 @@ class ClaudeClient:
             str(system_file),
             "--print",
         ]
-        return "".join(
+        output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()
+        raise_for_provider_error_output(output)
+        return output
 
     def resume_session(
         self,
@@ -1291,9 +1389,11 @@ class ClaudeClient:
             session_id,
             "--print",
         ]
-        return "".join(
+        output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()
+        raise_for_provider_error_output(output)
+        return output
 
     # ── Subprocess one-shot helpers ──────────────────────────────────────
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -40,11 +40,13 @@ class Action:
     )
 
 
-def _pr_number_from_api_url(url: str, kind: str) -> int | None:
+def _pr_number_from_api_url(url: str, kind: str) -> int:
     """Extract a PR/issue number from a GitHub API URL."""
     pattern = r"/issues/(\d+)$" if kind == "issues" else r"/pulls/(\d+)$"
     match = re.search(pattern, url)
-    return int(match.group(1)) if match else None
+    if match is None:
+        raise ValueError(f"invalid GitHub API URL for {kind}: {url!r}")
+    return int(match.group(1))
 
 
 def _build_review_comment_action(
@@ -57,8 +59,8 @@ def _build_review_comment_action(
     comment_body: str | None = None,
 ) -> Action:
     """Rebuild a review-comment Action from live GitHub state."""
-    user = comment.get("user", {}).get("login", "")
-    body = comment_body if comment_body is not None else (comment.get("body", "") or "")
+    user = comment["user"]["login"]
+    body = comment_body if comment_body is not None else (comment["body"] or "")
     is_bot = user.endswith("[bot]")
     return Action(
         prompt=(
@@ -69,7 +71,7 @@ def _build_review_comment_action(
             "repo": repo,
             "pr": pr_number,
             "comment_id": comment["id"],
-            "url": comment.get("html_url", ""),
+            "url": comment["html_url"],
             "author": user,
             "comment_type": "pulls",
         },
@@ -78,9 +80,9 @@ def _build_review_comment_action(
         context={
             "pr_title": pr_title,
             "pr_body": pr_body,
-            "file": comment.get("path", ""),
-            "line": comment.get("line"),
-            "diff_hunk": comment.get("diff_hunk", ""),
+            "file": comment["path"],
+            "line": comment["line"],
+            "diff_hunk": comment["diff_hunk"],
         },
     )
 
@@ -93,8 +95,8 @@ def _build_issue_comment_action(
     comment: dict[str, Any],
 ) -> Action:
     """Rebuild a top-level PR-comment Action from live GitHub state."""
-    user = comment.get("user", {}).get("login", "")
-    body = comment.get("body", "") or ""
+    user = comment["user"]["login"]
+    body = comment["body"] or ""
     is_bot = user.endswith("[bot]")
     comment_id = int(comment["id"])
     return Action(
@@ -111,7 +113,7 @@ def _build_issue_comment_action(
             "repo": repo,
             "pr": pr_number,
             "comment_id": comment_id,
-            "url": comment.get("html_url", ""),
+            "url": comment["html_url"],
             "author": user,
             "comment_type": "issues",
         },
@@ -160,9 +162,12 @@ def recover_reply_promises(
 
     pr_issue = gh.view_issue(repo_cfg.name, pr_number)
     pr_title = pr_issue["title"]
-    pr_body = pr_issue.get("body", "") or ""
+    pr_body = pr_issue["body"] or ""
     processed_any = False
     handled_keys: set[tuple[str, int]] = set()
+    promise_by_key = {
+        (promise.comment_type, promise.comment_id): promise for promise in promises
+    }
 
     pull_entries: dict[tuple[str, int], tuple[dict[str, Any], int, int]] = {}
     issue_entries: dict[tuple[str, int], tuple[dict[str, Any], int]] = {}
@@ -172,27 +177,23 @@ def recover_reply_promises(
         if promise.comment_type == "pulls":
             comment = gh.get_pull_comment(repo_cfg.name, promise.comment_id)
             if comment is None:
-                promise.path.unlink(missing_ok=True)
+                promise.path.unlink()
                 handled_keys.add(key)
                 continue
-            comment_pr = _pr_number_from_api_url(
-                str(comment.get("pull_request_url", "")), "pulls"
+            comment_pr = _pr_number_from_api_url(comment["pull_request_url"], "pulls")
+            root_id = (
+                int(comment["in_reply_to_id"])
+                if "in_reply_to_id" in comment and comment["in_reply_to_id"] is not None
+                else int(comment["id"])
             )
-            if comment_pr is None:
-                continue
-            root_id = int(comment.get("in_reply_to_id") or comment["id"])
             pull_entries[key] = (comment, comment_pr, root_id)
         else:
             comment = gh.get_issue_comment(repo_cfg.name, promise.comment_id)
             if comment is None:
-                promise.path.unlink(missing_ok=True)
+                promise.path.unlink()
                 handled_keys.add(key)
                 continue
-            comment_pr = _pr_number_from_api_url(
-                str(comment.get("issue_url", "")), "issues"
-            )
-            if comment_pr is None:
-                continue
+            comment_pr = _pr_number_from_api_url(comment["issue_url"], "issues")
             issue_entries[key] = (comment, comment_pr)
 
     for promise in promises:
@@ -201,10 +202,7 @@ def recover_reply_promises(
             continue
 
         if promise.comment_type == "issues":
-            entry = issue_entries.get(key)
-            if entry is None:
-                continue
-            comment, comment_pr = entry
+            comment, comment_pr = issue_entries[key]
             if comment_pr != pr_number:
                 continue
             action = _build_issue_comment_action(
@@ -234,28 +232,24 @@ def recover_reply_promises(
             processed_any = True
             continue
 
-        entry = pull_entries.get(key)
-        if entry is None:
-            continue
-        comment, comment_pr, root_id = entry
+        comment, comment_pr, root_id = pull_entries[key]
         if comment_pr != pr_number:
             continue
 
         group: list[tuple[reply_promises.ReplyPromise, dict[str, Any]]] = []
-        for candidate in promises:
-            candidate_key = (candidate.comment_type, candidate.comment_id)
+        for candidate_key, (
+            candidate_comment,
+            candidate_pr,
+            candidate_root_id,
+        ) in pull_entries.items():
             if candidate_key in handled_keys:
                 continue
-            candidate_entry = pull_entries.get(candidate_key)
-            if candidate_entry is None:
-                continue
-            candidate_comment, candidate_pr, candidate_root_id = candidate_entry
             if candidate_pr == pr_number and candidate_root_id == root_id:
-                group.append((candidate, candidate_comment))
+                group.append((promise_by_key[candidate_key], candidate_comment))
 
         combined_parts: list[str] = []
         for _, group_comment in group:
-            body = group_comment.get("body", "") or ""
+            body = group_comment["body"] or ""
             if body and body not in combined_parts:
                 combined_parts.append(body)
         combined_body = "\n\n---\n\n".join(combined_parts) if combined_parts else None

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -218,6 +218,10 @@ def recover_reply_promises(
                 claude_client=claude_client,
                 prompts=prompts,
             )
+            reply_promises.remove_reply_promise(
+                fido_dir, promise.comment_type, promise.comment_id
+            )
+            handled_keys.add(key)
             _apply_reply_result(
                 category,
                 titles,
@@ -227,10 +231,6 @@ def recover_reply_promises(
                 thread=action.thread,
                 registry=registry,
             )
-            reply_promises.remove_reply_promise(
-                fido_dir, promise.comment_type, promise.comment_id
-            )
-            handled_keys.add(key)
             processed_any = True
             continue
 
@@ -276,6 +276,11 @@ def recover_reply_promises(
             claude_client=claude_client,
             prompts=prompts,
         )
+        for group_promise, _ in group:
+            reply_promises.remove_reply_promise(
+                fido_dir, group_promise.comment_type, group_promise.comment_id
+            )
+            handled_keys.add((group_promise.comment_type, group_promise.comment_id))
         _apply_reply_result(
             category,
             titles,
@@ -285,11 +290,6 @@ def recover_reply_promises(
             thread=action.reply_to,
             registry=registry,
         )
-        for group_promise, _ in group:
-            reply_promises.remove_reply_promise(
-                fido_dir, group_promise.comment_type, group_promise.comment_id
-            )
-            handled_keys.add((group_promise.comment_type, group_promise.comment_id))
         processed_any = True
 
     return processed_any

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from kennel import reply_promises
 from kennel.claude import ClaudeClient
 from kennel.config import Config, RepoConfig
 from kennel.github import GitHub
@@ -37,6 +38,261 @@ class Action:
     thread: dict[str, Any] | None = (
         None  # {repo, pr, comment_id} for task prioritisation
     )
+
+
+def _pr_number_from_api_url(url: str, kind: str) -> int | None:
+    """Extract a PR/issue number from a GitHub API URL."""
+    pattern = r"/issues/(\d+)$" if kind == "issues" else r"/pulls/(\d+)$"
+    match = re.search(pattern, url)
+    return int(match.group(1)) if match else None
+
+
+def _build_review_comment_action(
+    repo: str,
+    pr_number: int,
+    pr_title: str,
+    pr_body: str,
+    comment: dict[str, Any],
+    *,
+    comment_body: str | None = None,
+) -> Action:
+    """Rebuild a review-comment Action from live GitHub state."""
+    user = comment.get("user", {}).get("login", "")
+    body = comment_body if comment_body is not None else (comment.get("body", "") or "")
+    is_bot = user.endswith("[bot]")
+    return Action(
+        prompt=(
+            f"Review comment on PR #{pr_number} by {user}"
+            f" ({'bot' if is_bot else 'human/owner'}):\n\n{body}"
+        ),
+        reply_to={
+            "repo": repo,
+            "pr": pr_number,
+            "comment_id": comment["id"],
+            "url": comment.get("html_url", ""),
+            "author": user,
+            "comment_type": "pulls",
+        },
+        comment_body=body,
+        is_bot=is_bot,
+        context={
+            "pr_title": pr_title,
+            "pr_body": pr_body,
+            "file": comment.get("path", ""),
+            "line": comment.get("line"),
+            "diff_hunk": comment.get("diff_hunk", ""),
+        },
+    )
+
+
+def _build_issue_comment_action(
+    repo: str,
+    pr_number: int,
+    pr_title: str,
+    pr_body: str,
+    comment: dict[str, Any],
+) -> Action:
+    """Rebuild a top-level PR-comment Action from live GitHub state."""
+    user = comment.get("user", {}).get("login", "")
+    body = comment.get("body", "") or ""
+    is_bot = user.endswith("[bot]")
+    comment_id = int(comment["id"])
+    return Action(
+        prompt=f"PR top-level comment on #{pr_number} by {user}:\n\n{body}",
+        reply_to=None,
+        comment_body=body,
+        is_bot=is_bot,
+        context={
+            "pr_title": pr_title,
+            "pr_body": pr_body,
+            "comment_id": comment_id,
+        },
+        thread={
+            "repo": repo,
+            "pr": pr_number,
+            "comment_id": comment_id,
+            "url": comment.get("html_url", ""),
+            "author": user,
+            "comment_type": "issues",
+        },
+    )
+
+
+def _apply_reply_result(
+    category: str,
+    titles: list[str],
+    config: Config,
+    repo_cfg: RepoConfig,
+    gh: GitHub,
+    *,
+    thread: dict[str, Any] | None,
+    registry: WorkerRegistry | None,
+) -> None:
+    """Apply ACT/DO titles from a recovered reply just like webhook handling."""
+    if category in ("DUMP", "ANSWER", "ASK", "DEFER"):
+        return
+    for title in titles:
+        create_task(
+            title,
+            config,
+            repo_cfg,
+            gh,
+            thread=thread,
+            registry=registry,
+        )
+
+
+def recover_reply_promises(
+    fido_dir: Path,
+    config: Config,
+    repo_cfg: RepoConfig,
+    gh: GitHub,
+    pr_number: int,
+    *,
+    claude_client: ClaudeClient | None = None,
+    prompts: Prompts | None = None,
+    registry: WorkerRegistry | None = None,
+) -> bool:
+    """Recover queued webhook replies for the current PR from promise files."""
+    promises = reply_promises.list_reply_promises(fido_dir)
+    if not promises:
+        return False
+
+    pr_issue = gh.view_issue(repo_cfg.name, pr_number)
+    pr_title = pr_issue["title"]
+    pr_body = pr_issue.get("body", "") or ""
+    processed_any = False
+    handled_keys: set[tuple[str, int]] = set()
+
+    pull_entries: dict[tuple[str, int], tuple[dict[str, Any], int, int]] = {}
+    issue_entries: dict[tuple[str, int], tuple[dict[str, Any], int]] = {}
+
+    for promise in promises:
+        key = (promise.comment_type, promise.comment_id)
+        if promise.comment_type == "pulls":
+            comment = gh.get_pull_comment(repo_cfg.name, promise.comment_id)
+            if comment is None:
+                promise.path.unlink(missing_ok=True)
+                handled_keys.add(key)
+                continue
+            comment_pr = _pr_number_from_api_url(
+                str(comment.get("pull_request_url", "")), "pulls"
+            )
+            if comment_pr is None:
+                continue
+            root_id = int(comment.get("in_reply_to_id") or comment["id"])
+            pull_entries[key] = (comment, comment_pr, root_id)
+        else:
+            comment = gh.get_issue_comment(repo_cfg.name, promise.comment_id)
+            if comment is None:
+                promise.path.unlink(missing_ok=True)
+                handled_keys.add(key)
+                continue
+            comment_pr = _pr_number_from_api_url(
+                str(comment.get("issue_url", "")), "issues"
+            )
+            if comment_pr is None:
+                continue
+            issue_entries[key] = (comment, comment_pr)
+
+    for promise in promises:
+        key = (promise.comment_type, promise.comment_id)
+        if key in handled_keys:
+            continue
+
+        if promise.comment_type == "issues":
+            entry = issue_entries.get(key)
+            if entry is None:
+                continue
+            comment, comment_pr = entry
+            if comment_pr != pr_number:
+                continue
+            action = _build_issue_comment_action(
+                repo_cfg.name, pr_number, pr_title, pr_body, comment
+            )
+            category, titles = reply_to_issue_comment(
+                action,
+                config,
+                repo_cfg,
+                gh,
+                claude_client=claude_client,
+                prompts=prompts,
+            )
+            _apply_reply_result(
+                category,
+                titles,
+                config,
+                repo_cfg,
+                gh,
+                thread=action.thread,
+                registry=registry,
+            )
+            reply_promises.remove_reply_promise(
+                fido_dir, promise.comment_type, promise.comment_id
+            )
+            handled_keys.add(key)
+            processed_any = True
+            continue
+
+        entry = pull_entries.get(key)
+        if entry is None:
+            continue
+        comment, comment_pr, root_id = entry
+        if comment_pr != pr_number:
+            continue
+
+        group: list[tuple[reply_promises.ReplyPromise, dict[str, Any]]] = []
+        for candidate in promises:
+            candidate_key = (candidate.comment_type, candidate.comment_id)
+            if candidate_key in handled_keys:
+                continue
+            candidate_entry = pull_entries.get(candidate_key)
+            if candidate_entry is None:
+                continue
+            candidate_comment, candidate_pr, candidate_root_id = candidate_entry
+            if candidate_pr == pr_number and candidate_root_id == root_id:
+                group.append((candidate, candidate_comment))
+
+        combined_parts: list[str] = []
+        for _, group_comment in group:
+            body = group_comment.get("body", "") or ""
+            if body and body not in combined_parts:
+                combined_parts.append(body)
+        combined_body = "\n\n---\n\n".join(combined_parts) if combined_parts else None
+        representative = group[-1][1]
+        action = _build_review_comment_action(
+            repo_cfg.name,
+            pr_number,
+            pr_title,
+            pr_body,
+            representative,
+            comment_body=combined_body,
+        )
+        category, titles = reply_to_comment(
+            action,
+            config,
+            repo_cfg,
+            gh,
+            claude_client=claude_client,
+            prompts=prompts,
+        )
+        _apply_reply_result(
+            category,
+            titles,
+            config,
+            repo_cfg,
+            gh,
+            thread=action.reply_to,
+            registry=registry,
+        )
+        for group_promise, _ in group:
+            reply_promises.remove_reply_promise(
+                fido_dir, group_promise.comment_type, group_promise.comment_id
+            )
+            handled_keys.add((group_promise.comment_type, group_promise.comment_id))
+        processed_any = True
+
+    return processed_any
 
 
 def _is_allowed(user: str, repo_cfg: RepoConfig, config: Config) -> bool:

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -173,6 +173,17 @@ class GitHub:
         """Return all inline review comments on a pull request."""
         return list(self._paginate(f"{self.BASE}/repos/{repo}/pulls/{pr}/comments"))
 
+    def get_pull_comment(
+        self, repo: str, comment_id: int | str
+    ) -> dict[str, Any] | None:
+        """Return one inline review comment by id, or None if it no longer exists."""
+        try:
+            return self._get(f"/repos/{repo}/pulls/comments/{comment_id}")
+        except _requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return None
+            raise
+
     def fetch_sibling_threads(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return all review-comment threads for a PR as a structured list.
 
@@ -537,6 +548,17 @@ class GitHub:
         return list(
             self._paginate(f"{self.BASE}/repos/{repo}/issues/{number}/comments")
         )
+
+    def get_issue_comment(
+        self, repo: str, comment_id: int | str
+    ) -> dict[str, Any] | None:
+        """Return one issue comment by id, or None if it no longer exists."""
+        try:
+            return self._get(f"/repos/{repo}/issues/comments/{comment_id}")
+        except _requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return None
+            raise
 
     def get_issue_events(self, repo: str, number: int | str) -> list[dict[str, Any]]:
         """Return all events on an issue."""

--- a/kennel/reply_promises.py
+++ b/kennel/reply_promises.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+_COMMENT_TYPES = frozenset({"issues", "pulls"})
+
 
 @dataclass(frozen=True)
 class ReplyPromise:
@@ -23,8 +25,27 @@ def _promise_path(fido_dir: Path, comment_type: str, comment_id: int) -> Path:
     return _promise_dir(fido_dir) / f"{comment_type}-{comment_id}"
 
 
+def _validate_comment_type(comment_type: str) -> str:
+    if comment_type not in _COMMENT_TYPES:
+        raise ValueError(f"invalid reply promise comment type: {comment_type!r}")
+    return comment_type
+
+
+def _parse_promise_name(name: str) -> tuple[str, int]:
+    comment_type, sep, raw_id = name.partition("-")
+    if sep != "-":
+        raise ValueError(f"invalid reply promise filename: {name!r}")
+    _validate_comment_type(comment_type)
+    try:
+        comment_id = int(raw_id)
+    except ValueError as exc:
+        raise ValueError(f"invalid reply promise filename: {name!r}") from exc
+    return comment_type, comment_id
+
+
 def add_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> Path:
     """Create the durable promise file if it does not already exist."""
+    _validate_comment_type(comment_type)
     path = _promise_path(fido_dir, comment_type, comment_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.touch(exist_ok=True)
@@ -32,26 +53,26 @@ def add_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> Pat
 
 
 def remove_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> None:
-    """Delete the durable promise file if it exists."""
-    _promise_path(fido_dir, comment_type, comment_id).unlink(missing_ok=True)
+    """Delete the durable promise file."""
+    _validate_comment_type(comment_type)
+    _promise_path(fido_dir, comment_type, comment_id).unlink()
+
+
+def has_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> bool:
+    """Return whether the durable promise file currently exists."""
+    _validate_comment_type(comment_type)
+    return _promise_path(fido_dir, comment_type, comment_id).exists()
 
 
 def list_reply_promises(fido_dir: Path) -> list[ReplyPromise]:
     """Return promises in filesystem timestamp order."""
-    result: list[ReplyPromise] = []
     promise_dir = _promise_dir(fido_dir)
-    if not promise_dir.exists():
-        return result
+    promise_dir.mkdir(parents=True, exist_ok=True)
+    result: list[ReplyPromise] = []
     for path in promise_dir.iterdir():
         if not path.is_file():
-            continue
-        comment_type, sep, raw_id = path.name.partition("-")
-        if sep != "-" or comment_type not in {"issues", "pulls"}:
-            continue
-        try:
-            comment_id = int(raw_id)
-        except ValueError:
-            continue
+            raise IsADirectoryError(f"reply promise entry is not a file: {path}")
+        comment_type, comment_id = _parse_promise_name(path.name)
         result.append(
             ReplyPromise(
                 comment_type=comment_type,

--- a/kennel/reply_promises.py
+++ b/kennel/reply_promises.py
@@ -1,0 +1,63 @@
+"""Durable per-comment reply promises stored as empty files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReplyPromise:
+    """One owed reply keyed only by comment type and comment id."""
+
+    comment_type: str
+    comment_id: int
+    path: Path
+
+
+def _promise_dir(fido_dir: Path) -> Path:
+    return fido_dir / "reply-promises"
+
+
+def _promise_path(fido_dir: Path, comment_type: str, comment_id: int) -> Path:
+    return _promise_dir(fido_dir) / f"{comment_type}-{comment_id}"
+
+
+def add_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> Path:
+    """Create the durable promise file if it does not already exist."""
+    path = _promise_path(fido_dir, comment_type, comment_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch(exist_ok=True)
+    return path
+
+
+def remove_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> None:
+    """Delete the durable promise file if it exists."""
+    _promise_path(fido_dir, comment_type, comment_id).unlink(missing_ok=True)
+
+
+def list_reply_promises(fido_dir: Path) -> list[ReplyPromise]:
+    """Return promises in filesystem timestamp order."""
+    result: list[ReplyPromise] = []
+    promise_dir = _promise_dir(fido_dir)
+    if not promise_dir.exists():
+        return result
+    for path in promise_dir.iterdir():
+        if not path.is_file():
+            continue
+        comment_type, sep, raw_id = path.name.partition("-")
+        if sep != "-" or comment_type not in {"issues", "pulls"}:
+            continue
+        try:
+            comment_id = int(raw_id)
+        except ValueError:
+            continue
+        result.append(
+            ReplyPromise(
+                comment_type=comment_type,
+                comment_id=comment_id,
+                path=path,
+            )
+        )
+    result.sort(key=lambda item: item.path.stat().st_mtime_ns)
+    return result

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -469,6 +469,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             handled = False
 
             if action.reply_to:
+                promise = self._reply_promise(action)
                 cid = action.reply_to.get("comment_id")
                 if cid and cid in _replied_comments:
                     log.info("already replied to comment %s — skipping", cid)
@@ -480,7 +481,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
                             action, self.config, repo_cfg, gh
                         )
                     except Exception:
-                        promise = self._reply_promise(action)
                         if promise is not None:
                             reply_promises.add_reply_promise(
                                 repo_cfg.work_dir / ".git" / "fido",
@@ -488,6 +488,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
                                 promise[1],
                             )
                         raise
+                    if promise is not None:
+                        reply_promises.remove_reply_promise(
+                            repo_cfg.work_dir / ".git" / "fido",
+                            promise[0],
+                            promise[1],
+                        )
                     if cid:
                         _replied_comments.add(cid)
                     handled = True
@@ -513,19 +519,32 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
             # Top-level PR comments (issue_comment) — no reply_to, but has comment_body
             if not handled and action.comment_body:
-                try:
-                    category, titles = type(self)._fn_reply_to_issue_comment(
-                        action, self.config, repo_cfg, gh
-                    )
-                except Exception:
-                    promise = self._reply_promise(action)
+                promise = self._reply_promise(action)
+                cid = action.thread.get("comment_id") if action.thread else None
+                if cid and cid in _replied_comments:
+                    log.info("already replied to comment %s — skipping", cid)
+                    category, titles = None, []
+                else:
+                    try:
+                        category, titles = type(self)._fn_reply_to_issue_comment(
+                            action, self.config, repo_cfg, gh
+                        )
+                    except Exception:
+                        if promise is not None:
+                            reply_promises.add_reply_promise(
+                                repo_cfg.work_dir / ".git" / "fido",
+                                promise[0],
+                                promise[1],
+                            )
+                        raise
                     if promise is not None:
-                        reply_promises.add_reply_promise(
+                        reply_promises.remove_reply_promise(
                             repo_cfg.work_dir / ".git" / "fido",
                             promise[0],
                             promise[1],
                         )
-                    raise
+                    if cid:
+                        _replied_comments.add(cid)
                 handled = True
                 # DEFER files a GitHub issue — no tasks.json entry.
                 if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -451,10 +451,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
         thread = action.reply_to or action.thread
         if not thread:
             return None
-        comment_type = thread.get("comment_type")
-        comment_id = thread.get("comment_id")
-        if comment_type not in {"issues", "pulls"} or not isinstance(comment_id, int):
-            return None
+        comment_type = thread["comment_type"]
+        comment_id = thread["comment_id"]
+        if comment_type not in {"issues", "pulls"}:
+            raise ValueError(f"invalid reply promise comment type: {comment_type!r}")
+        if not isinstance(comment_id, int):
+            raise TypeError(f"invalid reply promise comment id: {comment_id!r}")
         return comment_type, comment_id
 
     def _process_action_inner(self, action: Action, repo_cfg: RepoConfig) -> None:
@@ -488,7 +490,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
                                 promise[1],
                             )
                         raise
-                    if promise is not None:
+                    if promise is not None and reply_promises.has_reply_promise(
+                        repo_cfg.work_dir / ".git" / "fido",
+                        promise[0],
+                        promise[1],
+                    ):
                         reply_promises.remove_reply_promise(
                             repo_cfg.work_dir / ".git" / "fido",
                             promise[0],
@@ -537,7 +543,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
                                 promise[1],
                             )
                         raise
-                    if promise is not None:
+                    if promise is not None and reply_promises.has_reply_promise(
+                        repo_cfg.work_dir / ".git" / "fido",
+                        promise[0],
+                        promise[1],
+                    ):
                         reply_promises.remove_reply_promise(
                             repo_cfg.work_dir / ".git" / "fido",
                             promise[0],

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
 
-from kennel import claude
+from kennel import claude, reply_promises
 from kennel.claude import kill_active_children
 from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.events import (
@@ -446,6 +446,17 @@ class WebhookHandler(BaseHTTPRequestHandler):
             return "triaging PR comment"
         return "handling webhook action"
 
+    def _reply_promise(self, action: Action) -> tuple[str, int] | None:
+        """Return the durable reply-promise key for reply-capable webhook actions."""
+        thread = action.reply_to or action.thread
+        if not thread:
+            return None
+        comment_type = thread.get("comment_type")
+        comment_id = thread.get("comment_id")
+        if comment_type not in {"issues", "pulls"} or not isinstance(comment_id, int):
+            return None
+        return comment_type, comment_id
+
     def _process_action_inner(self, action: Action, repo_cfg: RepoConfig) -> None:
         # The worker thread's own ``worker_what`` is not touched here — this
         # handler runs on a separate webhook thread and its activity is
@@ -464,9 +475,19 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     handled = True
                     category, titles = None, []
                 else:
-                    category, titles = type(self)._fn_reply_to_comment(
-                        action, self.config, repo_cfg, gh
-                    )
+                    try:
+                        category, titles = type(self)._fn_reply_to_comment(
+                            action, self.config, repo_cfg, gh
+                        )
+                    except Exception:
+                        promise = self._reply_promise(action)
+                        if promise is not None:
+                            reply_promises.add_reply_promise(
+                                repo_cfg.work_dir / ".git" / "fido",
+                                promise[0],
+                                promise[1],
+                            )
+                        raise
                     if cid:
                         _replied_comments.add(cid)
                     handled = True
@@ -492,9 +513,19 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
             # Top-level PR comments (issue_comment) — no reply_to, but has comment_body
             if not handled and action.comment_body:
-                category, titles = type(self)._fn_reply_to_issue_comment(
-                    action, self.config, repo_cfg, gh
-                )
+                try:
+                    category, titles = type(self)._fn_reply_to_issue_comment(
+                        action, self.config, repo_cfg, gh
+                    )
+                except Exception:
+                    promise = self._reply_promise(action)
+                    if promise is not None:
+                        reply_promises.add_reply_promise(
+                            repo_cfg.work_dir / ".git" / "fido",
+                            promise[0],
+                            promise[1],
+                        )
+                    raise
                 handled = True
                 # DEFER files a GitHub issue — no tasks.json entry.
                 if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -18,7 +18,7 @@ from typing import IO, Any, Protocol
 
 from kennel import claude, hooks, tasks
 from kennel.claude import ClaudeClient
-from kennel.config import RepoMembership
+from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.github import GitHub
 from kennel.prompts import Prompts
 from kennel.state import (
@@ -1961,6 +1961,30 @@ class Worker:
                 pr_number, slug = self.find_or_create_pr(
                     ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
                 )
+                recovery_repo_cfg = RepoConfig(
+                    name=repo_ctx.repo,
+                    work_dir=self.work_dir,
+                    membership=repo_ctx.membership,
+                )
+                recovery_config = Config(
+                    port=0,
+                    secret=b"",
+                    repos={repo_ctx.repo: recovery_repo_cfg},
+                    allowed_bots=frozenset(),
+                    log_level="WARNING",
+                    sub_dir=_sub_dir(),
+                )
+                from kennel.events import recover_reply_promises
+
+                recovered_promises = recover_reply_promises(
+                    ctx.fido_dir,
+                    recovery_config,
+                    recovery_repo_cfg,
+                    self.gh,
+                    pr_number,
+                    claude_client=self._claude_client,
+                    prompts=self._get_prompts(),
+                )
                 self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
                 if session_fresh and self._session is not None:
                     self._session.switch_model("claude-sonnet-4-6")
@@ -1972,8 +1996,11 @@ class Worker:
                 if self.execute_task(ctx.fido_dir, repo_ctx, pr_number, slug):
                     self.resolve_addressed_threads(repo_ctx, pr_number)
                     return 1
-                return self.handle_promote_merge(
+                promote_result = self.handle_promote_merge(
                     ctx.fido_dir, repo_ctx, pr_number, slug, issue
+                )
+                return (
+                    1 if recovered_promises and promote_result == 0 else promote_result
                 )
             finally:
                 self.teardown_hooks(ctx.fido_dir, compact_cmd, sync_cmd)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -11,6 +11,7 @@ from kennel.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
     ClaudeClient,
+    ClaudeProviderError,
     ClaudeSession,
     ClaudeStreamError,
     _active_children,
@@ -21,6 +22,7 @@ from kennel.claude import (
     extract_result_text,
     extract_session_id,
     kill_active_children,
+    raise_for_provider_error_output,
 )
 
 
@@ -1396,7 +1398,29 @@ class TestClaudeSessionConsumeUntilResult:
         lines = [_json.dumps({"type": "error", "error": "something broke"}) + "\n"]
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
-        assert session.consume_until_result() == ""
+        with patch.object(session, "restart") as mock_restart:
+            with pytest.raises(ClaudeProviderError, match="something broke"):
+                session.consume_until_result()
+        mock_restart.assert_called_once_with()
+
+    def test_raises_on_provider_error_result(self, tmp_path: Path) -> None:
+        import json as _json
+
+        lines = [
+            _json.dumps(
+                {
+                    "type": "result",
+                    "result": 'API Error: 500 {"type":"error","message":"Internal server error"}',
+                }
+            )
+            + "\n"
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        with patch.object(session, "restart") as mock_restart:
+            with pytest.raises(ClaudeProviderError, match="500"):
+                session.consume_until_result()
+        mock_restart.assert_called_once_with()
 
     def test_returns_empty_when_result_field_not_a_string(self, tmp_path: Path) -> None:
         import json as _json
@@ -2153,6 +2177,58 @@ class TestClaudeClientPrintPromptFromFile:
         client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6", cwd="/some/dir")
         assert mock_stream.call_args[1]["cwd"] == "/some/dir"
 
+    def test_raises_on_provider_error_output(self, tmp_path: Path) -> None:
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(
+            return_value=iter(
+                ['API Error: 500 {"type":"error","message":"Internal server error"}']
+            )
+        )
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeProviderError, match="500"):
+            client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
+
+
+class TestRaiseForProviderErrorOutput:
+    def test_parses_plain_text_api_error(self) -> None:
+        with pytest.raises(ClaudeProviderError) as exc_info:
+            raise_for_provider_error_output("API Error: 500 upstream unavailable")
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.request_id is None
+        assert exc_info.value.payload == {}
+        assert "upstream unavailable" in str(exc_info.value)
+
+    def test_parses_result_event_with_json_payload(self) -> None:
+        import json as _json
+
+        output = "\n" + _json.dumps(
+            {
+                "type": "result",
+                "result": 'API Error: 500 {"error":{"message":"Internal server error"},"request_id":"req_123"}',
+            }
+        )
+        with pytest.raises(ClaudeProviderError) as exc_info:
+            raise_for_provider_error_output(output)
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.request_id == "req_123"
+        assert exc_info.value.payload == {
+            "error": {"message": "Internal server error"},
+            "request_id": "req_123",
+        }
+        assert "Internal server error" in str(exc_info.value)
+
+    def test_parses_error_event_dict(self) -> None:
+        import json as _json
+
+        output = _json.dumps(
+            {"type": "error", "error": {"message": "boom"}, "request_id": "req_9"}
+        )
+        with pytest.raises(ClaudeProviderError) as exc_info:
+            raise_for_provider_error_output(output)
+        assert exc_info.value.request_id == "req_9"
+        assert exc_info.value.payload["type"] == "error"
+        assert "boom" in str(exc_info.value)
+
 
 class TestClaudeClientResumeSession:
     def test_returns_stdout_on_success(self, tmp_path: Path) -> None:
@@ -2183,6 +2259,18 @@ class TestClaudeClientResumeSession:
         assert "--resume" in cmd
         assert "sess-123" in cmd
         assert "--print" in cmd
+
+    def test_raises_on_provider_error_output(self, tmp_path: Path) -> None:
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(
+            return_value=iter(
+                ['API Error: 500 {"type":"error","message":"Internal server error"}']
+            )
+        )
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeProviderError, match="500"):
+            client.resume_session("sess-123", prompt_file, "claude-sonnet-4-6")
 
     def test_passes_idle_timeout(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -310,6 +310,42 @@ class TestRecoverReplyPromises:
         mock_create_task.assert_not_called()
         assert not (fido_dir / "reply-promises" / "issues-302").exists()
 
+    def test_issue_recovery_clears_promise_before_task_creation(
+        self, tmp_path: Path
+    ) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        promise_path = add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "please fix",
+            "html_url": "https://github.com/owner/repo/pull/7#issuecomment-302",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/7",
+            "user": {"login": "owner"},
+        }
+
+        def fail_after_reply(*args, **kwargs):
+            assert not promise_path.exists()
+            raise RuntimeError("task add failed")
+
+        with (
+            patch(
+                "kennel.events.reply_to_issue_comment",
+                return_value=("ACT", ["task one"]),
+            ),
+            patch("kennel.events.create_task", side_effect=fail_after_reply),
+        ):
+            with pytest.raises(RuntimeError, match="task add failed"):
+                recover_reply_promises(
+                    fido_dir,
+                    _config(tmp_path),
+                    _repo_cfg(tmp_path),
+                    gh,
+                    7,
+                )
+        assert not promise_path.exists()
+
     def test_coalesces_review_comment_promises_in_same_thread(
         self, tmp_path: Path
     ) -> None:
@@ -368,6 +404,63 @@ class TestRecoverReplyPromises:
         assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
         assert mock_create_task.call_count == 2
         assert not any((fido_dir / "reply-promises").iterdir())
+
+    def test_review_recovery_clears_group_promises_before_task_creation(
+        self, tmp_path: Path
+    ) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        first = add_reply_promise(fido_dir, "pulls", 101)
+        second = add_reply_promise(fido_dir, "pulls", 102)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+
+        def get_pull_comment(_repo: str, comment_id: int) -> dict[str, object]:
+            comments = {
+                101: {
+                    "id": 101,
+                    "body": "first",
+                    "path": "foo.py",
+                    "line": 1,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r101",
+                    "user": {"login": "owner"},
+                },
+                102: {
+                    "id": 102,
+                    "body": "second",
+                    "path": "foo.py",
+                    "line": 2,
+                    "diff_hunk": "@@ @@",
+                    "in_reply_to_id": 101,
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r102",
+                    "user": {"login": "owner"},
+                },
+            }
+            return comments[comment_id]
+
+        gh.get_pull_comment.side_effect = get_pull_comment
+
+        def fail_after_reply(*args, **kwargs):
+            assert not first.exists()
+            assert not second.exists()
+            raise RuntimeError("task add failed")
+
+        with (
+            patch("kennel.events.reply_to_comment", return_value=("DO", ["task a"])),
+            patch("kennel.events.create_task", side_effect=fail_after_reply),
+        ):
+            with pytest.raises(RuntimeError, match="task add failed"):
+                recover_reply_promises(
+                    fido_dir,
+                    _config(tmp_path),
+                    _repo_cfg(tmp_path),
+                    gh,
+                    7,
+                )
+        assert not first.exists()
+        assert not second.exists()
 
     def test_recovery_skips_handled_and_invalid_candidates_in_later_groups(
         self, tmp_path: Path

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -234,7 +234,7 @@ class TestRecoverReplyPromises:
         )
         assert (fido_dir / "reply-promises" / "issues-302").exists()
 
-    def test_issue_comment_without_pr_url_is_ignored(self, tmp_path: Path) -> None:
+    def test_issue_comment_without_pr_url_raises(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / ".git" / "fido"
         add_reply_promise(fido_dir, "issues", 302)
         gh = MagicMock()
@@ -246,8 +246,11 @@ class TestRecoverReplyPromises:
             "html_url": "https://github.com/owner/repo/pull/7#issuecomment-302",
             "user": {"login": "owner"},
         }
-        with patch("kennel.events.reply_to_issue_comment") as mock_reply:
-            assert not recover_reply_promises(
+        with (
+            pytest.raises(ValueError, match="invalid GitHub API URL"),
+            patch("kennel.events.reply_to_issue_comment") as mock_reply,
+        ):
+            recover_reply_promises(
                 fido_dir,
                 _config(tmp_path),
                 _repo_cfg(tmp_path),
@@ -257,7 +260,7 @@ class TestRecoverReplyPromises:
         mock_reply.assert_not_called()
         assert (fido_dir / "reply-promises" / "issues-302").exists()
 
-    def test_pull_comment_without_pr_url_is_ignored(self, tmp_path: Path) -> None:
+    def test_pull_comment_without_pr_url_raises(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / ".git" / "fido"
         add_reply_promise(fido_dir, "pulls", 205)
         gh = MagicMock()
@@ -269,8 +272,11 @@ class TestRecoverReplyPromises:
             "html_url": "https://github.com/owner/repo/pull/7#discussion_r205",
             "user": {"login": "owner"},
         }
-        with patch("kennel.events.reply_to_comment") as mock_reply:
-            assert not recover_reply_promises(
+        with (
+            pytest.raises(ValueError, match="invalid GitHub API URL"),
+            patch("kennel.events.reply_to_comment") as mock_reply,
+        ):
+            recover_reply_promises(
                 fido_dir,
                 _config(tmp_path),
                 _repo_cfg(tmp_path),
@@ -462,7 +468,7 @@ class TestRecoverReplyPromises:
         assert not first.exists()
         assert not second.exists()
 
-    def test_recovery_skips_handled_and_invalid_candidates_in_later_groups(
+    def test_recovery_raises_on_invalid_candidate_in_later_group(
         self, tmp_path: Path
     ) -> None:
         fido_dir = tmp_path / ".git" / "fido"
@@ -526,6 +532,71 @@ class TestRecoverReplyPromises:
             ) as mock_reply,
             patch("kennel.events.create_task") as mock_create_task,
         ):
+            with pytest.raises(ValueError, match="invalid GitHub API URL"):
+                recover_reply_promises(
+                    fido_dir,
+                    _config(tmp_path),
+                    _repo_cfg(tmp_path),
+                    gh,
+                    7,
+                )
+        assert mock_reply.call_count == 0
+        mock_create_task.assert_not_called()
+        assert (fido_dir / "reply-promises" / "pulls-101").exists()
+        assert (fido_dir / "reply-promises" / "pulls-102").exists()
+        assert (fido_dir / "reply-promises" / "pulls-201").exists()
+        assert (fido_dir / "reply-promises" / "pulls-999").exists()
+
+    def test_recovery_skips_handled_candidates_when_processing_later_groups(
+        self, tmp_path: Path
+    ) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "pulls", 101)
+        add_reply_promise(fido_dir, "pulls", 102)
+        add_reply_promise(fido_dir, "pulls", 201)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+
+        def get_pull_comment(_repo: str, comment_id: int) -> dict[str, object]:
+            comments = {
+                101: {
+                    "id": 101,
+                    "body": "first",
+                    "path": "foo.py",
+                    "line": 1,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r101",
+                    "user": {"login": "owner"},
+                },
+                102: {
+                    "id": 102,
+                    "body": "second",
+                    "path": "foo.py",
+                    "line": 2,
+                    "diff_hunk": "@@ @@",
+                    "in_reply_to_id": 101,
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r102",
+                    "user": {"login": "owner"},
+                },
+                201: {
+                    "id": 201,
+                    "body": "third",
+                    "path": "bar.py",
+                    "line": 3,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r201",
+                    "user": {"login": "owner"},
+                },
+            }
+            return comments[comment_id]
+
+        gh.get_pull_comment.side_effect = get_pull_comment
+        with patch(
+            "kennel.events.reply_to_comment", return_value=("ANSWER", [])
+        ) as mock_reply:
             result = recover_reply_promises(
                 fido_dir,
                 _config(tmp_path),
@@ -535,8 +606,7 @@ class TestRecoverReplyPromises:
             )
         assert result is True
         assert mock_reply.call_count == 2
-        mock_create_task.assert_not_called()
-        assert (fido_dir / "reply-promises" / "pulls-999").exists()
+        assert not any((fido_dir / "reply-promises").iterdir())
 
 
 class TestIsAllowed:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -24,10 +24,12 @@ from kennel.events import (
     launch_worker,
     maybe_react,
     needs_more_context,
+    recover_reply_promises,
     reply_to_comment,
     reply_to_issue_comment,
     reply_to_review,
 )
+from kennel.reply_promises import add_reply_promise
 
 
 def _config(tmp_path: Path) -> Config:
@@ -109,6 +111,339 @@ class TestNeedsMoreContext:
             result = needs_more_context("some comment")
         MockCls.assert_called_once_with()
         assert result is False
+
+
+class TestRecoverReplyPromises:
+    def test_returns_false_when_no_promises(self, tmp_path: Path) -> None:
+        assert not recover_reply_promises(
+            tmp_path / ".git" / "fido",
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            MagicMock(),
+            7,
+        )
+
+    def test_recovers_issue_comment_promise(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "please fix",
+            "html_url": "https://github.com/owner/repo/pull/7#issuecomment-302",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/7",
+            "user": {"login": "owner"},
+        }
+        with (
+            patch(
+                "kennel.events.reply_to_issue_comment",
+                return_value=("ACT", ["task one"]),
+            ),
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            result = recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        assert result is True
+        assert not (fido_dir / "reply-promises" / "issues-302").exists()
+        mock_create_task.assert_called_once()
+        assert mock_create_task.call_args.args[0] == "task one"
+        assert mock_create_task.call_args.kwargs["thread"] == {
+            "repo": "owner/repo",
+            "pr": 7,
+            "comment_id": 302,
+            "url": "https://github.com/owner/repo/pull/7#issuecomment-302",
+            "author": "owner",
+            "comment_type": "issues",
+        }
+
+    def test_deleted_comment_promise_is_removed(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "pulls", 205)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_pull_comment.return_value = None
+        assert not recover_reply_promises(
+            fido_dir,
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            7,
+        )
+        assert not (fido_dir / "reply-promises" / "pulls-205").exists()
+
+    def test_deleted_issue_comment_promise_is_removed(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = None
+        assert not recover_reply_promises(
+            fido_dir,
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            7,
+        )
+        assert not (fido_dir / "reply-promises" / "issues-302").exists()
+
+    def test_other_pr_promise_is_left_for_later(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "pulls", 205)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_pull_comment.return_value = {
+            "id": 205,
+            "body": "please fix",
+            "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/8",
+            "html_url": "https://github.com/owner/repo/pull/8#discussion_r205",
+            "user": {"login": "owner"},
+        }
+        assert not recover_reply_promises(
+            fido_dir,
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            7,
+        )
+        assert (fido_dir / "reply-promises" / "pulls-205").exists()
+
+    def test_other_pr_issue_promise_is_left_for_later(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "please fix",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/8",
+            "html_url": "https://github.com/owner/repo/pull/8#issuecomment-302",
+            "user": {"login": "owner"},
+        }
+        assert not recover_reply_promises(
+            fido_dir,
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            7,
+        )
+        assert (fido_dir / "reply-promises" / "issues-302").exists()
+
+    def test_issue_comment_without_pr_url_is_ignored(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "please fix",
+            "issue_url": "https://api.github.com/repos/owner/repo/not-an-issue",
+            "html_url": "https://github.com/owner/repo/pull/7#issuecomment-302",
+            "user": {"login": "owner"},
+        }
+        with patch("kennel.events.reply_to_issue_comment") as mock_reply:
+            assert not recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        mock_reply.assert_not_called()
+        assert (fido_dir / "reply-promises" / "issues-302").exists()
+
+    def test_pull_comment_without_pr_url_is_ignored(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "pulls", 205)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_pull_comment.return_value = {
+            "id": 205,
+            "body": "please fix",
+            "pull_request_url": "https://api.github.com/repos/owner/repo/not-a-pr",
+            "html_url": "https://github.com/owner/repo/pull/7#discussion_r205",
+            "user": {"login": "owner"},
+        }
+        with patch("kennel.events.reply_to_comment") as mock_reply:
+            assert not recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        mock_reply.assert_not_called()
+        assert (fido_dir / "reply-promises" / "pulls-205").exists()
+
+    def test_defer_recovery_skips_task_creation(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "issues", 302)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "please fix",
+            "html_url": "https://github.com/owner/repo/pull/7#issuecomment-302",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/7",
+            "user": {"login": "owner"},
+        }
+        with (
+            patch(
+                "kennel.events.reply_to_issue_comment",
+                return_value=("DEFER", ["later"]),
+            ),
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            result = recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        assert result is True
+        mock_create_task.assert_not_called()
+        assert not (fido_dir / "reply-promises" / "issues-302").exists()
+
+    def test_coalesces_review_comment_promises_in_same_thread(
+        self, tmp_path: Path
+    ) -> None:
+        import os
+
+        fido_dir = tmp_path / ".git" / "fido"
+        first = add_reply_promise(fido_dir, "pulls", 101)
+        second = add_reply_promise(fido_dir, "pulls", 102)
+        os.utime(first, ns=(1, 1))
+        os.utime(second, ns=(2, 2))
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+
+        def get_pull_comment(_repo: str, comment_id: int) -> dict[str, object]:
+            comments = {
+                101: {
+                    "id": 101,
+                    "body": "first",
+                    "path": "foo.py",
+                    "line": 1,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r101",
+                    "user": {"login": "owner"},
+                },
+                102: {
+                    "id": 102,
+                    "body": "second",
+                    "path": "foo.py",
+                    "line": 2,
+                    "diff_hunk": "@@ @@",
+                    "in_reply_to_id": 101,
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r102",
+                    "user": {"login": "owner"},
+                },
+            }
+            return comments[comment_id]
+
+        gh.get_pull_comment.side_effect = get_pull_comment
+        with (
+            patch(
+                "kennel.events.reply_to_comment",
+                return_value=("DO", ["task a", "task b"]),
+            ) as mock_reply,
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            result = recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        assert result is True
+        assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
+        assert mock_create_task.call_count == 2
+        assert not any((fido_dir / "reply-promises").iterdir())
+
+    def test_recovery_skips_handled_and_invalid_candidates_in_later_groups(
+        self, tmp_path: Path
+    ) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        add_reply_promise(fido_dir, "pulls", 101)
+        add_reply_promise(fido_dir, "pulls", 102)
+        add_reply_promise(fido_dir, "pulls", 201)
+        add_reply_promise(fido_dir, "pulls", 999)
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+
+        def get_pull_comment(_repo: str, comment_id: int) -> dict[str, object]:
+            comments = {
+                101: {
+                    "id": 101,
+                    "body": "first",
+                    "path": "foo.py",
+                    "line": 1,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r101",
+                    "user": {"login": "owner"},
+                },
+                102: {
+                    "id": 102,
+                    "body": "second",
+                    "path": "foo.py",
+                    "line": 2,
+                    "diff_hunk": "@@ @@",
+                    "in_reply_to_id": 101,
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r102",
+                    "user": {"login": "owner"},
+                },
+                201: {
+                    "id": 201,
+                    "body": "third",
+                    "path": "bar.py",
+                    "line": 3,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/7",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r201",
+                    "user": {"login": "owner"},
+                },
+                999: {
+                    "id": 999,
+                    "body": "ignored",
+                    "path": "zap.py",
+                    "line": 9,
+                    "diff_hunk": "@@ @@",
+                    "pull_request_url": "https://api.github.com/repos/owner/repo/not-a-pr",
+                    "html_url": "https://github.com/owner/repo/pull/7#discussion_r999",
+                    "user": {"login": "owner"},
+                },
+            }
+            return comments[comment_id]
+
+        gh.get_pull_comment.side_effect = get_pull_comment
+        with (
+            patch(
+                "kennel.events.reply_to_comment", return_value=("ANSWER", [])
+            ) as mock_reply,
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            result = recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+            )
+        assert result is True
+        assert mock_reply.call_count == 2
+        mock_create_task.assert_not_called()
+        assert (fido_dir / "reply-promises" / "pulls-999").exists()
 
 
 class TestIsAllowed:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -273,6 +273,35 @@ class TestGitHubClass:
         url = mock_s.get.call_args.args[0]
         assert "repos/o/r/pulls/7/comments" in url
 
+    def test_get_pull_comment(self) -> None:
+        gh, mock_s = self._gh()
+        comment = {"id": 10, "body": "hi"}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = comment
+        mock_s.get.return_value = mock_resp
+        assert gh.get_pull_comment("o/r", 10) == comment
+
+    def test_get_pull_comment_returns_none_on_404(self) -> None:
+        import requests
+
+        gh, mock_s = self._gh()
+        response = MagicMock(status_code=404)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_s.get.return_value = mock_resp
+        assert gh.get_pull_comment("o/r", 10) is None
+
+    def test_get_pull_comment_reraises_non_404(self) -> None:
+        import requests
+
+        gh, mock_s = self._gh()
+        response = MagicMock(status_code=500)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_s.get.return_value = mock_resp
+        with pytest.raises(requests.HTTPError):
+            gh.get_pull_comment("o/r", 10)
+
     def test_get_review_comments(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()
@@ -1093,6 +1122,35 @@ class TestGitHubClass:
         url = mock_s.get.call_args.args[0]
         assert "repos/o/r/issues/9/comments" in url
         assert result == comments
+
+    def test_get_issue_comment(self) -> None:
+        gh, mock_s = self._gh()
+        comment = {"id": 9, "body": "hi"}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = comment
+        mock_s.get.return_value = mock_resp
+        assert gh.get_issue_comment("o/r", 9) == comment
+
+    def test_get_issue_comment_returns_none_on_404(self) -> None:
+        import requests
+
+        gh, mock_s = self._gh()
+        response = MagicMock(status_code=404)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_s.get.return_value = mock_resp
+        assert gh.get_issue_comment("o/r", 9) is None
+
+    def test_get_issue_comment_reraises_non_404(self) -> None:
+        import requests
+
+        gh, mock_s = self._gh()
+        response = MagicMock(status_code=500)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.HTTPError(response=response)
+        mock_s.get.return_value = mock_resp
+        with pytest.raises(requests.HTTPError):
+            gh.get_issue_comment("o/r", 9)
 
     def test_get_issue_events(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_reply_promises.py
+++ b/tests/test_reply_promises.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from kennel.reply_promises import (
     ReplyPromise,
     add_reply_promise,
@@ -37,12 +39,15 @@ def test_remove_reply_promise_deletes_file(tmp_path: Path) -> None:
     assert not path.exists()
 
 
-def test_remove_reply_promise_missing_file_is_noop(tmp_path: Path) -> None:
-    remove_reply_promise(tmp_path / "fido", "pulls", 999)
+def test_remove_reply_promise_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        remove_reply_promise(tmp_path / "fido", "pulls", 999)
 
 
 def test_list_reply_promises_returns_empty_when_dir_missing(tmp_path: Path) -> None:
-    assert list_reply_promises(tmp_path / "fido") == []
+    fido_dir = tmp_path / "fido"
+    assert list_reply_promises(fido_dir) == []
+    assert (fido_dir / "reply-promises").is_dir()
 
 
 def test_list_reply_promises_sorts_by_mtime(tmp_path: Path) -> None:
@@ -57,15 +62,47 @@ def test_list_reply_promises_sorts_by_mtime(tmp_path: Path) -> None:
     ]
 
 
-def test_list_reply_promises_ignores_non_files_and_bad_names(tmp_path: Path) -> None:
+def test_list_reply_promises_raises_on_directory_entry(tmp_path: Path) -> None:
     fido_dir = tmp_path / "fido"
     promise_dir = fido_dir / "reply-promises"
     promise_dir.mkdir(parents=True)
-    (promise_dir / "pulls-42").touch()
-    (promise_dir / "junk").touch()
-    (promise_dir / "pulls-nope").touch()
-    (promise_dir / "comments-7").touch()
     (promise_dir / "subdir").mkdir()
-    assert list_reply_promises(fido_dir) == [
-        ReplyPromise(comment_type="pulls", comment_id=42, path=promise_dir / "pulls-42")
-    ]
+    with pytest.raises(IsADirectoryError):
+        list_reply_promises(fido_dir)
+
+
+def test_list_reply_promises_raises_on_bad_filename(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    promise_dir = fido_dir / "reply-promises"
+    promise_dir.mkdir(parents=True)
+    (promise_dir / "junk").touch()
+    with pytest.raises(ValueError, match="invalid reply promise filename"):
+        list_reply_promises(fido_dir)
+
+
+def test_list_reply_promises_raises_on_bad_comment_type(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    promise_dir = fido_dir / "reply-promises"
+    promise_dir.mkdir(parents=True)
+    (promise_dir / "comments-7").touch()
+    with pytest.raises(ValueError, match="invalid reply promise comment type"):
+        list_reply_promises(fido_dir)
+
+
+def test_list_reply_promises_raises_on_bad_comment_id(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    promise_dir = fido_dir / "reply-promises"
+    promise_dir.mkdir(parents=True)
+    (promise_dir / "pulls-nope").touch()
+    with pytest.raises(ValueError, match="invalid reply promise filename"):
+        list_reply_promises(fido_dir)
+
+
+def test_add_reply_promise_raises_on_bad_comment_type(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid reply promise comment type"):
+        add_reply_promise(tmp_path / "fido", "comments", 7)
+
+
+def test_remove_reply_promise_raises_on_bad_comment_type(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid reply promise comment type"):
+        remove_reply_promise(tmp_path / "fido", "comments", 7)

--- a/tests/test_reply_promises.py
+++ b/tests/test_reply_promises.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from kennel.reply_promises import (
+    ReplyPromise,
+    add_reply_promise,
+    list_reply_promises,
+    remove_reply_promise,
+)
+
+
+def test_add_reply_promise_creates_empty_file(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    path = add_reply_promise(fido_dir, "pulls", 123)
+    assert path == fido_dir / "reply-promises" / "pulls-123"
+    assert path.exists()
+    assert path.read_text() == ""
+
+
+def test_add_reply_promise_is_idempotent(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    first = add_reply_promise(fido_dir, "issues", 55)
+    first.write_text("")
+    second = add_reply_promise(fido_dir, "issues", 55)
+    assert first == second
+    assert list_reply_promises(fido_dir) == [
+        ReplyPromise(comment_type="issues", comment_id=55, path=first)
+    ]
+
+
+def test_remove_reply_promise_deletes_file(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    path = add_reply_promise(fido_dir, "pulls", 321)
+    remove_reply_promise(fido_dir, "pulls", 321)
+    assert not path.exists()
+
+
+def test_remove_reply_promise_missing_file_is_noop(tmp_path: Path) -> None:
+    remove_reply_promise(tmp_path / "fido", "pulls", 999)
+
+
+def test_list_reply_promises_returns_empty_when_dir_missing(tmp_path: Path) -> None:
+    assert list_reply_promises(tmp_path / "fido") == []
+
+
+def test_list_reply_promises_sorts_by_mtime(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    first = add_reply_promise(fido_dir, "pulls", 1)
+    second = add_reply_promise(fido_dir, "issues", 2)
+    os.utime(first, ns=(1, 1))
+    os.utime(second, ns=(2, 2))
+    assert list_reply_promises(fido_dir) == [
+        ReplyPromise(comment_type="pulls", comment_id=1, path=first),
+        ReplyPromise(comment_type="issues", comment_id=2, path=second),
+    ]
+
+
+def test_list_reply_promises_ignores_non_files_and_bad_names(tmp_path: Path) -> None:
+    fido_dir = tmp_path / "fido"
+    promise_dir = fido_dir / "reply-promises"
+    promise_dir.mkdir(parents=True)
+    (promise_dir / "pulls-42").touch()
+    (promise_dir / "junk").touch()
+    (promise_dir / "pulls-nope").touch()
+    (promise_dir / "comments-7").touch()
+    (promise_dir / "subdir").mkdir()
+    assert list_reply_promises(fido_dir) == [
+        ReplyPromise(comment_type="pulls", comment_id=42, path=promise_dir / "pulls-42")
+    ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -555,6 +555,67 @@ class TestProcessAction:
             / "pulls-205"
         ).exists()
 
+    def test_successful_redelivery_clears_stale_review_promise(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        import kennel.server as ks
+
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 206,
+                "body": "please add logging",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "foo.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 5, "title": "My PR", "body": ""},
+        }
+        mock_task = MagicMock()
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=[RuntimeError("network down"), ("DO", ["from redelivery"])]
+        )
+        WebhookHandler._fn_create_task = mock_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler.gh = MagicMock()
+        try:
+            assert (
+                _post_webhook(url, cfg, "pull_request_review_comment", payload) == 200
+            )
+            promise = (
+                cfg.repos["owner/repo"].work_dir
+                / ".git"
+                / "fido"
+                / "reply-promises"
+                / "pulls-206"
+            )
+            assert promise.exists()
+            assert (
+                _post_webhook(url, cfg, "pull_request_review_comment", payload) == 200
+            )
+            assert not promise.exists()
+            mock_task.assert_called_once_with(
+                "from redelivery",
+                cfg,
+                cfg.repos["owner/repo"],
+                WebhookHandler.gh,
+                thread={
+                    "repo": "owner/repo",
+                    "pr": 5,
+                    "comment_id": 206,
+                    "url": "https://example.com",
+                    "author": "owner",
+                    "comment_type": "pulls",
+                },
+                registry=WebhookHandler.registry,
+            )
+        finally:
+            ks._replied_comments.discard(206)
+
     def test_failed_review_comment_webhook_recovers_once_from_live_state(
         self, server: tuple
     ) -> None:
@@ -703,6 +764,41 @@ class TestProcessAction:
         finally:
             ks._replied_comments.discard(203)
 
+    def test_duplicate_issue_comment_delivery_skips_second_reply(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        import kennel.server as ks
+
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 303,
+                "body": "looks good",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/11#issuecomment-303",
+            },
+            "issue": {
+                "number": 11,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        mock_gh = MagicMock()
+        mock_ic = MagicMock(return_value=("ANSWER", ["because"]))
+        WebhookHandler.gh = mock_gh
+        WebhookHandler._fn_reply_to_issue_comment = mock_ic
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+        try:
+            assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+            assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+            mock_ic.assert_called_once()
+        finally:
+            ks._replied_comments.discard(303)
+
     def test_review_comments_handled(self, server: tuple) -> None:
         url, cfg = server
         payload = {
@@ -820,6 +916,68 @@ class TestProcessAction:
             / "reply-promises"
             / "issues-302"
         ).exists()
+
+    def test_successful_redelivery_clears_stale_issue_promise(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        import kennel.server as ks
+
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 304,
+                "body": "please fix",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/13#issuecomment-304",
+            },
+            "issue": {
+                "number": 13,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        mock_task = MagicMock()
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            side_effect=[
+                RuntimeError("network down"),
+                ("ACT", ["from issue redelivery"]),
+            ]
+        )
+        WebhookHandler._fn_create_task = mock_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler.gh = MagicMock()
+        try:
+            assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+            promise = (
+                cfg.repos["owner/repo"].work_dir
+                / ".git"
+                / "fido"
+                / "reply-promises"
+                / "issues-304"
+            )
+            assert promise.exists()
+            assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+            assert not promise.exists()
+            mock_task.assert_called_once_with(
+                "from issue redelivery",
+                cfg,
+                cfg.repos["owner/repo"],
+                WebhookHandler.gh,
+                thread={
+                    "repo": "owner/repo",
+                    "pr": 13,
+                    "comment_id": 304,
+                    "url": "https://github.com/owner/repo/pull/13#issuecomment-304",
+                    "author": "owner",
+                    "comment_type": "issues",
+                },
+                registry=WebhookHandler.registry,
+            )
+        finally:
+            ks._replied_comments.discard(304)
 
     def test_failed_issue_comment_webhook_recovers_once_from_live_state(
         self, server: tuple

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from kennel.config import Config, RepoConfig
-from kennel.events import Action
+from kennel.events import Action, recover_reply_promises
 from kennel.infra import Infra
 from kennel.server import PreflightError, WebhookHandler
 
@@ -555,6 +555,93 @@ class TestProcessAction:
             / "pulls-205"
         ).exists()
 
+    def test_failed_review_comment_webhook_recovers_once_from_live_state(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 205,
+                "body": "please add logging",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "foo.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 5, "title": "My PR", "body": ""},
+        }
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=RuntimeError("network down")
+        )
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler.gh = MagicMock()
+        assert _post_webhook(url, cfg, "pull_request_review_comment", payload) == 200
+        assert _post_webhook(url, cfg, "pull_request_review_comment", payload) == 200
+
+        promise_dir = (
+            cfg.repos["owner/repo"].work_dir / ".git" / "fido" / "reply-promises"
+        )
+        assert sorted(path.name for path in promise_dir.iterdir()) == ["pulls-205"]
+
+        recovery_gh = MagicMock()
+        recovery_gh.view_issue.return_value = {"title": "My PR", "body": "body"}
+        recovery_gh.get_pull_comment.return_value = {
+            "id": 205,
+            "body": "edited after webhook",
+            "path": "foo.py",
+            "line": 2,
+            "diff_hunk": "@@ @@",
+            "pull_request_url": "https://api.github.com/repos/owner/repo/pulls/5",
+            "html_url": "https://github.com/owner/repo/pull/5#discussion_r205",
+            "user": {"login": "owner"},
+        }
+
+        def fake_reply(action, *args, **kwargs):
+            assert action.comment_body == "edited after webhook"
+            return ("DO", ["task from recovery"])
+
+        with (
+            patch(
+                "kennel.events.reply_to_comment", side_effect=fake_reply
+            ) as mock_reply,
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            assert recover_reply_promises(
+                cfg.repos["owner/repo"].work_dir / ".git" / "fido",
+                cfg,
+                cfg.repos["owner/repo"],
+                recovery_gh,
+                5,
+            )
+            assert not recover_reply_promises(
+                cfg.repos["owner/repo"].work_dir / ".git" / "fido",
+                cfg,
+                cfg.repos["owner/repo"],
+                recovery_gh,
+                5,
+            )
+        assert mock_reply.call_count == 1
+        mock_create_task.assert_called_once_with(
+            "task from recovery",
+            cfg,
+            cfg.repos["owner/repo"],
+            recovery_gh,
+            thread={
+                "repo": "owner/repo",
+                "pr": 5,
+                "comment_id": 205,
+                "url": "https://github.com/owner/repo/pull/5#discussion_r205",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            registry=None,
+        )
+        assert list(promise_dir.iterdir()) == []
+
     def test_reply_to_comment_do_creates_task(self, server: tuple) -> None:
         """DO adds to tasks.json."""
         url, cfg = server
@@ -733,6 +820,87 @@ class TestProcessAction:
             / "reply-promises"
             / "issues-302"
         ).exists()
+
+    def test_failed_issue_comment_webhook_recovers_once_from_live_state(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {"id": 302, "body": "please fix", "user": {"login": "owner"}},
+            "issue": {
+                "number": 13,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            side_effect=RuntimeError("network down")
+        )
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler.gh = MagicMock()
+        assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+        assert _post_webhook(url, cfg, "issue_comment", payload) == 200
+
+        promise_dir = (
+            cfg.repos["owner/repo"].work_dir / ".git" / "fido" / "reply-promises"
+        )
+        assert sorted(path.name for path in promise_dir.iterdir()) == ["issues-302"]
+
+        recovery_gh = MagicMock()
+        recovery_gh.view_issue.return_value = {"title": "my pr", "body": "body"}
+        recovery_gh.get_issue_comment.return_value = {
+            "id": 302,
+            "body": "edited top-level comment",
+            "html_url": "https://github.com/owner/repo/pull/13#issuecomment-302",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/13",
+            "user": {"login": "owner"},
+        }
+
+        def fake_reply(action, *args, **kwargs):
+            assert action.comment_body == "edited top-level comment"
+            return ("ACT", ["task from issue recovery"])
+
+        with (
+            patch(
+                "kennel.events.reply_to_issue_comment", side_effect=fake_reply
+            ) as mock_reply,
+            patch("kennel.events.create_task") as mock_create_task,
+        ):
+            assert recover_reply_promises(
+                cfg.repos["owner/repo"].work_dir / ".git" / "fido",
+                cfg,
+                cfg.repos["owner/repo"],
+                recovery_gh,
+                13,
+            )
+            assert not recover_reply_promises(
+                cfg.repos["owner/repo"].work_dir / ".git" / "fido",
+                cfg,
+                cfg.repos["owner/repo"],
+                recovery_gh,
+                13,
+            )
+        assert mock_reply.call_count == 1
+        mock_create_task.assert_called_once_with(
+            "task from issue recovery",
+            cfg,
+            cfg.repos["owner/repo"],
+            recovery_gh,
+            thread={
+                "repo": "owner/repo",
+                "pr": 13,
+                "comment_id": 302,
+                "url": "https://github.com/owner/repo/pull/13#issuecomment-302",
+                "author": "owner",
+                "comment_type": "issues",
+            },
+            registry=None,
+        )
+        assert list(promise_dir.iterdir()) == []
 
     def test_process_action_does_not_overwrite_worker_what(self, server: tuple) -> None:
         """_process_action must not call report_activity — the webhook runs on

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -410,10 +410,17 @@ class TestReplyPromiseKey:
         handler = object.__new__(WebhookHandler)
         assert handler._reply_promise(Action(prompt="x")) is None
 
-    def test_returns_none_for_invalid_thread_data(self) -> None:
+    def test_raises_for_invalid_thread_data(self) -> None:
         handler = object.__new__(WebhookHandler)
         action = Action(prompt="x", thread={"comment_type": "wat", "comment_id": "5"})
-        assert handler._reply_promise(action) is None
+        with pytest.raises(ValueError, match="invalid reply promise comment type"):
+            handler._reply_promise(action)
+
+    def test_raises_for_non_integer_comment_id(self) -> None:
+        handler = object.__new__(WebhookHandler)
+        action = Action(prompt="x", thread={"comment_type": "pulls", "comment_id": "5"})
+        with pytest.raises(TypeError, match="invalid reply promise comment id"):
+            handler._reply_promise(action)
 
 
 class TestProcessAction:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from kennel.config import Config, RepoConfig
+from kennel.events import Action
 from kennel.infra import Infra
 from kennel.server import PreflightError, WebhookHandler
 
@@ -404,6 +405,17 @@ def _post_webhook(url: str, cfg: Config, event: str, payload: dict) -> int:
     return resp.status
 
 
+class TestReplyPromiseKey:
+    def test_returns_none_without_replyable_thread(self) -> None:
+        handler = object.__new__(WebhookHandler)
+        assert handler._reply_promise(Action(prompt="x")) is None
+
+    def test_returns_none_for_invalid_thread_data(self) -> None:
+        handler = object.__new__(WebhookHandler)
+        action = Action(prompt="x", thread={"comment_type": "wat", "comment_id": "5"})
+        assert handler._reply_promise(action) is None
+
+
 class TestProcessAction:
     """Tests for _process_action — the background thread that dispatches actions."""
 
@@ -509,7 +521,7 @@ class TestProcessAction:
         mock_task.assert_not_called()
 
     def test_reply_to_comment_failure_skips_task(self, server: tuple) -> None:
-        """If reply posting raises, no task is created (fail closed)."""
+        """If reply posting raises, queue recovery and skip task creation."""
         url, cfg = server
         payload = {
             **self._payload(),
@@ -535,6 +547,13 @@ class TestProcessAction:
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
         mock_task.assert_not_called()
+        assert (
+            cfg.repos["owner/repo"].work_dir
+            / ".git"
+            / "fido"
+            / "reply-promises"
+            / "pulls-205"
+        ).exists()
 
     def test_reply_to_comment_do_creates_task(self, server: tuple) -> None:
         """DO adds to tasks.json."""
@@ -684,7 +703,7 @@ class TestProcessAction:
         mock_task.assert_not_called()
 
     def test_reply_to_issue_comment_failure_skips_task(self, server: tuple) -> None:
-        """If issue comment reply raises, no task is created (fail closed)."""
+        """If issue comment reply raises, queue recovery and skip task creation."""
         url, cfg = server
         payload = {
             **self._payload(),
@@ -707,6 +726,13 @@ class TestProcessAction:
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
         mock_task.assert_not_called()
+        assert (
+            cfg.repos["owner/repo"].work_dir
+            / ".git"
+            / "fido"
+            / "reply-promises"
+            / "issues-302"
+        ).exists()
 
     def test_process_action_does_not_overwrite_worker_what(self, server: tuple) -> None:
         """_process_action must not call report_activity — the webhook runs on

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -685,6 +685,7 @@ class TestWorker:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     # --- create_session / stop_session ---
@@ -823,6 +824,46 @@ class TestWorker:
         ):
             worker.run()
         mock_create.assert_called_once_with()
+
+    def test_run_recovers_reply_promises_before_normal_handlers(
+        self, tmp_path: Path
+    ) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        order: list[str] = []
+
+        def mark_recover(*args, **kwargs):
+            order.append("recover")
+            return True
+
+        def mark_ci(*args, **kwargs):
+            order.append("ci")
+            return False
+
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-bug")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_ensure_session_alive"),
+            patch("kennel.events.recover_reply_promises", side_effect=mark_recover),
+            patch.object(worker, "handle_ci", side_effect=mark_ci),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        assert order[:2] == ["recover", "ci"]
 
     def test_run_switches_to_sonnet_after_setup_for_fresh_session(
         self, tmp_path: Path
@@ -3781,6 +3822,7 @@ class TestRunSeedTasksIntegration:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     def test_seed_called_after_find_or_create_pr(self, tmp_path: Path) -> None:
@@ -4348,6 +4390,7 @@ class TestRunHandleCiIntegration:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     def test_handle_ci_called_with_pr_and_slug(self, tmp_path: Path) -> None:
@@ -4993,6 +5036,7 @@ class TestRunThreadsIntegration:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     def test_handle_threads_called_when_review_feedback_passes(
@@ -6312,6 +6356,7 @@ class TestRunExecuteTaskIntegration:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     def test_execute_task_called_when_all_others_return_false(
@@ -7993,6 +8038,7 @@ class TestRunPromoteMergeIntegration:
         repo_ctx.repo = "owner/repo"
         repo_ctx.gh_user = "fido-bot"
         repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
         return repo_ctx
 
     def test_handle_promote_merge_called_when_execute_task_returns_false(


### PR DESCRIPTION
## Summary
- detect Claude provider failures from session and one-shot stream output and raise them loudly instead of treating them as empty turns
- queue durable empty-file reply promises for failed webhook PR comment replies and recover them from live GitHub comment state in the worker
- add regression coverage for provider errors, promise storage/recovery, GitHub comment lookups, server queuing, and worker integration

Closes #546