### PR TITLE
Status: mark task counts as uncertain during rescope (e.g. '1/6?') (closes #462)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1264,15 +1264,21 @@ def _reorder_tasks_background(
     def run_loop() -> None:
         cs = commit_summary
         kw = kwargs
-        while True:
-            reorder(work_dir, cs, **kw)
-            with _reorder_coalesce_lock:
-                pending = state[key].get("pending")
-                if pending is None:
-                    state[key]["running"] = False
-                    return
-                state[key]["pending"] = None
-                cs, kw = pending
+        if registry is not None and repo_cfg is not None:
+            registry.set_rescoping(repo_cfg.name, True)
+        try:
+            while True:
+                reorder(work_dir, cs, **kw)
+                with _reorder_coalesce_lock:
+                    pending = state[key].get("pending")
+                    if pending is None:
+                        state[key]["running"] = False
+                        return
+                    state[key]["pending"] = None
+                    cs, kw = pending
+        finally:
+            if registry is not None and repo_cfg is not None:
+                registry.set_rescoping(repo_cfg.name, False)
 
     t = threading.Thread(
         target=run_loop,

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -89,6 +89,8 @@ class WorkerRegistry:
         self._started_at_lock = threading.Lock()
         self._webhook_activities: dict[str, list[WebhookActivity]] = {}
         self._webhook_lock = threading.Lock()
+        self._rescoping: dict[str, bool] = {}
+        self._rescoping_lock = threading.Lock()
 
     def start(self, repo_cfg: RepoConfig) -> None:
         """Create and start a WorkerThread for *repo_cfg*.
@@ -302,6 +304,24 @@ class WorkerRegistry:
         """
         thread = self._threads.get(repo_name)
         return thread.session_pid if thread is not None else None
+
+    def set_rescoping(self, repo_name: str, active: bool) -> None:
+        """Set the rescoping-active flag for *repo_name*.
+
+        Called by the background reorder thread when it starts (``active=True``)
+        and when it finishes (``active=False``), so the status display can show
+        uncertain task counts while the task list is being rewritten by Opus.
+        """
+        with self._rescoping_lock:
+            self._rescoping[repo_name] = active
+
+    def is_rescoping(self, repo_name: str) -> bool:
+        """Return True if a background rescope is currently in flight for *repo_name*.
+
+        Returns False for unknown repos (no rescope has ever been registered).
+        """
+        with self._rescoping_lock:
+            return self._rescoping.get(repo_name, False)
 
     def get_session(self, repo_name: str) -> ClaudeSession | None:
         """Return the live :class:`~kennel.claude.ClaudeSession` for *repo_name*.

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -663,6 +663,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         "claude_talker": _serialize_talker(
                             claude.get_talker(a.repo_name)
                         ),
+                        "rescoping": self.registry.is_rescoping(a.repo_name),
                     }
                 )
             body = json.dumps(activities).encode()

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -68,6 +68,7 @@ class RepoStatus:
     session_owner: str | None = None
     session_alive: bool = False
     claude_talker: ClaudeTalkerInfo | None = None
+    rescoping: bool = False  # True while a background Opus reorder is in flight
 
 
 @dataclass
@@ -339,6 +340,7 @@ def repo_status(
     session_alive: bool = False,
     session_pid: int | None = None,
     claude_talker: ClaudeTalkerInfo | None = None,
+    rescoping: bool = False,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     webhook_activities = list(webhook_activities or [])
@@ -368,6 +370,7 @@ def repo_status(
             session_owner=session_owner,
             session_alive=session_alive,
             claude_talker=claude_talker,
+            rescoping=rescoping,
         )
 
     fido_dir = git_dir / "fido"
@@ -419,6 +422,7 @@ def repo_status(
         session_owner=session_owner,
         session_alive=session_alive,
         claude_talker=claude_talker,
+        rescoping=rescoping,
     )
 
 
@@ -475,6 +479,7 @@ def collect() -> KennelStatus:
                 session_alive=bool(info.get("session_alive")) if info else False,
                 session_pid=session_pid_val,
                 claude_talker=talker_info,
+                rescoping=bool(info.get("rescoping")) if info else False,
             )
         )
     return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
@@ -607,8 +612,9 @@ def _worker_thread_state(repo: RepoStatus) -> str:
     Never shows webhook-thread activity — that's surfaced separately.
     """
     if repo.task_number is not None and repo.task_total is not None:
+        uncertainty = "?" if repo.rescoping else ""
         suffix = f" — {repo.current_task}" if repo.current_task else ""
-        return f"{color(BOLD, f'task {repo.task_number}/{repo.task_total}')}{suffix}"
+        return f"{color(BOLD, f'task {repo.task_number}/{repo.task_total}{uncertainty}')}{suffix}"
     if repo.current_task is not None:
         return f"task: {repo.current_task}"
     what = (repo.worker_what or "").strip()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3039,6 +3039,95 @@ class TestReorderTasksBackground:
         )
         assert len(started) == 2  # each dir gets its own thread
 
+    def test_sets_rescoping_true_before_reorder(self, tmp_path: Path) -> None:
+        """set_rescoping(True) is called on the registry before reorder runs."""
+        started: list = []
+        rescoping_calls: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        registry = MagicMock()
+        registry.set_rescoping.side_effect = lambda repo, active: (
+            rescoping_calls.append(active)
+        )
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        assert rescoping_calls[0] is True
+
+    def test_clears_rescoping_false_after_reorder(self, tmp_path: Path) -> None:
+        """set_rescoping(False) is called on the registry after the loop finishes."""
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        registry = MagicMock()
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        # Last call must clear the flag
+        last_call = registry.set_rescoping.call_args_list[-1]
+        assert last_call[0] == ("owner/repo", False)
+
+    def test_clears_rescoping_on_reorder_exception(self, tmp_path: Path) -> None:
+        """set_rescoping(False) is called even when reorder raises."""
+        started: list = []
+        registry = MagicMock()
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+
+        def boom(work_dir, commit_summary, **kwargs):
+            raise RuntimeError("reorder exploded")
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=boom,
+            _coalesce_state={},
+        )
+        import pytest as _pytest
+
+        with _pytest.raises(RuntimeError, match="reorder exploded"):
+            self._run_thread(started)
+        last_call = registry.set_rescoping.call_args_list[-1]
+        assert last_call[0] == ("owner/repo", False)
+
+    def test_no_rescoping_calls_when_no_registry(self, tmp_path: Path) -> None:
+        """When registry is None, set_rescoping is not called."""
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        # No registry provided — must not raise and must complete normally
+
 
 class TestNotifyThreadChange:
     def _cfg(self, tmp_path: Path) -> Config:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -631,3 +631,55 @@ class TestWebhookActivity:
     def test_unknown_repo_returns_empty_list(self) -> None:
         reg = WorkerRegistry(MagicMock())
         assert reg.get_webhook_activities("ghost/repo") == []
+
+
+class TestRescoping:
+    def test_is_rescoping_false_for_unknown_repo(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        assert reg.is_rescoping("unknown/repo") is False
+
+    def test_set_rescoping_true(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        reg.set_rescoping("foo/bar", True)
+        assert reg.is_rescoping("foo/bar") is True
+
+    def test_set_rescoping_false_clears_flag(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        reg.set_rescoping("foo/bar", True)
+        reg.set_rescoping("foo/bar", False)
+        assert reg.is_rescoping("foo/bar") is False
+
+    def test_rescoping_is_per_repo(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        reg.set_rescoping("foo/bar", True)
+        assert reg.is_rescoping("foo/bar") is True
+        assert reg.is_rescoping("foo/baz") is False
+
+    def test_rescoping_is_threadsafe(self) -> None:
+        """Concurrent set_rescoping and is_rescoping calls must not corrupt state."""
+        reg = WorkerRegistry(MagicMock())
+        errors: list[Exception] = []
+
+        def toggler(repo: str) -> None:
+            try:
+                for i in range(200):
+                    reg.set_rescoping(repo, i % 2 == 0)
+            except Exception as exc:
+                errors.append(exc)
+
+        def reader(repo: str) -> None:
+            try:
+                for _ in range(200):
+                    reg.is_rescoping(repo)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=toggler, args=("foo/bar",)),
+            threading.Thread(target=reader, args=("foo/bar",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,6 +202,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         assert resp.status == 200
         data = json.loads(resp.read())
@@ -238,6 +239,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["session_owner"] == "worker-home"
@@ -263,6 +265,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["session_alive"] is True
@@ -293,6 +296,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
@@ -332,9 +336,62 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True
+
+    def test_status_endpoint_includes_rescoping_flag(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = True
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["rescoping"] is True
+
+    def test_status_endpoint_rescoping_false_by_default(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Napping",
+                busy=False,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status")
+        data = json.loads(resp.read())
+        assert data[0]["rescoping"] is False
 
 
 class TestEmptyBody:
@@ -1117,6 +1174,7 @@ class TestProcessAction:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
         with patch("kennel.claude.get_talker", return_value=talker):
             resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -862,6 +862,7 @@ class TestCollect:
         worker_uptime_seconds: int | None = None,
         webhook_activities: list | None = None,
         session_owner: str | None = None,
+        rescoping: bool = False,
     ) -> dict:
         return {
             "what": what,
@@ -871,6 +872,7 @@ class TestCollect:
             "worker_uptime_seconds": worker_uptime_seconds,
             "webhook_activities": webhook_activities or [],
             "session_owner": session_owner,
+            "rescoping": rescoping,
         }
 
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:
@@ -930,6 +932,7 @@ class TestCollect:
             session_alive=False,
             session_pid=None,
             claude_talker=None,
+            rescoping=False,
         )
 
     def test_passes_crash_info_to_repo_status(self, tmp_path: Path) -> None:
@@ -964,6 +967,7 @@ class TestCollect:
             session_alive=False,
             session_pid=None,
             claude_talker=None,
+            rescoping=False,
         )
 
     def test_worker_what_none_for_unknown_repo(self, tmp_path: Path) -> None:
@@ -991,6 +995,7 @@ class TestCollect:
             session_alive=False,
             session_pid=None,
             claude_talker=None,
+            rescoping=False,
         )
 
     def test_passes_claude_talker_to_repo_status(self, tmp_path: Path) -> None:
@@ -1066,7 +1071,44 @@ class TestCollect:
             session_alive=False,
             session_pid=None,
             claude_talker=None,
+            rescoping=False,
         )
+
+    def test_passes_rescoping_true_to_repo_status(self, tmp_path: Path) -> None:
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch(
+                "kennel.status._fetch_activities",
+                return_value={"owner/repo": self._activity_info(rescoping=True)},
+            ),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_rs,
+        ):
+            collect()
+        kwargs = mock_rs.call_args.kwargs
+        assert kwargs["rescoping"] is True
+
+    def test_rescoping_false_when_no_activity_info(self, tmp_path: Path) -> None:
+        """Repos with no activity entry (unknown to the live server) get rescoping=False."""
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=0),
+            patch("kennel.status._port_from_pid", return_value=9000),
+            patch("kennel.status._fetch_activities", return_value={}),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_rs,
+        ):
+            collect()
+        kwargs = mock_rs.call_args.kwargs
+        assert kwargs["rescoping"] is False
 
 
 class TestFormatStatus:
@@ -1138,6 +1180,31 @@ class TestFormatStatus:
         output = format_status(status)
         assert "Issue:  #42 — Add widget" in output
         assert "Worker: task 3/3 — Do the thing" in output
+
+    def test_task_count_shows_question_mark_when_rescoping(self) -> None:
+        repo = self._repo(
+            issue=1,
+            current_task="Reorder spec",
+            task_number=2,
+            task_total=5,
+            rescoping=True,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "task 2/5?" in output
+
+    def test_task_count_no_question_mark_when_not_rescoping(self) -> None:
+        repo = self._repo(
+            issue=1,
+            current_task="Do stuff",
+            task_number=2,
+            task_total=5,
+            rescoping=False,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "task 2/5" in output
+        assert "task 2/5?" not in output
 
     def test_repo_issue_without_title(self) -> None:
         repo = self._repo(issue=5, pending=2, completed=0, task_number=1, task_total=2)


### PR DESCRIPTION
Fixes #462.

Surfaces rescope uncertainty in `kennel status` by tracking per-repo rescope-active state in the registry and appending a `?` suffix to task counts (e.g. `task 1/6?`) while an Opus reorder is in flight. The same flag is exposed in the `/status` health endpoint payload so dashboards can reflect it too.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add per-repo rescope-active flag to registry and set from events <!-- type:spec -->
- [x] Thread rescoping flag through /status endpoint and display '?' suffix on task counts <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->