### PR TITLE
Skip CI fix when mergeStateStatus is not BLOCKED

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1273,6 +1273,14 @@ class Worker:
         6. Triggers a background sync of the work queue.
         """
         log.info("checking: ci")
+        pr_info = self.gh.get_pr(repo_ctx.repo, pr_number)
+        merge_state = pr_info.get("mergeStateStatus", "")
+        if merge_state not in ("BLOCKED", "DIRTY"):
+            log.info(
+                "CI check skipped — mergeStateStatus=%s (non-required failures ignored)",
+                merge_state,
+            )
+            return False
         checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
         failing = next(
             (c for c in checks if c.get("state") in ("FAILURE", "ERROR")),

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4077,6 +4077,7 @@ class TestHandleCi:
 
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
+        gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
         return Worker(tmp_path, gh), gh
 
     def _repo_ctx(self) -> RepoContext:
@@ -4366,6 +4367,50 @@ class TestHandleCi:
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
         assert "flaky" in caplog.text
+
+    def test_returns_false_when_merge_state_not_blocked(self, tmp_path: Path) -> None:
+        """Non-required check failures (UNSTABLE) must not trigger CI fixing."""
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "UNSTABLE"}
+        fido_dir = self._fido_dir(tmp_path)
+        assert worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch") is False
+        gh.pr_checks.assert_not_called()
+
+    def test_returns_false_when_merge_state_clean(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
+        fido_dir = self._fido_dir(tmp_path)
+        assert worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch") is False
+        gh.pr_checks.assert_not_called()
+
+    def test_proceeds_when_merge_state_blocked(self, tmp_path: Path) -> None:
+        """BLOCKED merge state should still trigger CI fixing on failure."""
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
+        gh.pr_checks.return_value = [
+            {"name": "required-check", "state": "FAILURE", "link": ""},
+        ]
+        gh.get_run_log.return_value = ""
+        gh.get_review_threads.return_value = []
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", return_value=("sid", "")),
+            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.sync_tasks"),
+        ):
+            result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
+        assert result is True
+
+    def test_proceeds_when_merge_state_dirty(self, tmp_path: Path) -> None:
+        """DIRTY merge state (merge conflicts) should still check CI."""
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "DIRTY"}
+        gh.pr_checks.return_value = []
+        fido_dir = self._fido_dir(tmp_path)
+        assert worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch") is False
+        gh.pr_checks.assert_called_once()
 
 
 class TestRunHandleCiIntegration:


### PR DESCRIPTION
Closes #567

## What

`handle_ci` now checks the PR's `mergeStateStatus` before looking at individual check conclusions. If the merge state is anything other than `BLOCKED` or `DIRTY`, the failing checks are non-required and should not trigger CI fixing.

## Why

A PR with `mergeStateStatus: UNSTABLE` is mergeable — GitHub will allow the merge despite failing non-required checks. The old code would see a failing check and enter a CI fix loop, blocking the merge indefinitely even after the user made the check optional.

## Test

Four new tests covering UNSTABLE (skip, no checks fetched), CLEAN (skip), BLOCKED (proceed), and DIRTY (proceed).