### PR TITLE
Fix missing closing brace in find_all_open_issues GraphQL query (closes #573)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -496,6 +496,7 @@ class GitHub:
             "orderBy:{field:CREATED_AT,direction:ASC}){"
             f"nodes{{{issue_fields} state "
             f"subIssues(first:100){{nodes{{state {issue_fields}}}}}"
+            "}"
             "pageInfo{endCursor hasNextPage}"
             "}}}"
         )


### PR DESCRIPTION
The `subIssues` nodes block was not closed before `pageInfo`, leaving the query with an unbalanced brace. GitHub's parser rejects it with `Expected NAME, actual: (none) at column 431`. The home worker crash-looped on every iteration since faster-issue-pickup merged.

Add the missing `}` to close `nodes{}` before the connection-level `pageInfo`.