### PR TITLE
Rescope task list on every worker iteration for maximum PR responsiveness (closes #570)

### DIFF
--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from kennel.claude import ClaudeSession
-from kennel.config import RepoConfig
+from kennel.config import Config, RepoConfig
 from kennel.github import GitHub
 from kennel.worker import WorkerThread
 
@@ -343,6 +343,7 @@ def _make_thread(
     gh: GitHub,
     session: ClaudeSession | None = None,
     session_issue: int | None = None,
+    config: Config | None = None,
     _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client."""
@@ -354,12 +355,15 @@ def _make_thread(
         repo_cfg.membership,
         session=session,
         session_issue=session_issue,
+        config=config,
+        repo_cfg=repo_cfg,
     )
 
 
 def make_registry(
     repos: dict[str, RepoConfig],
     gh: GitHub,
+    config: Config | None = None,
     *,
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
@@ -377,7 +381,12 @@ def make_registry(
         session_issue: int | None = None,
     ) -> WorkerThread:
         return _thread_factory(
-            cfg, registry, gh=gh, session=session, session_issue=session_issue
+            cfg,
+            registry,
+            gh=gh,
+            session=session,
+            session_issue=session_issue,
+            config=config,
         )
 
     registry = WorkerRegistry(factory)

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -815,7 +815,7 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = gh
-    registry = _make_registry(config.repos, gh)
+    registry = _make_registry(config.repos, gh, config)
     WebhookHandler.registry = registry
     # Route webhook-handler prompt calls through the per-repo persistent
     # ClaudeSession (closes #479 — "one claude per repo" invariant).

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -776,6 +776,8 @@ class Worker:
         _tasks: Tasks | None = None,
         claude_client: ClaudeClient | None = None,
         prompts: Prompts | None = None,
+        config: Config | None = None,
+        repo_cfg: RepoConfig | None = None,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
@@ -790,6 +792,8 @@ class Worker:
             claude_client if claude_client is not None else ClaudeClient()
         )
         self._prompts = prompts
+        self._config = config
+        self._repo_cfg = repo_cfg
 
     def _get_prompts(self, *, _sub_dir_fn: Callable[..., Path] = _sub_dir) -> Prompts:
         """Return the injected Prompts or build one from the persona file."""
@@ -2066,6 +2070,8 @@ class WorkerThread(threading.Thread):
         membership: RepoMembership | None = None,
         session: claude.ClaudeSession | None = None,
         session_issue: int | None = None,
+        config: Config | None = None,
+        repo_cfg: RepoConfig | None = None,
     ) -> None:
         super().__init__(name=f"worker-{work_dir.name}", daemon=True)
         self.work_dir = work_dir
@@ -2079,6 +2085,8 @@ class WorkerThread(threading.Thread):
         self.crash_error: str | None = None
         self._session: claude.ClaudeSession | None = session
         self._session_issue: int | None = session_issue
+        self._config = config
+        self._repo_cfg = repo_cfg
 
     @property
     def session_owner(self) -> str | None:
@@ -2180,6 +2188,8 @@ class WorkerThread(threading.Thread):
                     self._membership,
                     session=self._session,
                     session_issue=self._session_issue,
+                    config=self._config,
+                    repo_cfg=self._repo_cfg,
                 )
                 try:
                     result = worker.run()

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1928,6 +1928,55 @@ class Worker:
         self.set_status("Napping — waiting for work", busy=False)
         return 0
 
+    def rescope_before_pick(self) -> None:
+        """Run a synchronous Opus rescope before picking the next task.
+
+        Called at the start of every worker iteration so the PR task list
+        stays fresh.  Skips when :attr:`_config` or :attr:`_repo_cfg` are not
+        injected (standalone :func:`run` invocation) or when fewer than two
+        tasks are pending (nothing to reorder).
+
+        Uses the same ``_on_changes`` and ``_on_done`` callbacks as the
+        background rescope triggered by ``create_task()``: thread-task authors
+        are notified of any changes and the PR description is rewritten after a
+        successful reorder.
+
+        Does **not** pass ``_on_inprogress_affected``: there is no running task
+        to abort at pick time, so the abort signal would be either a no-op or
+        harmful to the task that is about to be picked.
+        """
+        if self._config is None or self._repo_cfg is None:
+            log.debug("rescope_before_pick: no config/repo_cfg — skipping")
+            return
+
+        pending = [
+            t for t in self._tasks.list() if t.get("status") == TaskStatus.PENDING
+        ]
+        if len(pending) < 2:
+            log.debug("rescope_before_pick: fewer than 2 pending tasks — skipping")
+            return
+
+        from kennel.events import (
+            _get_commit_summary,  # pyright: ignore[reportPrivateUsage]
+            _make_reorder_kwargs,  # pyright: ignore[reportPrivateUsage]
+            _rewrite_pr_description,  # pyright: ignore[reportPrivateUsage]
+        )
+        from kennel.tasks import reorder_tasks
+
+        commit_summary = _get_commit_summary(self.work_dir)
+        kwargs = _make_reorder_kwargs(
+            self.work_dir,
+            self._config,
+            self._repo_cfg,
+            None,  # no _on_inprogress_affected: no running task to abort at pick time
+            self.gh,
+            self._claude_client,
+            self._get_prompts(),
+            _rewrite_pr_description,
+        )
+        log.info("rescope_before_pick: rescoping task list before next pick")
+        reorder_tasks(self.work_dir, commit_summary, **kwargs)
+
     def run(self) -> int:
         """Run one iteration of the worker loop.
 
@@ -2012,6 +2061,7 @@ class Worker:
                 if session_fresh and self._session is not None:
                     self._session.switch_model("claude-sonnet-4-6")
                 self._ensure_session_alive(ctx.fido_dir)
+                self.rescope_before_pick()
                 if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1
                 if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -525,6 +525,8 @@ class TestMakeThread:
             RepoMembership(),
             session=None,
             session_issue=None,
+            config=None,
+            repo_cfg=cfg,
         )
         assert result is mock_wt_cls.return_value
 
@@ -535,6 +537,30 @@ class TestMakeThread:
         mock_wt_cls = MagicMock()
         _make_thread(cfg, MagicMock(), gh=MagicMock(), _WorkerThread=mock_wt_cls)
         assert mock_wt_cls.call_args[0][0] == work_dir
+
+    def test_config_forwarded_to_worker_thread(self, tmp_path: Path) -> None:
+        from kennel.config import Config
+
+        cfg = _repo("foo/bar", tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"foo/bar": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        mock_wt_cls = MagicMock()
+        _make_thread(
+            cfg, MagicMock(), gh=MagicMock(), config=config, _WorkerThread=mock_wt_cls
+        )
+        assert mock_wt_cls.call_args.kwargs["config"] is config
+
+    def test_repo_cfg_forwarded_to_worker_thread(self, tmp_path: Path) -> None:
+        cfg = _repo("foo/bar", tmp_path)
+        mock_wt_cls = MagicMock()
+        _make_thread(cfg, MagicMock(), gh=MagicMock(), _WorkerThread=mock_wt_cls)
+        assert mock_wt_cls.call_args.kwargs["repo_cfg"] is cfg
 
 
 class TestMakeRegistry:
@@ -576,6 +602,24 @@ class TestMakeRegistry:
             _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert reg.is_alive("foo/bar") is True
+
+    def test_config_forwarded_to_thread_factory(self, tmp_path: Path) -> None:
+        from kennel.config import Config
+
+        cfg = _repo("foo/bar", tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"foo/bar": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        mock_factory = MagicMock(return_value=MagicMock())
+        make_registry(
+            {"foo/bar": cfg}, MagicMock(), config, _thread_factory=mock_factory
+        )
+        assert mock_factory.call_args.kwargs["config"] is config
 
 
 class TestThreadStartedAt:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -299,6 +299,38 @@ class TestWorker:
         gh.get_pr.return_value = {"body": ""}
         return gh
 
+    # --- constructor / config injection ---
+
+    def test_config_stored_when_passed(self, tmp_path: Path) -> None:
+        from kennel.config import Config, RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"owner/repo": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        worker = Worker(tmp_path, MagicMock(), config=config)
+        assert worker._config is config
+
+    def test_repo_cfg_stored_when_passed(self, tmp_path: Path) -> None:
+        from kennel.config import RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        worker = Worker(tmp_path, MagicMock(), repo_cfg=cfg)
+        assert worker._repo_cfg is cfg
+
+    def test_config_defaults_to_none(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        assert worker._config is None
+
+    def test_repo_cfg_defaults_to_none(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        assert worker._repo_cfg is None
+
     # --- discover_repo_context ---
 
     def test_discover_returns_repo_context(self, tmp_path: Path) -> None:
@@ -8801,6 +8833,8 @@ class TestWorkerThread:
             membership=None,
             session=None,
             session_issue=None,
+            config=None,
+            repo_cfg=None,
         ):
             captured.append(abort_task)
             self_w.work_dir = work_dir
@@ -8877,6 +8911,8 @@ class TestWorkerThread:
             membership=None,
             session=None,
             session_issue=None,
+            config=None,
+            repo_cfg=None,
         ) -> None:
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -8925,6 +8961,8 @@ class TestWorkerThread:
             membership=None,
             session=None,
             session_issue=None,
+            config=None,
+            repo_cfg=None,
         ) -> None:
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -9051,3 +9089,89 @@ class TestWorkerThread:
         wt._registry.report_activity.side_effect = claude.ClaudeLeakError("leak")
         wt.run()
         assert exits == [3]
+
+    # ── config / repo_cfg injection ───────────────────────────────────────
+
+    def test_config_stored_when_passed(self, tmp_path: Path) -> None:
+        from kennel.config import Config, RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"owner/repo": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), config=config)
+        assert wt._config is config
+
+    def test_repo_cfg_stored_when_passed(self, tmp_path: Path) -> None:
+        from kennel.config import RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=cfg)
+        assert wt._repo_cfg is cfg
+
+    def test_config_defaults_to_none(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt._config is None
+
+    def test_repo_cfg_defaults_to_none(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt._repo_cfg is None
+
+    def test_config_and_repo_cfg_passed_to_worker(self, tmp_path: Path) -> None:
+        """WorkerThread.run() forwards config and repo_cfg to every Worker."""
+        from kennel.config import Config, RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"owner/repo": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        wt = WorkerThread(
+            tmp_path, "owner/repo", MagicMock(), config=config, repo_cfg=cfg
+        )
+        wt._wake = MagicMock()
+        received_config: list = []
+        received_repo_cfg: list = []
+
+        def fake_worker_init(
+            self_w,
+            work_dir,
+            gh,
+            abort_task=None,
+            repo_name="",
+            registry=None,
+            membership=None,
+            session=None,
+            session_issue=None,
+            config=None,
+            repo_cfg=None,
+        ) -> None:
+            self_w.work_dir = work_dir
+            self_w.gh = gh
+            self_w._abort_task = abort_task
+            self_w._session = session
+            self_w._session_issue = session_issue
+            received_config.append(config)
+            received_repo_cfg.append(repo_cfg)
+
+        def fake_worker_run(self_w) -> int:
+            wt._stop = True
+            return 0
+
+        with (
+            patch.object(Worker, "__init__", fake_worker_init),
+            patch.object(Worker, "run", fake_worker_run),
+        ):
+            wt.run()
+
+        assert received_config == [config]
+        assert received_repo_cfg == [cfg]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5226,6 +5226,251 @@ class TestPickNextTask:
         assert result is spec  # returned via fallthrough, not thread path
 
 
+class TestRescopeBeforePick:
+    """Tests for Worker.rescope_before_pick."""
+
+    def _pending(self, title: str = "do something") -> dict:
+        return {"id": "t1", "title": title, "status": "pending", "type": "spec"}
+
+    def _completed(self, title: str = "done") -> dict:
+        return {"id": "t2", "title": title, "status": "completed", "type": "spec"}
+
+    def _make_worker(self, tmp_path: Path, *, with_config: bool = True) -> Worker:
+        from kennel.config import Config, RepoConfig
+
+        cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={"owner/repo": cfg},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        if with_config:
+            return Worker(tmp_path, MagicMock(), config=config, repo_cfg=cfg)
+        return Worker(tmp_path, MagicMock())
+
+    def test_skips_when_config_is_none(self, tmp_path: Path) -> None:
+        worker = Worker(tmp_path, MagicMock())
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        with patch("kennel.tasks.reorder_tasks") as mock_reorder:
+            worker.rescope_before_pick()
+        mock_reorder.assert_not_called()
+
+    def test_skips_when_repo_cfg_is_none(self, tmp_path: Path) -> None:
+        from kennel.config import Config
+
+        config = Config(
+            port=9000,
+            secret=b"s",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="DEBUG",
+            sub_dir=tmp_path,
+        )
+        worker = Worker(tmp_path, MagicMock(), config=config)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        with patch("kennel.tasks.reorder_tasks") as mock_reorder:
+            worker.rescope_before_pick()
+        mock_reorder.assert_not_called()
+
+    def test_skips_when_no_pending_tasks(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = []
+        worker._tasks = mock_tasks
+        with patch("kennel.tasks.reorder_tasks") as mock_reorder:
+            worker.rescope_before_pick()
+        mock_reorder.assert_not_called()
+
+    def test_skips_when_exactly_one_pending_task(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending()]
+        worker._tasks = mock_tasks
+        with patch("kennel.tasks.reorder_tasks") as mock_reorder:
+            worker.rescope_before_pick()
+        mock_reorder.assert_not_called()
+
+    def test_skips_completed_tasks_in_pending_count(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        # one pending, one completed — should skip
+        mock_tasks.list.return_value = [self._pending(), self._completed()]
+        worker._tasks = mock_tasks
+        with patch("kennel.tasks.reorder_tasks") as mock_reorder:
+            worker.rescope_before_pick()
+        mock_reorder.assert_not_called()
+
+    def test_calls_reorder_when_two_pending_tasks(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        with (
+            patch("kennel.tasks.reorder_tasks") as mock_reorder,
+            patch("kennel.events._get_commit_summary", return_value="abc def"),
+            patch("kennel.events._make_reorder_kwargs", return_value={}),
+        ):
+            worker.rescope_before_pick()
+        mock_reorder.assert_called_once()
+
+    def test_passes_work_dir_to_reorder(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        with (
+            patch("kennel.tasks.reorder_tasks") as mock_reorder,
+            patch("kennel.events._get_commit_summary", return_value=""),
+            patch("kennel.events._make_reorder_kwargs", return_value={}),
+        ):
+            worker.rescope_before_pick()
+        assert mock_reorder.call_args[0][0] == tmp_path
+
+    def test_passes_commit_summary_to_reorder(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        with (
+            patch("kennel.tasks.reorder_tasks") as mock_reorder,
+            patch(
+                "kennel.events._get_commit_summary", return_value="abc123 first commit"
+            ),
+            patch("kennel.events._make_reorder_kwargs", return_value={}),
+        ):
+            worker.rescope_before_pick()
+        assert mock_reorder.call_args[0][1] == "abc123 first commit"
+
+    def test_no_inprogress_affected_callback(self, tmp_path: Path) -> None:
+        """Registry is passed as None so _on_inprogress_affected is not registered."""
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
+        worker._tasks = mock_tasks
+        captured_registry: list = []
+        with (
+            patch("kennel.tasks.reorder_tasks"),
+            patch("kennel.events._get_commit_summary", return_value=""),
+            patch(
+                "kennel.events._make_reorder_kwargs",
+                side_effect=lambda wd, cfg, repo_cfg, reg, *a, **kw: (
+                    captured_registry.append(reg) or {}
+                ),
+            ),
+        ):
+            worker.rescope_before_pick()
+        assert captured_registry == [None]
+
+    def test_calls_reorder_with_three_or_more_pending_tasks(
+        self, tmp_path: Path
+    ) -> None:
+        worker = self._make_worker(tmp_path)
+        mock_tasks = MagicMock()
+        mock_tasks.list.return_value = [
+            self._pending("a"),
+            self._pending("b"),
+            self._pending("c"),
+        ]
+        worker._tasks = mock_tasks
+        with (
+            patch("kennel.tasks.reorder_tasks") as mock_reorder,
+            patch("kennel.events._get_commit_summary", return_value=""),
+            patch("kennel.events._make_reorder_kwargs", return_value={}),
+        ):
+            worker.rescope_before_pick()
+        mock_reorder.assert_called_once()
+
+
+class TestRunRescopeIntegration:
+    """Tests that Worker.run() calls rescope_before_pick before task selection."""
+
+    def _make_gh(self) -> MagicMock:
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.get_default_branch.return_value = "main"
+        gh.get_pr.return_value = {"body": ""}
+        return gh
+
+    def _make_mock_ctx(self, tmp_path: Path) -> MagicMock:
+        mock_ctx = MagicMock(spec=WorkerContext)
+        mock_ctx.git_dir = tmp_path / ".git"
+        mock_ctx.fido_dir = tmp_path / ".git" / "fido"
+        return mock_ctx
+
+    def _make_mock_repo_ctx(self) -> MagicMock:
+        repo_ctx = MagicMock(spec=RepoContext)
+        repo_ctx.repo = "owner/repo"
+        repo_ctx.gh_user = "fido-bot"
+        repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
+        return repo_ctx
+
+    def test_rescope_before_pick_called_from_run(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        repo_ctx = self._make_mock_repo_ctx()
+        mock_rescope = MagicMock()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-it")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "rescope_before_pick", mock_rescope),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+        ):
+            worker.run()
+        mock_rescope.assert_called_once_with()
+
+    def test_rescope_called_before_handle_ci(self, tmp_path: Path) -> None:
+        """rescope_before_pick must execute before handle_ci sees the task list."""
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        repo_ctx = self._make_mock_repo_ctx()
+        call_order: list[str] = []
+
+        def record_rescope() -> None:
+            call_order.append("rescope")
+
+        def record_ci(*_a: object, **_kw: object) -> bool:
+            call_order.append("handle_ci")
+            return False
+
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "find_or_create_pr", return_value=(42, "fix-it")),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "rescope_before_pick", record_rescope),
+            patch.object(worker, "handle_ci", record_ci),
+            patch.object(worker, "handle_threads", return_value=False),
+            patch.object(worker, "execute_task", return_value=False),
+        ):
+            worker.run()
+        assert call_order == ["rescope", "handle_ci"]
+
+
 class TestEnsurePushed:
     """Tests for Worker.ensure_pushed."""
 


### PR DESCRIPTION
Fixes #570.

Runs Opus rescoping at the start of every worker iteration so the PR task list always reflects what fido actually intends to do next. Threads Config and RepoConfig into Worker and WorkerThread to support the rescope callbacks.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Inject Config and RepoConfig into Worker and WorkerThread <!-- type:spec -->
- [x] Run rescoping at the start of every worker iteration <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->