### PR TITLE
Reply to new human comments in review thread instead of editing own previous reply (closes #571)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -628,9 +628,13 @@ def reply_to_comment(
             f"review-comment reply: print_prompt returned empty for PR #{info['pr']}"
         )
 
-    # Edit the last Fido reply in the thread instead of posting a new comment.
-    # This keeps the thread tidy — one acknowledgment per thread, updated in place.
+    # Edit the last Fido reply only if it is the most recent comment in the thread
+    # (i.e. no human has spoken since). If a human posted a new comment after
+    # Fido's last reply, post a fresh reply so the conversation stays coherent.
     _fido_logins = {"fidocancode", "fido-can-code"}
+    last_thread_author = (
+        thread_comments[-1].get("author", "").lower() if thread_comments else ""
+    )
     last_fido_id = next(
         (
             c["id"]
@@ -639,7 +643,7 @@ def reply_to_comment(
         ),
         None,
     )
-    if last_fido_id:
+    if last_fido_id and last_thread_author in _fido_logins:
         log.info("editing last fido reply %s on PR #%s", last_fido_id, info["pr"])
         gh.edit_review_comment(info["repo"], last_fido_id, body)
         log.info("reply edited")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1573,6 +1573,50 @@ class TestReplyToComment:
         mock_gh.reply_to_review_comment.assert_called_once()
         mock_gh.edit_review_comment.assert_not_called()
 
+    def test_posts_new_reply_when_human_comments_after_fido(
+        self, tmp_path: Path
+    ) -> None:
+        """When a human posts after Fido's reply, post a new reply rather than editing."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 300},
+            comment_body="We need sub issues in priority order.",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: reorder sub issues"
+            if "Convert this PR review comment" in prompt:
+                return "Reorder sub issues by priority"
+            return "On it!"
+
+        mock_gh = MagicMock()
+        # Thread: root → fido reply → NEW human comment (fido must not edit)
+        mock_gh.fetch_comment_thread.return_value = [
+            {"id": 300, "author": "rhencke", "body": "Add orderBy"},
+            {"id": 301, "author": "fidocancode", "body": "Got it!"},
+            {
+                "id": 302,
+                "author": "rhencke",
+                "body": "We need sub issues in priority order.",
+            },
+        ]
+        cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            claude_client=_client(side_effect=fake_pp),
+        )
+        assert cat == "ACT"
+        # Human spoke last — must post a fresh reply, never edit the old one
+        mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
+
     def test_ask_title_not_rederived_from_root(self, tmp_path: Path) -> None:
         """Non-task categories (ASK) are not affected by root body re-derivation."""
         cfg = self._cfg(tmp_path)


### PR DESCRIPTION
Fixes #571.

Changes review thread reply logic so Fido posts a fresh reply when a human comments after his last reply, instead of editing the previous reply in place. Only edits when Fido's reply is still the most recent comment in the thread.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Reply to new human comments instead of editing prior Fido reply <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->