### PR TITLE
Fido /status endpoint enhancements. (closes #532)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -16,6 +16,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 from kennel import claude, reply_promises
 from kennel.claude import kill_active_children
@@ -86,6 +87,52 @@ def _serialize_talker(talker: claude.ClaudeTalker | None) -> dict[str, Any] | No
         "claude_pid": talker.claude_pid,
         "started_at": talker.started_at.isoformat(),
     }
+
+
+def _xml_text(value: object) -> str | None:
+    """Convert a Python value to XML element text.
+
+    Booleans become ``"true"`` / ``"false"``, ``None`` becomes ``None``
+    (empty element), everything else becomes its ``str()`` representation.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
+    """Serialize activity dicts to XML with an XSLT processing instruction.
+
+    Pure function — transforms data, no I/O.  The resulting XML matches
+    the structure expected by ``status.xsl``.
+    """
+    root = Element("kennel")
+    for act in activities:
+        repo = SubElement(root, "repo")
+        for key, value in act.items():
+            if key == "webhook_activities":
+                wa_el = SubElement(repo, "webhook_activities")
+                for wh in value:
+                    webhook_el = SubElement(wa_el, "webhook")
+                    for wk, wv in wh.items():
+                        el = SubElement(webhook_el, wk)
+                        el.text = _xml_text(wv)
+            elif key == "claude_talker":
+                ct_el = SubElement(repo, "claude_talker")
+                if value is not None:
+                    for ck, cv in value.items():
+                        el = SubElement(ct_el, ck)
+                        el.text = _xml_text(cv)
+            else:
+                el = SubElement(repo, key)
+                el.text = _xml_text(value)
+    xml_body = tostring(root, encoding="unicode")
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<?xml-stylesheet type="text/xsl" href="/static/status.xsl"?>\n' + xml_body
+    ).encode("utf-8")
 
 
 def _parse_repo_from_url(url: str) -> str | None:
@@ -629,55 +676,60 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/status":
-            now = datetime.now(tz=timezone.utc)
-            activities = []
-            for a in self.registry.get_all_activities():
-                crash = self.registry.get_crash_info(a.repo_name)
-                started_at = self.registry.thread_started_at(a.repo_name)
-                worker_uptime = (
-                    (now - started_at).total_seconds()
-                    if started_at is not None
-                    else None
-                )
-                webhooks = [
-                    {
-                        "description": w.description,
-                        "elapsed_seconds": (now - w.started_at).total_seconds(),
-                        "thread_id": w.thread_id,
-                    }
-                    for w in self.registry.get_webhook_activities(a.repo_name)
-                ]
-                activities.append(
-                    {
-                        "repo_name": a.repo_name,
-                        "what": a.what,
-                        "busy": a.busy,
-                        "crash_count": crash.death_count if crash else 0,
-                        "last_crash_error": crash.last_error if crash else None,
-                        "is_stuck": self.registry.is_stale(
-                            a.repo_name, _STALE_THRESHOLD
-                        ),
-                        "worker_uptime_seconds": worker_uptime,
-                        "webhook_activities": webhooks,
-                        "session_owner": self.registry.get_session_owner(a.repo_name),
-                        "session_alive": self.registry.get_session_alive(a.repo_name),
-                        "session_pid": self.registry.get_session_pid(a.repo_name),
-                        "claude_talker": _serialize_talker(
-                            claude.get_talker(a.repo_name)
-                        ),
-                        "rescoping": self.registry.is_rescoping(a.repo_name),
-                    }
-                )
-            body = json.dumps(activities).encode()
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            body = _activities_to_xml(self._collect_activities())
+            self._respond_body("application/xml; charset=utf-8", body)
+        elif self.path == "/status.json":
+            body = json.dumps(self._collect_activities()).encode()
+            self._respond_body("application/json", body)
         elif self.path.startswith("/static/"):
             self._serve_static()
         else:
             self._respond(200, "kennel is running")
+
+    def _collect_activities(self) -> list[dict[str, Any]]:
+        """Build the activity snapshot for all registered repos."""
+        now = datetime.now(tz=timezone.utc)
+        activities: list[dict[str, Any]] = []
+        for a in self.registry.get_all_activities():
+            crash = self.registry.get_crash_info(a.repo_name)
+            started_at = self.registry.thread_started_at(a.repo_name)
+            worker_uptime = (
+                (now - started_at).total_seconds() if started_at is not None else None
+            )
+            webhooks = [
+                {
+                    "description": w.description,
+                    "elapsed_seconds": (now - w.started_at).total_seconds(),
+                    "thread_id": w.thread_id,
+                }
+                for w in self.registry.get_webhook_activities(a.repo_name)
+            ]
+            activities.append(
+                {
+                    "repo_name": a.repo_name,
+                    "what": a.what,
+                    "busy": a.busy,
+                    "crash_count": crash.death_count if crash else 0,
+                    "last_crash_error": crash.last_error if crash else None,
+                    "is_stuck": self.registry.is_stale(a.repo_name, _STALE_THRESHOLD),
+                    "worker_uptime_seconds": worker_uptime,
+                    "webhook_activities": webhooks,
+                    "session_owner": self.registry.get_session_owner(a.repo_name),
+                    "session_alive": self.registry.get_session_alive(a.repo_name),
+                    "session_pid": self.registry.get_session_pid(a.repo_name),
+                    "claude_talker": _serialize_talker(claude.get_talker(a.repo_name)),
+                    "rescoping": self.registry.is_rescoping(a.repo_name),
+                }
+            )
+        return activities
+
+    def _respond_body(self, content_type: str, body: bytes) -> None:
+        """Send a 200 response with the given content type and body."""
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def _serve_static(self) -> None:
         if self.static_files is None:

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -16,7 +16,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
-from xml.etree.ElementTree import Element, SubElement, tostring
+from xml.etree.ElementTree import Element, SubElement, register_namespace, tostring
 
 from kennel import claude, reply_promises
 from kennel.claude import kill_active_children
@@ -57,6 +57,15 @@ _replied_comments: set[int] = set()
 # exceeds _PULL_BUDGET_SECONDS, even if a retry window remains.
 _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
+
+# XML namespace URIs for the /status endpoint structural XML.
+_NS_KENNEL = "https://fidocancode.dog/kennel"
+_NS_DOG = "https://fidocancode.dog/woof"
+
+# Register namespace prefixes for clean XML serialization.  Idempotent —
+# safe to call at module scope before any threads start.
+register_namespace("", _NS_KENNEL)
+register_namespace("dog", _NS_DOG)
 
 
 class PreflightError(RuntimeError):
@@ -102,31 +111,52 @@ def _xml_text(value: object) -> str | None:
     return str(value)
 
 
-def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
-    """Serialize activity dicts to XML with an XSLT processing instruction.
+def _repo_status(act: dict[str, Any]) -> str:
+    """Derive a single status word from activity flags.
 
-    Pure function — transforms data, no I/O.  The resulting XML matches
-    the structure expected by ``status.xsl``.
+    Priority: stuck > crashed > busy > idle.  Used as the ``dog:status``
+    attribute on ``<repo>`` elements so XSLT and CSS can style by state.
     """
-    root = Element("kennel")
+    if act.get("is_stuck"):
+        return "stuck"
+    if act.get("crash_count", 0) > 0:
+        return "crashed"
+    if act.get("busy"):
+        return "busy"
+    return "idle"
+
+
+def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
+    """Serialize activity dicts to namespaced structural XML with an XSLT PI.
+
+    Pure function — transforms data, no I/O.  The server emits this structural
+    XML in the ``https://fidocancode.dog/kennel`` namespace.  The browser
+    fetches ``status.xsl`` (via the XSLT processing instruction), which
+    transforms it into display-oriented XML in a separate namespace, which
+    is then styled by ``status.css`` via a CSS processing instruction.
+
+    Three-layer pipeline: structural XML → XSLT → display XML → CSS.
+    """
+    root = Element(f"{{{_NS_KENNEL}}}kennel")
     for act in activities:
-        repo = SubElement(root, "repo")
+        repo = SubElement(root, f"{{{_NS_KENNEL}}}repo")
+        repo.set(f"{{{_NS_DOG}}}status", _repo_status(act))
         for key, value in act.items():
             if key == "webhook_activities":
-                wa_el = SubElement(repo, "webhook_activities")
+                wa_el = SubElement(repo, f"{{{_NS_KENNEL}}}webhook_activities")
                 for wh in value:
-                    webhook_el = SubElement(wa_el, "webhook")
+                    webhook_el = SubElement(wa_el, f"{{{_NS_KENNEL}}}webhook")
                     for wk, wv in wh.items():
-                        el = SubElement(webhook_el, wk)
+                        el = SubElement(webhook_el, f"{{{_NS_KENNEL}}}{wk}")
                         el.text = _xml_text(wv)
             elif key == "claude_talker":
-                ct_el = SubElement(repo, "claude_talker")
+                ct_el = SubElement(repo, f"{{{_NS_KENNEL}}}claude_talker")
                 if value is not None:
                     for ck, cv in value.items():
-                        el = SubElement(ct_el, ck)
+                        el = SubElement(ct_el, f"{{{_NS_KENNEL}}}{ck}")
                         el.text = _xml_text(cv)
             else:
-                el = SubElement(repo, key)
+                el = SubElement(repo, f"{{{_NS_KENNEL}}}{key}")
                 el.text = _xml_text(value)
     xml_body = tostring(root, encoding="unicode")
     return (

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -39,6 +39,7 @@ from kennel.infra import (
     real_infra,
 )
 from kennel.registry import WorkerRegistry, make_registry
+from kennel.static_files import StaticFiles
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
     Watchdog,
@@ -316,6 +317,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     gh: GitHub | None = None
     # Infrastructure ports — set by server.run() composition root.
     infra: Infra = real_infra()
+    static_files: StaticFiles | None = None
     _fn_dispatch = staticmethod(dispatch)
     _fn_reply_to_comment = staticmethod(reply_to_comment)
     _fn_reply_to_review = staticmethod(reply_to_review)
@@ -672,8 +674,29 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+        elif self.path.startswith("/static/"):
+            self._serve_static()
         else:
             self._respond(200, "kennel is running")
+
+    def _serve_static(self) -> None:
+        if self.static_files is None:
+            self._respond(404, "not found")
+            return
+        response = self.static_files.serve(
+            self.path,
+            self.headers.get("If-None-Match"),
+            self.headers.get("If-Modified-Since"),
+        )
+        if response is None:
+            self._respond(404, "not found")
+            return
+        self.send_response(response.status)
+        for name, value in response.headers:
+            self.send_header(name, value)
+        self.end_headers()
+        if response.body:
+            self.wfile.write(response.body)
 
     def _verify_signature(self, body: bytes) -> bool:
         header = self.headers.get("X-Hub-Signature-256", "")
@@ -815,6 +838,9 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = gh
+    WebhookHandler.static_files = StaticFiles(
+        Path(__file__).resolve().parent / "static"
+    )
     registry = _make_registry(config.repos, gh, config)
     WebhookHandler.registry = registry
     # Route webhook-handler prompt calls through the per-repo persistent

--- a/kennel/static/status.css
+++ b/kennel/static/status.css
@@ -1,0 +1,342 @@
+/* kennel status — warm, functional, unmistakably fido */
+
+:root {
+  --cream: #faf6f0;
+  --warm-white: #ffffff;
+  --amber: #c87c0a;
+  --amber-light: #fdf0d5;
+  --gold: #d4880f;
+  --green: #1a7f37;
+  --green-light: #dafbe1;
+  --green-glow: #2da44e;
+  --red: #cf222e;
+  --red-light: #ffebe9;
+  --blue: #0969da;
+  --blue-light: #ddf4ff;
+  --text: #1f2328;
+  --text-secondary: #656d76;
+  --text-muted: #8b949e;
+  --border: #d8dee4;
+  --shadow: rgba(31, 35, 40, 0.06);
+  --shadow-lg: rgba(31, 35, 40, 0.12);
+  --radius: 10px;
+  --mono: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
+    Helvetica, Arial, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 15px;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  background: var(--cream);
+  color: var(--text);
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+/* header */
+
+header {
+  padding: 1.5rem 1.5rem 0;
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+header h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.paw {
+  margin-right: 0.15em;
+}
+
+/* layout */
+
+main {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 1rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* empty state */
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 4rem 1rem;
+  font-size: 1.1rem;
+}
+
+/* repo cards */
+
+.repo {
+  background: var(--warm-white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 3px var(--shadow);
+  transition: border-color 0.2s ease;
+}
+
+.repo.stuck {
+  border-left: 3px solid var(--red);
+}
+
+.repo.crashed {
+  border-left: 3px solid var(--red);
+}
+
+.repo.busy {
+  border-left: 3px solid var(--green);
+}
+
+.repo.idle {
+  border-left: 3px solid var(--border);
+}
+
+/* repo header */
+
+.repo-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.repo-header h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+/* status dots */
+
+.dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot-busy {
+  background: var(--green-glow);
+  box-shadow: 0 0 0 2px rgba(45, 164, 78, 0.2);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.dot-idle {
+  background: var(--text-muted);
+}
+
+.dot-stuck {
+  background: var(--red);
+  box-shadow: 0 0 0 2px rgba(207, 34, 46, 0.2);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.dot-crash {
+  background: var(--red);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* uptime badge in header */
+
+.uptime {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* activity line — what the worker is doing */
+
+.activity {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  padding: 0.15rem 0 0.5rem 1.15rem;
+}
+
+/* metadata badges */
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-left: 1.15rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.15rem 0.55rem;
+  border-radius: 2rem;
+}
+
+.badge-crash {
+  background: var(--red-light);
+  color: var(--red);
+}
+
+.badge-rescope {
+  background: var(--blue-light);
+  color: var(--blue);
+}
+
+.badge-session {
+  background: var(--amber-light);
+  color: var(--amber);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+/* claude talker */
+
+.talker {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-left: 1.15rem;
+  background: var(--green-light);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.talker-label {
+  font-weight: 600;
+  color: var(--green);
+}
+
+.talker-kind {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--green);
+  background: rgba(26, 127, 55, 0.1);
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+}
+
+.talker-desc {
+  color: var(--text-secondary);
+}
+
+.talker-pid {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+/* crash error details */
+
+.crash-error {
+  margin-top: 0.5rem;
+  margin-left: 1.15rem;
+}
+
+.crash-error summary {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--red);
+  cursor: pointer;
+}
+
+.crash-error pre {
+  margin: 0.35rem 0 0;
+  padding: 0.6rem 0.75rem;
+  background: var(--red-light);
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--red);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+/* webhook activities */
+
+.webhooks {
+  margin-top: 0.5rem;
+  padding-left: 1.15rem;
+}
+
+.webhooks-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.webhooks ul {
+  list-style: none;
+  margin: 0.2rem 0 0;
+  padding: 0;
+}
+
+.webhooks li {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  padding: 0.15rem 0;
+  padding-left: 0.75rem;
+  border-left: 2px solid var(--border);
+}
+
+.webhooks li::before {
+  content: none;
+}
+
+.elapsed {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  margin-left: 0.4rem;
+}
+
+/* responsive */
+
+@media (max-width: 600px) {
+  header {
+    padding: 1rem 1rem 0;
+  }
+
+  main {
+    padding: 0.75rem 1rem 2rem;
+  }
+
+  .repo {
+    padding: 0.85rem 1rem;
+  }
+}

--- a/kennel/static/status.css
+++ b/kennel/static/status.css
@@ -1,201 +1,158 @@
-/* kennel status — warm, functional, unmistakably fido */
+/*
+ * Rube Goldberg layer 3: CSS styles display-oriented XML.
+ *
+ * Pipeline: server emits structural XML → XSLT transforms to display XML →
+ *           this CSS styles the display XML via @namespace selectors.
+ *
+ * Display namespace: https://fidocancode.dog/display
+ * Attribute namespace: https://fidocancode.dog/woof (dog:status, dog:kind)
+ */
 
-:root {
-  --cream: #faf6f0;
-  --warm-white: #ffffff;
-  --amber: #c87c0a;
-  --amber-light: #fdf0d5;
-  --gold: #d4880f;
-  --green: #1a7f37;
-  --green-light: #dafbe1;
-  --green-glow: #2da44e;
-  --red: #cf222e;
-  --red-light: #ffebe9;
-  --blue: #0969da;
-  --blue-light: #ddf4ff;
-  --text: #1f2328;
-  --text-secondary: #656d76;
-  --text-muted: #8b949e;
-  --border: #d8dee4;
-  --shadow: rgba(31, 35, 40, 0.06);
-  --shadow-lg: rgba(31, 35, 40, 0.12);
-  --radius: 10px;
-  --mono: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
+@namespace url(https://fidocancode.dog/display);
+@namespace dog url(https://fidocancode.dog/woof);
+
+/* === base === */
+
+dashboard {
+  display: block;
+  margin: 0;
+  padding: 1rem 0 3rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
     Helvetica, Arial, sans-serif;
-}
-
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html {
+  background: #faf6f0;
+  color: #1f2328;
+  line-height: 1.5;
+  min-height: 100vh;
   font-size: 15px;
 }
 
-body {
-  margin: 0;
-  padding: 0;
-  font-family: var(--sans);
-  background: var(--cream);
-  color: var(--text);
-  line-height: 1.5;
-  min-height: 100vh;
-}
+/* === title === */
 
-/* header */
-
-header {
-  padding: 1.5rem 1.5rem 0;
-  max-width: 52rem;
-  margin: 0 auto;
-}
-
-header h1 {
+title {
+  display: block;
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--text-secondary);
-  margin: 0;
+  color: #656d76;
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 0.5rem 1.5rem;
   letter-spacing: -0.01em;
 }
 
-.paw {
-  margin-right: 0.15em;
-}
+/* === empty state === */
 
-/* layout */
-
-main {
-  max-width: 52rem;
-  margin: 0 auto;
-  padding: 1rem 1.5rem 3rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-/* empty state */
-
-.empty {
+empty {
+  display: block;
   text-align: center;
-  color: var(--text-muted);
+  color: #8b949e;
   padding: 4rem 1rem;
   font-size: 1.1rem;
 }
 
-/* repo cards */
+/* === repo cards === */
 
-.repo {
-  background: var(--warm-white);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+card {
+  display: block;
+  background: #ffffff;
+  border: 1px solid #d8dee4;
+  border-radius: 10px;
   padding: 1rem 1.25rem;
-  box-shadow: 0 1px 3px var(--shadow);
+  max-width: 52rem;
+  margin: 0.75rem auto;
+  box-shadow: 0 1px 3px rgba(31, 35, 40, 0.06);
   transition: border-color 0.2s ease;
 }
 
-.repo.stuck {
-  border-left: 3px solid var(--red);
+card[dog|status="stuck"],
+card[dog|status="crashed"] {
+  border-left: 3px solid #cf222e;
 }
 
-.repo.crashed {
-  border-left: 3px solid var(--red);
+card[dog|status="busy"] {
+  border-left: 3px solid #1a7f37;
 }
 
-.repo.busy {
-  border-left: 3px solid var(--green);
+card[dog|status="idle"] {
+  border-left: 3px solid #d8dee4;
 }
 
-.repo.idle {
-  border-left: 3px solid var(--border);
-}
+/* === status dot via name::before === */
 
-/* repo header */
-
-.repo-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+name {
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   margin-bottom: 0.25rem;
 }
 
-.repo-header h2 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-
-/* status dots */
-
-.dot {
+name::before {
+  content: "";
   display: inline-block;
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  flex-shrink: 0;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+  background: #8b949e;
 }
 
-.dot-busy {
-  background: var(--green-glow);
+card[dog|status="busy"] > name::before {
+  background: #2da44e;
   box-shadow: 0 0 0 2px rgba(45, 164, 78, 0.2);
   animation: pulse 2s ease-in-out infinite;
 }
 
-.dot-idle {
-  background: var(--text-muted);
-}
-
-.dot-stuck {
-  background: var(--red);
+card[dog|status="stuck"] > name::before {
+  background: #cf222e;
   box-shadow: 0 0 0 2px rgba(207, 34, 46, 0.2);
   animation: pulse 1s ease-in-out infinite;
 }
 
-.dot-crash {
-  background: var(--red);
+card[dog|status="crashed"] > name::before {
+  background: #cf222e;
 }
 
 @keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
 
-/* uptime badge in header */
+/* === uptime === */
 
-.uptime {
-  margin-left: auto;
+uptime {
+  display: block;
+  float: right;
   font-size: 0.8rem;
-  color: var(--text-muted);
-  font-family: var(--mono);
+  color: #8b949e;
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-variant-numeric: tabular-nums;
 }
 
-/* activity line — what the worker is doing */
+/* === activity === */
 
-.activity {
-  color: var(--text-secondary);
+activity {
+  display: block;
+  color: #656d76;
   font-size: 0.9rem;
   padding: 0.15rem 0 0.5rem 1.15rem;
+  clear: both;
 }
 
-/* metadata badges */
+/* === badges === */
 
-.meta {
+badges {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
   padding-left: 1.15rem;
 }
 
-.badge {
+badges:empty {
+  display: none;
+}
+
+badge {
   display: inline-flex;
   align-items: center;
   font-size: 0.75rem;
@@ -204,139 +161,136 @@ main {
   border-radius: 2rem;
 }
 
-.badge-crash {
-  background: var(--red-light);
-  color: var(--red);
+badge[dog|kind="crash"] {
+  background: #ffebe9;
+  color: #cf222e;
 }
 
-.badge-rescope {
-  background: var(--blue-light);
-  color: var(--blue);
+badge[dog|kind="rescope"] {
+  background: #ddf4ff;
+  color: #0969da;
 }
 
-.badge-session {
-  background: var(--amber-light);
-  color: var(--amber);
-  font-family: var(--mono);
+badge[dog|kind="session"] {
+  background: #fdf0d5;
+  color: #c87c0a;
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-size: 0.7rem;
 }
 
-/* claude talker */
+/* === claude talker === */
 
-.talker {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  margin-left: 1.15rem;
-  background: var(--green-light);
-  border-radius: 6px;
-  font-size: 0.8rem;
+talker {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 0.4rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-left: 1.15rem;
+  background: #dafbe1;
+  border-radius: 6px;
+  font-size: 0.8rem;
 }
 
-.talker-label {
+talker > label {
+  display: inline;
   font-weight: 600;
-  color: var(--green);
+  color: #1a7f37;
 }
 
-.talker-kind {
-  font-family: var(--mono);
+talker > kind {
+  display: inline;
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-size: 0.75rem;
-  color: var(--green);
+  color: #1a7f37;
   background: rgba(26, 127, 55, 0.1);
   padding: 0.05rem 0.4rem;
   border-radius: 3px;
 }
 
-.talker-desc {
-  color: var(--text-secondary);
+talker > desc {
+  display: inline;
+  color: #656d76;
 }
 
-.talker-pid {
-  color: var(--text-muted);
-  font-family: var(--mono);
+talker > pid {
+  display: inline;
+  color: #8b949e;
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-size: 0.7rem;
 }
 
-/* crash error details */
+/* === crash error === */
 
-.crash-error {
-  margin-top: 0.5rem;
-  margin-left: 1.15rem;
-}
-
-.crash-error summary {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--red);
-  cursor: pointer;
-}
-
-.crash-error pre {
-  margin: 0.35rem 0 0;
+crash-detail {
+  display: block;
+  margin: 0.5rem 0 0 1.15rem;
   padding: 0.6rem 0.75rem;
-  background: var(--red-light);
+  background: #ffebe9;
   border-radius: 6px;
-  font-family: var(--mono);
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-size: 0.75rem;
-  color: var(--red);
+  color: #cf222e;
   white-space: pre-wrap;
   word-break: break-word;
-  overflow-x: auto;
 }
 
-/* webhook activities */
+crash-detail::before {
+  content: "last crash";
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
+    Helvetica, Arial, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 500;
+  margin-bottom: 0.35rem;
+}
 
-.webhooks {
+/* === webhook activities === */
+
+hooks {
+  display: block;
   margin-top: 0.5rem;
   padding-left: 1.15rem;
 }
 
-.webhooks-label {
+hooks-label {
+  display: block;
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--text-secondary);
+  color: #656d76;
+  margin-bottom: 0.2rem;
 }
 
-.webhooks ul {
-  list-style: none;
-  margin: 0.2rem 0 0;
-  padding: 0;
-}
-
-.webhooks li {
+hook {
+  display: block;
   font-size: 0.8rem;
-  color: var(--text-secondary);
-  padding: 0.15rem 0;
-  padding-left: 0.75rem;
-  border-left: 2px solid var(--border);
+  color: #656d76;
+  padding: 0.15rem 0 0.15rem 0.75rem;
+  border-left: 2px solid #d8dee4;
 }
 
-.webhooks li::before {
-  content: none;
+hook-desc {
+  display: inline;
 }
 
-.elapsed {
-  color: var(--text-muted);
-  font-family: var(--mono);
+elapsed {
+  display: inline;
+  color: #8b949e;
+  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
   font-size: 0.7rem;
   margin-left: 0.4rem;
 }
 
-/* responsive */
+/* === responsive === */
 
 @media (max-width: 600px) {
-  header {
-    padding: 1rem 1rem 0;
+  title {
+    padding: 0.5rem 1rem;
   }
 
-  main {
-    padding: 0.75rem 1rem 2rem;
-  }
-
-  .repo {
+  card {
+    margin: 0.5rem 1rem;
     padding: 0.85rem 1rem;
   }
 }

--- a/kennel/static/status.xsl
+++ b/kennel/static/status.xsl
@@ -1,142 +1,125 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-<xsl:output method="html" encoding="UTF-8" indent="yes"/>
+<!--
+  Rube Goldberg layer 2: structural XML → display XML.
 
-<xsl:template match="/kennel">
-<html lang="en">
-<head>
-  <meta http-equiv="refresh" content="2"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <link rel="stylesheet" href="/static/status.css"/>
-  <title>kennel</title>
-</head>
-<body>
-  <header>
-    <h1><span class="paw">&#x1F43E;</span> kennel</h1>
-  </header>
-  <main>
+  Input:  structural XML in xmlns="https://fidocancode.dog/kennel"
+          with dog:status attributes from xmlns:dog="https://fidocancode.dog/woof"
+  Output: display XML in xmlns="https://fidocancode.dog/display"
+          with dog:status attributes preserved, plus a CSS PI so the browser
+          styles the result via status.css
+
+  Pipeline: server → structural XML → [this XSLT] → display XML → CSS
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:k="https://fidocancode.dog/kennel"
+  xmlns:dog="https://fidocancode.dog/woof"
+  xmlns="https://fidocancode.dog/display"
+  exclude-result-prefixes="k">
+
+<xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+<xsl:template match="/">
+  <xsl:processing-instruction name="xml-stylesheet">type="text/css" href="/static/status.css"</xsl:processing-instruction>
+  <dashboard>
+    <title>&#x1F43E; kennel</title>
     <xsl:choose>
-      <xsl:when test="repo">
-        <xsl:apply-templates select="repo"/>
+      <xsl:when test="k:kennel/k:repo">
+        <xsl:apply-templates select="k:kennel/k:repo"/>
       </xsl:when>
       <xsl:otherwise>
-        <div class="empty">No repos configured. Napping &#x1F4A4;</div>
+        <empty>No repos configured. Napping &#x1F4A4;</empty>
       </xsl:otherwise>
     </xsl:choose>
-  </main>
-</body>
-</html>
+  </dashboard>
 </xsl:template>
 
-<xsl:template match="repo">
-<section>
-  <xsl:attribute name="class">
-    <xsl:text>repo</xsl:text>
-    <xsl:if test="is_stuck = 'true'"> stuck</xsl:if>
-    <xsl:if test="crash_count &gt; 0"> crashed</xsl:if>
-    <xsl:if test="busy = 'true' and is_stuck != 'true'"> busy</xsl:if>
-    <xsl:if test="busy != 'true' and is_stuck != 'true' and not(crash_count &gt; 0)"> idle</xsl:if>
-  </xsl:attribute>
+<xsl:template match="k:repo">
+  <card>
+    <xsl:attribute name="dog:status">
+      <xsl:value-of select="@dog:status"/>
+    </xsl:attribute>
 
-  <div class="repo-header">
-    <span>
-      <xsl:attribute name="class">
-        <xsl:text>dot</xsl:text>
-        <xsl:choose>
-          <xsl:when test="is_stuck = 'true'"> dot-stuck</xsl:when>
-          <xsl:when test="crash_count &gt; 0"> dot-crash</xsl:when>
-          <xsl:when test="busy = 'true'"> dot-busy</xsl:when>
-          <xsl:otherwise> dot-idle</xsl:otherwise>
-        </xsl:choose>
-      </xsl:attribute>
-    </span>
-    <h2><xsl:value-of select="repo_name"/></h2>
-    <xsl:if test="worker_uptime_seconds != ''">
-      <span class="uptime">
+    <name><xsl:value-of select="k:repo_name"/></name>
+
+    <xsl:if test="k:worker_uptime_seconds != ''">
+      <uptime>
         <xsl:text>up </xsl:text>
         <xsl:call-template name="format-duration">
-          <xsl:with-param name="seconds" select="worker_uptime_seconds"/>
+          <xsl:with-param name="seconds" select="k:worker_uptime_seconds"/>
         </xsl:call-template>
-      </span>
-    </xsl:if>
-  </div>
-
-  <div class="activity">
-    <xsl:value-of select="what"/>
-  </div>
-
-  <div class="meta">
-    <xsl:if test="crash_count &gt; 0">
-      <span class="badge badge-crash">
-        <xsl:value-of select="crash_count"/>
-        <xsl:text> crash</xsl:text>
-        <xsl:if test="crash_count &gt; 1">es</xsl:if>
-      </span>
+      </uptime>
     </xsl:if>
 
-    <xsl:if test="rescoping = 'true'">
-      <span class="badge badge-rescope">rescoping &#x27F3;</span>
-    </xsl:if>
+    <activity><xsl:value-of select="k:what"/></activity>
 
-    <xsl:if test="session_alive = 'true'">
-      <span class="badge badge-session">
-        <xsl:text>session</xsl:text>
-        <xsl:if test="session_owner != ''">
-          <xsl:text>: </xsl:text>
-          <xsl:value-of select="session_owner"/>
-        </xsl:if>
-        <xsl:if test="session_pid != ''">
-          <xsl:text> (pid </xsl:text>
-          <xsl:value-of select="session_pid"/>
-          <xsl:text>)</xsl:text>
-        </xsl:if>
-      </span>
-    </xsl:if>
-  </div>
-
-  <xsl:if test="claude_talker/kind">
-    <div class="talker">
-      <span class="talker-label">claude</span>
-      <span class="talker-kind"><xsl:value-of select="claude_talker/kind"/></span>
-      <span class="talker-desc"><xsl:value-of select="claude_talker/description"/></span>
-      <xsl:if test="claude_talker/claude_pid != ''">
-        <span class="talker-pid">
-          <xsl:text>pid </xsl:text>
-          <xsl:value-of select="claude_talker/claude_pid"/>
-        </span>
+    <badges>
+      <xsl:if test="k:crash_count &gt; 0">
+        <badge dog:kind="crash">
+          <xsl:value-of select="k:crash_count"/>
+          <xsl:text> crash</xsl:text>
+          <xsl:if test="k:crash_count &gt; 1">es</xsl:if>
+        </badge>
       </xsl:if>
-    </div>
-  </xsl:if>
 
-  <xsl:if test="last_crash_error != ''">
-    <details class="crash-error">
-      <summary>last crash</summary>
-      <pre><xsl:value-of select="last_crash_error"/></pre>
-    </details>
-  </xsl:if>
+      <xsl:if test="k:rescoping = 'true'">
+        <badge dog:kind="rescope">rescoping &#x27F3;</badge>
+      </xsl:if>
 
-  <xsl:if test="webhook_activities/webhook">
-    <div class="webhooks">
-      <span class="webhooks-label">webhooks</span>
-      <ul>
-        <xsl:for-each select="webhook_activities/webhook">
-          <li>
-            <xsl:value-of select="description"/>
-            <span class="elapsed">
+      <xsl:if test="k:session_alive = 'true'">
+        <badge dog:kind="session">
+          <xsl:text>session</xsl:text>
+          <xsl:if test="k:session_owner != ''">
+            <xsl:text>: </xsl:text>
+            <xsl:value-of select="k:session_owner"/>
+          </xsl:if>
+          <xsl:if test="k:session_pid != ''">
+            <xsl:text> (pid </xsl:text>
+            <xsl:value-of select="k:session_pid"/>
+            <xsl:text>)</xsl:text>
+          </xsl:if>
+        </badge>
+      </xsl:if>
+    </badges>
+
+    <xsl:if test="k:claude_talker/k:kind">
+      <talker>
+        <label>claude</label>
+        <kind><xsl:value-of select="k:claude_talker/k:kind"/></kind>
+        <desc><xsl:value-of select="k:claude_talker/k:description"/></desc>
+        <xsl:if test="k:claude_talker/k:claude_pid != ''">
+          <pid>
+            <xsl:text>pid </xsl:text>
+            <xsl:value-of select="k:claude_talker/k:claude_pid"/>
+          </pid>
+        </xsl:if>
+      </talker>
+    </xsl:if>
+
+    <xsl:if test="k:last_crash_error != ''">
+      <crash-detail><xsl:value-of select="k:last_crash_error"/></crash-detail>
+    </xsl:if>
+
+    <xsl:if test="k:webhook_activities/k:webhook">
+      <hooks>
+        <hooks-label>webhooks</hooks-label>
+        <xsl:for-each select="k:webhook_activities/k:webhook">
+          <hook>
+            <hook-desc><xsl:value-of select="k:description"/></hook-desc>
+            <elapsed>
               <xsl:call-template name="format-duration">
-                <xsl:with-param name="seconds" select="elapsed_seconds"/>
+                <xsl:with-param name="seconds" select="k:elapsed_seconds"/>
               </xsl:call-template>
-            </span>
-          </li>
+            </elapsed>
+          </hook>
         </xsl:for-each>
-      </ul>
-    </div>
-  </xsl:if>
+      </hooks>
+    </xsl:if>
 
-</section>
+  </card>
 </xsl:template>
 
-<!-- Format seconds into compact human-readable duration (matches CLI style) -->
+<!-- Format seconds into compact human-readable duration -->
 <xsl:template name="format-duration">
   <xsl:param name="seconds"/>
   <xsl:variable name="s" select="floor(number($seconds))"/>
@@ -145,22 +128,17 @@
   <xsl:variable name="sec" select="$s mod 60"/>
   <xsl:choose>
     <xsl:when test="$h &gt; 0 and $m &gt; 0">
-      <xsl:value-of select="$h"/>
-      <xsl:text>h</xsl:text>
-      <xsl:value-of select="$m"/>
-      <xsl:text>m</xsl:text>
+      <xsl:value-of select="$h"/><xsl:text>h</xsl:text>
+      <xsl:value-of select="$m"/><xsl:text>m</xsl:text>
     </xsl:when>
     <xsl:when test="$h &gt; 0">
-      <xsl:value-of select="$h"/>
-      <xsl:text>h</xsl:text>
+      <xsl:value-of select="$h"/><xsl:text>h</xsl:text>
     </xsl:when>
     <xsl:when test="$m &gt; 0">
-      <xsl:value-of select="$m"/>
-      <xsl:text>m</xsl:text>
+      <xsl:value-of select="$m"/><xsl:text>m</xsl:text>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:value-of select="$sec"/>
-      <xsl:text>s</xsl:text>
+      <xsl:value-of select="$sec"/><xsl:text>s</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>

--- a/kennel/static/status.xsl
+++ b/kennel/static/status.xsl
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="html" encoding="UTF-8" indent="yes"/>
+
+<xsl:template match="/kennel">
+<html lang="en">
+<head>
+  <meta http-equiv="refresh" content="2"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <link rel="stylesheet" href="/static/status.css"/>
+  <title>kennel</title>
+</head>
+<body>
+  <header>
+    <h1><span class="paw">&#x1F43E;</span> kennel</h1>
+  </header>
+  <main>
+    <xsl:choose>
+      <xsl:when test="repo">
+        <xsl:apply-templates select="repo"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <div class="empty">No repos configured. Napping &#x1F4A4;</div>
+      </xsl:otherwise>
+    </xsl:choose>
+  </main>
+</body>
+</html>
+</xsl:template>
+
+<xsl:template match="repo">
+<section>
+  <xsl:attribute name="class">
+    <xsl:text>repo</xsl:text>
+    <xsl:if test="is_stuck = 'true'"> stuck</xsl:if>
+    <xsl:if test="crash_count &gt; 0"> crashed</xsl:if>
+    <xsl:if test="busy = 'true' and is_stuck != 'true'"> busy</xsl:if>
+    <xsl:if test="busy != 'true' and is_stuck != 'true' and not(crash_count &gt; 0)"> idle</xsl:if>
+  </xsl:attribute>
+
+  <div class="repo-header">
+    <span>
+      <xsl:attribute name="class">
+        <xsl:text>dot</xsl:text>
+        <xsl:choose>
+          <xsl:when test="is_stuck = 'true'"> dot-stuck</xsl:when>
+          <xsl:when test="crash_count &gt; 0"> dot-crash</xsl:when>
+          <xsl:when test="busy = 'true'"> dot-busy</xsl:when>
+          <xsl:otherwise> dot-idle</xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+    </span>
+    <h2><xsl:value-of select="repo_name"/></h2>
+    <xsl:if test="worker_uptime_seconds != ''">
+      <span class="uptime">
+        <xsl:text>up </xsl:text>
+        <xsl:call-template name="format-duration">
+          <xsl:with-param name="seconds" select="worker_uptime_seconds"/>
+        </xsl:call-template>
+      </span>
+    </xsl:if>
+  </div>
+
+  <div class="activity">
+    <xsl:value-of select="what"/>
+  </div>
+
+  <div class="meta">
+    <xsl:if test="crash_count &gt; 0">
+      <span class="badge badge-crash">
+        <xsl:value-of select="crash_count"/>
+        <xsl:text> crash</xsl:text>
+        <xsl:if test="crash_count &gt; 1">es</xsl:if>
+      </span>
+    </xsl:if>
+
+    <xsl:if test="rescoping = 'true'">
+      <span class="badge badge-rescope">rescoping &#x27F3;</span>
+    </xsl:if>
+
+    <xsl:if test="session_alive = 'true'">
+      <span class="badge badge-session">
+        <xsl:text>session</xsl:text>
+        <xsl:if test="session_owner != ''">
+          <xsl:text>: </xsl:text>
+          <xsl:value-of select="session_owner"/>
+        </xsl:if>
+        <xsl:if test="session_pid != ''">
+          <xsl:text> (pid </xsl:text>
+          <xsl:value-of select="session_pid"/>
+          <xsl:text>)</xsl:text>
+        </xsl:if>
+      </span>
+    </xsl:if>
+  </div>
+
+  <xsl:if test="claude_talker/kind">
+    <div class="talker">
+      <span class="talker-label">claude</span>
+      <span class="talker-kind"><xsl:value-of select="claude_talker/kind"/></span>
+      <span class="talker-desc"><xsl:value-of select="claude_talker/description"/></span>
+      <xsl:if test="claude_talker/claude_pid != ''">
+        <span class="talker-pid">
+          <xsl:text>pid </xsl:text>
+          <xsl:value-of select="claude_talker/claude_pid"/>
+        </span>
+      </xsl:if>
+    </div>
+  </xsl:if>
+
+  <xsl:if test="last_crash_error != ''">
+    <details class="crash-error">
+      <summary>last crash</summary>
+      <pre><xsl:value-of select="last_crash_error"/></pre>
+    </details>
+  </xsl:if>
+
+  <xsl:if test="webhook_activities/webhook">
+    <div class="webhooks">
+      <span class="webhooks-label">webhooks</span>
+      <ul>
+        <xsl:for-each select="webhook_activities/webhook">
+          <li>
+            <xsl:value-of select="description"/>
+            <span class="elapsed">
+              <xsl:call-template name="format-duration">
+                <xsl:with-param name="seconds" select="elapsed_seconds"/>
+              </xsl:call-template>
+            </span>
+          </li>
+        </xsl:for-each>
+      </ul>
+    </div>
+  </xsl:if>
+
+</section>
+</xsl:template>
+
+<!-- Format seconds into compact human-readable duration (matches CLI style) -->
+<xsl:template name="format-duration">
+  <xsl:param name="seconds"/>
+  <xsl:variable name="s" select="floor(number($seconds))"/>
+  <xsl:variable name="h" select="floor($s div 3600)"/>
+  <xsl:variable name="m" select="floor(($s mod 3600) div 60)"/>
+  <xsl:variable name="sec" select="$s mod 60"/>
+  <xsl:choose>
+    <xsl:when test="$h &gt; 0 and $m &gt; 0">
+      <xsl:value-of select="$h"/>
+      <xsl:text>h</xsl:text>
+      <xsl:value-of select="$m"/>
+      <xsl:text>m</xsl:text>
+    </xsl:when>
+    <xsl:when test="$h &gt; 0">
+      <xsl:value-of select="$h"/>
+      <xsl:text>h</xsl:text>
+    </xsl:when>
+    <xsl:when test="$m &gt; 0">
+      <xsl:value-of select="$m"/>
+      <xsl:text>m</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:value-of select="$sec"/>
+      <xsl:text>s</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kennel/static_files.py
+++ b/kennel/static_files.py
@@ -1,0 +1,110 @@
+"""Static file serving with etag, last-modified, and cache-control caching."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from datetime import datetime, timezone
+from email.utils import format_datetime, parsedate_to_datetime
+from pathlib import Path
+from urllib.parse import unquote
+
+_CONTENT_TYPES: dict[str, str] = {
+    ".css": "text/css; charset=utf-8",
+    ".xsl": "application/xslt+xml; charset=utf-8",
+}
+
+_MAX_AGE = 3600
+
+
+@dataclasses.dataclass
+class StaticFileResponse:
+    """Response from static file serving — status, headers, and body."""
+
+    status: int
+    headers: list[tuple[str, str]]
+    body: bytes
+
+
+class StaticFiles:
+    """Serves files from a directory root with HTTP caching headers.
+
+    Supports ``ETag`` (content-hash), ``Last-Modified`` (filesystem mtime),
+    and ``Cache-Control`` headers.  Honors ``If-None-Match`` and
+    ``If-Modified-Since`` conditional requests with 304 Not Modified.
+
+    Injected into ``WebhookHandler`` at the composition root.  Tests construct
+    with a ``tmp_path`` containing real files — no filesystem mocking needed.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.resolve()
+
+    def serve(
+        self,
+        url_path: str,
+        if_none_match: str | None,
+        if_modified_since: str | None,
+    ) -> StaticFileResponse | None:
+        """Serve a static file, or return ``None`` if not found / not allowed.
+
+        Only serves files with recognized extensions directly under the root.
+        Returns 304 responses when conditional headers match.
+        """
+        relative = unquote(url_path.removeprefix("/static/"))
+        if not relative:
+            return None
+
+        full_path = (self._root / relative).resolve()
+        if not full_path.is_relative_to(self._root):
+            return None
+
+        if not full_path.is_file():
+            return None
+
+        content_type = _CONTENT_TYPES.get(full_path.suffix)
+        if content_type is None:
+            return None
+
+        content = full_path.read_bytes()
+        etag = '"' + hashlib.sha256(content).hexdigest()[:16] + '"'
+        # Truncate to second precision — HTTP dates don't carry sub-second.
+        mtime = datetime.fromtimestamp(int(full_path.stat().st_mtime), tz=timezone.utc)
+        last_modified = format_datetime(mtime, usegmt=True)
+
+        cache_control = f"public, max-age={_MAX_AGE}"
+
+        if if_none_match == etag:
+            return StaticFileResponse(
+                status=304,
+                headers=[("ETag", etag), ("Cache-Control", cache_control)],
+                body=b"",
+            )
+
+        if if_modified_since:
+            try:
+                since = parsedate_to_datetime(if_modified_since)
+                if mtime <= since:
+                    return StaticFileResponse(
+                        status=304,
+                        headers=[
+                            ("ETag", etag),
+                            ("Last-Modified", last_modified),
+                            ("Cache-Control", cache_control),
+                        ],
+                        body=b"",
+                    )
+            except ValueError, TypeError:
+                pass
+
+        return StaticFileResponse(
+            status=200,
+            headers=[
+                ("Content-Type", content_type),
+                ("Content-Length", str(len(content))),
+                ("ETag", etag),
+                ("Last-Modified", last_modified),
+                ("Cache-Control", cache_control),
+            ],
+            body=content,
+        )

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -206,9 +206,9 @@ def _port_from_pid(pid: int) -> int | None:
 def _fetch_activities(
     port: int, *, _urlopen: Callable[..., Any] = urllib.request.urlopen
 ) -> dict[str, dict[str, Any]]:
-    """Query GET /status, returning {repo_name: {what, crash_count, last_crash_error, is_stuck}}."""
+    """Query GET /status.json, returning {repo_name: {what, crash_count, last_crash_error, is_stuck}}."""
     try:
-        with _urlopen(f"http://localhost:{port}/status", timeout=2) as resp:
+        with _urlopen(f"http://localhost:{port}/status.json", timeout=2) as resp:
             data = json.loads(resp.read())
         return {
             item["repo_name"]: {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,7 +204,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
         data = json.loads(resp.read())
         assert len(data) == 1
@@ -241,7 +241,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["session_owner"] == "worker-home"
 
@@ -267,7 +267,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["session_alive"] is True
         assert data[0]["session_owner"] is None
@@ -298,7 +298,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["crash_count"] == 3
         assert data[0]["last_crash_error"] == "RuntimeError: boom"
@@ -306,14 +306,14 @@ class TestGetEndpoint:
     def test_status_endpoint_empty_when_no_activities(self, server: tuple) -> None:
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = []
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
         assert json.loads(resp.read()) == []
 
     def test_status_endpoint_content_type_json(self, server: tuple) -> None:
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = []
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.headers.get("Content-Type") == "application/json"
 
     def test_status_endpoint_is_stuck_true_when_stale(self, server: tuple) -> None:
@@ -338,7 +338,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["is_stuck"] is True
 
@@ -364,7 +364,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = True
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["rescoping"] is True
 
@@ -390,9 +390,127 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        resp = urllib.request.urlopen(f"{url}/status")
+        resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["rescoping"] is False
+
+
+class TestStatusXml:
+    def test_status_returns_xml_with_xslt_pi(self, server: tuple) -> None:
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert resp.headers.get("Content-Type") == "application/xml; charset=utf-8"
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in body
+        assert '<?xml-stylesheet type="text/xsl" href="/static/status.xsl"?>' in body
+        assert "<kennel" in body
+
+    def test_status_xml_contains_repo_data(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<repo_name>owner/repo</repo_name>" in body
+        assert "<what>Working on: #1</what>" in body
+        assert "<busy>true</busy>" in body
+
+    def test_status_xml_empty_kennel(self, server: tuple) -> None:
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<kennel />" in body or "<kennel/>" in body
+
+    def test_status_xml_includes_claude_talker(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.claude import ClaudeTalker
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        talker = ClaudeTalker(
+            repo_name="owner/repo",
+            thread_id=42,
+            kind="worker",
+            description="implementing task",
+            claude_pid=9999,
+            started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
+        )
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="working",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        with patch("kennel.claude.get_talker", return_value=talker):
+            resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<kind>worker</kind>" in body
+        assert "<claude_pid>9999</claude_pid>" in body
+
+    def test_status_xml_includes_webhooks(self, server: tuple) -> None:
+        from datetime import datetime, timezone
+
+        from kennel.registry import WebhookActivity, WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="working",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = [
+            WebhookActivity(
+                handle_id=1,
+                description="replying to review",
+                started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                thread_id=789,
+            ),
+        ]
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<description>replying to review</description>" in body
+        assert "<thread_id>789</thread_id>" in body
 
 
 class TestStaticFileServing:
@@ -1249,7 +1367,7 @@ class TestProcessAction:
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
         with patch("kennel.claude.get_talker", return_value=talker):
-            resp = urllib.request.urlopen(f"{url}/status")
+            resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         talker_data = data[0]["claude_talker"]
         assert talker_data["repo_name"] == "owner/repo"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,7 @@ import pytest
 from kennel.config import Config, RepoConfig
 from kennel.events import Action, recover_reply_promises
 from kennel.infra import Infra
-from kennel.server import PreflightError, WebhookHandler
+from kennel.server import PreflightError, WebhookHandler, _repo_status
 
 # Thread-capture and do_POST synchronisation helpers ---------------------------
 #
@@ -395,8 +395,23 @@ class TestGetEndpoint:
         assert data[0]["rescoping"] is False
 
 
+class TestRepoStatus:
+    @pytest.mark.parametrize(
+        ("act", "expected"),
+        [
+            ({"is_stuck": True, "crash_count": 2, "busy": True}, "stuck"),
+            ({"is_stuck": False, "crash_count": 3, "busy": True}, "crashed"),
+            ({"is_stuck": False, "crash_count": 0, "busy": True}, "busy"),
+            ({"is_stuck": False, "crash_count": 0, "busy": False}, "idle"),
+        ],
+        ids=["stuck", "crashed", "busy", "idle"],
+    )
+    def test_repo_status_priority(self, act: dict, expected: str) -> None:
+        assert _repo_status(act) == expected
+
+
 class TestStatusXml:
-    def test_status_returns_xml_with_xslt_pi(self, server: tuple) -> None:
+    def test_status_returns_namespaced_xml_with_xslt_pi(self, server: tuple) -> None:
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
@@ -405,8 +420,9 @@ class TestStatusXml:
         assert '<?xml version="1.0" encoding="UTF-8"?>' in body
         assert '<?xml-stylesheet type="text/xsl" href="/static/status.xsl"?>' in body
         assert "<kennel" in body
+        assert 'xmlns="https://fidocancode.dog/kennel"' in body
 
-    def test_status_xml_contains_repo_data(self, server: tuple) -> None:
+    def test_status_xml_contains_repo_data_with_namespaces(self, server: tuple) -> None:
         from datetime import datetime, timezone
 
         from kennel.registry import WorkerActivity
@@ -433,13 +449,16 @@ class TestStatusXml:
         assert "<repo_name>owner/repo</repo_name>" in body
         assert "<what>Working on: #1</what>" in body
         assert "<busy>true</busy>" in body
+        assert 'dog:status="busy"' in body
 
     def test_status_xml_empty_kennel(self, server: tuple) -> None:
         url, _ = server
         WebhookHandler.registry.get_all_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
-        assert "<kennel />" in body or "<kennel/>" in body
+        assert 'xmlns="https://fidocancode.dog/kennel"' in body
+        # Empty kennel — self-closing root element (with namespace attrs)
+        assert "/>" in body
 
     def test_status_xml_includes_claude_talker(self, server: tuple) -> None:
         from datetime import datetime, timezone

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -89,6 +89,7 @@ def _restore_handler_fns():
         "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
         "infra": WebhookHandler.infra,
+        "static_files": WebhookHandler.static_files,
     }
     # Override _fn_after_do_post for all tests so _post_webhook can wait for
     # do_POST to complete without sleeping (see module-level comment above).
@@ -392,6 +393,78 @@ class TestGetEndpoint:
         resp = urllib.request.urlopen(f"{url}/status")
         data = json.loads(resp.read())
         assert data[0]["rescoping"] is False
+
+
+class TestStaticFileServing:
+    def test_serves_static_css(self, server: tuple, tmp_path: Path) -> None:
+        url, _ = server
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "style.css").write_text("body { color: red; }")
+
+        from kennel.static_files import StaticFiles
+
+        WebhookHandler.static_files = StaticFiles(static_dir)
+        resp = urllib.request.urlopen(f"{url}/static/style.css")
+        assert resp.status == 200
+        assert resp.read() == b"body { color: red; }"
+        assert resp.headers["Content-Type"] == "text/css; charset=utf-8"
+
+    def test_static_includes_caching_headers(
+        self, server: tuple, tmp_path: Path
+    ) -> None:
+        url, _ = server
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "style.css").write_text("x")
+
+        from kennel.static_files import StaticFiles
+
+        WebhookHandler.static_files = StaticFiles(static_dir)
+        resp = urllib.request.urlopen(f"{url}/static/style.css")
+        assert resp.headers["ETag"] is not None
+        assert resp.headers["Last-Modified"] is not None
+        assert resp.headers["Cache-Control"] == "public, max-age=3600"
+
+    def test_static_304_on_etag_match(self, server: tuple, tmp_path: Path) -> None:
+        url, _ = server
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        content = b"body { color: blue; }"
+        (static_dir / "style.css").write_bytes(content)
+
+        import hashlib
+
+        from kennel.static_files import StaticFiles
+
+        WebhookHandler.static_files = StaticFiles(static_dir)
+        etag = '"' + hashlib.sha256(content).hexdigest()[:16] + '"'
+        req = urllib.request.Request(
+            f"{url}/static/style.css",
+            headers={"If-None-Match": etag},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+        assert exc_info.value.code == 304
+
+    def test_static_404_when_no_static_files(self, server: tuple) -> None:
+        url, _ = server
+        WebhookHandler.static_files = None
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"{url}/static/style.css")
+        assert exc_info.value.code == 404
+
+    def test_static_404_for_missing_file(self, server: tuple, tmp_path: Path) -> None:
+        url, _ = server
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+
+        from kennel.static_files import StaticFiles
+
+        WebhookHandler.static_files = StaticFiles(static_dir)
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(f"{url}/static/nope.css")
+        assert exc_info.value.code == 404
 
 
 class TestEmptyBody:

--- a/tests/test_static_files.py
+++ b/tests/test_static_files.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from pathlib import Path
+
+from kennel.static_files import StaticFiles
+
+
+class TestServeBasic:
+    def test_serves_css_file(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("body { color: red; }")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", None, None)
+        assert resp is not None
+        assert resp.status == 200
+        assert resp.body == b"body { color: red; }"
+        headers = dict(resp.headers)
+        assert headers["Content-Type"] == "text/css; charset=utf-8"
+        assert headers["Content-Length"] == str(len(resp.body))
+
+    def test_serves_xsl_file(self, tmp_path: Path) -> None:
+        (tmp_path / "status.xsl").write_text("<xsl:stylesheet/>")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/status.xsl", None, None)
+        assert resp is not None
+        assert resp.status == 200
+        assert resp.body == b"<xsl:stylesheet/>"
+        headers = dict(resp.headers)
+        assert headers["Content-Type"] == "application/xslt+xml; charset=utf-8"
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        sf = StaticFiles(tmp_path)
+        assert sf.serve("/static/nope.css", None, None) is None
+
+    def test_returns_none_for_unknown_extension(self, tmp_path: Path) -> None:
+        (tmp_path / "secrets.txt").write_text("oh no")
+        sf = StaticFiles(tmp_path)
+        assert sf.serve("/static/secrets.txt", None, None) is None
+
+    def test_returns_none_for_empty_path(self, tmp_path: Path) -> None:
+        sf = StaticFiles(tmp_path)
+        assert sf.serve("/static/", None, None) is None
+
+    def test_returns_none_for_path_traversal(self, tmp_path: Path) -> None:
+        # Create a file outside the static root
+        (tmp_path / "outside.css").write_text("naughty")
+        sub = tmp_path / "static"
+        sub.mkdir()
+        sf = StaticFiles(sub)
+        assert sf.serve("/static/../outside.css", None, None) is None
+
+    def test_returns_none_for_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        sf = StaticFiles(tmp_path)
+        assert sf.serve("/static/sub", None, None) is None
+
+
+class TestCachingHeaders:
+    def test_etag_present(self, tmp_path: Path) -> None:
+        content = b"body { color: blue; }"
+        (tmp_path / "style.css").write_bytes(content)
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", None, None)
+        assert resp is not None
+        headers = dict(resp.headers)
+        expected_etag = '"' + hashlib.sha256(content).hexdigest()[:16] + '"'
+        assert headers["ETag"] == expected_etag
+
+    def test_last_modified_present(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", None, None)
+        assert resp is not None
+        headers = dict(resp.headers)
+        assert "Last-Modified" in headers
+
+    def test_cache_control_present(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", None, None)
+        assert resp is not None
+        headers = dict(resp.headers)
+        assert headers["Cache-Control"] == "public, max-age=3600"
+
+
+class TestConditionalRequests:
+    def test_etag_match_returns_304(self, tmp_path: Path) -> None:
+        content = b"body { color: red; }"
+        (tmp_path / "style.css").write_bytes(content)
+        sf = StaticFiles(tmp_path)
+        etag = '"' + hashlib.sha256(content).hexdigest()[:16] + '"'
+        resp = sf.serve("/static/style.css", etag, None)
+        assert resp is not None
+        assert resp.status == 304
+        assert resp.body == b""
+        headers = dict(resp.headers)
+        assert headers["ETag"] == etag
+        assert headers["Cache-Control"] == "public, max-age=3600"
+
+    def test_etag_mismatch_returns_200(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", '"stale"', None)
+        assert resp is not None
+        assert resp.status == 200
+
+    def test_if_modified_since_not_modified(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        # Use a date far in the future so the file is definitely not newer
+        future = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        since = format_datetime(future, usegmt=True)
+        resp = sf.serve("/static/style.css", None, since)
+        assert resp is not None
+        assert resp.status == 304
+        assert resp.body == b""
+
+    def test_if_modified_since_modified(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        # Use a date far in the past so the file is newer
+        past = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        since = format_datetime(past, usegmt=True)
+        resp = sf.serve("/static/style.css", None, since)
+        assert resp is not None
+        assert resp.status == 200
+
+    def test_if_modified_since_malformed_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/style.css", None, "not-a-date")
+        assert resp is not None
+        assert resp.status == 200
+
+    def test_etag_takes_precedence_over_if_modified_since(self, tmp_path: Path) -> None:
+        content = b"body { color: red; }"
+        (tmp_path / "style.css").write_bytes(content)
+        sf = StaticFiles(tmp_path)
+        etag = '"' + hashlib.sha256(content).hexdigest()[:16] + '"'
+        # Etag matches → 304, even though If-Modified-Since is in the past
+        past = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        since = format_datetime(past, usegmt=True)
+        resp = sf.serve("/static/style.css", etag, since)
+        assert resp is not None
+        assert resp.status == 304
+
+
+class TestUrlDecoding:
+    def test_percent_encoded_filename(self, tmp_path: Path) -> None:
+        (tmp_path / "my style.css").write_text("x")
+        sf = StaticFiles(tmp_path)
+        resp = sf.serve("/static/my%20style.css", None, None)
+        assert resp is not None
+        assert resp.status == 200

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -524,7 +524,9 @@ class TestFetchActivities:
     def test_calls_correct_url(self) -> None:
         mock_urlopen = self._make_urlopen(b"[]")
         _fetch_activities(8888, _urlopen=mock_urlopen)
-        mock_urlopen.assert_called_once_with("http://localhost:8888/status", timeout=2)
+        mock_urlopen.assert_called_once_with(
+            "http://localhost:8888/status.json", timeout=2
+        )
 
 
 class TestClaudePid:


### PR DESCRIPTION
Fixes #532.

Three-layer Rube Goldberg status pipeline: the server emits structural XML with namespaces, XSLT transforms it into display-oriented XML (also namespaced), and CSS styles the final output via @namespace selectors. Static assets are served with intelligent HTTP caching using etag, last-modified, and cache-control headers.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] [Add XSLT transform layer between structural XML and CSS-styled display XML](https://github.com/FidoCanCode/home/pull/590#issuecomment-4256618178) <!-- type:thread -->
- [x] [Replace XSLT-to-HTML with direct XML plus CSS stylesheet and add namespaces](https://github.com/FidoCanCode/home/pull/590#discussion_r3090144298) <!-- type:thread -->
- [x] Create XSLT and CSS stylesheets for status page display <!-- type:spec -->
- [x] Serve /status as XML with XSLT processing instruction and auto-refresh <!-- type:spec -->
- [x] Add static file serving with etag/last-modified/cache-control caching <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->