### PR TITLE
Fido should remediate merge conflicts. (closes #531)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1216,6 +1216,53 @@ class Worker:
         return pr_number, slug, True
 
     # ------------------------------------------------------------------
+    # Merge conflict handling
+    # ------------------------------------------------------------------
+
+    def handle_merge_conflict(
+        self,
+        fido_dir: Path,
+        repo_ctx: RepoContext,
+        pr_number: int,
+        slug: str,
+    ) -> bool:
+        """Detect and remediate a merge conflict on the branch.
+
+        Returns ``True`` if the branch had merge conflicts and sub-Claude was
+        invoked to resolve them (the caller should re-run the work loop
+        immediately).  Returns ``False`` when there are no conflicts.
+        """
+        log.info("checking: merge conflicts")
+        pr_info = self.gh.get_pr(repo_ctx.repo, pr_number)
+        merge_state = pr_info.get("mergeStateStatus", "")
+        if merge_state != "DIRTY":
+            log.info(
+                "merge conflict check skipped — mergeStateStatus=%s",
+                merge_state,
+            )
+            return False
+
+        log.info("merge conflict detected on PR #%s (branch=%s)", pr_number, slug)
+        self.set_status(f"Resolving merge conflicts on PR #{pr_number}")
+
+        context = (
+            f"PR: {pr_number}\n"
+            f"Repo: {repo_ctx.repo}\n"
+            f"Branch: {slug}\n"
+            f"Upstream: origin/{repo_ctx.default_branch}\n"
+            f"Work dir: {self.work_dir}\n"
+        )
+        build_prompt(fido_dir, "merge", context)
+        session_id, _ = claude_run(
+            fido_dir,
+            cwd=self.work_dir,
+            session=self._session,
+            claude_client=self._claude_client,
+        )
+        log.info("merge conflict resolution done (session=%s)", session_id)
+        return True
+
+    # ------------------------------------------------------------------
     # CI failure handling
     # ------------------------------------------------------------------
 
@@ -2066,6 +2113,10 @@ class Worker:
                     log.info("fresh PR — skipping CI/thread/rescope checks")
                 else:
                     self.rescope_before_pick()
+                    if self.handle_merge_conflict(
+                        ctx.fido_dir, repo_ctx, pr_number, slug
+                    ):
+                        return 1
                     if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
                         return 1
                     if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):

--- a/sub/merge.md
+++ b/sub/merge.md
@@ -1,0 +1,43 @@
+The branch has a merge conflict with upstream. All context (PR, repo, branch, upstream) is in the Context section above.
+
+## Steps
+
+### 1. Fetch and merge upstream
+```bash
+git fetch origin
+git merge origin/<default_branch>
+```
+
+If the merge succeeds cleanly (exit 0, no conflicts), skip to step 3.
+
+### 2. Resolve conflicts
+
+Find all conflicted files:
+```bash
+git status --short | grep '^UU\|^AA\|^DD\|^AU\|^UA\|^DU\|^UD' | awk '{print $2}'
+```
+
+For each conflicted file:
+1. Read the file. Understand both sides of the conflict (ours vs theirs).
+2. Resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) by writing the correct merged result.
+3. Do NOT leave any conflict markers in the file.
+
+After resolving all files:
+```bash
+git add <resolved-files>
+```
+
+### 3. Commit and push
+```bash
+git commit -m "Merge origin/<default_branch> into <branch>"
+git push
+```
+
+## Done when
+Merge complete, no conflict markers remain, committed and pushed.
+
+## Constraints
+- **Never** rebase, amend, or force-push. New commits only.
+- **Never** mark the PR as ready for review (`gh pr ready`). It must stay draft.
+- **Never** use TaskCreate, TaskUpdate, TaskList, TodoWrite, TodoRead, or `kennel task`.
+- **Never** edit the PR body directly.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4224,6 +4224,257 @@ class TestFilterCiThreads:
         assert w._filter_ci_threads([node], "fido-bot", "check") == []
 
 
+class TestHandleMergeConflict:
+    """Tests for Worker.handle_merge_conflict."""
+
+    def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
+        gh = MagicMock()
+        gh.get_pr.return_value = {"mergeStateStatus": "DIRTY"}
+        return Worker(tmp_path, gh), gh
+
+    def _repo_ctx(self) -> RepoContext:
+        return RepoContext(
+            repo="owner/repo",
+            owner="owner",
+            repo_name="repo",
+            gh_user="fido-bot",
+            default_branch="main",
+            membership=RepoMembership(collaborators=frozenset({"owner"})),
+        )
+
+    def _fido_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".git" / "fido"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_returns_false_when_not_dirty(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
+        fido_dir = self._fido_dir(tmp_path)
+        assert (
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 1, "branch")
+            is False
+        )
+
+    def test_returns_false_when_blocked(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
+        fido_dir = self._fido_dir(tmp_path)
+        assert (
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 1, "branch")
+            is False
+        )
+
+    def test_returns_false_when_missing_merge_state(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"body": ""}
+        fido_dir = self._fido_dir(tmp_path)
+        assert (
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 1, "branch")
+            is False
+        )
+
+    def test_returns_true_when_dirty(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", return_value=("sid", "")),
+        ):
+            result = worker.handle_merge_conflict(
+                fido_dir, self._repo_ctx(), 1, "branch"
+            )
+        assert result is True
+
+    def test_calls_set_status_with_pr_number(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status") as mock_status,
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", return_value=("", "")),
+        ):
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 42, "my-branch")
+        mock_status.assert_called_once_with("Resolving merge conflicts on PR #42")
+
+    def test_builds_merge_prompt(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt") as mock_bp,
+            patch("kennel.worker.claude_run", return_value=("", "")),
+        ):
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 5, "fix-branch")
+        mock_bp.assert_called_once()
+        _, subskill, context = mock_bp.call_args[0]
+        assert subskill == "merge"
+        assert "fix-branch" in context
+        assert "PR: 5" in context
+        assert "origin/main" in context
+
+    def test_runs_claude(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", return_value=("sess-1", "")) as mock_cr,
+        ):
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 1, "branch")
+        mock_cr.assert_called_once_with(
+            fido_dir, cwd=tmp_path, session=None, claude_client=ANY
+        )
+
+    def test_does_not_call_claude_when_not_dirty(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.get_pr.return_value = {"mergeStateStatus": "CLEAN"}
+        fido_dir = self._fido_dir(tmp_path)
+        with patch("kennel.worker.claude_run") as mock_cr:
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 1, "branch")
+        mock_cr.assert_not_called()
+
+    def test_checks_pr_merge_state(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.claude_run", return_value=("", "")),
+        ):
+            worker.handle_merge_conflict(fido_dir, self._repo_ctx(), 7, "branch")
+        gh.get_pr.assert_called_once_with("owner/repo", 7)
+
+
+class TestRunHandleMergeConflictIntegration:
+    """Tests that Worker.run() calls handle_merge_conflict before handle_ci."""
+
+    def _make_gh(self) -> MagicMock:
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.get_default_branch.return_value = "main"
+        gh.get_pr.return_value = {"body": ""}
+        return gh
+
+    def _make_mock_ctx(self, tmp_path: Path) -> MagicMock:
+        mock_ctx = MagicMock(spec=WorkerContext)
+        mock_ctx.git_dir = tmp_path / ".git"
+        mock_ctx.fido_dir = tmp_path / ".git" / "fido"
+        return mock_ctx
+
+    def _make_mock_repo_ctx(self) -> MagicMock:
+        repo_ctx = MagicMock(spec=RepoContext)
+        repo_ctx.repo = "owner/repo"
+        repo_ctx.gh_user = "fido-bot"
+        repo_ctx.default_branch = "main"
+        repo_ctx.membership = RepoMembership()
+        return repo_ctx
+
+    def test_handle_merge_conflict_called_with_pr_and_slug(
+        self, tmp_path: Path
+    ) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        mock_handle_mc = MagicMock(return_value=False)
+        repo_ctx = self._make_mock_repo_ctx()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", False)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "handle_merge_conflict", mock_handle_mc),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+        ):
+            worker.run()
+        mock_handle_mc.assert_called_once_with(
+            mock_ctx.fido_dir, repo_ctx, 42, "fix-bug"
+        )
+
+    def test_returns_1_when_merge_conflict_handled(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        repo_ctx = self._make_mock_repo_ctx()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", False)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "handle_merge_conflict", return_value=True),
+        ):
+            result = worker.run()
+        assert result == 1
+
+    def test_handle_ci_not_called_when_merge_conflict_handled(
+        self, tmp_path: Path
+    ) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        repo_ctx = self._make_mock_repo_ctx()
+        mock_ci = MagicMock(return_value=False)
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", False)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "handle_merge_conflict", return_value=True),
+            patch.object(worker, "handle_ci", mock_ci),
+        ):
+            worker.run()
+        mock_ci.assert_not_called()
+
+    def test_handle_merge_conflict_not_called_on_fresh_pr(self, tmp_path: Path) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        repo_ctx = self._make_mock_repo_ctx()
+        mock_mc = MagicMock(return_value=False)
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", True)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "handle_merge_conflict", mock_mc),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+        mock_mc.assert_not_called()
+
+
 class TestHandleCi:
     """Tests for Worker.handle_ci."""
 


### PR DESCRIPTION
Fixes #531.

Adds merge conflict remediation so fido detects dirty merge state before CI checks and resolves conflicts by merging upstream, invoking a new merge sub-skill for conflict resolution, and pushing. This unblocks CI, which can't run at all while the branch has merge conflicts.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add sub/merge.md sub-skill for merge conflict resolution <!-- type:spec -->
- [x] Add handle_merge_conflict to Worker and wire into work loop before CI <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->