### PR TITLE
Try gh-status providers configured on the live kennel

### DIFF
--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -53,12 +53,7 @@ def _default_provider_factories(
 
     repo_cfgs = _running_repo_configs_fn()
     if not repo_cfgs:
-        return (
-            lambda: ClaudeClient(
-                session_system_file=_PERSONA_PATH,
-                work_dir=Path.cwd(),
-            ),
-        )
+        return ()
 
     provider_factory = DefaultProviderFactory(session_system_file=_PERSONA_PATH)
     factories: list[Callable[[], ProviderAgent]] = []

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -9,8 +9,11 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from kennel.claude import ClaudeClient
+from kennel.config import RepoConfig
 from kennel.github import GitHub
 from kennel.provider import ProviderAgent
+from kennel.provider_factory import DefaultProviderFactory
+from kennel.status import running_repo_configs
 
 log = logging.getLogger(__name__)
 
@@ -28,110 +31,59 @@ _EMOJI_SYSTEM = (
     " the status message. Output ONLY the emoji shortcode, nothing else."
 )
 
-_NAP_MESSAGES = (
-    "Taking a little nap. Back soon.",
-    "Curled up for a quick nap.",
-    "Dozing by the keyboard for a bit.",
-    "Snoring softly under the desk.",
-    "Resting my paws and rebooting my brain.",
-    "Power nap time. Woof soon.",
-    "Taking a breather in the sunbeam.",
-    "Sleeping off a big debugging session.",
-    "Paws up. Eyes closed. Back later.",
-    "Nap mode engaged.",
-    "Catching a quick snooze between bugs.",
-    "Tucked in for a tiny dog nap.",
-    "Dreaming about clean test runs.",
-    "Resting my little programmer paws.",
-    "Sleeping until the next good idea arrives.",
-    "Having a cozy floor nap.",
-    "Dozing while the thoughts settle.",
-    "Taking five in a warm patch of sun.",
-    "Sniffed too many logs. Need a nap.",
-    "Recharging with a small sleepy woof.",
-    "Out for a brief nap walk in dreamland.",
-    "Napping now. Back when my tail reboots.",
-    "Having a quiet nap and a slower heartbeat.",
-    "Resting after a long code chase.",
-    "Snoozing with one ear on the build.",
-    "Paused for a gentle nap.",
-    "Sleeping through the noisy part.",
-    "Just me, a blanket, and a quick nap.",
-    "Settled in for some quality dozing.",
-    "Nap first. Clever fix later.",
-    "Letting my brain fetch a little rest.",
-    "Tiny nap. Big comeback.",
-    "Taking a sleepy lap around dreamland.",
-    "Tail still. Nose tucked. Napping.",
-    "Having a soft little reset nap.",
-    "Camping out in nap mode.",
-    "Do not disturb. Dreaming of green checks.",
-    "Sleeping on the next move for a minute.",
-    "Back soon. Currently very snoozy.",
-    "Stepping away for a nap and a stretch.",
-    "Quiet paws. Closed eyes. Gentle nap.",
-    "Snoozing until the next bark-worthy task.",
-    "Taking a warm, lazy nap.",
-    "Letting the zoomies cool off.",
-    "Having a thoughtful nap about architecture.",
-    "Paused for a pillow-level refactor.",
-    "Napping with extreme professionalism.",
-    "Resting before the next fetch.",
-    "Low-power dog mode for a minute.",
-    "Sleeping like a very tired code hound.",
-    "Tuning out for a tiny nap.",
-    "Stashed my paws and took a nap.",
-    "Having a hallway nap and a nice dream.",
-    "Short snooze. Long wag later.",
-    "Listening to the hum of a nap.",
-    "Taking a calm little timeout nap.",
-    "All tucked in with my thoughts.",
-    "Gone to fetch some rest.",
-    "Sleeping through the lint in my dreams.",
-    "Resting until the ideas line back up.",
-    "A nap is in progress.",
-    "Having a low-noise, high-comfort nap.",
-    "Snoozing near the charging cable.",
-    "Taking a reset break with a blanket.",
-    "Paws folded. Brain idling. Napping.",
-    "On a tiny nap detour.",
-    "Resting up for the next round of fixes.",
-    "Closed my laptop. Opened my nap.",
-    "Having a code hound catnap.",
-    "Dreaming in tidy little commits.",
-    "Nap vibes only right now.",
-    "Took my thoughts to bed for a bit.",
-    "Sleeping off some stack traces.",
-    "A short nap should do the trick.",
-    "Letting the brain cache cool down.",
-    "Snuggled into a productive nap.",
-    "Dozing until the next tail wag.",
-    "Resting in a very responsible way.",
-    "Nap break. Nothing dramatic.",
-    "Laying low and sleeping lightly.",
-    "Having a peaceful puppy pause.",
-    "Sleeping until the code smells fresher.",
-    "Quietly recharging in nap mode.",
-    "A comfy nap is currently deployed.",
-    "Flat on the rug. Out for a bit.",
-    "Taking a soft reboot nap.",
-    "Pacing stopped. Napping started.",
-    "Resting with excellent blanket coverage.",
-    "Nose tucked, tail still, brain rebooting.",
-    "Just a good old-fashioned nap.",
-    "Borrowing a little rest from the afternoon.",
-    "Snoozing where the light is nicest.",
-    "Nap in progress. Bark later.",
-    "On break with a sleepy sigh.",
-    "Dreaming about elegant diffs.",
-    "Having a paws-off minute.",
-    "Settling into a strategic snooze.",
-    "Resting the snout and the neurons.",
-    "Taking the kind of nap that fixes everything.",
-    "Sleeping now. Will wag again soon.",
-    "One small nap for dog. One big reset for brain.",
-    "Curled up and temporarily unavailable.",
+_FALLBACK_MESSAGES = (
+    "Having a quiet think. Back soon.",
+    "Paws tangled in the status wires for a minute.",
+    "Snout in the logs. Words later.",
+    "Taking a beat and wagging back soon.",
+    "Brain buffering. Tail still works though.",
+    "Having a small dog moment. Back in a sec.",
+    "Status machine made a funny noise. Woof later.",
+    "A little scrambled right now. I will be back soon.",
+    "Stepping away to sniff out the right words.",
+    "Temporarily unavailable, but still a very good dog.",
 )
+
+
+def _default_provider_factories(
+    *,
+    _running_repo_configs_fn: Callable[[], list[RepoConfig]] = running_repo_configs,
+) -> tuple[Callable[[], ProviderAgent], ...]:
+    """Return provider factories for the providers configured on the live kennel."""
+
+    repo_cfgs = _running_repo_configs_fn()
+    if not repo_cfgs:
+        return (
+            lambda: ClaudeClient(
+                session_system_file=_PERSONA_PATH,
+                work_dir=Path.cwd(),
+            ),
+        )
+
+    provider_factory = DefaultProviderFactory(session_system_file=_PERSONA_PATH)
+    factories: list[Callable[[], ProviderAgent]] = []
+    seen_providers: set[object] = set()
+    for repo_cfg in repo_cfgs:
+        if repo_cfg.provider in seen_providers:
+            continue
+        seen_providers.add(repo_cfg.provider)
+        factories.append(
+            lambda cfg=repo_cfg: provider_factory.create_agent(
+                cfg,
+                work_dir=cfg.work_dir,
+                repo_name=cfg.name,
+            )
+        )
+    return tuple(factories)
+
+
+def _candidate_providers(
+    provider: ProviderAgent | None,
+    provider_factories: Sequence[Callable[[], ProviderAgent]],
+) -> tuple[ProviderAgent, ...]:
+    if provider is not None:
+        return (provider,)
+    return tuple(factory() for factory in provider_factories)
 
 
 def generate_persona_status(
@@ -178,25 +130,33 @@ def set_gh_status(
     persona_path: Path = _PERSONA_PATH,
     provider: ProviderAgent | None = None,
     _gh: GitHub,
+    _provider_factories: Sequence[Callable[[], ProviderAgent]] | None = None,
     _choice: Callable[[Sequence[str]], str] = random.choice,
 ) -> None:
     try:
         persona = persona_path.read_text()
     except FileNotFoundError:
         persona = ""
-    current_provider = ClaudeClient() if provider is None else provider
-    try:
-        text = generate_persona_status(message, persona, provider=current_provider)
-        emoji = generate_persona_emoji(text, persona, provider=current_provider)
-    except Exception as exc:
-        log.warning(
-            "set_gh_status: provider %s failed: %s",
-            getattr(current_provider, "provider_id", "unknown"),
-            exc,
-        )
-        _gh.set_user_status(_choice(_NAP_MESSAGES), ":sleeping:", busy=True)
+    providers = _candidate_providers(
+        provider,
+        _default_provider_factories()
+        if _provider_factories is None
+        else tuple(_provider_factories),
+    )
+    for current_provider in providers:
+        try:
+            text = generate_persona_status(message, persona, provider=current_provider)
+            emoji = generate_persona_emoji(text, persona, provider=current_provider)
+        except Exception as exc:
+            log.warning(
+                "set_gh_status: provider %s failed, trying next: %s",
+                getattr(current_provider, "provider_id", "unknown"),
+                exc,
+            )
+            continue
+        _gh.set_user_status(text, emoji, busy=True)
         return
-    _gh.set_user_status(text, emoji, busy=True)
+    _gh.set_user_status(_choice(_FALLBACK_MESSAGES), ":sleeping:", busy=True)
 
 
 def main(argv: list[str], *, _GitHub: type[GitHub] = GitHub) -> None:

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -53,7 +53,7 @@ def _default_provider_factories(
 
     repo_cfgs = _running_repo_configs_fn()
     if not repo_cfgs:
-        return ()
+        raise RuntimeError("No running kennel repo configs found")
 
     provider_factory = DefaultProviderFactory(session_system_file=_PERSONA_PATH)
     factories: list[Callable[[], ProviderAgent]] = []
@@ -132,12 +132,15 @@ def set_gh_status(
         persona = persona_path.read_text()
     except FileNotFoundError:
         persona = ""
-    providers = _candidate_providers(
-        provider,
-        _default_provider_factories()
-        if _provider_factories is None
-        else tuple(_provider_factories),
-    )
+    if provider is not None:
+        providers = (provider,)
+    else:
+        provider_factories = (
+            _default_provider_factories()
+            if _provider_factories is None
+            else tuple(_provider_factories)
+        )
+        providers = _candidate_providers(None, provider_factories)
     for current_provider in providers:
         try:
             text = generate_persona_status(message, persona, provider=current_provider)

--- a/kennel/gh_status.py
+++ b/kennel/gh_status.py
@@ -134,20 +134,6 @@ _NAP_MESSAGES = (
 )
 
 
-def _default_provider_factories() -> tuple[Callable[[], ProviderAgent], ...]:
-    """Return the currently available provider constructors for gh-status."""
-    return (ClaudeClient,)
-
-
-def _candidate_providers(
-    provider: ProviderAgent | None,
-    provider_factories: Sequence[Callable[[], ProviderAgent]],
-) -> tuple[ProviderAgent, ...]:
-    if provider is not None:
-        return (provider,)
-    return tuple(factory() for factory in provider_factories)
-
-
 def generate_persona_status(
     message: str,
     persona: str,
@@ -192,33 +178,25 @@ def set_gh_status(
     persona_path: Path = _PERSONA_PATH,
     provider: ProviderAgent | None = None,
     _gh: GitHub,
-    _provider_factories: Sequence[Callable[[], ProviderAgent]] | None = None,
     _choice: Callable[[Sequence[str]], str] = random.choice,
 ) -> None:
     try:
         persona = persona_path.read_text()
     except FileNotFoundError:
         persona = ""
-    providers = _candidate_providers(
-        provider,
-        _default_provider_factories()
-        if _provider_factories is None
-        else tuple(_provider_factories),
-    )
-    for current_provider in providers:
-        try:
-            text = generate_persona_status(message, persona, provider=current_provider)
-            emoji = generate_persona_emoji(text, persona, provider=current_provider)
-        except Exception as exc:
-            log.warning(
-                "set_gh_status: provider %s failed, trying next: %s",
-                getattr(current_provider, "provider_id", "unknown"),
-                exc,
-            )
-            continue
-        _gh.set_user_status(text, emoji, busy=True)
+    current_provider = ClaudeClient() if provider is None else provider
+    try:
+        text = generate_persona_status(message, persona, provider=current_provider)
+        emoji = generate_persona_emoji(text, persona, provider=current_provider)
+    except Exception as exc:
+        log.warning(
+            "set_gh_status: provider %s failed: %s",
+            getattr(current_provider, "provider_id", "unknown"),
+            exc,
+        )
+        _gh.set_user_status(_choice(_NAP_MESSAGES), ":sleeping:", busy=True)
         return
-    _gh.set_user_status(_choice(_NAP_MESSAGES), ":sleeping:", busy=True)
+    _gh.set_user_status(text, emoji, busy=True)
 
 
 def main(argv: list[str], *, _GitHub: type[GitHub] = GitHub) -> None:

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -201,6 +201,18 @@ def _kennel_pid() -> int | None:
     return pids[0] if pids else None
 
 
+def running_repo_configs(
+    *,
+    _kennel_pid_fn: Callable[[], int | None] = _kennel_pid,
+    _repos_from_pid_fn: Callable[[int], list[RepoConfig]] = _repos_from_pid,
+) -> list[RepoConfig]:
+    """Return the repo configs for the currently running kennel, or []."""
+    pid = _kennel_pid_fn()
+    if pid is None:
+        return []
+    return _repos_from_pid_fn(pid)
+
+
 def _port_from_pid(pid: int) -> int | None:
     """Extract the --port value from kennel's /proc/<pid>/cmdline, or None."""
     try:

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -10,7 +10,6 @@ import pytest
 from kennel.claude import ClaudeClient
 from kennel.config import RepoConfig
 from kennel.gh_status import (
-    _PERSONA_PATH,
     _default_provider_factories,
     generate_persona_emoji,
     generate_persona_status,
@@ -194,29 +193,27 @@ class TestSetGhStatus:
 
 
 class TestDefaultProviderFactories:
-    def test_falls_back_to_owned_claude_when_no_live_kennel(self) -> None:
-        sentinel = _client()
-        with (
-            patch("kennel.gh_status.Path.cwd", return_value=Path("/tmp/here")),
-            patch("kennel.gh_status.ClaudeClient", return_value=sentinel) as mock_cls,
-        ):
-            factories = _default_provider_factories(_running_repo_configs_fn=lambda: [])
-            assert [factory() for factory in factories] == [sentinel]
-        mock_cls.assert_called_once_with(
-            session_system_file=_PERSONA_PATH,
-            work_dir=Path("/tmp/here"),
+    def test_returns_no_factories_when_no_live_kennel(self) -> None:
+        assert _default_provider_factories(_running_repo_configs_fn=lambda: []) == ()
+
+    def test_uses_generic_fallback_when_no_live_kennel(self, tmp_path: Path) -> None:
+        persona_file = tmp_path / "persona.md"
+        persona_file.write_text("persona")
+        mock_gh = MagicMock()
+
+        set_gh_status(
+            "test",
+            persona_path=persona_file,
+            _gh=mock_gh,
+            _provider_factories=(),
+            _choice=lambda options: options[0],
         )
 
-    def test_falls_back_to_owned_claude_when_running_kennel_has_no_repo_specs(
-        self,
-    ) -> None:
-        sentinel = _client()
-        with (
-            patch("kennel.gh_status.Path.cwd", return_value=Path("/tmp/here")),
-            patch("kennel.gh_status.ClaudeClient", return_value=sentinel),
-        ):
-            factories = _default_provider_factories(_running_repo_configs_fn=lambda: [])
-            assert [factory() for factory in factories] == [sentinel]
+        mock_gh.set_user_status.assert_called_once_with(
+            "Having a quiet think. Back soon.",
+            ":sleeping:",
+            busy=True,
+        )
 
     def test_uses_each_configured_provider_once(self, tmp_path: Path) -> None:
         claude_cfg = RepoConfig(

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kennel.claude import ClaudeClient
+from kennel.config import RepoConfig
 from kennel.gh_status import (
+    _PERSONA_PATH,
+    _default_provider_factories,
     generate_persona_emoji,
     generate_persona_status,
     main,
     set_gh_status,
 )
+from kennel.provider import ProviderID
 
 
 def _client(**overrides: object) -> MagicMock:
@@ -134,56 +139,129 @@ class TestSetGhStatus:
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("persona")
         mock_gh = MagicMock()
+        mock_client = _client()
+        mock_client.run_turn.return_value = "woof"
+        mock_client.generate_status_emoji.return_value = ":dog:"
         with patch(
-            "kennel.gh_status.ClaudeClient",
-            return_value=_client(),
-        ) as mock_cls:
-            mock_cls.return_value.run_turn.return_value = "woof"
-            mock_cls.return_value.generate_status_emoji.return_value = ":dog:"
+            "kennel.gh_status._default_provider_factories",
+            return_value=(lambda: mock_client,),
+        ):
             set_gh_status("test", persona_path=persona_file, _gh=mock_gh)
-            mock_cls.assert_called_once_with()
+        mock_gh.set_user_status.assert_called_once_with("woof", ":dog:", busy=True)
 
-    def test_falls_back_to_nap_message_when_provider_fails(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def test_tries_next_provider_when_first_fails(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("persona")
         mock_gh = MagicMock()
-        mock_client = _client()
-        mock_client.run_turn.side_effect = RuntimeError("boom")
+        first = _client()
+        first.run_turn.side_effect = RuntimeError("nope")
+        second = _client()
+        second.run_turn.return_value = "back soon"
+        second.generate_status_emoji.return_value = ":dog:"
 
         set_gh_status(
             "test",
             persona_path=persona_file,
-            provider=mock_client,
             _gh=mock_gh,
-            _choice=lambda options: options[7],
+            _provider_factories=(lambda: first, lambda: second),
         )
 
-        mock_gh.set_user_status.assert_called_once_with(
-            "Sleeping off a big debugging session.",
-            ":sleeping:",
-            busy=True,
-        )
+        mock_gh.set_user_status.assert_called_once_with("back soon", ":dog:", busy=True)
 
-    def test_falls_back_to_nap_message_when_default_client_fails(
+    def test_falls_back_to_generic_message_when_all_providers_fail(
         self, tmp_path
     ) -> None:  # type: ignore[no-untyped-def]
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("persona")
         mock_gh = MagicMock()
-        with patch("kennel.gh_status.ClaudeClient", return_value=_client()) as mock_cls:
-            mock_cls.return_value.run_turn.side_effect = RuntimeError("boom")
-            set_gh_status(
-                "test",
-                persona_path=persona_file,
-                _gh=mock_gh,
-                _choice=lambda options: options[7],
-            )
+        first = _client()
+        first.run_turn.side_effect = RuntimeError("boom")
+        second = _client()
+        second.run_turn.side_effect = RuntimeError("still boom")
+        set_gh_status(
+            "test",
+            persona_path=persona_file,
+            _gh=mock_gh,
+            _provider_factories=(lambda: first, lambda: second),
+            _choice=lambda options: options[7],
+        )
 
         mock_gh.set_user_status.assert_called_once_with(
-            "Sleeping off a big debugging session.",
+            "A little scrambled right now. I will be back soon.",
             ":sleeping:",
             busy=True,
         )
+
+
+class TestDefaultProviderFactories:
+    def test_falls_back_to_owned_claude_when_no_live_kennel(self) -> None:
+        sentinel = _client()
+        with (
+            patch("kennel.gh_status.Path.cwd", return_value=Path("/tmp/here")),
+            patch("kennel.gh_status.ClaudeClient", return_value=sentinel) as mock_cls,
+        ):
+            factories = _default_provider_factories(_running_repo_configs_fn=lambda: [])
+            assert [factory() for factory in factories] == [sentinel]
+        mock_cls.assert_called_once_with(
+            session_system_file=_PERSONA_PATH,
+            work_dir=Path("/tmp/here"),
+        )
+
+    def test_falls_back_to_owned_claude_when_running_kennel_has_no_repo_specs(
+        self,
+    ) -> None:
+        sentinel = _client()
+        with (
+            patch("kennel.gh_status.Path.cwd", return_value=Path("/tmp/here")),
+            patch("kennel.gh_status.ClaudeClient", return_value=sentinel),
+        ):
+            factories = _default_provider_factories(_running_repo_configs_fn=lambda: [])
+            assert [factory() for factory in factories] == [sentinel]
+
+    def test_uses_each_configured_provider_once(self, tmp_path: Path) -> None:
+        claude_cfg = RepoConfig(
+            name="owner/repo-a",
+            work_dir=tmp_path / "a",
+            provider=ProviderID.CLAUDE_CODE,
+        )
+        copilot_cfg = RepoConfig(
+            name="owner/repo-b",
+            work_dir=tmp_path / "b",
+            provider=ProviderID.COPILOT_CLI,
+        )
+        duplicate_claude_cfg = RepoConfig(
+            name="owner/repo-c",
+            work_dir=tmp_path / "c",
+            provider=ProviderID.CLAUDE_CODE,
+        )
+        for cfg in (claude_cfg, copilot_cfg, duplicate_claude_cfg):
+            cfg.work_dir.mkdir()
+        factory = MagicMock()
+        first = _client()
+        second = _client()
+        factory.create_agent.side_effect = [first, second]
+        with (
+            patch("kennel.gh_status.DefaultProviderFactory", return_value=factory),
+        ):
+            factories = _default_provider_factories(
+                _running_repo_configs_fn=lambda: [
+                    claude_cfg,
+                    copilot_cfg,
+                    duplicate_claude_cfg,
+                ],
+            )
+            assert [build() for build in factories] == [first, second]
+        factory.create_agent.assert_any_call(
+            claude_cfg,
+            work_dir=claude_cfg.work_dir,
+            repo_name=claude_cfg.name,
+        )
+        factory.create_agent.assert_any_call(
+            copilot_cfg,
+            work_dir=copilot_cfg.work_dir,
+            repo_name=copilot_cfg.name,
+        )
+        assert factory.create_agent.call_count == 2
 
 
 class TestMain:

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -143,41 +143,41 @@ class TestSetGhStatus:
             set_gh_status("test", persona_path=persona_file, _gh=mock_gh)
             mock_cls.assert_called_once_with()
 
-    def test_tries_next_provider_when_first_fails(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def test_falls_back_to_nap_message_when_provider_fails(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("persona")
         mock_gh = MagicMock()
-        first = _client()
-        first.run_turn.side_effect = RuntimeError("nope")
-        second = _client()
-        second.run_turn.return_value = "back soon"
-        second.generate_status_emoji.return_value = ":dog:"
+        mock_client = _client()
+        mock_client.run_turn.side_effect = RuntimeError("boom")
 
         set_gh_status(
             "test",
             persona_path=persona_file,
+            provider=mock_client,
             _gh=mock_gh,
-            _provider_factories=(lambda: first, lambda: second),
-        )
-
-        mock_gh.set_user_status.assert_called_once_with("back soon", ":dog:", busy=True)
-
-    def test_falls_back_to_nap_message_when_all_providers_fail(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
-        persona_file = tmp_path / "persona.md"
-        persona_file.write_text("persona")
-        mock_gh = MagicMock()
-        first = _client()
-        first.run_turn.side_effect = RuntimeError("boom")
-        second = _client()
-        second.run_turn.side_effect = RuntimeError("still boom")
-
-        set_gh_status(
-            "test",
-            persona_path=persona_file,
-            _gh=mock_gh,
-            _provider_factories=(lambda: first, lambda: second),
             _choice=lambda options: options[7],
         )
+
+        mock_gh.set_user_status.assert_called_once_with(
+            "Sleeping off a big debugging session.",
+            ":sleeping:",
+            busy=True,
+        )
+
+    def test_falls_back_to_nap_message_when_default_client_fails(
+        self, tmp_path
+    ) -> None:  # type: ignore[no-untyped-def]
+        persona_file = tmp_path / "persona.md"
+        persona_file.write_text("persona")
+        mock_gh = MagicMock()
+        with patch("kennel.gh_status.ClaudeClient", return_value=_client()) as mock_cls:
+            mock_cls.return_value.run_turn.side_effect = RuntimeError("boom")
+            set_gh_status(
+                "test",
+                persona_path=persona_file,
+                _gh=mock_gh,
+                _choice=lambda options: options[7],
+            )
 
         mock_gh.set_user_status.assert_called_once_with(
             "Sleeping off a big debugging session.",

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -10,6 +10,7 @@ import pytest
 from kennel.claude import ClaudeClient
 from kennel.config import RepoConfig
 from kennel.gh_status import (
+    _candidate_providers,
     _default_provider_factories,
     generate_persona_emoji,
     generate_persona_status,
@@ -192,28 +193,39 @@ class TestSetGhStatus:
         )
 
 
-class TestDefaultProviderFactories:
-    def test_returns_no_factories_when_no_live_kennel(self) -> None:
-        assert _default_provider_factories(_running_repo_configs_fn=lambda: []) == ()
+class TestCandidateProviders:
+    def test_returns_explicit_provider_without_building_factories(self) -> None:
+        provider = _client()
+        factory = MagicMock()
 
-    def test_uses_generic_fallback_when_no_live_kennel(self, tmp_path: Path) -> None:
+        assert _candidate_providers(provider, (factory,)) == (provider,)
+        factory.assert_not_called()
+
+
+class TestDefaultProviderFactories:
+    def test_raises_when_no_live_kennel(self) -> None:
+        with pytest.raises(RuntimeError, match="No running kennel repo configs found"):
+            _default_provider_factories(_running_repo_configs_fn=lambda: [])
+
+    def test_set_gh_status_propagates_when_no_live_kennel(self, tmp_path: Path) -> None:
         persona_file = tmp_path / "persona.md"
         persona_file.write_text("persona")
         mock_gh = MagicMock()
 
-        set_gh_status(
-            "test",
-            persona_path=persona_file,
-            _gh=mock_gh,
-            _provider_factories=(),
-            _choice=lambda options: options[0],
-        )
+        with (
+            patch(
+                "kennel.gh_status._default_provider_factories",
+                side_effect=RuntimeError("No running kennel repo configs found"),
+            ),
+            pytest.raises(RuntimeError, match="No running kennel repo configs found"),
+        ):
+            set_gh_status(
+                "test",
+                persona_path=persona_file,
+                _gh=mock_gh,
+            )
 
-        mock_gh.set_user_status.assert_called_once_with(
-            "Having a quiet think. Back soon.",
-            ":sleeping:",
-            busy=True,
-        )
+        mock_gh.set_user_status.assert_not_called()
 
     def test_uses_each_configured_provider_once(self, tmp_path: Path) -> None:
         claude_cfg = RepoConfig(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -31,6 +31,7 @@ from kennel.status import (
     collect,
     format_status,
     repo_status,
+    running_repo_configs,
 )
 
 
@@ -125,6 +126,18 @@ class TestPgrep:
             capture_output=True,
             text=True,
         )
+
+
+class TestRunningRepoConfigs:
+    def test_returns_empty_when_kennel_not_running(self) -> None:
+        assert running_repo_configs(_kennel_pid_fn=lambda: None) == []
+
+    def test_reads_repos_from_running_kennel(self, tmp_path: Path) -> None:
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        assert running_repo_configs(
+            _kennel_pid_fn=lambda: 123,
+            _repos_from_pid_fn=lambda pid: [repo_cfg],
+        ) == [repo_cfg]
 
 
 class TestProcessUptimeSeconds:


### PR DESCRIPTION
Closes #310

This finishes the remaining status-path routing cleanup after #537:
- discover the providers actually configured on the running kennel and try each provider type once
- stop importing private status helpers by using the new public `running_repo_configs()` helper
- keep a generic Fido-voice fallback message only when every configured provider fails

The worker and event paths were already repo-configured in #537; this closes the last gh-status fallback seam without fanning out to arbitrary providers.