### PR TITLE
Add provider pressure observability

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -46,6 +46,7 @@ _CLAUDE_API_TIMEOUT = 20
 _CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _CLAUDE_USAGE_BETA = "oauth-2025-04-20"
 _CLAUDE_USAGE_USER_AGENT = "claude-code/2.1.110"
+_CLAUDE_USAGE_CACHE_SECONDS = 300.0
 
 
 class _Trunc:
@@ -1365,54 +1366,81 @@ class ClaudeAPI(ProviderAPI):
         oauth_state_fn: Callable[
             [], _ClaudeOAuthState | None
         ] = _load_claude_oauth_state,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         self._session = session if session is not None else _requests.Session()
         self._oauth_state_fn = oauth_state_fn
+        self._monotonic = monotonic
+        self._limit_snapshot_lock = threading.Lock()
+        self._limit_snapshot_cached_at: float | None = None
+        self._limit_snapshot_cache: ProviderLimitSnapshot | None = None
 
     @property
     def provider_id(self) -> ProviderID:
         return ProviderID.CLAUDE_CODE
 
     def get_limit_snapshot(self) -> ProviderLimitSnapshot:
-        oauth_state = self._oauth_state_fn()
-        if oauth_state is None:
-            return ProviderLimitSnapshot(
-                provider=self.provider_id,
-                unavailable_reason="Claude Code is not logged in.",
-            )
-        try:
-            response = self._session.get(
-                _CLAUDE_USAGE_URL,
-                headers={
-                    "Authorization": f"Bearer {oauth_state.access_token}",
-                    "anthropic-beta": _CLAUDE_USAGE_BETA,
-                    "Content-Type": "application/json",
-                    "User-Agent": _CLAUDE_USAGE_USER_AGENT,
-                },
-                timeout=_CLAUDE_API_TIMEOUT,
-            )
-            response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict):
-                raise ValueError("Claude usage response must be a JSON object")
-            windows = tuple(
-                window
-                for window in (
-                    _usage_window("five_hour", payload.get("five_hour")),
-                    _usage_window("seven_day", payload.get("seven_day")),
-                    _usage_window("seven_day_sonnet", payload.get("seven_day_sonnet")),
+        with self._limit_snapshot_lock:
+            if (
+                self._limit_snapshot_cache is not None
+                and self._limit_snapshot_cached_at is not None
+                and self._monotonic() - self._limit_snapshot_cached_at
+                < _CLAUDE_USAGE_CACHE_SECONDS
+            ):
+                return self._limit_snapshot_cache
+            oauth_state = self._oauth_state_fn()
+            if oauth_state is None:
+                snapshot = ProviderLimitSnapshot(
+                    provider=self.provider_id,
+                    unavailable_reason="Claude Code is not logged in.",
                 )
-                if window is not None
-            )
-            if windows:
-                return ProviderLimitSnapshot(provider=self.provider_id, windows=windows)
-            return ProviderLimitSnapshot(
-                provider=self.provider_id,
-                unavailable_reason="Claude usage is only available for subscription plans.",
-            )
-        except Exception:
-            log.exception("ClaudeAPI: failed to fetch usage snapshot")
-            raise
+            else:
+                try:
+                    response = self._session.get(
+                        _CLAUDE_USAGE_URL,
+                        headers={
+                            "Authorization": f"Bearer {oauth_state.access_token}",
+                            "anthropic-beta": _CLAUDE_USAGE_BETA,
+                            "Content-Type": "application/json",
+                            "User-Agent": _CLAUDE_USAGE_USER_AGENT,
+                        },
+                        timeout=_CLAUDE_API_TIMEOUT,
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+                    if not isinstance(payload, dict):
+                        raise ValueError("Claude usage response must be a JSON object")
+                    windows = tuple(
+                        window
+                        for window in (
+                            _usage_window("five_hour", payload.get("five_hour")),
+                            _usage_window("seven_day", payload.get("seven_day")),
+                            _usage_window(
+                                "seven_day_sonnet", payload.get("seven_day_sonnet")
+                            ),
+                        )
+                        if window is not None
+                    )
+                    if windows:
+                        snapshot = ProviderLimitSnapshot(
+                            provider=self.provider_id, windows=windows
+                        )
+                    else:
+                        snapshot = ProviderLimitSnapshot(
+                            provider=self.provider_id,
+                            unavailable_reason=(
+                                "Claude usage is only available for subscription plans."
+                            ),
+                        )
+                except Exception as exc:
+                    log.exception("ClaudeAPI: failed to fetch usage snapshot")
+                    snapshot = ProviderLimitSnapshot(
+                        provider=self.provider_id,
+                        unavailable_reason=f"Claude usage unavailable: {exc}",
+                    )
+            self._limit_snapshot_cache = snapshot
+            self._limit_snapshot_cached_at = self._monotonic()
+            return snapshot
 
 
 class ClaudeClient(ProviderAgent):

--- a/kennel/color.py
+++ b/kennel/color.py
@@ -23,6 +23,7 @@ CYAN = "cyan"
 MAGENTA = "magenta"
 GREEN = "green"
 YELLOW = "yellow"
+DARK_GRAY = "dark_gray"
 
 # ANSI escape sequences
 _RESET = "\033[0m"
@@ -35,6 +36,7 @@ _CODES: dict[str, str] = {
     MAGENTA: "\033[35m",
     GREEN: "\033[32m",
     YELLOW: "\033[33m",
+    DARK_GRAY: "\033[90m",
 }
 
 

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -98,6 +98,63 @@ class ProviderLimitSnapshot:
         return self.windows[0] if self.windows else None
 
 
+PROVIDER_PRESSURE_WARN_THRESHOLD = 0.90
+PROVIDER_PRESSURE_PAUSE_THRESHOLD = 0.95
+
+
+@dataclass(frozen=True)
+class ProviderPressureStatus:
+    """Normalized provider-pressure summary used by status UI and pause policy."""
+
+    provider: ProviderID
+    window_name: str | None = None
+    pressure: float | None = None
+    resets_at: datetime | None = None
+    unavailable_reason: str | None = None
+
+    @classmethod
+    def from_snapshot(cls, snapshot: ProviderLimitSnapshot) -> "ProviderPressureStatus":
+        """Summarize the closest-to-hit window from *snapshot*."""
+        closest = snapshot.closest_to_exhaustion()
+        return cls(
+            provider=snapshot.provider,
+            window_name=closest.name if closest is not None else None,
+            pressure=closest.pressure if closest is not None else None,
+            resets_at=closest.resets_at if closest is not None else None,
+            unavailable_reason=snapshot.unavailable_reason,
+        )
+
+    @property
+    def percent_used(self) -> int | None:
+        """Return the nearest whole-percent pressure, or ``None`` when unknown."""
+        if self.pressure is None:
+            return None
+        return round(self.pressure * 100)
+
+    @property
+    def level(self) -> Literal["ok", "warning", "paused", "unavailable", "unknown"]:
+        """Return the normalized pressure level for display/policy."""
+        if self.unavailable_reason is not None:
+            return "unavailable"
+        if self.pressure is None:
+            return "unknown"
+        if self.pressure >= PROVIDER_PRESSURE_PAUSE_THRESHOLD:
+            return "paused"
+        if self.pressure >= PROVIDER_PRESSURE_WARN_THRESHOLD:
+            return "warning"
+        return "ok"
+
+    @property
+    def warning(self) -> bool:
+        """Return whether the provider has crossed the warning threshold."""
+        return self.level == "warning"
+
+    @property
+    def paused(self) -> bool:
+        """Return whether the provider has crossed the pause threshold."""
+        return self.level == "paused"
+
+
 class PromptSession(Protocol):
     """Persistent prompt/session collaborator owned by a repo worker thread."""
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -41,6 +41,7 @@ from kennel.infra import (
 )
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.static_files import StaticFiles
+from kennel.status import provider_statuses_for_repo_configs
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
     Watchdog,
@@ -114,9 +115,12 @@ def _xml_text(value: object) -> str | None:
 def _repo_status(act: dict[str, Any]) -> str:
     """Derive a single status word from activity flags.
 
-    Priority: stuck > crashed > busy > idle.  Used as the ``dog:status``
+    Priority: paused > stuck > crashed > busy > idle.  Used as the ``dog:status``
     attribute on ``<repo>`` elements so XSLT and CSS can style by state.
     """
+    provider_status = act.get("provider_status")
+    if isinstance(provider_status, dict) and provider_status.get("paused"):
+        return "paused"
     if act.get("is_stuck"):
         return "stuck"
     if act.get("crash_count", 0) > 0:
@@ -155,6 +159,12 @@ def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
                     for ck, cv in value.items():
                         el = SubElement(ct_el, f"{{{_NS_KENNEL}}}{ck}")
                         el.text = _xml_text(cv)
+            elif key == "provider_status":
+                ps_el = SubElement(repo, f"{{{_NS_KENNEL}}}provider_status")
+                if value is not None:
+                    for pk, pv in value.items():
+                        el = SubElement(ps_el, f"{{{_NS_KENNEL}}}{pk}")
+                        el.text = _xml_text(pv)
             else:
                 el = SubElement(repo, f"{{{_NS_KENNEL}}}{key}")
                 el.text = _xml_text(value)
@@ -179,6 +189,23 @@ def _parse_repo_from_url(url: str) -> str | None:
     path = path.lstrip("/").removesuffix(".git")
     parts = path.split("/")
     return path if len(parts) == 2 and all(parts) else None
+
+
+def _serialize_provider_status(status: Any) -> dict[str, Any] | None:
+    """Convert a ProviderPressureStatus to a JSON-friendly dict."""
+    if status is None:
+        return None
+    return {
+        "provider": status.provider,
+        "window_name": status.window_name,
+        "pressure": status.pressure,
+        "percent_used": status.percent_used,
+        "resets_at": status.resets_at.isoformat() if status.resets_at else None,
+        "unavailable_reason": status.unavailable_reason,
+        "level": status.level,
+        "warning": status.warning,
+        "paused": status.paused,
+    }
 
 
 def _get_self_repo(runner_dir: Path, proc: ProcessRunner) -> str | None:
@@ -720,9 +747,13 @@ class WebhookHandler(BaseHTTPRequestHandler):
         """Build the activity snapshot for all registered repos."""
         now = datetime.now(tz=timezone.utc)
         activities: list[dict[str, Any]] = []
+        provider_statuses = provider_statuses_for_repo_configs(
+            list(self.config.repos.values())
+        )
         for a in self.registry.get_all_activities():
             crash = self.registry.get_crash_info(a.repo_name)
             started_at = self.registry.thread_started_at(a.repo_name)
+            repo_cfg = self.config.repos.get(a.repo_name)
             worker_uptime = (
                 (now - started_at).total_seconds() if started_at is not None else None
             )
@@ -744,6 +775,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "is_stuck": self.registry.is_stale(a.repo_name, _STALE_THRESHOLD),
                     "worker_uptime_seconds": worker_uptime,
                     "webhook_activities": webhooks,
+                    "provider": repo_cfg.provider if repo_cfg is not None else None,
+                    "provider_status": _serialize_provider_status(
+                        provider_statuses.get(repo_cfg.provider)
+                        if repo_cfg is not None
+                        else None
+                    ),
                     "session_owner": self.registry.get_session_owner(a.repo_name),
                     "session_alive": self.registry.get_session_alive(a.repo_name),
                     "session_pid": self.registry.get_session_pid(a.repo_name),

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -12,9 +12,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from kennel.color import BOLD, CYAN, DIM, GREEN, MAGENTA, RED, RED_BOLD, YELLOW, color
+from kennel.color import (
+    BOLD,
+    CYAN,
+    DARK_GRAY,
+    DIM,
+    GREEN,
+    MAGENTA,
+    RED,
+    RED_BOLD,
+    YELLOW,
+    color,
+)
 from kennel.config import RepoConfig
-from kennel.provider import ProviderID
+from kennel.provider import ProviderID, ProviderPressureStatus
+from kennel.provider_factory import DefaultProviderFactory
 from kennel.state import State
 from kennel.tasks import Tasks
 
@@ -57,6 +69,8 @@ class RepoStatus:
     crash_count: int  # number of unexpected worker deaths since kennel started
     last_crash_error: str | None  # error from the most recent crash, if any
     worker_stuck: bool  # True if the worker is alive but making no progress
+    provider: ProviderID = ProviderID.CLAUDE_CODE
+    provider_status: ProviderPressureStatus | None = None
     # Newer fields default so callers (tests) can omit them safely.
     issue_title: str | None = None
     issue_elapsed_seconds: int | None = None
@@ -77,6 +91,7 @@ class KennelStatus:
     kennel_pid: int | None
     kennel_uptime: int | None  # seconds
     repos: list[RepoStatus]
+    provider_statuses: list[ProviderPressureStatus] = field(default_factory=list)
 
 
 def _format_uptime(seconds: int) -> str:
@@ -211,6 +226,35 @@ def running_repo_configs(
     if pid is None:
         return []
     return _repos_from_pid_fn(pid)
+
+
+def _status_persona_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "sub" / "persona.md"
+
+
+def provider_statuses_for_repo_configs(
+    repo_configs: list[RepoConfig],
+    *,
+    _provider_factory: DefaultProviderFactory | None = None,
+) -> dict[ProviderID, ProviderPressureStatus]:
+    """Return one normalized provider-pressure summary per configured provider."""
+    provider_factory = _provider_factory or DefaultProviderFactory(
+        session_system_file=_status_persona_path()
+    )
+    statuses: dict[ProviderID, ProviderPressureStatus] = {}
+    for repo_cfg in repo_configs:
+        if repo_cfg.provider in statuses:
+            continue
+        provider = provider_factory.create_provider(
+            repo_cfg,
+            work_dir=repo_cfg.work_dir,
+            repo_name=repo_cfg.name,
+            session=None,
+        )
+        statuses[repo_cfg.provider] = ProviderPressureStatus.from_snapshot(
+            provider.api.get_limit_snapshot()
+        )
+    return statuses
 
 
 def _port_from_pid(pid: int) -> int | None:
@@ -367,6 +411,7 @@ def repo_status(
     session_pid: int | None = None,
     claude_talker: ClaudeTalkerInfo | None = None,
     rescoping: bool = False,
+    provider_status: ProviderPressureStatus | None = None,
 ) -> RepoStatus:
     """Collect status for a single repo."""
     webhook_activities = list(webhook_activities or [])
@@ -392,6 +437,8 @@ def repo_status(
             crash_count=crash_count,
             last_crash_error=last_crash_error,
             worker_stuck=worker_stuck,
+            provider=repo_config.provider,
+            provider_status=provider_status,
             webhook_activities=webhook_activities,
             session_owner=session_owner,
             session_alive=session_alive,
@@ -444,6 +491,8 @@ def repo_status(
         crash_count=crash_count,
         last_crash_error=last_crash_error,
         worker_stuck=worker_stuck,
+        provider=repo_config.provider,
+        provider_status=provider_status,
         webhook_activities=webhook_activities,
         session_owner=session_owner,
         session_alive=session_alive,
@@ -457,6 +506,7 @@ def collect() -> KennelStatus:
     pid = _kennel_pid()
     uptime = _process_uptime_seconds(pid) if pid is not None else None
     repo_configs = _repos_from_pid(pid) if pid is not None else []
+    provider_statuses = provider_statuses_for_repo_configs(repo_configs)
 
     activities: dict[str, Any] = {}
     if pid is not None:
@@ -506,9 +556,15 @@ def collect() -> KennelStatus:
                 session_pid=session_pid_val,
                 claude_talker=talker_info,
                 rescoping=bool(info.get("rescoping")) if info else False,
+                provider_status=provider_statuses.get(rc.provider),
             )
         )
-    return KennelStatus(kennel_pid=pid, kennel_uptime=uptime, repos=repos)
+    return KennelStatus(
+        kennel_pid=pid,
+        kennel_uptime=uptime,
+        repos=repos,
+        provider_statuses=list(provider_statuses.values()),
+    )
 
 
 _SILENT_DISPLAY_THRESHOLD: int = 300  # seconds of claude silence before we note it
@@ -543,6 +599,46 @@ def _claude_stats_suffix(repo: RepoStatus) -> str:
     return f" {arrow} {pid_str}"
 
 
+def _format_reset_at(resets_at: datetime) -> str:
+    """Format provider reset times in a compact UTC form."""
+    return resets_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _provider_status_style(status: ProviderPressureStatus) -> str:
+    if status.paused:
+        return DARK_GRAY
+    if status.warning or status.level == "unavailable":
+        return DIM
+    return ""
+
+
+def _provider_status_summary(status: ProviderPressureStatus) -> str:
+    provider = str(status.provider)
+    if status.unavailable_reason is not None:
+        return f"{provider} unavailable"
+    if status.percent_used is None:
+        return f"{provider} limits unknown"
+    details: list[str] = []
+    if status.window_name:
+        details.append(status.window_name.replace("_", " "))
+    if status.resets_at is not None:
+        details.append(f"resets {_format_reset_at(status.resets_at)}")
+    detail_text = f" ({', '.join(details)})" if details else ""
+    return f"{provider} {status.percent_used}%{detail_text}"
+
+
+def _styled_provider_status(status: ProviderPressureStatus) -> str:
+    return color(_provider_status_style(status), _provider_status_summary(status))
+
+
+def _format_provider_summary_line(statuses: list[ProviderPressureStatus]) -> str | None:
+    if not statuses:
+        return None
+    ordered = sorted(statuses, key=lambda status: status.provider.value)
+    rendered = " | ".join(_styled_provider_status(status) for status in ordered)
+    return f"{color(BOLD, 'limits:')} {rendered}"
+
+
 def _format_repo_header(repo: RepoStatus) -> str:
     """Top line per repo: ``<name>: fido <state> — <stats>[ → <claude>]``.
 
@@ -556,6 +652,10 @@ def _format_repo_header(repo: RepoStatus) -> str:
     state_word = "running" if repo.fido_running else "idle"
     state_style = GREEN if repo.fido_running else DIM
     stats: list[str] = []
+    if repo.provider_status is not None:
+        stats.append(_styled_provider_status(repo.provider_status))
+    else:
+        stats.append(str(repo.provider))
     if repo.crash_count > 0:
         stats.append(color(RED_BOLD, f"crashes {repo.crash_count}"))
     if repo.worker_uptime is not None:
@@ -637,6 +737,17 @@ def _worker_thread_state(repo: RepoStatus) -> str:
     and title) > PR-but-no-task > the live ``worker_what`` field > ``idle``.
     Never shows webhook-thread activity — that's surfaced separately.
     """
+    provider_status = repo.provider_status
+    if provider_status is not None and provider_status.paused:
+        until = (
+            f" until {_format_reset_at(provider_status.resets_at)}"
+            if provider_status.resets_at is not None
+            else ""
+        )
+        return color(
+            DARK_GRAY,
+            f"paused for {provider_status.provider} reset{until}",
+        )
     if repo.task_number is not None and repo.task_total is not None:
         uncertainty = "?" if repo.rescoping else ""
         suffix = f" — {repo.current_task}" if repo.current_task else ""
@@ -699,6 +810,10 @@ def format_status(status: KennelStatus) -> str:
         )
     else:
         lines.append(f"{color(BOLD, 'kennel:')} {color(RED_BOLD, 'DOWN')}")
+
+    provider_summary = _format_provider_summary_line(status.provider_statuses)
+    if provider_summary is not None:
+        lines.append(provider_summary)
 
     for repo in status.repos:
         lines.append(_format_repo_header(repo))

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -26,6 +26,7 @@ from kennel.provider import (
     Provider,
     ProviderAgent,
     ProviderModel,
+    ProviderPressureStatus,
 )
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.state import (
@@ -216,6 +217,23 @@ def _parse_status_nudge(raw: str) -> tuple[str, str]:
         if isinstance(status, str) and isinstance(emoji, str):
             return status, emoji
     return "", ""
+
+
+def _format_provider_reset_time(resets_at: datetime | None) -> str:
+    if resets_at is None:
+        return "a little while"
+    return resets_at.astimezone(timezone.utc).strftime("%H:%M UTC")
+
+
+def _provider_pause_activity(status: ProviderPressureStatus) -> str:
+    until = _format_provider_reset_time(status.resets_at)
+    percent = f"{status.percent_used}%" if status.percent_used is not None else "limit"
+    return f"Paused for {status.provider} reset ({percent}, until {until})"
+
+
+def _provider_pause_status_text(status: ProviderPressureStatus) -> str:
+    until = _format_provider_reset_time(status.resets_at)
+    return f"Leaving the last 5% for the human until {until}."
 
 
 def _sanitize_slug(raw: str, fallback: str) -> str:
@@ -1009,6 +1027,29 @@ class Worker:
             self.gh.set_user_status(text, emoji, busy=busy)
             log.info("set_status: %s %s", emoji, text)
 
+    def _provider_pressure_status(self) -> ProviderPressureStatus:
+        """Return the normalized pressure summary for this worker's provider."""
+        return ProviderPressureStatus.from_snapshot(
+            self._ensure_provider().api.get_limit_snapshot()
+        )
+
+    def _set_provider_pause_status(self, status: ProviderPressureStatus) -> None:
+        """Publish a direct break status without consuming more provider budget."""
+        what = _provider_pause_activity(status)
+        ctx = (
+            self._registry.status_update()
+            if self._registry is not None
+            else nullcontext()
+        )
+        with ctx:
+            if self._registry is not None:
+                self._registry.report_activity(self._repo_name, what, False)
+            self.gh.set_user_status(
+                _provider_pause_status_text(status),
+                ":sleeping:",
+                busy=False,
+            )
+
     def find_next_issue(self, fido_dir: Path, repo_ctx: RepoContext) -> int | None:
         """Find the next eligible open issue assigned to gh_user.
 
@@ -1020,6 +1061,15 @@ class Worker:
         are needed during the walk.
         """
         log.info("finding next eligible issue")
+        provider_status = self._provider_pressure_status()
+        if provider_status.paused:
+            log.info(
+                "provider %s is paused at %s%% — leaving the last 5%% for the human",
+                provider_status.provider,
+                provider_status.percent_used,
+            )
+            self._set_provider_pause_status(provider_status)
+            return None
         all_issues = self.gh.find_all_open_issues(repo_ctx.owner, repo_ctx.repo_name)
         issue_index: dict[int, dict[str, Any]] = {i["number"]: i for i in all_issues}
         candidates = self.gh.find_issues(

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2601,6 +2601,31 @@ class TestClaudeAPI:
             timeout=20,
         )
 
+    def test_limit_snapshot_uses_five_minute_cache(self) -> None:
+        response = MagicMock()
+        response.json.return_value = {
+            "five_hour": {
+                "utilization": 37.0,
+                "resets_at": "2026-04-16T07:00:00+00:00",
+            }
+        }
+        session = MagicMock()
+        session.get.return_value = response
+        times = iter([100.0, 160.0, 200.0])
+        api = ClaudeAPI(
+            session=session,
+            oauth_state_fn=lambda: type(
+                "OAuthState", (), {"access_token": "tok-123"}
+            )(),
+            monotonic=lambda: next(times),
+        )
+
+        first = api.get_limit_snapshot()
+        second = api.get_limit_snapshot()
+
+        assert first == second
+        session.get.assert_called_once()
+
     def test_limit_snapshot_marks_non_subscription_accounts_unavailable(self) -> None:
         response = MagicMock()
         response.json.return_value = {
@@ -2621,7 +2646,7 @@ class TestClaudeAPI:
             unavailable_reason="Claude usage is only available for subscription plans.",
         )
 
-    def test_limit_snapshot_logs_and_raises_when_fetch_fails(
+    def test_limit_snapshot_logs_and_marks_unavailable_when_fetch_fails(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         response = MagicMock()
@@ -2635,11 +2660,14 @@ class TestClaudeAPI:
             )(),
         )
         with caplog.at_level(logging.ERROR, logger="kennel.claude"):
-            with pytest.raises(RuntimeError, match="boom"):
-                api.get_limit_snapshot()
+            snapshot = api.get_limit_snapshot()
+        assert snapshot == ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE,
+            unavailable_reason="Claude usage unavailable: boom",
+        )
         assert "ClaudeAPI: failed to fetch usage snapshot" in caplog.text
 
-    def test_limit_snapshot_logs_and_raises_when_payload_is_not_an_object(
+    def test_limit_snapshot_logs_and_marks_unavailable_when_payload_is_not_an_object(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         response = MagicMock()
@@ -2653,8 +2681,13 @@ class TestClaudeAPI:
             )(),
         )
         with caplog.at_level(logging.ERROR, logger="kennel.claude"):
-            with pytest.raises(ValueError, match="must be a JSON object"):
-                api.get_limit_snapshot()
+            snapshot = api.get_limit_snapshot()
+        assert snapshot == ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE,
+            unavailable_reason=(
+                "Claude usage unavailable: Claude usage response must be a JSON object"
+            ),
+        )
         assert "ClaudeAPI: failed to fetch usage snapshot" in caplog.text
 
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -11,6 +11,7 @@ from kennel.color import (
     _RESET,
     BOLD,
     CYAN,
+    DARK_GRAY,
     DIM,
     GREEN,
     MAGENTA,
@@ -86,7 +87,7 @@ class TestColor:
 
     @pytest.mark.parametrize(
         "style",
-        [BOLD, DIM, RED, RED_BOLD, CYAN, MAGENTA, GREEN, YELLOW],
+        [BOLD, DIM, RED, RED_BOLD, CYAN, MAGENTA, GREEN, YELLOW, DARK_GRAY],
     )
     def test_each_style_wraps_with_ansi(self, style: str) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
@@ -124,3 +125,7 @@ class TestColor:
     def test_color_enabled_yellow(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(YELLOW, "webhook") == "\033[33mwebhook\033[0m"
+
+    def test_color_enabled_dark_gray(self) -> None:
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert color(DARK_GRAY, "paused") == "\033[90mpaused\033[0m"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -7,6 +7,7 @@ from kennel.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    ProviderPressureStatus,
 )
 
 
@@ -52,6 +53,68 @@ class TestProviderLimitSnapshot:
     def test_closest_to_exhaustion_returns_none_for_empty_snapshot(self) -> None:
         snapshot = ProviderLimitSnapshot(provider=ProviderID.GEMINI)
         assert snapshot.closest_to_exhaustion() is None
+
+
+class TestProviderPressureStatus:
+    def test_from_snapshot_uses_closest_window(self) -> None:
+        low = ProviderLimitWindow(name="tokens", used=20, limit=100)
+        high = ProviderLimitWindow(
+            name="requests",
+            used=96,
+            limit=100,
+            resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+        )
+        status = ProviderPressureStatus.from_snapshot(
+            ProviderLimitSnapshot(
+                provider=ProviderID.CLAUDE_CODE,
+                windows=(low, high),
+            )
+        )
+        assert status.provider is ProviderID.CLAUDE_CODE
+        assert status.window_name == "requests"
+        assert status.pressure == 0.96
+        assert status.resets_at == datetime(2026, 4, 16, 7, 0, tzinfo=UTC)
+
+    def test_level_is_warning_at_ninety_percent(self) -> None:
+        status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.9,
+        )
+        assert status.level == "warning"
+        assert status.warning is True
+        assert status.paused is False
+
+    def test_level_is_paused_at_ninety_five_percent(self) -> None:
+        status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.95,
+        )
+        assert status.level == "paused"
+        assert status.warning is False
+        assert status.paused is True
+
+    def test_level_is_unavailable_when_reason_present(self) -> None:
+        status = ProviderPressureStatus(
+            provider=ProviderID.COPILOT_CLI,
+            pressure=0.99,
+            unavailable_reason="limits unavailable",
+        )
+        assert status.level == "unavailable"
+
+    def test_percent_used_rounds_to_nearest_whole_percent(self) -> None:
+        status = ProviderPressureStatus(provider=ProviderID.CLAUDE_CODE, pressure=0.946)
+        assert status.percent_used == 95
+
+    def test_percent_used_is_none_when_pressure_unknown(self) -> None:
+        status = ProviderPressureStatus(provider=ProviderID.CLAUDE_CODE)
+        assert status.percent_used is None
+
+    def test_level_is_ok_below_warning_threshold(self) -> None:
+        status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.42,
+        )
+        assert status.level == "ok"
 
 
 class TestProviderModel:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -112,6 +112,12 @@ def _restore_handler_fns():
         setattr(WebhookHandler, attr, val)
 
 
+@pytest.fixture(autouse=True)
+def _stub_provider_statuses():
+    with patch("kennel.server.provider_statuses_for_repo_configs", return_value={}):
+        yield
+
+
 @pytest.fixture()
 def server(tmp_path: Path):
     cfg = _config(tmp_path)
@@ -376,6 +382,50 @@ class TestGetEndpoint:
         data = json.loads(resp.read())
         assert data[0]["rescoping"] is True
 
+    def test_status_endpoint_includes_provider_status(self, server: tuple) -> None:
+        from datetime import UTC, datetime
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        with patch(
+            "kennel.server.provider_statuses_for_repo_configs",
+            return_value={
+                ProviderID.CLAUDE_CODE: MagicMock(
+                    provider=ProviderID.CLAUDE_CODE,
+                    window_name="five_hour",
+                    pressure=0.96,
+                    percent_used=96,
+                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+                    unavailable_reason=None,
+                    level="paused",
+                    warning=False,
+                    paused=True,
+                )
+            },
+        ):
+            resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        assert data[0]["provider"] == ProviderID.CLAUDE_CODE
+        assert data[0]["provider_status"]["level"] == "paused"
+        assert data[0]["provider_status"]["percent_used"] == 96
+
     def test_status_endpoint_rescoping_false_by_default(self, server: tuple) -> None:
         from datetime import datetime, timezone
 
@@ -407,12 +457,21 @@ class TestRepoStatus:
     @pytest.mark.parametrize(
         ("act", "expected"),
         [
+            (
+                {
+                    "provider_status": {"paused": True},
+                    "is_stuck": False,
+                    "crash_count": 0,
+                    "busy": True,
+                },
+                "paused",
+            ),
             ({"is_stuck": True, "crash_count": 2, "busy": True}, "stuck"),
             ({"is_stuck": False, "crash_count": 3, "busy": True}, "crashed"),
             ({"is_stuck": False, "crash_count": 0, "busy": True}, "busy"),
             ({"is_stuck": False, "crash_count": 0, "busy": False}, "idle"),
         ],
-        ids=["stuck", "crashed", "busy", "idle"],
+        ids=["paused", "stuck", "crashed", "busy", "idle"],
     )
     def test_repo_status_priority(self, act: dict, expected: str) -> None:
         assert _repo_status(act) == expected
@@ -504,6 +563,50 @@ class TestStatusXml:
         body = resp.read().decode()
         assert "<kind>worker</kind>" in body
         assert "<claude_pid>9999</claude_pid>" in body
+
+    def test_status_xml_includes_provider_status(self, server: tuple) -> None:
+        from datetime import UTC, datetime
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="working",
+                busy=False,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        with patch(
+            "kennel.server.provider_statuses_for_repo_configs",
+            return_value={
+                ProviderID.CLAUDE_CODE: MagicMock(
+                    provider=ProviderID.CLAUDE_CODE,
+                    window_name="five_hour",
+                    pressure=0.96,
+                    percent_used=96,
+                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+                    unavailable_reason=None,
+                    level="paused",
+                    warning=False,
+                    paused=True,
+                )
+            },
+        ):
+            resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<provider>claude-code</provider>" in body
+        assert "<provider_status>" in body
+        assert "<percent_used>96</percent_used>" in body
 
     def test_status_xml_includes_webhooks(self, server: tuple) -> None:
         from datetime import datetime, timezone

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import fcntl
 import json
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from kennel.color import _CODES
 from kennel.config import RepoConfig as _RepoConfig
-from kennel.provider import ProviderID
+from kennel.provider import (
+    ProviderID,
+    ProviderLimitSnapshot,
+    ProviderPressureStatus,
+)
 from kennel.status import (
     ClaudeTalkerInfo,
     KennelStatus,
@@ -30,6 +37,7 @@ from kennel.status import (
     _repos_from_pid,
     collect,
     format_status,
+    provider_statuses_for_repo_configs,
     repo_status,
     running_repo_configs,
 )
@@ -138,6 +146,46 @@ class TestRunningRepoConfigs:
             _kennel_pid_fn=lambda: 123,
             _repos_from_pid_fn=lambda pid: [repo_cfg],
         ) == [repo_cfg]
+
+
+class TestProviderStatusesForRepoConfigs:
+    def test_dedupes_by_provider(self, tmp_path: Path) -> None:
+        claude_a = RepoConfig(name="owner/a", work_dir=tmp_path / "a")
+        claude_b = RepoConfig(name="owner/b", work_dir=tmp_path / "b")
+        copilot = RepoConfig(
+            name="owner/c",
+            work_dir=tmp_path / "c",
+            provider=ProviderID.COPILOT_CLI,
+        )
+        factory = MagicMock()
+        first = MagicMock()
+        second = MagicMock()
+        first.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE
+        )
+        second.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.COPILOT_CLI
+        )
+        factory.create_provider.side_effect = [first, second]
+
+        statuses = provider_statuses_for_repo_configs(
+            [claude_a, claude_b, copilot],
+            _provider_factory=factory,
+        )
+
+        assert list(statuses) == [ProviderID.CLAUDE_CODE, ProviderID.COPILOT_CLI]
+        factory.create_provider.assert_any_call(
+            claude_a,
+            work_dir=claude_a.work_dir,
+            repo_name=claude_a.name,
+            session=None,
+        )
+        factory.create_provider.assert_any_call(
+            copilot,
+            work_dir=copilot.work_dir,
+            repo_name=copilot.name,
+            session=None,
+        )
 
 
 class TestProcessUptimeSeconds:
@@ -825,8 +873,21 @@ class TestRepoStatus:
             result = repo_status(cfg, worker_stuck=True)
         assert result.worker_stuck is True
 
+    def test_provider_status_passed_through(self, tmp_path: Path) -> None:
+        cfg = self._make_config(tmp_path)
+        status = ProviderPressureStatus(provider=ProviderID.CLAUDE_CODE, pressure=0.95)
+        with patch("kennel.status._git_dir", return_value=None):
+            result = repo_status(cfg, provider_status=status)
+        assert result.provider is ProviderID.CLAUDE_CODE
+        assert result.provider_status == status
+
 
 class TestCollect:
+    @pytest.fixture(autouse=True)
+    def _stub_provider_statuses(self):
+        with patch("kennel.status.provider_statuses_for_repo_configs", return_value={}):
+            yield
+
     def _fake_repo_status(self, name: str = "owner/repo") -> RepoStatus:
         return RepoStatus(
             name=name,
@@ -857,6 +918,7 @@ class TestCollect:
         assert result.kennel_pid == 42
         assert result.kennel_uptime == 600
         assert len(result.repos) == 1
+        assert result.provider_statuses == []
 
     def test_kennel_down(self) -> None:
         with (
@@ -874,6 +936,30 @@ class TestCollect:
         mock_port.assert_not_called()
         assert result.kennel_pid is None
         assert result.kennel_uptime is None
+
+    def test_passes_provider_status_to_repo_status(self, tmp_path: Path) -> None:
+        rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.91,
+        )
+        with (
+            patch("kennel.status._kennel_pid", return_value=42),
+            patch("kennel.status._repos_from_pid", return_value=[rc]),
+            patch("kennel.status._process_uptime_seconds", return_value=600),
+            patch("kennel.status._port_from_pid", return_value=None),
+            patch(
+                "kennel.status.provider_statuses_for_repo_configs",
+                return_value={ProviderID.CLAUDE_CODE: provider_status},
+            ),
+            patch(
+                "kennel.status.repo_status", return_value=self._fake_repo_status()
+            ) as mock_repo,
+        ):
+            result = collect()
+
+        assert result.provider_statuses == [provider_status]
+        assert mock_repo.call_args.kwargs["provider_status"] == provider_status
 
     def _activity_info(
         self,
@@ -950,6 +1036,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            provider_status=None,
             session_owner=None,
             session_alive=False,
             session_pid=None,
@@ -985,6 +1072,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            provider_status=None,
             session_owner=None,
             session_alive=False,
             session_pid=None,
@@ -1013,6 +1101,7 @@ class TestCollect:
             worker_stuck=False,
             worker_uptime=None,
             webhook_activities=[],
+            provider_status=None,
             session_owner=None,
             session_alive=False,
             session_pid=None,
@@ -1089,6 +1178,7 @@ class TestCollect:
             worker_stuck=True,
             worker_uptime=None,
             webhook_activities=[],
+            provider_status=None,
             session_owner=None,
             session_alive=False,
             session_pid=None,
@@ -1157,6 +1247,67 @@ class TestFormatStatus:
         output = format_status(status)
         assert output == "kennel: UP (pid 12345, uptime 2h13m)"
 
+    def test_includes_provider_limits_summary_and_repo_pressure(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.91,
+            window_name="five_hour",
+        )
+        status = KennelStatus(
+            kennel_pid=12345,
+            kennel_uptime=None,
+            repos=[self._repo(provider_status=provider_status)],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "limits: claude-code 91% (five hour)" in output
+        assert "owner/repo: fido idle — claude-code 91% (five hour)" in output
+
+    def test_includes_provider_reset_time_in_summary(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.96,
+            window_name="five_hour",
+            resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+        )
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[self._repo(provider_status=provider_status)],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "resets 2026-04-16 07:00 UTC" in output
+
+    def test_includes_provider_unavailable_summary(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.COPILOT_CLI,
+            unavailable_reason="limits unavailable",
+        )
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[
+                self._repo(
+                    provider=ProviderID.COPILOT_CLI, provider_status=provider_status
+                )
+            ],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "copilot-cli unavailable" in output
+
+    def test_includes_provider_unknown_summary(self) -> None:
+        provider_status = ProviderPressureStatus(provider=ProviderID.CLAUDE_CODE)
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[self._repo(provider_status=provider_status)],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "claude-code limits unknown" in output
+
     def test_kennel_up_no_uptime(self) -> None:
         status = KennelStatus(kennel_pid=12345, kennel_uptime=None, repos=[])
         output = format_status(status)
@@ -1202,6 +1353,27 @@ class TestFormatStatus:
         output = format_status(status)
         assert "Issue:  #42 — Add widget" in output
         assert "Worker: task 3/3 — Do the thing" in output
+
+    def test_paused_provider_overrides_worker_state(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.97,
+        )
+        repo = self._repo(
+            issue=42,
+            current_task="Do the thing",
+            task_number=3,
+            task_total=3,
+            provider_status=provider_status,
+        )
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[repo],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "Worker: paused for claude-code reset" in output
 
     def test_task_count_shows_question_mark_when_rescoping(self) -> None:
         repo = self._repo(
@@ -1599,6 +1771,54 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         assert f"{_CODES['red']}BUSY" in output
+
+    def test_provider_warning_dim(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.9,
+        )
+        repo = self._repo(provider_status=provider_status)
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[repo],
+            provider_statuses=[provider_status],
+        )
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dim']}claude-code 90%" in output
+
+    def test_provider_pause_dark_gray(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.95,
+        )
+        repo = self._repo(provider_status=provider_status)
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[repo],
+            provider_statuses=[provider_status],
+        )
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dark_gray']}claude-code 95%" in output
+
+    def test_provider_ok_has_no_warning_color(self) -> None:
+        provider_status = ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.5,
+        )
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[self._repo(provider_status=provider_status)],
+            provider_statuses=[provider_status],
+        )
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert f"{_CODES['dim']}claude-code 50%" not in output
+        assert f"{_CODES['dark_gray']}claude-code 50%" not in output
 
     def test_crash_red_bold(self) -> None:
         repo = self._repo(crash_count=2, last_crash_error="RuntimeError: boom")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
@@ -16,7 +17,12 @@ import kennel.worker as worker_module
 from kennel.claude import ClaudeClient
 from kennel.config import RepoConfig, RepoMembership
 from kennel.prompts import Prompts
-from kennel.provider import ProviderID, ProviderModel
+from kennel.provider import (
+    ProviderID,
+    ProviderLimitSnapshot,
+    ProviderLimitWindow,
+    ProviderModel,
+)
 from kennel.state import (
     State,
     _resolve_git_dir,
@@ -1512,7 +1518,11 @@ class TestWorkerFindNextIssue:
 
     def _make_worker(self, tmp_path: Path) -> tuple["Worker", MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh), gh
+        provider = MagicMock()
+        provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE
+        )
+        return Worker(tmp_path, gh, provider=provider), gh
 
     def _make_repo_ctx(
         self,
@@ -1543,6 +1553,87 @@ class TestWorkerFindNextIssue:
         with patch.object(worker, "set_status"):
             result = worker.find_next_issue(fido_dir, self._make_repo_ctx())
         assert result is None
+
+    def test_pauses_before_querying_when_provider_is_over_ninety_five_percent(
+        self, tmp_path: Path
+    ) -> None:
+        gh = MagicMock()
+        provider = MagicMock()
+        provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE,
+            windows=(
+                ProviderLimitWindow(
+                    name="five_hour",
+                    used=96,
+                    limit=100,
+                ),
+            ),
+        )
+        worker = Worker(tmp_path, gh, provider=provider, repo_name="owner/repo")
+        fido_dir = self._fido_dir(tmp_path)
+
+        result = worker.find_next_issue(fido_dir, self._make_repo_ctx())
+
+        assert result is None
+        gh.find_all_open_issues.assert_not_called()
+        gh.find_issues.assert_not_called()
+        gh.set_user_status.assert_called_once_with(
+            "Leaving the last 5% for the human until a little while.",
+            ":sleeping:",
+            busy=False,
+        )
+
+    def test_pause_message_uses_reset_time_when_known(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        provider = MagicMock()
+        provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE,
+            windows=(
+                ProviderLimitWindow(
+                    name="five_hour",
+                    used=97,
+                    limit=100,
+                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=timezone.utc),
+                ),
+            ),
+        )
+        worker = Worker(tmp_path, gh, provider=provider, repo_name="owner/repo")
+        fido_dir = self._fido_dir(tmp_path)
+
+        worker.find_next_issue(fido_dir, self._make_repo_ctx())
+
+        gh.set_user_status.assert_called_once_with(
+            "Leaving the last 5% for the human until 07:00 UTC.",
+            ":sleeping:",
+            busy=False,
+        )
+
+    def test_pause_reports_activity_to_registry(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        provider = MagicMock()
+        provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CLAUDE_CODE,
+            windows=(ProviderLimitWindow(name="five_hour", used=95, limit=100),),
+        )
+        registry = MagicMock()
+        registry.status_update.return_value.__enter__.return_value = None
+        registry.status_update.return_value.__exit__.return_value = None
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider=provider,
+            repo_name="owner/repo",
+            registry=registry,
+        )
+        fido_dir = self._fido_dir(tmp_path)
+
+        worker.find_next_issue(fido_dir, self._make_repo_ctx())
+
+        registry.report_activity.assert_called_once_with(
+            "owner/repo",
+            "Paused for claude-code reset (95%, until a little while)",
+            False,
+        )
 
     def test_returns_issue_number_when_eligible_no_subissues(
         self, tmp_path: Path


### PR DESCRIPTION
Closes #309

## Summary
- add normalized provider pressure status for provider snapshots and surface it in kennel status output
- expose provider pressure in /status and /status.json and pause new issue pickup when usage crosses 95%
- cache Claude usage snapshots for five minutes and cover the new observability paths with tests