### PR TITLE
Unify session-backed provider helpers

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -30,6 +30,7 @@ from kennel.provider import (
     ProviderModel,
     model_name,
 )
+from kennel.session_agent import SessionBackedAgent
 
 log = logging.getLogger(__name__)
 
@@ -352,6 +353,9 @@ def _claude(
         stdout=stdout,
         stderr=stderr,
     )
+
+
+_TEST_EXPORTS = (_Trunc, _claude)
 
 
 _RETURNCODE_IDLE_TIMEOUT = -1
@@ -1443,7 +1447,7 @@ class ClaudeAPI(ProviderAPI):
             return snapshot
 
 
-class ClaudeClient(ProviderAgent):
+class ClaudeClient(SessionBackedAgent, ProviderAgent):
     """Injectable collaborator for one-shot Claude CLI interactions.
 
     Wraps subprocess-based, session-based, and streaming Claude helpers
@@ -1474,63 +1478,22 @@ class ClaudeClient(ProviderAgent):
         session: PromptSession | None = None,
     ) -> None:
         self._runner = runner
-        self._session_fn = session_fn
         self._streaming_runner = streaming_runner
         self._sleep_fn = sleep_fn
         self._session_factory = (
             ClaudeSession if session_factory is None else session_factory
         )
-        self._session_system_file = session_system_file
-        self._work_dir = work_dir
-        self._repo_name = repo_name
-        self._session_lock = threading.Lock()
-        self._session: PromptSession | None = session
+        super().__init__(
+            session_fn=session_fn,
+            session_system_file=session_system_file,
+            work_dir=work_dir,
+            repo_name=repo_name,
+            session=session,
+        )
 
     @property
     def provider_id(self) -> ProviderID:
         return ProviderID.CLAUDE_CODE
-
-    @property
-    def session(self) -> PromptSession | None:
-        with self._session_lock:
-            return self._session
-
-    def attach_session(self, session: PromptSession | None) -> None:
-        with self._session_lock:
-            self._session = session
-
-    def detach_session(self) -> PromptSession | None:
-        with self._session_lock:
-            session = self._session
-            self._session = None
-            return session
-
-    @property
-    def session_owner(self) -> str | None:
-        with self._session_lock:
-            session = self._session
-        return session.owner if session is not None else None
-
-    @property
-    def session_alive(self) -> bool:
-        with self._session_lock:
-            session = self._session
-        return session is not None and session.is_alive()
-
-    @property
-    def session_pid(self) -> int | None:
-        with self._session_lock:
-            session = self._session
-        return session.pid if session is not None else None
-
-    @property
-    def session_id(self) -> str | None:
-        with self._session_lock:
-            session = self._session
-        if session is None or not hasattr(session, "session_id"):
-            return None
-        session_id = getattr(session, "session_id")
-        return session_id if isinstance(session_id, str) and session_id else None
 
     def _spawn_owned_session(self, model: ProviderModel | None = None) -> PromptSession:
         system_file = self._session_system_file
@@ -1563,43 +1526,6 @@ class ClaudeClient(ProviderAgent):
         if model is None or (created and model == self.voice_model):
             return
         session.switch_model(model)
-
-    def stop_session(self) -> None:
-        with self._session_lock:
-            session = self._session
-            self._session = None
-        if session is not None:
-            session.stop()
-
-    def _can_spawn_owned_session(self) -> bool:
-        return self._session_system_file is not None and self._work_dir is not None
-
-    def _resolve_turn_session(
-        self,
-        *,
-        model: ProviderModel | None,
-        fresh_session: bool,
-    ) -> PromptSession:
-        with self._session_lock:
-            session = self._session
-            if session is None and self._can_spawn_owned_session():
-                if model is None:
-                    raise ValueError(
-                        "ClaudeClient.run_turn requires model when creating a session"
-                    )
-                session = self._spawn_owned_session(model)
-                self._session = session
-                return session
-        if session is None:
-            session = self._session_fn()
-        if fresh_session:
-            reset = getattr(session, "reset", None)
-            if not callable(reset):
-                raise ValueError(
-                    "ClaudeClient.run_turn fresh_session requires resettable session"
-                )
-            reset(model)
-        return session
 
     def _session_is_dead(self, session: PromptSession) -> bool:
         return session.is_alive() is False
@@ -1799,147 +1725,6 @@ class ClaudeClient(ProviderAgent):
         ).strip()
         raise_for_provider_error_output(output)
         return output
-
-    # ── Subprocess one-shot helpers ──────────────────────────────────────
-
-    def generate_reply(
-        self,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 30,
-    ) -> str:
-        """Ask claude to generate a short reply. Returns stripped output or empty string."""
-        effective_model = self.voice_model if model is None else model
-        try:
-            result = _claude(
-                "--model",
-                model_name(effective_model),
-                "--print",
-                "-p",
-                prompt,
-                timeout=timeout,
-                runner=self._runner,
-            )
-            return result.stdout.strip() if result.returncode == 0 else ""
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
-
-    def generate_branch_name(
-        self,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> str:
-        """Ask claude to generate a git branch name slug. Returns first line of output."""
-        effective_model = self.brief_model if model is None else model
-        try:
-            result = _claude(
-                "--model",
-                model_name(effective_model),
-                "--print",
-                "-p",
-                prompt,
-                timeout=timeout,
-                runner=self._runner,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip().splitlines()[0]
-            return ""
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
-
-    def generate_status_with_session(
-        self,
-        prompt: str,
-        system_prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> tuple[str, str]:
-        """Generate a GitHub status, returning (status_text, session_id)."""
-        effective_model = self.voice_model if model is None else model
-        for attempt in range(_EMPTY_RETRY_COUNT + 1):
-            try:
-                result = _claude(
-                    "--model",
-                    model_name(effective_model),
-                    "--output-format",
-                    "stream-json",
-                    "--verbose",
-                    "--dangerously-skip-permissions",
-                    "--system-prompt",
-                    system_prompt,
-                    "--print",
-                    "-p",
-                    prompt,
-                    timeout=timeout,
-                    runner=self._runner,
-                )
-                if result.returncode != 0:
-                    log.warning(
-                        "generate_status_with_session: claude exited %d",
-                        result.returncode,
-                    )
-                    return "", ""
-                raw = result.stdout.strip()
-                text = extract_result_text(raw)
-                sid = extract_session_id(raw)
-                if text:
-                    return text, sid
-                if result.stderr:
-                    log.warning(
-                        "generate_status_with_session: stderr=%r",
-                        _Trunc(result.stderr),
-                    )
-                log.debug(
-                    "generate_status_with_session: stdout=%r",
-                    _Trunc(result.stdout),
-                )
-                if attempt < _EMPTY_RETRY_COUNT:
-                    log.warning(
-                        "generate_status_with_session: empty output on attempt %d"
-                        " — retrying",
-                        attempt + 1,
-                    )
-                    self._sleep_fn(_EMPTY_RETRY_DELAY)
-            except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-                log.warning("generate_status_with_session: %s", exc)
-                return "", ""
-        log.warning(
-            "generate_status_with_session: empty output after %d attempts",
-            _EMPTY_RETRY_COUNT + 1,
-        )
-        return "", ""
-
-    def resume_status(
-        self,
-        session_id: str,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> str:
-        """Resume an existing claude session to refine a status response."""
-        effective_model = self.voice_model if model is None else model
-        try:
-            result = _claude(
-                "--model",
-                model_name(effective_model),
-                "--output-format",
-                "stream-json",
-                "--verbose",
-                "--dangerously-skip-permissions",
-                "--resume",
-                session_id,
-                "--print",
-                "-p",
-                prompt,
-                timeout=timeout,
-                runner=self._runner,
-            )
-            if result.returncode != 0:
-                return ""
-            return extract_result_text(result.stdout.strip())
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
 
     def extract_session_id(self, output: str) -> str:
         return extract_session_id(output)

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -42,6 +42,7 @@ from kennel.provider import (
     ReasoningEffort,
     coerce_provider_model,
 )
+from kennel.session_agent import SessionBackedAgent
 
 log = logging.getLogger(__name__)
 
@@ -858,7 +859,7 @@ class CopilotCLIAPI(ProviderAPI):
         )
 
 
-class CopilotCLIClient(ProviderAgent):
+class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     """Injectable collaborator for Copilot CLI interactions."""
 
     voice_model = ProviderModel("gpt-5.4", "high")
@@ -877,64 +878,23 @@ class CopilotCLIClient(ProviderAgent):
         session: PromptSession | None = None,
     ) -> None:
         self._runner = runner
-        self._session_fn = (
-            claude.current_repo_session if session_fn is None else session_fn
-        )
         self._sleep_fn = sleep_fn
         self._session_factory = (
             CopilotCLISession if session_factory is None else session_factory
         )
-        self._session_system_file = session_system_file
-        self._work_dir = work_dir
-        self._repo_name = repo_name
-        self._session_lock = threading.Lock()
-        self._session: PromptSession | None = session
+        super().__init__(
+            session_fn=claude.current_repo_session
+            if session_fn is None
+            else session_fn,
+            session_system_file=session_system_file,
+            work_dir=work_dir,
+            repo_name=repo_name,
+            session=session,
+        )
 
     @property
     def provider_id(self) -> ProviderID:
         return ProviderID.COPILOT_CLI
-
-    @property
-    def session(self) -> PromptSession | None:
-        with self._session_lock:
-            return self._session
-
-    def attach_session(self, session: PromptSession | None) -> None:
-        with self._session_lock:
-            self._session = session
-
-    def detach_session(self) -> PromptSession | None:
-        with self._session_lock:
-            session = self._session
-            self._session = None
-            return session
-
-    @property
-    def session_owner(self) -> str | None:
-        with self._session_lock:
-            session = self._session
-        return session.owner if session is not None else None
-
-    @property
-    def session_alive(self) -> bool:
-        with self._session_lock:
-            session = self._session
-        return session is not None and session.is_alive()
-
-    @property
-    def session_pid(self) -> int | None:
-        with self._session_lock:
-            session = self._session
-        return session.pid if session is not None else None
-
-    @property
-    def session_id(self) -> str | None:
-        with self._session_lock:
-            session = self._session
-        if session is None or not hasattr(session, "session_id"):
-            return None
-        session_id = getattr(session, "session_id")
-        return session_id if isinstance(session_id, str) and session_id else None
 
     def _spawn_owned_session(self, model: ProviderModel) -> PromptSession:
         system_file = self._session_system_file
@@ -947,61 +907,6 @@ class CopilotCLIClient(ProviderAgent):
             model=model,
             repo_name=self._repo_name,
         )
-
-    def ensure_session(self, model: ProviderModel | None = None) -> None:
-        with self._session_lock:
-            session = self._session
-            if session is None:
-                if self._session_system_file is None or self._work_dir is None:
-                    raise ValueError(
-                        "CopilotCLIClient.ensure_session requires session_system_file and work_dir"
-                    )
-                if model is None:
-                    raise ValueError(
-                        "CopilotCLIClient.ensure_session requires model when creating a session"
-                    )
-                session = self._spawn_owned_session(model)
-                self._session = session
-                return
-        if model is not None:
-            session.switch_model(model)
-
-    def stop_session(self) -> None:
-        with self._session_lock:
-            session = self._session
-            self._session = None
-        if session is not None:
-            session.stop()
-
-    def _can_spawn_owned_session(self) -> bool:
-        return self._session_system_file is not None and self._work_dir is not None
-
-    def _resolve_turn_session(
-        self,
-        *,
-        model: ProviderModel | None,
-        fresh_session: bool,
-    ) -> PromptSession:
-        with self._session_lock:
-            session = self._session
-            if session is None and self._can_spawn_owned_session():
-                if model is None:
-                    raise ValueError(
-                        "CopilotCLIClient.run_turn requires model when creating a session"
-                    )
-                session = self._spawn_owned_session(model)
-                self._session = session
-                return session
-        if session is None:
-            session = self._session_fn()
-        if fresh_session:
-            reset = getattr(session, "reset", None)
-            if not callable(reset):
-                raise ValueError(
-                    "CopilotCLIClient.run_turn fresh_session requires resettable session"
-                )
-            reset(model)
-        return session
 
     def _session_is_dead(self, session: PromptSession) -> bool:
         return session.is_alive() is False
@@ -1120,31 +1025,6 @@ class CopilotCLIClient(ProviderAgent):
                 return obj[key]
         return ""
 
-    def generate_status(
-        self,
-        prompt: str,
-        system_prompt: str,
-        model: ProviderModel | None = None,
-    ) -> str:
-        return self.run_turn(
-            prompt,
-            model=self.voice_model if model is None else model,
-            system_prompt=system_prompt,
-        )
-
-    def generate_status_emoji(
-        self,
-        prompt: str,
-        system_prompt: str,
-        model: ProviderModel | None = None,
-    ) -> str:
-        return self._run_turn_json_value(
-            prompt,
-            "emoji",
-            self.voice_model if model is None else model,
-            system_prompt=system_prompt,
-        )
-
     def print_prompt_from_file(
         self,
         system_file: Path,
@@ -1178,74 +1058,6 @@ class CopilotCLIClient(ProviderAgent):
             cwd=cwd,
             session_id=session_id,
         )
-
-    def generate_reply(
-        self,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 30,
-    ) -> str:
-        effective_model = self.voice_model if model is None else model
-        try:
-            output = self._run_cli_prompt(
-                prompt, model=effective_model, timeout=timeout
-            )
-            return extract_result_text(output).strip()
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
-
-    def generate_branch_name(
-        self,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> str:
-        effective_model = self.brief_model if model is None else model
-        try:
-            output = self._run_cli_prompt(
-                prompt, model=effective_model, timeout=timeout
-            )
-            text = extract_result_text(output).strip()
-            return text.splitlines()[0] if text else ""
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
-
-    def generate_status_with_session(
-        self,
-        prompt: str,
-        system_prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> tuple[str, str]:
-        effective_model = self.voice_model if model is None else model
-        try:
-            output = self._run_cli_prompt(
-                _combine_prompt(prompt, system_prompt=system_prompt),
-                model=effective_model,
-                timeout=timeout,
-            )
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return "", ""
-        return extract_result_text(output).strip(), extract_session_id(output)
-
-    def resume_status(
-        self,
-        session_id: str,
-        prompt: str,
-        model: ProviderModel | None = None,
-        timeout: int = 15,
-    ) -> str:
-        effective_model = self.voice_model if model is None else model
-        try:
-            output = self._run_cli_prompt(
-                prompt,
-                model=effective_model,
-                timeout=timeout,
-                session_id=session_id,
-            )
-        except subprocess.TimeoutExpired, FileNotFoundError:
-            return ""
-        return extract_result_text(output).strip()
 
     def extract_session_id(self, output: str) -> str:
         return extract_session_id(output)

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -1,0 +1,288 @@
+"""Shared session-backed provider agent behavior."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+from kennel.provider import PromptSession, ProviderModel
+
+
+class SessionBackedAgent:
+    """Common session attachment and lifecycle logic for provider agents."""
+
+    voice_model: ProviderModel
+    brief_model: ProviderModel
+
+    def __init__(
+        self,
+        *,
+        session_fn: Callable[[], PromptSession],
+        session_system_file: Path | None,
+        work_dir: Path | str | None,
+        repo_name: str | None,
+        session: PromptSession | None,
+    ) -> None:
+        self._session_fn = session_fn
+        self._session_system_file = session_system_file
+        self._work_dir = work_dir
+        self._repo_name = repo_name
+        self._session_lock = threading.Lock()
+        self._session: PromptSession | None = session
+
+    @property
+    def session(self) -> PromptSession | None:
+        with self._session_lock:
+            return self._session
+
+    def attach_session(self, session: PromptSession | None) -> None:
+        with self._session_lock:
+            self._session = session
+
+    def detach_session(self) -> PromptSession | None:
+        with self._session_lock:
+            session = self._session
+            self._session = None
+            return session
+
+    @property
+    def session_owner(self) -> str | None:
+        with self._session_lock:
+            session = self._session
+        return session.owner if session is not None else None
+
+    @property
+    def session_alive(self) -> bool:
+        with self._session_lock:
+            session = self._session
+        return session is not None and session.is_alive()
+
+    @property
+    def session_pid(self) -> int | None:
+        with self._session_lock:
+            session = self._session
+        return session.pid if session is not None else None
+
+    @property
+    def session_id(self) -> str | None:
+        with self._session_lock:
+            session = self._session
+        if session is None or not hasattr(session, "session_id"):
+            return None
+        session_id = getattr(session, "session_id")
+        return session_id if isinstance(session_id, str) and session_id else None
+
+    def ensure_session(self, model: ProviderModel | None = None) -> None:
+        with self._session_lock:
+            session = self._session
+            if session is None:
+                if self._session_system_file is None or self._work_dir is None:
+                    raise ValueError(
+                        f"{type(self).__name__}.ensure_session requires session_system_file and work_dir"
+                    )
+                if model is None:
+                    raise ValueError(
+                        f"{type(self).__name__}.ensure_session requires model when creating a session"
+                    )
+                self._session = self._spawn_owned_session(model)
+                return
+        if model is not None:
+            session.switch_model(model)
+
+    def stop_session(self) -> None:
+        with self._session_lock:
+            session = self._session
+            self._session = None
+        if session is not None:
+            session.stop()
+
+    def _can_spawn_owned_session(self) -> bool:
+        return self._session_system_file is not None and self._work_dir is not None
+
+    def _resolve_turn_session(
+        self,
+        *,
+        model: ProviderModel | None,
+        fresh_session: bool,
+    ) -> PromptSession:
+        resolver_error: RuntimeError | None = None
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            try:
+                session = self._session_fn()
+            except RuntimeError as exc:
+                resolver_error = exc
+                session = None
+        if session is None and self._can_spawn_owned_session():
+            if model is None:
+                raise ValueError(
+                    f"{type(self).__name__}.run_turn requires model when creating a session"
+                )
+            session = self._spawn_owned_session(model)
+            with self._session_lock:
+                self._session = session
+            return session
+        if session is None and resolver_error is not None:
+            raise resolver_error
+        if session is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.run_turn could not resolve a session"
+            )
+        if fresh_session:
+            reset = getattr(session, "reset", None)
+            if not callable(reset):
+                raise ValueError(
+                    f"{type(self).__name__}.run_turn fresh_session requires resettable session"
+                )
+            reset(model)
+        return session
+
+    def run_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+        retry_on_preempt: bool = False,
+        fresh_session: bool = False,
+    ) -> str:
+        del content, model, system_prompt, retry_on_preempt, fresh_session
+        raise NotImplementedError
+
+    def _spawn_owned_session(self, model: ProviderModel) -> PromptSession:
+        raise NotImplementedError
+
+    def _run_turn_json_value(
+        self,
+        prompt: str,
+        key: str,
+        model: ProviderModel,
+        system_prompt: str | None = None,
+    ) -> str:
+        json_instruction = (
+            f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
+            " No other text before or after the JSON."
+        )
+        full_system = (
+            f"{system_prompt}\n\n{json_instruction}"
+            if system_prompt
+            else json_instruction
+        )
+        raw = self.run_turn(prompt, model=model, system_prompt=full_system)
+        if not raw:
+            return ""
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            return ""
+        return (
+            obj[key] if isinstance(obj, dict) and isinstance(obj.get(key), str) else ""
+        )
+
+    def _run_shared_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel,
+        system_prompt: str | None = None,
+    ) -> tuple[str, str]:
+        session = self._resolve_turn_session(model=model, fresh_session=False)
+        text = session.prompt(content, model=model, system_prompt=system_prompt)
+        session_id = getattr(session, "session_id", None)
+        return text, session_id if isinstance(session_id, str) else ""
+
+    def _require_matching_session(self, session_id: str) -> PromptSession:
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            session = self._session_fn()
+        live_session_id = getattr(session, "session_id", None)
+        if live_session_id != session_id:
+            raise RuntimeError(
+                f"{type(self).__name__} resume helpers require the matching live session"
+            )
+        return session
+
+    def generate_status(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: ProviderModel | None = None,
+    ) -> str:
+        return self.run_turn(
+            prompt,
+            model=self.voice_model if model is None else model,
+            system_prompt=system_prompt,
+        )
+
+    def generate_status_emoji(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: ProviderModel | None = None,
+    ) -> str:
+        return self._run_turn_json_value(
+            prompt,
+            "emoji",
+            self.voice_model if model is None else model,
+            system_prompt=system_prompt,
+        )
+
+    def generate_reply(
+        self,
+        prompt: str,
+        model: ProviderModel | None = None,
+        timeout: int = 30,
+    ) -> str:
+        del timeout
+        text, _ = self._run_shared_turn(
+            prompt,
+            model=self.voice_model if model is None else model,
+        )
+        return text.strip()
+
+    def generate_branch_name(
+        self,
+        prompt: str,
+        model: ProviderModel | None = None,
+        timeout: int = 15,
+    ) -> str:
+        del timeout
+        text, _ = self._run_shared_turn(
+            prompt,
+            model=self.brief_model if model is None else model,
+        )
+        stripped = text.strip()
+        return stripped.splitlines()[0] if stripped else ""
+
+    def generate_status_with_session(
+        self,
+        prompt: str,
+        system_prompt: str,
+        model: ProviderModel | None = None,
+        timeout: int = 15,
+    ) -> tuple[str, str]:
+        del timeout
+        text, session_id = self._run_shared_turn(
+            prompt,
+            model=self.voice_model if model is None else model,
+            system_prompt=system_prompt,
+        )
+        return text.strip(), session_id
+
+    def resume_status(
+        self,
+        session_id: str,
+        prompt: str,
+        model: ProviderModel | None = None,
+        timeout: int = 15,
+    ) -> str:
+        del timeout
+        session = self._require_matching_session(session_id)
+        return session.prompt(
+            prompt,
+            model=self.voice_model if model is None else model,
+        ).strip()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2983,257 +2983,27 @@ class TestClaudeClientResumeSession:
         assert mock_stream.call_args[0][2] == 600.0
 
 
-class TestClaudeClientGenerateReply:
-    def test_returns_stripped_output(self) -> None:
-        mock_run = MagicMock(return_value=_completed("  woof!  \n"))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_reply("write a reply") == "woof!"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed("err", returncode=1))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_reply("write") == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 30))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_reply("write") == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_reply("write") == ""
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ok"))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_reply("write a reply")
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 30
-
-    def test_custom_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("ok"))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_reply("write", model="claude-sonnet-4-6", timeout=10)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-sonnet-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 10
-
-
-class TestClaudeClientGenerateBranchName:
-    def test_returns_first_line(self) -> None:
-        mock_run = MagicMock(return_value=_completed("fix-the-bug\nextra"))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_branch_name("name this") == "fix-the-bug"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed("slug", returncode=1))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_branch_name("name this") == ""
-
-    def test_returns_empty_on_empty_output(self) -> None:
-        mock_run = MagicMock(return_value=_completed(""))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_branch_name("name this") == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_branch_name("name") == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        client = ClaudeClient(runner=mock_run)
-        assert client.generate_branch_name("name") == ""
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("slug"))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_branch_name("name this")
-        cmd = mock_run.call_args.args[0]
-        assert "claude-haiku-4-5-20251001" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_custom_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed("slug"))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_branch_name("name", model="claude-opus-4-6", timeout=5)
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 5
-
-
-class TestClaudeClientGenerateStatusWithSession:
-    _RESULT_LINE = '{"type":"result","result":"🐶\\ncoding","session_id":"sess-42"}'
-
-    def test_returns_text_and_session_id_on_success(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        text, sid = client.generate_status_with_session("doing stuff", "be fido")
-        assert text == "🐶\ncoding"
-        assert sid == "sess-42"
-
-    def test_returns_empty_pair_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
-        mock_run.assert_called_once()
-
-    def test_returns_empty_pair_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
-        mock_run.assert_called_once()
-
-    def test_returns_empty_pair_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        assert client.generate_status_with_session("doing stuff", "sys") == ("", "")
-        mock_run.assert_called_once()
-
-    def test_passes_correct_flags(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_status_with_session(
-            "working on #42", "be a dog", model="claude-sonnet-4-6", timeout=10
+class TestClaudeClientSharedHelpers:
+    def test_helpers_delegate_through_live_session(self) -> None:
+        session = MagicMock()
+        session.session_id = "sess-42"
+        session.prompt.side_effect = [
+            "reply text",
+            "branch-name\nextra",
+            "status text",
+            "resumed status",
+        ]
+        client = ClaudeClient(session=session)
+        assert client.generate_reply("write a reply") == "reply text"
+        assert client.generate_branch_name("name this") == "branch-name"
+        assert client.generate_status_with_session("doing stuff", "be fido") == (
+            "status text",
+            "sess-42",
         )
-        cmd = mock_run.call_args.args[0]
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
-        assert "--output-format" in cmd
-        assert "stream-json" in cmd
-        assert "--verbose" in cmd
-        assert "--dangerously-skip-permissions" in cmd
-        assert "--system-prompt" in cmd
-        assert "be a dog" in cmd
-        assert "--print" in cmd
-        assert "-p" in cmd
-        assert "working on #42" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 10
+        assert client.resume_status("sess-42", "please shorten") == "resumed status"
 
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        client.generate_status_with_session("working", "sys")
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_retries_on_empty_output_then_succeeds(self) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(
-            side_effect=[
-                _completed(empty_line),
-                _completed(empty_line),
-                _completed(self._RESULT_LINE),
-            ]
-        )
-        mock_sleep = MagicMock()
-        client = ClaudeClient(runner=mock_run, sleep_fn=mock_sleep)
-        text, sid = client.generate_status_with_session("working", "sys")
-        assert text == "🐶\ncoding"
-        assert sid == "sess-42"
-        assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    def test_returns_empty_pair_after_all_retries_exhausted(self) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        mock_sleep = MagicMock()
-        client = ClaudeClient(runner=mock_run, sleep_fn=mock_sleep)
-        assert client.generate_status_with_session("working", "sys") == ("", "")
-        assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2
-
-    def test_returns_empty_session_when_no_session_id(self) -> None:
-        no_sid = '{"type":"result","result":"🐶\\nwoof"}'
-        mock_run = MagicMock(return_value=_completed(no_sid))
-        client = ClaudeClient(runner=mock_run)
-        text, sid = client.generate_status_with_session("working", "sys")
-        assert text == "🐶\nwoof"
-        assert sid == ""
-
-    def test_logs_stderr_at_warning_on_empty_output(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(
-            return_value=_completed(empty_line, stderr="Rate limit exceeded")
-        )
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            client.generate_status_with_session("working", "sys")
-        assert "Rate limit exceeded" in caplog.text
-
-    def test_logs_raw_stdout_at_debug_on_empty_output(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        with caplog.at_level(logging.DEBUG, logger="kennel.claude"):
-            client.generate_status_with_session("working", "sys")
-        assert "stdout=" in caplog.text
-
-    def test_no_stderr_log_when_stderr_empty(self, caplog) -> None:
-        empty_line = '{"type":"result","session_id":"s1"}'
-        mock_run = MagicMock(return_value=_completed(empty_line))
-        client = ClaudeClient(runner=mock_run, sleep_fn=MagicMock())
-        with caplog.at_level(logging.WARNING, logger="kennel.claude"):
-            client.generate_status_with_session("working", "sys")
-        assert "stderr=" not in caplog.text
-
-
-class TestClaudeClientResumeStatus:
-    _RESULT_LINE = '{"type":"result","result":"🐕\\nfetching","session_id":"s-1"}'
-
-    def test_returns_text_on_success(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        assert client.resume_status("s-1", "please shorten") == "🐕\nfetching"
-
-    def test_returns_empty_on_nonzero(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE, returncode=1))
-        client = ClaudeClient(runner=mock_run)
-        assert client.resume_status("s-1", "shorten") == ""
-
-    def test_returns_empty_on_timeout(self) -> None:
-        mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 15))
-        client = ClaudeClient(runner=mock_run)
-        assert client.resume_status("s-1", "shorten") == ""
-
-    def test_returns_empty_on_file_not_found(self) -> None:
-        mock_run = MagicMock(side_effect=FileNotFoundError)
-        client = ClaudeClient(runner=mock_run)
-        assert client.resume_status("s-1", "shorten") == ""
-
-    def test_passes_correct_flags(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        client.resume_status(
-            "my-session", "shorten to 80 chars", model="claude-sonnet-4-6", timeout=20
-        )
-        cmd = mock_run.call_args.args[0]
-        assert "--model" in cmd
-        assert "claude-sonnet-4-6" in cmd
-        assert "--output-format" in cmd
-        assert "stream-json" in cmd
-        assert "--verbose" in cmd
-        assert "--dangerously-skip-permissions" in cmd
-        assert "--resume" in cmd
-        assert "my-session" in cmd
-        assert "--print" in cmd
-        assert "-p" in cmd
-        assert "shorten to 80 chars" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 20
-
-    def test_default_model_and_timeout(self) -> None:
-        mock_run = MagicMock(return_value=_completed(self._RESULT_LINE))
-        client = ClaudeClient(runner=mock_run)
-        client.resume_status("s-1", "shorten")
-        cmd = mock_run.call_args.args[0]
-        assert "claude-opus-4-6" in cmd
-        assert mock_run.call_args.kwargs["timeout"] == 15
-
-    def test_returns_empty_when_no_result_field(self) -> None:
-        no_result = '{"type":"result","session_id":"s-1"}'
-        mock_run = MagicMock(return_value=_completed(no_result))
-        client = ClaudeClient(runner=mock_run)
-        assert client.resume_status("s-1", "shorten") == ""
+    def test_resume_status_requires_matching_live_session(self) -> None:
+        session = MagicMock(session_id="other")
+        client = ClaudeClient(session=session)
+        with pytest.raises(RuntimeError, match="matching live session"):
+            client.resume_status("sess-42", "please shorten")

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -936,11 +936,8 @@ class TestCopilotCLIClient:
         prompt_file = tmp_path / "prompt"
         system_file.write_text("system")
         prompt_file.write_text("prompt")
-        session = MagicMock()
-        session.prompt.return_value = '{"emoji": "rocket"}'
         client = CopilotCLIClient(
             runner=runner,
-            session=session,
             session_system_file=system_file,
             work_dir=tmp_path,
         )
@@ -949,36 +946,37 @@ class TestCopilotCLIClient:
             system_file, prompt_file, client.work_model
         ) == _copilot_output("line1\nline2")
         assert client.resume_session("sess-1", prompt_file, client.brief_model)
-        assert client.generate_reply("reply", client.voice_model) == "line1\nline2"
-        assert client.generate_branch_name("branch", client.brief_model) == "line1"
-        assert client.generate_status_with_session(
-            "status", "system", client.voice_model
-        ) == (
-            "line1\nline2",
-            "sess-123",
-        )
-        assert (
-            client.resume_status("sess-1", "status", client.voice_model)
-            == "line1\nline2"
-        )
         cmd = runner.call_args.args[0]
         assert "--model" in cmd
         assert "gpt-5.4" in cmd
 
-    def test_status_helpers_delegate_to_run_turn(self) -> None:
+    def test_shared_helpers_delegate_to_run_turn(self) -> None:
         session = MagicMock()
-        session.prompt.side_effect = ["ok", '{"emoji": "ok"}']
+        session.session_id = "sess-1"
+        session.prompt.side_effect = [
+            "reply text",
+            "branch-name\nextra",
+            "ok",
+            '{"emoji": "ok"}',
+            "status text",
+            "resumed text",
+        ]
         client = CopilotCLIClient(session=session)
+        assert client.generate_reply("reply", client.voice_model) == "reply text"
+        assert (
+            client.generate_branch_name("branch", client.brief_model) == "branch-name"
+        )
         assert client.generate_status("status", "system", client.voice_model) == "ok"
         assert (
             client.generate_status_emoji("emoji", "system", client.voice_model) == "ok"
         )
-
-    def test_generate_reply_handles_failures(self) -> None:
-        client = CopilotCLIClient(
-            runner=MagicMock(side_effect=subprocess.TimeoutExpired("copilot", 1))
+        assert client.generate_status_with_session(
+            "status", "system", client.voice_model
+        ) == ("status text", "sess-1")
+        assert (
+            client.resume_status("sess-1", "status", client.voice_model)
+            == "resumed text"
         )
-        assert client.generate_reply("reply", client.voice_model) == ""
 
     def test_generate_status_emoji_handles_empty_or_malformed_json(
         self, tmp_path: Path
@@ -989,13 +987,10 @@ class TestCopilotCLIClient:
         assert client.generate_status_emoji("q", "sys", client.voice_model) == ""
         assert client.generate_status_emoji("q", "sys", client.voice_model) == ""
 
-        runner = MagicMock(side_effect=FileNotFoundError("missing"))
-        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
-        assert client.generate_branch_name("branch", client.brief_model) == ""
-        assert client.generate_status_with_session(
-            "status", "system", client.voice_model
-        ) == ("", "")
-        assert client.resume_status("sess", "status", client.voice_model) == ""
+        bad_session = MagicMock(session_id="other")
+        client = CopilotCLIClient(session=bad_session)
+        with pytest.raises(RuntimeError, match="matching live session"):
+            client.resume_status("sess", "status", client.voice_model)
 
         runner = MagicMock(return_value=_completed("", returncode=1))
         client = CopilotCLIClient(runner=runner, work_dir=tmp_path)

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kennel.provider import ProviderModel
+from kennel.session_agent import SessionBackedAgent
+
+
+class _FakeAgent(SessionBackedAgent):
+    voice_model = ProviderModel("voice")
+    brief_model = ProviderModel("brief")
+
+    def __init__(
+        self,
+        *,
+        session_fn=lambda: None,
+        session_system_file: Path | None = None,
+        work_dir: Path | str | None = None,
+        repo_name: str | None = None,
+        session=None,
+        session_factory=None,
+    ) -> None:
+        self._session_factory = (
+            MagicMock() if session_factory is None else session_factory
+        )
+        super().__init__(
+            session_fn=session_fn,
+            session_system_file=session_system_file,
+            work_dir=work_dir,
+            repo_name=repo_name,
+            session=session,
+        )
+
+    def _spawn_owned_session(self, model: ProviderModel):
+        return self._session_factory(model)
+
+    def run_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+        retry_on_preempt: bool = False,
+        fresh_session: bool = False,
+    ) -> str:
+        del retry_on_preempt
+        session = self._resolve_turn_session(model=model, fresh_session=fresh_session)
+        return session.prompt(content, model=model, system_prompt=system_prompt)
+
+
+class TestSessionBackedAgent:
+    def test_base_abstract_methods_raise(self) -> None:
+        agent = SessionBackedAgent(
+            session_fn=lambda: None,
+            session_system_file=None,
+            work_dir=None,
+            repo_name=None,
+            session=None,
+        )
+        with pytest.raises(NotImplementedError):
+            agent.run_turn("hi")
+        with pytest.raises(NotImplementedError):
+            agent._spawn_owned_session(ProviderModel("model"))
+
+    def test_session_properties_attach_and_detach(self) -> None:
+        session = MagicMock(owner="worker", pid=123, session_id="sess-1")
+        session.is_alive.return_value = True
+        agent = _FakeAgent(session=session)
+        assert agent.session is session
+        assert agent.session_owner == "worker"
+        assert agent.session_alive is True
+        assert agent.session_pid == 123
+        assert agent.session_id == "sess-1"
+        assert agent.detach_session() is session
+        assert agent.session is None
+
+    def test_session_id_none_branches(self) -> None:
+        assert _FakeAgent().session_id is None
+        assert _FakeAgent(session=object()).session_id is None
+        assert (
+            _FakeAgent(session=type("S", (), {"session_id": 123})()).session_id is None
+        )
+
+    def test_ensure_session_requires_factory_inputs(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="_FakeAgent.ensure_session requires session_system_file and work_dir",
+        ):
+            _FakeAgent().ensure_session()
+
+    def test_ensure_session_requires_model_when_creating_session(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(
+            ValueError,
+            match="_FakeAgent.ensure_session requires model when creating a session",
+        ):
+            _FakeAgent(
+                session_system_file=tmp_path / "persona.md",
+                work_dir=tmp_path,
+            ).ensure_session()
+
+    def test_ensure_session_spawns_owned_and_switches_existing(
+        self, tmp_path: Path
+    ) -> None:
+        spawned = MagicMock()
+        factory = MagicMock(return_value=spawned)
+        agent = _FakeAgent(
+            session_system_file=tmp_path / "persona.md",
+            work_dir=tmp_path,
+            session_factory=factory,
+        )
+        agent.ensure_session(agent.voice_model)
+        factory.assert_called_once_with(agent.voice_model)
+        attached = MagicMock()
+        agent = _FakeAgent(session=attached)
+        agent.ensure_session(agent.brief_model)
+        attached.switch_model.assert_called_once_with(agent.brief_model)
+
+    def test_resolve_turn_prefers_live_session_over_owned_spawn(
+        self, tmp_path: Path
+    ) -> None:
+        resolved = MagicMock()
+        resolved.prompt.return_value = "ok"
+        factory = MagicMock()
+        agent = _FakeAgent(
+            session_fn=lambda: resolved,
+            session_system_file=tmp_path / "persona.md",
+            work_dir=tmp_path,
+            session_factory=factory,
+        )
+        assert agent.generate_reply("hi") == "ok"
+        factory.assert_not_called()
+
+    def test_run_turn_requires_model_when_spawning_owned_session(
+        self, tmp_path: Path
+    ) -> None:
+        agent = _FakeAgent(
+            session_system_file=tmp_path / "persona.md",
+            work_dir=tmp_path,
+        )
+        with pytest.raises(
+            ValueError,
+            match="_FakeAgent.run_turn requires model when creating a session",
+        ):
+            agent.run_turn("hi")
+
+    def test_resolve_turn_raises_resolver_error_or_generic_error(self) -> None:
+        agent = _FakeAgent(
+            session_fn=lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            agent.generate_reply("hi")
+        with pytest.raises(
+            RuntimeError, match="_FakeAgent.run_turn could not resolve a session"
+        ):
+            _FakeAgent(session_fn=lambda: None).generate_reply("hi")
+
+    def test_fresh_session_requires_resettable_session(self) -> None:
+        agent = _FakeAgent(session=object())
+        with pytest.raises(
+            ValueError,
+            match="_FakeAgent.run_turn fresh_session requires resettable session",
+        ):
+            agent.run_turn("hi", model=agent.voice_model, fresh_session=True)
+
+    def test_shared_helper_methods_and_json_parsing(self) -> None:
+        session = MagicMock(session_id="sess-1")
+        session.prompt.side_effect = [
+            "reply text",
+            "branch-name\nextra",
+            "status text",
+            '{"emoji":"rocket"}',
+            "status with session",
+            "resumed status",
+        ]
+        agent = _FakeAgent(session=session)
+        assert agent.generate_reply("reply") == "reply text"
+        assert agent.generate_branch_name("branch") == "branch-name"
+        assert agent.generate_status("status", "system") == "status text"
+        assert agent.generate_status_emoji("emoji", "system") == "rocket"
+        assert agent.generate_status_with_session("status", "system") == (
+            "status with session",
+            "sess-1",
+        )
+        assert agent.resume_status("sess-1", "resume") == "resumed status"
+
+    def test_status_emoji_returns_empty_on_empty_or_bad_json(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = ["", "not json"]
+        agent = _FakeAgent(session=session)
+        assert agent.generate_status_emoji("emoji", "system") == ""
+        assert agent.generate_status_emoji("emoji", "system") == ""
+
+    def test_resume_status_requires_matching_live_session(self) -> None:
+        session = MagicMock(session_id="other")
+        agent = _FakeAgent(session=session)
+        with pytest.raises(
+            RuntimeError,
+            match="_FakeAgent resume helpers require the matching live session",
+        ):
+            agent.resume_status("sess-1", "resume")
+
+    def test_resume_status_uses_resolved_session_when_not_attached(self) -> None:
+        session = MagicMock(session_id="sess-1")
+        session.prompt.return_value = "resumed status"
+        agent = _FakeAgent(session_fn=lambda: session)
+        assert agent.resume_status("sess-1", "resume") == "resumed status"


### PR DESCRIPTION
## Summary
- extract shared session-backed helper behavior into `SessionBackedAgent`
- route Claude and Copilot one-shot helper methods through the same session-aware base logic
- add shared-agent coverage for resolver/session matching behavior

Closes #613