### PR TITLE
Make provider turn session mode explicit

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -28,6 +28,7 @@ from kennel.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    TurnSessionMode,
     model_name,
 )
 from kennel.session_agent import SessionBackedAgent
@@ -1586,11 +1587,11 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
-        fresh_session: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
         session = self._resolve_turn_session(
             model=model,
-            fresh_session=fresh_session,
+            session_mode=session_mode,
         )
         attempt = 0
         while True:

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -40,6 +40,7 @@ from kennel.provider import (
     ProviderLimitSnapshot,
     ProviderModel,
     ReasoningEffort,
+    TurnSessionMode,
     coerce_provider_model,
 )
 from kennel.session_agent import SessionBackedAgent
@@ -971,11 +972,11 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
-        fresh_session: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
         session = self._resolve_turn_session(
             model=model,
-            fresh_session=fresh_session,
+            session_mode=session_mode,
         )
         attempt = 0
         while True:

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -18,6 +18,13 @@ class ProviderID(StrEnum):
     GEMINI = "gemini"
 
 
+class TurnSessionMode(StrEnum):
+    """How a provider turn should treat existing conversation state."""
+
+    REUSE = "reuse"
+    FRESH = "fresh"
+
+
 ReasoningEffort: TypeAlias = Literal["low", "medium", "high"]
 ReasoningEffortSpec: TypeAlias = ReasoningEffort | tuple[ReasoningEffort, ...] | None
 
@@ -288,7 +295,7 @@ class ProviderAgent(Protocol):
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
-        fresh_session: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
         """Run one interactive turn through the persistent session and return text."""
         ...

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -7,7 +7,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from kennel.provider import PromptSession, ProviderModel
+from kennel.provider import PromptSession, ProviderModel, TurnSessionMode
 
 
 class SessionBackedAgent:
@@ -105,7 +105,7 @@ class SessionBackedAgent:
         self,
         *,
         model: ProviderModel | None,
-        fresh_session: bool,
+        session_mode: TurnSessionMode,
     ) -> PromptSession:
         resolver_error: RuntimeError | None = None
         with self._session_lock:
@@ -131,11 +131,11 @@ class SessionBackedAgent:
             raise RuntimeError(
                 f"{type(self).__name__}.run_turn could not resolve a session"
             )
-        if fresh_session:
+        if session_mode == TurnSessionMode.FRESH:
             reset = getattr(session, "reset", None)
             if not callable(reset):
                 raise ValueError(
-                    f"{type(self).__name__}.run_turn fresh_session requires resettable session"
+                    f"{type(self).__name__}.run_turn session_mode=fresh requires resettable session"
                 )
             reset(model)
         return session
@@ -147,9 +147,9 @@ class SessionBackedAgent:
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
-        fresh_session: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
-        del content, model, system_prompt, retry_on_preempt, fresh_session
+        del content, model, system_prompt, retry_on_preempt, session_mode
         raise NotImplementedError
 
     def _spawn_owned_session(self, model: ProviderModel) -> PromptSession:
@@ -189,7 +189,10 @@ class SessionBackedAgent:
         model: ProviderModel,
         system_prompt: str | None = None,
     ) -> tuple[str, str]:
-        session = self._resolve_turn_session(model=model, fresh_session=False)
+        session = self._resolve_turn_session(
+            model=model,
+            session_mode=TurnSessionMode.REUSE,
+        )
         text = session.prompt(content, model=model, system_prompt=system_prompt)
         session_id = getattr(session, "session_id", None)
         return text, session_id if isinstance(session_id, str) else ""

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -27,6 +27,7 @@ from kennel.provider import (
     ProviderAgent,
     ProviderModel,
     ProviderPressureStatus,
+    TurnSessionMode,
 )
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.state import (
@@ -258,7 +259,7 @@ def provider_start(
     session: str | None = None,
     timeout: int = 300,
     cwd: Path | str = ".",
-    fresh_session: bool = False,
+    session_mode: TurnSessionMode = TurnSessionMode.REUSE,
 ) -> str:
     """Start a new provider session from fido_dir/system and fido_dir/prompt.
 
@@ -279,7 +280,7 @@ def provider_start(
             _session_turn_prompt(fido_dir),
             model=model,
             retry_on_preempt=True,
-            fresh_session=fresh_session,
+            session_mode=session_mode,
         )
         return ""
     system_file = fido_dir / "system"
@@ -314,7 +315,7 @@ def provider_run(
     session: str | None = None,
     timeout: int = 300,
     cwd: Path | str = ".",
-    fresh_session: bool = False,
+    session_mode: TurnSessionMode = TurnSessionMode.REUSE,
 ) -> tuple[str, str]:
     """Continue or start a provider session, streaming progress as raw text.
 
@@ -335,7 +336,7 @@ def provider_run(
             _session_turn_prompt(fido_dir),
             model=model,
             retry_on_preempt=True,
-            fresh_session=fresh_session,
+            session_mode=session_mode,
         )
         return "", ""
     system_file = fido_dir / "system"
@@ -786,7 +787,7 @@ class Worker:
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
         self._session_issue: int | None = session_issue
-        self._fresh_session_pending = False
+        self._next_turn_session_mode = TurnSessionMode.REUSE
         self._tasks = _tasks if _tasks is not None else Tasks(work_dir)
         self._prompts = prompts
         self._config = config
@@ -919,10 +920,10 @@ class Worker:
         self._claude_client.stop_session()
         self._session = None
 
-    def _consume_fresh_session(self) -> bool:
-        fresh_session = self._fresh_session_pending
-        self._fresh_session_pending = False
-        return fresh_session
+    def _consume_turn_session_mode(self) -> TurnSessionMode:
+        session_mode = self._next_turn_session_mode
+        self._next_turn_session_mode = TurnSessionMode.REUSE
+        return session_mode
 
     # ------------------------------------------------------------------
     # Business logic
@@ -1202,7 +1203,7 @@ class Worker:
                     model=self._claude_client.voice_model,
                     cwd=self.work_dir,
                     session=None,
-                    fresh_session=self._consume_fresh_session(),
+                    session_mode=self._consume_turn_session_mode(),
                 )
                 if not self._tasks.list():
                     raise RuntimeError(f"setup produced no tasks for PR #{pr_number}")
@@ -1252,7 +1253,7 @@ class Worker:
             model=self._claude_client.voice_model,
             cwd=self.work_dir,
             session=None,
-            fresh_session=self._consume_fresh_session(),
+            session_mode=self._consume_turn_session_mode(),
         )
 
         if not self._tasks.list():
@@ -1331,7 +1332,7 @@ class Worker:
             model=self._claude_client.work_model,
             cwd=self.work_dir,
             session=None,
-            fresh_session=self._consume_fresh_session(),
+            session_mode=self._consume_turn_session_mode(),
         )
         log.info("merge conflict resolution done (session=%s)", session_id)
         return True
@@ -1462,7 +1463,7 @@ class Worker:
             model=self._claude_client.work_model,
             cwd=self.work_dir,
             session=None,
-            fresh_session=self._consume_fresh_session(),
+            session_mode=self._consume_turn_session_mode(),
         )
         log.info("CI fix done (session=%s)", session_id)
 
@@ -1593,7 +1594,7 @@ class Worker:
             model=self._claude_client.work_model,
             cwd=self.work_dir,
             session=None,
-            fresh_session=self._consume_fresh_session(),
+            session_mode=self._consume_turn_session_mode(),
         )
         log.info("threads done (session=%s)", session_id)
         tasks.sync_tasks_background(self.work_dir, self.gh)
@@ -1757,7 +1758,7 @@ class Worker:
             model=self._claude_client.work_model,
             cwd=self.work_dir,
             session=None,
-            fresh_session=self._consume_fresh_session(),
+            session_mode=self._consume_turn_session_mode(),
         )
         log.info("task done (session=%s)", session_id)
         head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
@@ -1820,14 +1821,19 @@ class Worker:
                     "task produced no commits — nudging session (attempt %d)",
                     attempt,
                 )
-            fresh_session = self._consume_fresh_session() or use_fresh_session
+            pending_session_mode = self._consume_turn_session_mode()
+            session_mode = (
+                TurnSessionMode.FRESH
+                if pending_session_mode == TurnSessionMode.FRESH or use_fresh_session
+                else TurnSessionMode.REUSE
+            )
             session_id, _output = claude_run(
                 fido_dir,
                 claude_client=self._claude_client,
                 model=self._claude_client.work_model,
                 cwd=self.work_dir,
                 session=session_id or None,
-                fresh_session=fresh_session,
+                session_mode=session_mode,
             )
             log.info("task resume done (session=%s)", session_id)
             head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
@@ -2191,13 +2197,13 @@ class Worker:
                 if issue is None:
                     return 0
 
-                self._fresh_session_pending = False
+                self._next_turn_session_mode = TurnSessionMode.REUSE
                 if not session_fresh and issue != self._session_issue:
                     log.info(
                         "worker: new issue #%s — restarting session at issue boundary",
                         issue,
                     )
-                    self._fresh_session_pending = True
+                    self._next_turn_session_mode = TurnSessionMode.FRESH
                 self._session_issue = issue
 
                 issue_data = self.gh.view_issue(repo_ctx.repo, issue)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -32,7 +32,12 @@ from kennel.claude import (
     kill_active_children,
     raise_for_provider_error_output,
 )
-from kennel.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
+from kennel.provider import (
+    ProviderID,
+    ProviderLimitSnapshot,
+    ProviderLimitWindow,
+    TurnSessionMode,
+)
 
 
 def _completed(
@@ -2385,15 +2390,21 @@ class TestClaudeClientSessionAttachment:
         ):
             client.run_turn("fetch")
 
-    def test_fresh_session_requires_reset_method(self) -> None:
+    def test_fresh_session_mode_requires_reset_method(self) -> None:
         client = ClaudeClient(session=object())
         with pytest.raises(
             ValueError,
-            match="ClaudeClient.run_turn fresh_session requires resettable session",
+            match="ClaudeClient.run_turn session_mode=fresh requires resettable session",
         ):
-            client.run_turn("fetch", model="claude-opus-4-6", fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model="claude-opus-4-6",
+                session_mode=TurnSessionMode.FRESH,
+            )
 
-    def test_fresh_session_spawns_when_session_missing(self, tmp_path: Path) -> None:
+    def test_fresh_session_mode_spawns_when_session_missing(
+        self, tmp_path: Path
+    ) -> None:
         session = MagicMock()
         session_factory = MagicMock(return_value=session)
         client = ClaudeClient(
@@ -2403,7 +2414,11 @@ class TestClaudeClientSessionAttachment:
         )
         session.prompt.return_value = "ok"
         assert (
-            client.run_turn("fetch", model="claude-opus-4-6", fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model="claude-opus-4-6",
+                session_mode=TurnSessionMode.FRESH,
+            )
             == "ok"
         )
         session_factory.assert_called_once_with(
@@ -2414,12 +2429,16 @@ class TestClaudeClientSessionAttachment:
         )
         session.reset.assert_not_called()
 
-    def test_fresh_session_resets_existing_session(self) -> None:
+    def test_fresh_session_mode_resets_existing_session(self) -> None:
         session = MagicMock()
         session.prompt.return_value = "ok"
         client = ClaudeClient(session=session)
         assert (
-            client.run_turn("fetch", model="claude-opus-4-6", fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model="claude-opus-4-6",
+                session_mode=TurnSessionMode.FRESH,
+            )
             == "ok"
         )
         session.reset.assert_called_once_with("claude-opus-4-6")

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -28,7 +28,12 @@ from kennel.copilotcli import (
     extract_result_text,
     extract_session_id,
 )
-from kennel.provider import ProviderID, ProviderLimitSnapshot, ProviderModel
+from kennel.provider import (
+    ProviderID,
+    ProviderLimitSnapshot,
+    ProviderModel,
+    TurnSessionMode,
+)
 
 
 def _completed(
@@ -804,13 +809,17 @@ class TestCopilotCLIClient:
         ):
             client.run_turn("fetch")
 
-    def test_fresh_session_requires_reset_method(self) -> None:
+    def test_fresh_session_mode_requires_reset_method(self) -> None:
         client = CopilotCLIClient(session=object())
         with pytest.raises(
             ValueError,
-            match="CopilotCLIClient.run_turn fresh_session requires resettable session",
+            match="CopilotCLIClient.run_turn session_mode=fresh requires resettable session",
         ):
-            client.run_turn("fetch", model=client.voice_model, fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model=client.voice_model,
+                session_mode=TurnSessionMode.FRESH,
+            )
 
     def test_ensure_fresh_stop_noop_branches(self, tmp_path: Path) -> None:
         session = MagicMock()
@@ -823,7 +832,11 @@ class TestCopilotCLIClient:
         client.ensure_session(client.voice_model)
         session.prompt.return_value = "ok"
         assert (
-            client.run_turn("fetch", model=client.work_model, fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model=client.work_model,
+                session_mode=TurnSessionMode.FRESH,
+            )
             == "ok"
         )
         client.stop_session()
@@ -843,7 +856,9 @@ class TestCopilotCLIClient:
         client.ensure_session(client.voice_model)
         session.switch_model.assert_called_once_with(client.voice_model)
 
-    def test_fresh_session_spawns_when_session_missing(self, tmp_path: Path) -> None:
+    def test_fresh_session_mode_spawns_when_session_missing(
+        self, tmp_path: Path
+    ) -> None:
         session = MagicMock()
         session_factory = MagicMock(return_value=session)
         client = CopilotCLIClient(
@@ -853,7 +868,11 @@ class TestCopilotCLIClient:
         )
         session.prompt.return_value = "ok"
         assert (
-            client.run_turn("fetch", model=client.voice_model, fresh_session=True)
+            client.run_turn(
+                "fetch",
+                model=client.voice_model,
+                session_mode=TurnSessionMode.FRESH,
+            )
             == "ok"
         )
         session_factory.assert_called_once_with(

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from kennel.provider import ProviderModel
+from kennel.provider import ProviderModel, TurnSessionMode
 from kennel.session_agent import SessionBackedAgent
 
 
@@ -44,10 +44,10 @@ class _FakeAgent(SessionBackedAgent):
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
-        fresh_session: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
         del retry_on_preempt
-        session = self._resolve_turn_session(model=model, fresh_session=fresh_session)
+        session = self._resolve_turn_session(model=model, session_mode=session_mode)
         return session.prompt(content, model=model, system_prompt=system_prompt)
 
 
@@ -159,13 +159,17 @@ class TestSessionBackedAgent:
         ):
             _FakeAgent(session_fn=lambda: None).generate_reply("hi")
 
-    def test_fresh_session_requires_resettable_session(self) -> None:
+    def test_fresh_session_mode_requires_resettable_session(self) -> None:
         agent = _FakeAgent(session=object())
         with pytest.raises(
             ValueError,
-            match="_FakeAgent.run_turn fresh_session requires resettable session",
+            match="_FakeAgent.run_turn session_mode=fresh requires resettable session",
         ):
-            agent.run_turn("hi", model=agent.voice_model, fresh_session=True)
+            agent.run_turn(
+                "hi",
+                model=agent.voice_model,
+                session_mode=TurnSessionMode.FRESH,
+            )
 
     def test_shared_helper_methods_and_json_parsing(self) -> None:
         session = MagicMock(session_id="sess-1")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -22,6 +22,7 @@ from kennel.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    TurnSessionMode,
 )
 from kennel.state import (
     State,
@@ -993,9 +994,9 @@ class TestWorker:
             patch.object(worker, "handle_promote_merge", return_value=0),
         ):
             worker.run()
-        assert worker._fresh_session_pending is False
+        assert worker._next_turn_session_mode == TurnSessionMode.REUSE
 
-    def test_run_marks_fresh_session_pending_at_issue_boundary(
+    def test_run_marks_fresh_session_mode_at_issue_boundary(
         self, tmp_path: Path
     ) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
@@ -1023,7 +1024,7 @@ class TestWorker:
             patch.object(worker, "handle_promote_merge", return_value=0),
         ):
             worker.run()
-        assert worker._fresh_session_pending is True
+        assert worker._next_turn_session_mode == TurnSessionMode.FRESH
 
     def test_run_sets_session_issue_after_picking_issue(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
@@ -2751,7 +2752,7 @@ class TestClaudeStart:
             "setup instructions\n\n---\n\nthe task prompt",
             model=client.voice_model,
             retry_on_preempt=True,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_session_path_calls_agent_once(self, tmp_path: Path) -> None:
@@ -2913,7 +2914,7 @@ class TestClaudeRun:
             "task instructions\n\n---\n\nrun this task",
             model=client.work_model,
             retry_on_preempt=True,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_session_path_calls_agent_once(self, tmp_path: Path) -> None:
@@ -3494,7 +3495,7 @@ class TestFindOrCreatePr:
             cwd=tmp_path,
             session=None,
             claude_client=mock_client,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_open_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
@@ -3726,7 +3727,7 @@ class TestFindOrCreatePr:
             cwd=tmp_path,
             session=None,
             claude_client=mock_client,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_no_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
@@ -4505,7 +4506,7 @@ class TestHandleMergeConflict:
             cwd=tmp_path,
             session=None,
             claude_client=ANY,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_does_not_call_claude_when_not_dirty(self, tmp_path: Path) -> None:
@@ -4875,7 +4876,7 @@ class TestHandleCi:
             cwd=tmp_path,
             session=None,
             claude_client=ANY,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_does_not_complete_ci_task(self, tmp_path: Path) -> None:
@@ -5626,7 +5627,7 @@ class TestHandleThreads:
             cwd=tmp_path,
             session=None,
             claude_client=ANY,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_spawns_sync_script(self, tmp_path: Path) -> None:
@@ -6653,7 +6654,7 @@ class TestExecuteTask:
             cwd=tmp_path,
             session=None,
             claude_client=ANY,
-            fresh_session=False,
+            session_mode=TurnSessionMode.REUSE,
         )
 
     def test_calls_ensure_pushed_with_origin_and_slug(self, tmp_path: Path) -> None:
@@ -6988,7 +6989,7 @@ class TestExecuteTask:
         # complete_by_id still called (idempotent — task already completed externally)
         mock_complete.assert_called_once_with(task["id"])
 
-    def test_uses_fresh_session_once_after_repeated_no_commit_nudges(
+    def test_uses_fresh_session_mode_once_after_repeated_no_commit_nudges(
         self, tmp_path: Path
     ) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -7025,8 +7026,17 @@ class TestExecuteTask:
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "br-42")
 
-        fresh_flags = [call.kwargs["fresh_session"] for call in mock_run.call_args_list]
-        assert fresh_flags == [False, False, False, False, True, False]
+        session_modes = [
+            call.kwargs["session_mode"] for call in mock_run.call_args_list
+        ]
+        assert session_modes == [
+            TurnSessionMode.REUSE,
+            TurnSessionMode.REUSE,
+            TurnSessionMode.REUSE,
+            TurnSessionMode.REUSE,
+            TurnSessionMode.FRESH,
+            TurnSessionMode.REUSE,
+        ]
         assert "session context was intentionally wiped" in prompt_snapshots[4]
         assert "Task title: Fix widget" in prompt_snapshots[4]
         assert "Branch: br-42" in prompt_snapshots[4]


### PR DESCRIPTION
## Summary
- replace the awkward `fresh_session` boolean with explicit `TurnSessionMode` values on `run_turn`
- thread that session mode through the shared session agent and worker orchestration
- update tests to assert explicit reuse vs fresh turn intent

Closes #609