### PR TITLE
Extract shared session-backed provider helpers

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1528,57 +1528,23 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             return
         session.switch_model(model)
 
-    def _session_is_dead(self, session: PromptSession) -> bool:
-        return session.is_alive() is False
+    def _prompt_failure_is_passthrough(self, exc: Exception) -> bool:
+        return isinstance(exc, ClaudeProviderError)
 
-    def _recover_prompt_session(self, session: PromptSession) -> bool:
-        recover = getattr(session, "recover", None)
-        if not callable(recover):
-            return False
-        recover()
-        return True
-
-    def _prompt_with_recovery(
+    def _should_retry_prompt_failure(
         self,
+        exc: Exception,
         session: PromptSession,
-        content: str,
-        *,
-        model: ProviderModel | None,
-        system_prompt: str | None,
-    ) -> str:
-        recovered = False
-        while True:
-            try:
-                result = session.prompt(
-                    content, model=model, system_prompt=system_prompt
-                )
-            except ClaudeProviderError:
-                raise
-            except Exception as exc:
-                should_retry = isinstance(
-                    exc, (ClaudeStreamError, BrokenPipeError, OSError)
-                ) or self._session_is_dead(session)
-                if (
-                    recovered
-                    or not should_retry
-                    or not self._recover_prompt_session(session)
-                ):
-                    raise
-                recovered = True
-                log.warning(
-                    "ClaudeClient: recovered session after prompt failure: %s", exc
-                )
-                continue
-            if (
-                result
-                or getattr(session, "last_turn_cancelled", False) is True
-                or not self._session_is_dead(session)
-            ):
-                return result
-            if recovered or not self._recover_prompt_session(session):
-                raise RuntimeError("Claude session died during prompt")
-            recovered = True
-            log.warning("ClaudeClient: recovered session after empty dead prompt")
+    ) -> bool:
+        return isinstance(exc, (ClaudeStreamError, BrokenPipeError, OSError)) or (
+            self._session_is_dead(session)
+        )
+
+    def _dead_prompt_error_message(self) -> str:
+        return "Claude session died during prompt"
+
+    def _json_parse_candidates(self, raw: str) -> tuple[str, ...]:
+        return (raw, *(m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)))
 
     def run_turn(
         self,
@@ -1609,38 +1575,6 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             session.wait_for_pending_preempt()
             attempt += 1
             log.info("ClaudeClient.run_turn: preempted mid-flight — retry %d", attempt)
-
-    def _run_turn_json_value(
-        self,
-        prompt: str,
-        key: str,
-        model: ProviderModel,
-        system_prompt: str | None = None,
-    ) -> str:
-        """Run a prompt turn and parse JSON from the response at *key*."""
-        json_instruction = (
-            f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
-            " No other text before or after the JSON."
-        )
-        full_system = (
-            f"{system_prompt}\n\n{json_instruction}"
-            if system_prompt
-            else json_instruction
-        )
-        raw = self.run_turn(prompt, model=model, system_prompt=full_system)
-        if not raw:
-            return ""
-        candidates = [raw] + [
-            m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)
-        ]
-        for candidate in candidates:
-            try:
-                obj = json.loads(candidate)
-                if isinstance(obj.get(key), str):
-                    return obj[key]
-            except json.JSONDecodeError, AttributeError:
-                continue
-        return ""
 
     def generate_status(
         self,

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -909,61 +909,23 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             repo_name=self._repo_name,
         )
 
-    def _session_is_dead(self, session: PromptSession) -> bool:
-        return session.is_alive() is False
-
-    def _recover_prompt_session(self, session: PromptSession) -> bool:
-        recover = getattr(session, "recover", None)
-        if not callable(recover):
-            return False
-        recover()
-        return True
-
-    def _prompt_with_recovery(
+    def _should_retry_prompt_failure(
         self,
+        exc: Exception,
         session: PromptSession,
-        content: str,
-        *,
-        model: ProviderModel | None,
-        system_prompt: str | None,
-    ) -> str:
-        recovered = False
-        while True:
-            try:
-                result = session.prompt(
-                    content, model=model, system_prompt=system_prompt
-                )
-            except Exception as exc:
-                message = str(exc)
-                should_retry = (
-                    isinstance(exc, (BrokenPipeError, OSError))
-                    or message == "Copilot ACP connection is not available"
-                    or (
-                        message != "Copilot ACP runtime is stopped"
-                        and self._session_is_dead(session)
-                    )
-                )
-                if (
-                    recovered
-                    or not should_retry
-                    or not self._recover_prompt_session(session)
-                ):
-                    raise
-                recovered = True
-                log.warning(
-                    "CopilotCLIClient: recovered session after prompt failure: %s", exc
-                )
-                continue
-            if (
-                result
-                or getattr(session, "last_turn_cancelled", False) is True
-                or not self._session_is_dead(session)
-            ):
-                return result
-            if recovered or not self._recover_prompt_session(session):
-                raise RuntimeError("Copilot CLI session died during prompt")
-            recovered = True
-            log.warning("CopilotCLIClient: recovered session after empty dead prompt")
+    ) -> bool:
+        message = str(exc)
+        return (
+            isinstance(exc, (BrokenPipeError, OSError))
+            or message == "Copilot ACP connection is not available"
+            or (
+                message != "Copilot ACP runtime is stopped"
+                and self._session_is_dead(session)
+            )
+        )
+
+    def _dead_prompt_error_message(self) -> str:
+        return "Copilot CLI session died during prompt"
 
     def run_turn(
         self,
@@ -996,35 +958,6 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             log.info(
                 "CopilotCLIClient.run_turn: preempted mid-flight — retry %d", attempt
             )
-
-    def _run_turn_json_value(
-        self,
-        prompt: str,
-        key: str,
-        model: ProviderModel,
-        system_prompt: str | None = None,
-    ) -> str:
-        json_instruction = (
-            f'Respond with ONLY a JSON object in the form {{"{key}": "your answer"}}.'
-            " No other text before or after the JSON."
-        )
-        full_system = (
-            f"{system_prompt}\n\n{json_instruction}"
-            if system_prompt
-            else json_instruction
-        )
-        raw = self.run_turn(prompt, model=model, system_prompt=full_system)
-        if not raw:
-            return ""
-        candidates = [raw]
-        for candidate in candidates:
-            try:
-                obj = json.loads(candidate)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(obj, dict) and isinstance(obj.get(key), str):
-                return obj[key]
-        return ""
 
     def print_prompt_from_file(
         self,

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
 
 from kennel.provider import PromptSession, ProviderModel, TurnSessionMode
+
+log = logging.getLogger(__name__)
 
 
 class SessionBackedAgent:
@@ -174,13 +177,85 @@ class SessionBackedAgent:
         raw = self.run_turn(prompt, model=model, system_prompt=full_system)
         if not raw:
             return ""
-        try:
-            obj = json.loads(raw)
-        except json.JSONDecodeError:
-            return ""
-        return (
-            obj[key] if isinstance(obj, dict) and isinstance(obj.get(key), str) else ""
-        )
+        for candidate in self._json_parse_candidates(raw):
+            try:
+                obj = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict) and isinstance(obj.get(key), str):
+                return obj[key]
+        return ""
+
+    def _json_parse_candidates(self, raw: str) -> tuple[str, ...]:
+        return (raw,)
+
+    def _session_is_dead(self, session: PromptSession) -> bool:
+        return session.is_alive() is False
+
+    def _recover_prompt_session(self, session: PromptSession) -> bool:
+        recover = getattr(session, "recover", None)
+        if not callable(recover):
+            return False
+        recover()
+        return True
+
+    def _prompt_failure_is_passthrough(self, exc: Exception) -> bool:
+        del exc
+        return False
+
+    def _should_retry_prompt_failure(
+        self,
+        exc: Exception,
+        session: PromptSession,
+    ) -> bool:
+        del exc
+        return self._session_is_dead(session)
+
+    def _dead_prompt_error_message(self) -> str:
+        return "session died during prompt"
+
+    def _prompt_with_recovery(
+        self,
+        session: PromptSession,
+        content: str,
+        *,
+        model: ProviderModel | None,
+        system_prompt: str | None,
+    ) -> str:
+        recovered = False
+        while True:
+            try:
+                result = session.prompt(
+                    content, model=model, system_prompt=system_prompt
+                )
+            except Exception as exc:
+                if self._prompt_failure_is_passthrough(exc):
+                    raise
+                should_retry = self._should_retry_prompt_failure(exc, session)
+                if (
+                    recovered
+                    or not should_retry
+                    or not self._recover_prompt_session(session)
+                ):
+                    raise
+                recovered = True
+                log_name = type(self).__name__
+                log.warning(
+                    "%s: recovered session after prompt failure: %s", log_name, exc
+                )
+                continue
+            if (
+                result
+                or getattr(session, "last_turn_cancelled", False) is True
+                or not self._session_is_dead(session)
+            ):
+                return result
+            if recovered or not self._recover_prompt_session(session):
+                raise RuntimeError(self._dead_prompt_error_message())
+            recovered = True
+            log.warning(
+                "%s: recovered session after empty dead prompt", type(self).__name__
+            )
 
     def _run_shared_turn(
         self,

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -51,6 +51,26 @@ class _FakeAgent(SessionBackedAgent):
         return session.prompt(content, model=model, system_prompt=system_prompt)
 
 
+class _RecoveringFakeAgent(_FakeAgent):
+    def run_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+        retry_on_preempt: bool = False,
+        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
+    ) -> str:
+        del retry_on_preempt
+        session = self._resolve_turn_session(model=model, session_mode=session_mode)
+        return self._prompt_with_recovery(
+            session,
+            content,
+            model=model,
+            system_prompt=system_prompt,
+        )
+
+
 class TestSessionBackedAgent:
     def test_base_abstract_methods_raise(self) -> None:
         agent = SessionBackedAgent(
@@ -213,3 +233,21 @@ class TestSessionBackedAgent:
         session.prompt.return_value = "resumed status"
         agent = _FakeAgent(session_fn=lambda: session)
         assert agent.resume_status("sess-1", "resume") == "resumed status"
+
+    def test_prompt_with_recovery_recovers_after_dead_prompt_failure(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = [BrokenPipeError("boom"), "done"]
+        session.is_alive.return_value = False
+        agent = _RecoveringFakeAgent(session=session)
+        assert agent.run_turn("hi", model=agent.voice_model) == "done"
+        session.recover.assert_called_once_with()
+
+    def test_prompt_with_recovery_raises_after_second_dead_empty_result(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = ["", ""]
+        session.last_turn_cancelled = False
+        session.is_alive.side_effect = [False, False]
+        agent = _RecoveringFakeAgent(session=session)
+        with pytest.raises(RuntimeError, match="session died during prompt"):
+            agent.run_turn("hi", model=agent.voice_model)
+        session.recover.assert_called_once_with()


### PR DESCRIPTION
## Summary
- move shared prompt-recovery and JSON parsing helpers into `SessionBackedAgent`
- keep only provider-specific retry and passthrough policy in Claude and Copilot clients
- add direct shared-agent tests for recovery behavior

Closes #608