### PR TITLE
Use status.json for provider pressure

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -38,7 +38,7 @@ Look deeper if you see:
 
 Investigation steps (look, don't touch):
 - `ps aux | grep claude | grep -v grep | grep -v "claude -c"` — any processes alive?
-- `tail -5 ~/log/kennel.log | grep -v '{"type'` — any errors?
+- `tail -5 ~/log/kennel-crash.log | grep -v '{"type'` — any errors?
 - Check if the fido session is still producing output
 - Check git status of managed repos for unexpected state
 
@@ -72,7 +72,7 @@ MY_PID=$PPID; ps aux | grep -E "kennel|claude" | grep -v grep | grep -v "claude 
 ```
 
 ### Step 3: Diagnose
-- Read the last 30 lines of `~/log/kennel.log` (filter out `{"type` JSON blobs)
+- Read the last 30 lines of `~/log/kennel-crash.log` (filter out `{"type` JSON blobs)
 - Check `tasks.json` state: `cat /home/rhencke/workspace/home/.git/fido/tasks.json`
 - Check `state.json`: `cat /home/rhencke/workspace/home/.git/fido/state.json`
 - Check git status and recent commits of managed repos
@@ -123,8 +123,7 @@ For each managed repo (kennel, confusio, home):
 ### Step 9: Restart kennel
 Kennel runs from the **runner clone** at `/home/rhencke/home-runner/`, not the workspace clone. The runner is always on `main`, never on a feature branch. Launch via the local launcher:
 ```bash
-/home/rhencke/start-kennel.sh >> ~/log/kennel.log 2>&1 &
-disown
+/home/rhencke/start-kennel.sh
 sleep 5 && /home/rhencke/home-runner/.venv/bin/kennel status
 ```
 

--- a/kennel/provider_factory.py
+++ b/kennel/provider_factory.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
-from kennel.claude import ClaudeClient, ClaudeCode
+from kennel.claude import ClaudeAPI, ClaudeClient, ClaudeCode
 from kennel.config import RepoConfig
-from kennel.copilotcli import CopilotCLI, CopilotCLIClient
-from kennel.provider import PromptSession, Provider, ProviderAgent, ProviderID
+from kennel.copilotcli import CopilotCLI, CopilotCLIAPI, CopilotCLIClient
+from kennel.provider import (
+    PromptSession,
+    Provider,
+    ProviderAgent,
+    ProviderAPI,
+    ProviderID,
+)
 
 
 class DefaultProviderFactory:
@@ -15,6 +22,23 @@ class DefaultProviderFactory:
 
     def __init__(self, *, session_system_file: Path) -> None:
         self._session_system_file = session_system_file
+        self._api_lock = threading.Lock()
+        self._apis: dict[ProviderID, ProviderAPI] = {}
+
+    def create_api(self, repo_cfg: RepoConfig) -> ProviderAPI:
+        with self._api_lock:
+            api = self._apis.get(repo_cfg.provider)
+            if api is not None:
+                return api
+            match repo_cfg.provider:
+                case ProviderID.CLAUDE_CODE:
+                    api = ClaudeAPI()
+                case ProviderID.COPILOT_CLI:
+                    api = CopilotCLIAPI()
+                case _:
+                    raise ValueError(f"unsupported provider: {repo_cfg.provider}")
+            self._apis[repo_cfg.provider] = api
+            return api
 
     def create_provider(
         self,

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -39,6 +39,7 @@ from kennel.infra import (
     ProcessRunner,
     real_infra,
 )
+from kennel.provider_factory import DefaultProviderFactory
 from kennel.registry import WorkerRegistry, make_registry
 from kennel.static_files import StaticFiles
 from kennel.status import provider_statuses_for_repo_configs
@@ -416,6 +417,7 @@ def _noop_after_post() -> None:
 class WebhookHandler(BaseHTTPRequestHandler):
     config: Config
     registry: WorkerRegistry
+    provider_factory: DefaultProviderFactory | None = None
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
@@ -748,7 +750,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         now = datetime.now(tz=timezone.utc)
         activities: list[dict[str, Any]] = []
         provider_statuses = provider_statuses_for_repo_configs(
-            list(self.config.repos.values())
+            list(self.config.repos.values()),
+            _provider_factory=self.provider_factory,
         )
         for a in self.registry.get_all_activities():
             crash = self.registry.get_crash_info(a.repo_name)
@@ -959,6 +962,9 @@ def run(
     WebhookHandler.gh = gh
     WebhookHandler.static_files = StaticFiles(
         Path(__file__).resolve().parent / "static"
+    )
+    WebhookHandler.provider_factory = DefaultProviderFactory(
+        session_system_file=config.sub_dir / "persona.md"
     )
     registry = _make_registry(config.repos, gh, config)
     WebhookHandler.registry = registry

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -245,16 +245,39 @@ def provider_statuses_for_repo_configs(
     for repo_cfg in repo_configs:
         if repo_cfg.provider in statuses:
             continue
-        provider = provider_factory.create_provider(
-            repo_cfg,
-            work_dir=repo_cfg.work_dir,
-            repo_name=repo_cfg.name,
-            session=None,
-        )
         statuses[repo_cfg.provider] = ProviderPressureStatus.from_snapshot(
-            provider.api.get_limit_snapshot()
+            provider_factory.create_api(repo_cfg).get_limit_snapshot()
         )
     return statuses
+
+
+def _parse_provider_status(raw: object) -> ProviderPressureStatus | None:
+    """Parse one serialized provider-pressure record from /status.json."""
+    if not isinstance(raw, dict):
+        return None
+    try:
+        provider = ProviderID(raw["provider"])
+    except KeyError, TypeError, ValueError:
+        return None
+    resets_at = raw.get("resets_at")
+    try:
+        parsed_reset = (
+            datetime.fromisoformat(resets_at) if isinstance(resets_at, str) else None
+        )
+    except ValueError:
+        parsed_reset = None
+    pressure = raw.get("pressure")
+    return ProviderPressureStatus(
+        provider=provider,
+        window_name=raw.get("window_name")
+        if isinstance(raw.get("window_name"), str)
+        else None,
+        pressure=float(pressure) if isinstance(pressure, int | float) else None,
+        resets_at=parsed_reset,
+        unavailable_reason=raw.get("unavailable_reason")
+        if isinstance(raw.get("unavailable_reason"), str)
+        else None,
+    )
 
 
 def _port_from_pid(pid: int) -> int | None:
@@ -276,7 +299,7 @@ def _port_from_pid(pid: int) -> int | None:
 def _fetch_activities(
     port: int, *, _urlopen: Callable[..., Any] = urllib.request.urlopen
 ) -> dict[str, dict[str, Any]]:
-    """Query GET /status.json, returning {repo_name: {what, crash_count, last_crash_error, is_stuck}}."""
+    """Query GET /status.json for live worker activity and provider pressure."""
     try:
         with _urlopen(f"http://localhost:{port}/status.json", timeout=2) as resp:
             data = json.loads(resp.read())
@@ -292,6 +315,8 @@ def _fetch_activities(
                 "session_alive": item.get("session_alive", False),
                 "session_pid": item.get("session_pid"),
                 "claude_talker": item.get("claude_talker"),
+                "provider_status": _parse_provider_status(item.get("provider_status")),
+                "rescoping": item.get("rescoping", False),
             }
             for item in data
             if "repo_name" in item and "what" in item
@@ -506,7 +531,6 @@ def collect() -> KennelStatus:
     pid = _kennel_pid()
     uptime = _process_uptime_seconds(pid) if pid is not None else None
     repo_configs = _repos_from_pid(pid) if pid is not None else []
-    provider_statuses = provider_statuses_for_repo_configs(repo_configs)
 
     activities: dict[str, Any] = {}
     if pid is not None:
@@ -514,6 +538,7 @@ def collect() -> KennelStatus:
         if port is not None:
             activities = _fetch_activities(port)
 
+    provider_statuses: dict[ProviderID, ProviderPressureStatus] = {}
     repos = []
     for rc in repo_configs:
         info = activities.get(rc.name)
@@ -542,6 +567,12 @@ def collect() -> KennelStatus:
                 )
             sp = info.get("session_pid")
             session_pid_val = int(sp) if sp is not None else None
+        provider_status = info.get("provider_status") if info else None
+        if (
+            isinstance(provider_status, ProviderPressureStatus)
+            and provider_status.provider not in provider_statuses
+        ):
+            provider_statuses[provider_status.provider] = provider_status
         repos.append(
             repo_status(
                 rc,
@@ -556,7 +587,7 @@ def collect() -> KennelStatus:
                 session_pid=session_pid_val,
                 claude_talker=talker_info,
                 rescoping=bool(info.get("rescoping")) if info else False,
-                provider_status=provider_statuses.get(rc.provider),
+                provider_status=provider_status,
             )
         )
     return KennelStatus(

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -10,6 +10,48 @@ from kennel.provider_factory import DefaultProviderFactory
 
 
 class TestDefaultProviderFactory:
+    def test_create_api_caches_by_provider(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        repo_a = RepoConfig(
+            name="owner/a",
+            work_dir=tmp_path / "a",
+            provider=ProviderID.CLAUDE_CODE,
+        )
+        repo_b = RepoConfig(
+            name="owner/b",
+            work_dir=tmp_path / "b",
+            provider=ProviderID.CLAUDE_CODE,
+        )
+        assert factory.create_api(repo_a) is factory.create_api(repo_b)
+
+    def test_create_api_builds_copilot(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        api = factory.create_api(
+            RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                provider=ProviderID.COPILOT_CLI,
+            )
+        )
+        assert api.provider_id == ProviderID.COPILOT_CLI
+
+    def test_create_api_rejects_unknown_provider(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        with pytest.raises(ValueError, match="unsupported provider"):
+            factory.create_api(
+                RepoConfig(
+                    name="owner/repo",
+                    work_dir=tmp_path,
+                    provider=ProviderID.GEMINI,
+                )
+            )
+
     def test_create_provider_builds_claude(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -9,8 +9,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from kennel.color import _CODES
 from kennel.config import RepoConfig as _RepoConfig
 from kennel.provider import (
@@ -160,13 +158,13 @@ class TestProviderStatusesForRepoConfigs:
         factory = MagicMock()
         first = MagicMock()
         second = MagicMock()
-        first.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+        first.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE
         )
-        second.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+        second.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.COPILOT_CLI
         )
-        factory.create_provider.side_effect = [first, second]
+        factory.create_api.side_effect = [first, second]
 
         statuses = provider_statuses_for_repo_configs(
             [claude_a, claude_b, copilot],
@@ -174,18 +172,18 @@ class TestProviderStatusesForRepoConfigs:
         )
 
         assert list(statuses) == [ProviderID.CLAUDE_CODE, ProviderID.COPILOT_CLI]
-        factory.create_provider.assert_any_call(
-            claude_a,
-            work_dir=claude_a.work_dir,
-            repo_name=claude_a.name,
-            session=None,
+        factory.create_api.assert_any_call(claude_a)
+        factory.create_api.assert_any_call(copilot)
+
+    def test_builds_default_factory_when_not_injected(self, tmp_path: Path) -> None:
+        repo = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        factory = MagicMock()
+        factory.create_api.return_value.get_limit_snapshot.return_value = (
+            ProviderLimitSnapshot(provider=ProviderID.CLAUDE_CODE)
         )
-        factory.create_provider.assert_any_call(
-            copilot,
-            work_dir=copilot.work_dir,
-            repo_name=copilot.name,
-            session=None,
-        )
+        with patch("kennel.status.DefaultProviderFactory", return_value=factory):
+            statuses = provider_statuses_for_repo_configs([repo])
+        assert list(statuses) == [ProviderID.CLAUDE_CODE]
 
 
 class TestProcessUptimeSeconds:
@@ -507,6 +505,8 @@ class TestFetchActivities:
                 "session_alive": False,
                 "session_pid": None,
                 "claude_talker": None,
+                "provider_status": None,
+                "rescoping": False,
             }
         }
 
@@ -544,6 +544,8 @@ class TestFetchActivities:
                 "session_alive": False,
                 "session_pid": None,
                 "claude_talker": None,
+                "provider_status": None,
+                "rescoping": False,
             },
             "c/d": {
                 "what": "Fixing CI",
@@ -556,8 +558,83 @@ class TestFetchActivities:
                 "session_alive": False,
                 "session_pid": None,
                 "claude_talker": None,
+                "provider_status": None,
+                "rescoping": False,
             },
         }
+
+    def test_parses_provider_status_from_json(self) -> None:
+        data = json.dumps(
+            [
+                {
+                    "repo_name": "owner/repo",
+                    "what": "Working on: #1",
+                    "busy": True,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                    "is_stuck": False,
+                    "provider_status": {
+                        "provider": "claude-code",
+                        "window_name": "five_hour",
+                        "pressure": 0.96,
+                        "percent_used": 96,
+                        "resets_at": "2026-04-16T07:00:00+00:00",
+                        "unavailable_reason": None,
+                        "level": "paused",
+                        "warning": False,
+                        "paused": True,
+                    },
+                }
+            ]
+        ).encode()
+        result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
+        assert result["owner/repo"]["provider_status"] == ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            window_name="five_hour",
+            pressure=0.96,
+            resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+        )
+
+    def test_invalid_provider_status_defaults_to_none(self) -> None:
+        data = json.dumps(
+            [
+                {
+                    "repo_name": "owner/repo",
+                    "what": "Working on: #1",
+                    "busy": True,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                    "is_stuck": False,
+                    "provider_status": {"provider": "nope"},
+                }
+            ]
+        ).encode()
+        result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
+        assert result["owner/repo"]["provider_status"] is None
+
+    def test_bad_provider_status_reset_time_defaults_to_none(self) -> None:
+        data = json.dumps(
+            [
+                {
+                    "repo_name": "owner/repo",
+                    "what": "Working on: #1",
+                    "busy": True,
+                    "crash_count": 0,
+                    "last_crash_error": None,
+                    "is_stuck": False,
+                    "provider_status": {
+                        "provider": "claude-code",
+                        "pressure": 0.5,
+                        "resets_at": "not-a-date",
+                    },
+                }
+            ]
+        ).encode()
+        result = _fetch_activities(9000, _urlopen=self._make_urlopen(data))
+        assert result["owner/repo"]["provider_status"] == ProviderPressureStatus(
+            provider=ProviderID.CLAUDE_CODE,
+            pressure=0.5,
+        )
 
     def test_returns_empty_on_exception(self) -> None:
         mock_urlopen = MagicMock(side_effect=OSError("refused"))
@@ -883,11 +960,6 @@ class TestRepoStatus:
 
 
 class TestCollect:
-    @pytest.fixture(autouse=True)
-    def _stub_provider_statuses(self):
-        with patch("kennel.status.provider_statuses_for_repo_configs", return_value={}):
-            yield
-
     def _fake_repo_status(self, name: str = "owner/repo") -> RepoStatus:
         return RepoStatus(
             name=name,
@@ -947,10 +1019,12 @@ class TestCollect:
             patch("kennel.status._kennel_pid", return_value=42),
             patch("kennel.status._repos_from_pid", return_value=[rc]),
             patch("kennel.status._process_uptime_seconds", return_value=600),
-            patch("kennel.status._port_from_pid", return_value=None),
+            patch("kennel.status._port_from_pid", return_value=9000),
             patch(
-                "kennel.status.provider_statuses_for_repo_configs",
-                return_value={ProviderID.CLAUDE_CODE: provider_status},
+                "kennel.status._fetch_activities",
+                return_value={
+                    "owner/repo": self._activity_info(provider_status=provider_status)
+                },
             ),
             patch(
                 "kennel.status.repo_status", return_value=self._fake_repo_status()
@@ -971,6 +1045,7 @@ class TestCollect:
         webhook_activities: list | None = None,
         session_owner: str | None = None,
         rescoping: bool = False,
+        provider_status: ProviderPressureStatus | None = None,
     ) -> dict:
         return {
             "what": what,
@@ -981,6 +1056,7 @@ class TestCollect:
             "webhook_activities": webhook_activities or [],
             "session_owner": session_owner,
             "rescoping": rescoping,
+            "provider_status": provider_status,
         }
 
     def test_fetches_activities_when_port_known(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- have `kennel status` consume provider pressure from `/status.json` instead of rebuilding it in each CLI process
- keep one cached provider API per provider in the long-lived server so Claude usage snapshots survive repeated status requests
- align the guarddog skill with the real launcher/log contract by using `start-kennel.sh` and `~/log/kennel-crash.log`

## Testing
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright
- uv run pytest --cov --cov-report=term-missing --cov-fail-under=100