### PR TITLE
Fix Copilot status wording and talker highlighting

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -24,8 +24,10 @@ checks. Keep it running and sample every 2 minutes:
 ### Collect status
 Run `uv run kennel status` from `/home/rhencke/workspace/home`.
 
-Also watch `~/log/kennel-crash.log` in the same monitor session so status
-changes and fresh errors are observed together.
+Also watch the log directory `~/log` in the same monitor session so status
+changes and fresh errors are observed together. Prefer the active kennel logs
+there (`kennel-crash.log`, `kennel.log`, `kennel-*.log`, repo-specific launch
+logs) instead of a single hard-coded file.
 
 ### All good — report deltas only
 Compare to the previous check. Report only what changed:
@@ -42,7 +44,7 @@ Look deeper if you see:
 
 Investigation steps (look, don't touch):
 - `ps aux | grep claude | grep -v grep | grep -v "claude -c"` — any processes alive?
-- `tail -5 ~/log/kennel-crash.log | grep -v '{"type'` — any errors?
+- inspect recent errors across the relevant files under `~/log/`, not just `kennel-crash.log`
 - Check if the fido session is still producing output
 - Check git status of managed repos for unexpected state
 

--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -18,10 +18,14 @@ When invoked, determine the current state automatically. Never ask — just dete
 
 ## Watch mode
 
-Create a recurring 2-minute cron. Every tick:
+Use a long-lived monitor tool/session for watch mode instead of ad-hoc one-shot
+checks. Keep it running and sample every 2 minutes:
 
 ### Collect status
 Run `uv run kennel status` from `/home/rhencke/workspace/home`.
+
+Also watch `~/log/kennel-crash.log` in the same monitor session so status
+changes and fresh errors are observed together.
 
 ### All good — report deltas only
 Compare to the previous check. Report only what changed:
@@ -48,7 +52,7 @@ If you discover missing diagnostic tools or logging that would have helped, file
 
 ### Confirmed bad — transition to Vet mode
 If the problem persists across two checks:
-1. Cancel the 2-minute cron
+1. Cancel the monitor session
 2. Gather diagnostic context: what you observed, relevant log snippets, how many cycles the problem persisted, the last known good status
 3. Transition to **Vet mode** below, passing all that context
 

--- a/kennel/color.py
+++ b/kennel/color.py
@@ -24,6 +24,8 @@ MAGENTA = "magenta"
 GREEN = "green"
 YELLOW = "yellow"
 DARK_GRAY = "dark_gray"
+GREEN_BG = "green_bg"
+YELLOW_BG = "yellow_bg"
 
 # ANSI escape sequences
 _RESET = "\033[0m"
@@ -37,6 +39,8 @@ _CODES: dict[str, str] = {
     GREEN: "\033[32m",
     YELLOW: "\033[33m",
     DARK_GRAY: "\033[90m",
+    GREEN_BG: "\033[30;42m",
+    YELLOW_BG: "\033[30;43m",
 }
 
 

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -56,7 +56,6 @@ _COPILOT_JSON_BASE_ARGS = (
     "--allow-all",
     "-s",
 )
-_COPILOT_LIMITS_UNAVAILABLE = "Copilot CLI does not expose local usage limits."
 
 
 def _iter_jsonl(output: str) -> list[dict[str, Any]]:
@@ -854,10 +853,7 @@ class CopilotCLIAPI(ProviderAPI):
         return ProviderID.COPILOT_CLI
 
     def get_limit_snapshot(self) -> ProviderLimitSnapshot:
-        return ProviderLimitSnapshot(
-            provider=self.provider_id,
-            unavailable_reason=_COPILOT_LIMITS_UNAVAILABLE,
-        )
+        return ProviderLimitSnapshot(provider=self.provider_id)
 
 
 class CopilotCLIClient(SessionBackedAgent, ProviderAgent):

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -18,10 +18,11 @@ from kennel.color import (
     DARK_GRAY,
     DIM,
     GREEN,
+    GREEN_BG,
     MAGENTA,
     RED,
     RED_BOLD,
-    YELLOW,
+    YELLOW_BG,
     color,
 )
 from kennel.config import RepoConfig
@@ -605,11 +606,11 @@ _WEBHOOK_DISPLAY_CAP: int = 5
 """Max webhook lines to print per repo; overflow rolled into a +N-more line."""
 
 
-def _claude_stats_suffix(repo: RepoStatus) -> str:
-    """`" → claude pid 123 (running 1m, session idle)"` or ``""``.
+def _agent_runtime_suffix(repo: RepoStatus) -> str:
+    """`" → pid 123 (running 1m, session idle)"` or ``""``.
 
-    Used both as the inline trailer on whatever line is "talking to" claude
-    and, when nobody is talking, appended to the worker summary line.
+    Used only when nobody is currently talking to the agent, so runtime/session
+    information still appears without hard-coding Claude onto active lines.
     """
     if repo.claude_pid is None and not repo.session_alive:
         return ""
@@ -619,9 +620,9 @@ def _claude_stats_suffix(repo: RepoStatus) -> str:
     if repo.session_alive and repo.claude_talker is None:
         parts.append(color(DIM, "session idle"))
     pid_str = (
-        color(DIM, f"claude pid {repo.claude_pid}")
+        color(DIM, f"pid {repo.claude_pid}")
         if repo.claude_pid is not None
-        else color(DIM, "claude")
+        else color(DIM, "agent")
     )
     arrow = color(DIM, "→")
     if parts:
@@ -676,9 +677,8 @@ def _format_repo_header(repo: RepoStatus) -> str:
     Stats list is comma-separated and only shows what matters right now:
     ``crashes N`` (skipped when 0), ``up X`` (worker thread uptime), ``BUSY``
     (no activity for ≥5m, informational since #444), optional ``last crash``
-    line when crash_count > 0.  If nobody is currently talking to claude the
-    claude pid/uptime suffix appears on this line; when a worker or webhook
-    IS talking, the suffix attaches to that line instead.
+    line when crash_count > 0.  If nobody is currently talking to the agent,
+    the generic pid/uptime suffix appears on this line.
     """
     state_word = "running" if repo.fido_running else "idle"
     state_style = GREEN if repo.fido_running else DIM
@@ -701,9 +701,9 @@ def _format_repo_header(repo: RepoStatus) -> str:
     header = f"{name_styled} {state_styled}"
     if stats:
         header += " — " + ", ".join(stats)
-    # Claude stats ride the worker summary only when nobody is talking.
+    # Runtime/session stats ride the repo summary only when nobody is talking.
     if repo.claude_talker is None:
-        header += _claude_stats_suffix(repo)
+        header += _agent_runtime_suffix(repo)
     return header
 
 
@@ -712,12 +712,11 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
 
     1. ``Issue:  #N — title  (elapsed Xm)``
     2. ``PR:     #N — title``
-    3. ``Worker: <state>`` (idle / task N/M — title / waiting on …), with
-       claude stats suffix when the worker thread is talking to claude
+    3. ``Worker: <state>`` (idle / task N/M — title / waiting on …)
     4. Webhook threads (indented ``├─`` / ``└─``), up to
-       :data:`_WEBHOOK_DISPLAY_CAP`; a webhook currently talking to claude
-       sorts to the top and gets the claude stats suffix; overflow rolled
-       into ``+N more webhook(s)``.
+       :data:`_WEBHOOK_DISPLAY_CAP`; a webhook currently talking to the agent
+       sorts to the top and gets an ANSI background-highlighted label; overflow
+       rolled into ``+N more webhook(s)``.
     """
     body: list[str] = []
 
@@ -748,17 +747,12 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
 
 
 def _format_worker_thread_line(repo: RepoStatus) -> str:
-    """Worker-thread state line.  Attach claude stats when this thread is
-    the one talking to claude.
-    """
+    """Worker-thread state line, background-highlighted when it has the agent."""
     state = _worker_thread_state(repo)
     talker = repo.claude_talker
     is_talker = talker is not None and talker.kind == "worker"
-    label = color(GREEN, "Worker:") if is_talker else color(BOLD, "Worker:")
-    line = f"  {label} {state}"
-    if is_talker:
-        line += _claude_stats_suffix(repo)
-    return line
+    label = color(GREEN_BG, "Worker:") if is_talker else color(BOLD, "Worker:")
+    return f"  {label} {state}"
 
 
 def _worker_thread_state(repo: RepoStatus) -> str:
@@ -802,7 +796,7 @@ def _format_webhook_lines(repo: RepoStatus) -> list[str]:
     talker_tid = (
         talker.thread_id if talker is not None and talker.kind == "webhook" else None
     )
-    # Stable sort: webhooks driving claude first, then everything else in
+    # Stable sort: webhooks driving the agent first, then everything else in
     # original order.
     webhooks.sort(key=lambda w: 0 if w.thread_id == talker_tid else 1)
 
@@ -812,11 +806,11 @@ def _format_webhook_lines(repo: RepoStatus) -> list[str]:
     for i, w in enumerate(shown):
         branch = color(DIM, "└─" if overflow == 0 and i == len(shown) - 1 else "├─")
         is_talker = talker_tid is not None and w.thread_id == talker_tid
-        wh_label = color(YELLOW, "webhook:") if is_talker else color(BOLD, "webhook:")
+        wh_label = (
+            color(YELLOW_BG, "webhook:") if is_talker else color(BOLD, "webhook:")
+        )
         elapsed = color(DIM, f"({_format_uptime(w.elapsed_seconds)})")
         line = f"  {branch} {wh_label} {w.description} {elapsed}"
-        if is_talker:
-            line += _claude_stats_suffix(repo)
         lines.append(line)
     if overflow > 0:
         lines.append(

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -729,10 +729,9 @@ class TestCopilotCLISession:
 
 
 class TestCopilotCLIAPI:
-    def test_limit_snapshot_is_unavailable(self) -> None:
+    def test_limit_snapshot_is_unknown(self) -> None:
         assert CopilotCLIAPI().get_limit_snapshot() == ProviderLimitSnapshot(
-            provider=ProviderID.COPILOT_CLI,
-            unavailable_reason="Copilot CLI does not expose local usage limits.",
+            provider=ProviderID.COPILOT_CLI
         )
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1357,21 +1357,17 @@ class TestFormatStatus:
 
     def test_includes_provider_unavailable_summary(self) -> None:
         provider_status = ProviderPressureStatus(
-            provider=ProviderID.COPILOT_CLI,
+            provider=ProviderID.CLAUDE_CODE,
             unavailable_reason="limits unavailable",
         )
         status = KennelStatus(
             kennel_pid=None,
             kennel_uptime=None,
-            repos=[
-                self._repo(
-                    provider=ProviderID.COPILOT_CLI, provider_status=provider_status
-                )
-            ],
+            repos=[self._repo(provider_status=provider_status)],
             provider_statuses=[provider_status],
         )
         output = format_status(status)
-        assert "copilot-cli unavailable" in output
+        assert "claude-code unavailable" in output
 
     def test_includes_provider_unknown_summary(self) -> None:
         provider_status = ProviderPressureStatus(provider=ProviderID.CLAUDE_CODE)
@@ -1383,6 +1379,21 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "claude-code limits unknown" in output
+
+    def test_includes_copilot_unknown_summary(self) -> None:
+        provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
+        status = KennelStatus(
+            kennel_pid=None,
+            kennel_uptime=None,
+            repos=[
+                self._repo(
+                    provider=ProviderID.COPILOT_CLI, provider_status=provider_status
+                )
+            ],
+            provider_statuses=[provider_status],
+        )
+        output = format_status(status)
+        assert "copilot-cli limits unknown" in output
 
     def test_kennel_up_no_uptime(self) -> None:
         status = KennelStatus(kennel_pid=12345, kennel_uptime=None, repos=[])
@@ -1492,15 +1503,14 @@ class TestFormatStatus:
         assert "Worker: idle" in output
 
     def test_claude_pid_on_worker_summary_when_no_talker(self) -> None:
-        """Claude stats ride the worker summary line when nobody is currently
-        talking to claude for this repo."""
+        """Runtime stats ride the repo summary when nobody is currently talking."""
         repo = self._repo(issue=1, claude_pid=9999, claude_uptime=185)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "→ claude pid 9999 (running 3m)" in output
+        assert "→ pid 9999 (running 3m)" in output
         # Header (worker summary) line carries the suffix.
         assert any(
-            line.startswith("owner/repo:") and "→ claude pid 9999" in line
+            line.startswith("owner/repo:") and "→ pid 9999" in line
             for line in output.splitlines()
         )
 
@@ -1508,11 +1518,11 @@ class TestFormatStatus:
         repo = self._repo(issue=1, claude_pid=9999, claude_uptime=None)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "→ claude pid 9999" in output
+        assert "→ pid 9999" in output
         assert "running" not in output
 
-    def test_claude_pid_attaches_to_worker_line_when_worker_talker(self) -> None:
-        """Worker-kind talker → claude stats on the Worker thread line."""
+    def test_worker_talker_highlights_worker_line_without_pid_suffix(self) -> None:
+        """Worker-kind talker → highlight the Worker label instead of a pid suffix."""
         repo = self._repo(
             issue=1,
             claude_pid=9999,
@@ -1527,16 +1537,15 @@ class TestFormatStatus:
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        # Worker line has the claude suffix.
         worker_lines = [
             line for line in output.splitlines() if line.startswith("  Worker:")
         ]
-        assert any("→ claude pid 9999 (running 1m)" in line for line in worker_lines)
+        assert any("→ pid" not in line for line in worker_lines)
         # Header does not duplicate it.
         header = next(line for line in output.splitlines() if line.startswith("owner"))
-        assert "→ claude pid" not in header
+        assert "→ pid" not in header
 
-    def test_claude_pid_session_alive_no_talker(self) -> None:
+    def test_agent_runtime_suffix_session_alive_no_talker(self) -> None:
         """Session subprocess alive but nobody holds the lock → 'session idle'."""
         repo = self._repo(
             issue=1,
@@ -1548,10 +1557,10 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         # Suffix appears on worker summary and mentions session idle.
-        assert "→ claude pid 9999 (running 1m, session idle)" in output
+        assert "→ pid 9999 (running 1m, session idle)" in output
 
     def test_session_alive_without_claude_pid(self) -> None:
-        """Session_alive with no pid still signals claude presence via 'session idle'."""
+        """Session_alive with no pid still signals idle agent presence."""
         repo = self._repo(
             issue=1,
             claude_pid=None,
@@ -1559,7 +1568,7 @@ class TestFormatStatus:
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "→ claude (session idle)" in output
+        assert "→ agent (session idle)" in output
 
     def test_multiple_repos(self) -> None:
         # Each repo emits a header + "no assigned issues" body line.
@@ -1656,9 +1665,8 @@ class TestFormatStatus:
         # Worker line shows the free-form task title.
         assert "Worker: task: Freeform task" in output
 
-    def test_webhook_talker_sorts_to_top_with_claude_stats(self) -> None:
-        """When a webhook is the ClaudeTalker, its line sorts to the top of
-        the webhook section and carries the claude pid suffix."""
+    def test_webhook_talker_sorts_to_top_without_pid_suffix(self) -> None:
+        """When a webhook is the talker, its line sorts to the top and is highlighted."""
         repo = self._repo(
             issue=1,
             claude_pid=8888,
@@ -1684,9 +1692,9 @@ class TestFormatStatus:
             line for line in format_status(status).splitlines() if "webhook:" in line
         ]
         assert "replying to review" in webhook_lines[0]
-        assert "→ claude pid 8888" in webhook_lines[0]
+        assert "→ pid" not in webhook_lines[0]
         assert "triaging comment" in webhook_lines[1]
-        assert "→ claude pid" not in webhook_lines[1]
+        assert "→ pid" not in webhook_lines[1]
 
     def test_webhook_overflow_summary_when_more_than_five(self) -> None:
         """More than 5 webhook activities → first 5 shown + '+N more' line."""
@@ -1924,7 +1932,7 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
-        assert f"{_CODES['green']}Worker:" in worker_line
+        assert f"{_CODES['green_bg']}Worker:" in worker_line
 
     def test_worker_label_plain_when_not_talker(self) -> None:
         repo = self._repo(issue=1)
@@ -1932,7 +1940,7 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
-        assert _CODES["green"] not in worker_line
+        assert _CODES["green_bg"] not in worker_line
 
     def test_webhook_label_yellow_when_talker(self) -> None:
         repo = self._repo(
@@ -1952,7 +1960,7 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         wh_line = [ln for ln in output.splitlines() if "webhook:" in ln][0]
-        assert f"{_CODES['yellow']}webhook:" in wh_line
+        assert f"{_CODES['yellow_bg']}webhook:" in wh_line
 
     def test_webhook_label_plain_when_not_talker(self) -> None:
         repo = self._repo(
@@ -1967,7 +1975,7 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         wh_line = [ln for ln in output.splitlines() if "webhook:" in ln][0]
-        assert _CODES["yellow"] not in wh_line
+        assert _CODES["yellow_bg"] not in wh_line
 
     def test_session_idle_dim(self) -> None:
         repo = self._repo(issue=1, claude_pid=999, session_alive=True)


### PR DESCRIPTION
## Summary
- treat Copilot usage as limits-unknown instead of provider-unavailable so installed Copilot does not show up as missing
- replace talker-line `claude` suffixes with ANSI background-highlighted Worker/webhook labels while keeping generic runtime/session info on the repo header when idle
- update guarddog watch-mode instructions to use a long-lived monitor session for status plus log watching

## Testing
- uv run ruff check .
- uv run pyright
- uv run pytest -n0 --cov --cov-report=term-missing --cov-fail-under=100