### PR TITLE
Highlight worker when Copilot session is owned

### DIFF
--- a/kennel/status.py
+++ b/kennel/status.py
@@ -617,7 +617,11 @@ def _agent_runtime_suffix(repo: RepoStatus) -> str:
     parts: list[str] = []
     if repo.claude_uptime is not None:
         parts.append(color(DIM, f"running {_format_uptime(repo.claude_uptime)}"))
-    if repo.session_alive and repo.claude_talker is None:
+    if (
+        repo.session_alive
+        and not _worker_is_agent_talker(repo)
+        and repo.claude_talker is None
+    ):
         parts.append(color(DIM, "session idle"))
     pid_str = (
         color(DIM, f"pid {repo.claude_pid}")
@@ -634,6 +638,14 @@ def _agent_runtime_suffix(repo: RepoStatus) -> str:
 def _format_reset_at(resets_at: datetime) -> str:
     """Format provider reset times in a compact UTC form."""
     return resets_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _worker_is_agent_talker(repo: RepoStatus) -> bool:
+    """True when the worker thread currently owns the provider session."""
+    if repo.claude_talker is not None:
+        return repo.claude_talker.kind == "worker"
+    owner = repo.session_owner or ""
+    return owner.startswith("worker-")
 
 
 def _provider_status_style(status: ProviderPressureStatus) -> str:
@@ -702,7 +714,7 @@ def _format_repo_header(repo: RepoStatus) -> str:
     if stats:
         header += " — " + ", ".join(stats)
     # Runtime/session stats ride the repo summary only when nobody is talking.
-    if repo.claude_talker is None:
+    if repo.claude_talker is None and not _worker_is_agent_talker(repo):
         header += _agent_runtime_suffix(repo)
     return header
 
@@ -749,8 +761,7 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
 def _format_worker_thread_line(repo: RepoStatus) -> str:
     """Worker-thread state line, background-highlighted when it has the agent."""
     state = _worker_thread_state(repo)
-    talker = repo.claude_talker
-    is_talker = talker is not None and talker.kind == "worker"
+    is_talker = _worker_is_agent_talker(repo)
     label = color(GREEN_BG, "Worker:") if is_talker else color(BOLD, "Worker:")
     return f"  {label} {state}"
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1942,6 +1942,14 @@ class TestFormatStatusColor:
         worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
         assert _CODES["green_bg"] not in worker_line
 
+    def test_worker_label_green_bg_when_session_owner_is_worker(self) -> None:
+        repo = self._repo(issue=1, session_owner="worker-orly", session_alive=True)
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
+        assert f"{_CODES['green_bg']}Worker:" in worker_line
+
     def test_webhook_label_yellow_when_talker(self) -> None:
         repo = self._repo(
             issue=1,
@@ -1983,6 +1991,18 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         assert f"{_CODES['dim']}session idle" in output
+
+    def test_session_idle_hidden_while_worker_owns_agent(self) -> None:
+        repo = self._repo(
+            issue=1,
+            claude_pid=999,
+            session_alive=True,
+            session_owner="worker-orly",
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        assert "session idle" not in output
 
     def test_claude_running_uptime_dim(self) -> None:
         repo = self._repo(issue=1, claude_pid=999, claude_uptime=120)


### PR DESCRIPTION
## Summary
- treat `session_owner` as the active-agent signal for worker-owned Copilot sessions when there is no Claude talker record
- stop showing `session idle` on the repo header while the worker owns the agent
- add status tests covering worker highlight and idle suppression from `session_owner`

## Testing
- uv run pytest -n0 --cov --cov-report=term-missing --cov-fail-under=100