### PR TITLE
Clean up status formatting and Copilot logging

### DIFF
--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import threading
@@ -140,6 +141,56 @@ def _copilot(
     )
 
 
+def _repo_log_extra(repo_name: str | None) -> dict[str, str]:
+    """Return a logging extra dict that routes records to the repo log."""
+    if not repo_name:
+        return {}
+    return {"repo_name": repo_name.rsplit("/", 1)[-1]}
+
+
+def _log_for_repo(
+    level: int,
+    repo_name: str | None,
+    message: str,
+    *args: object,
+) -> None:
+    extra = _repo_log_extra(repo_name)
+    if extra:
+        log.log(level, message, *args, extra=extra)
+        return
+    log.log(level, message, *args)
+
+
+def _transcript_block(label: str, content: str) -> str:
+    """Render one multiline transcript block for the log."""
+    return f"{label} >>>\n{content}\n<<< {label}"
+
+
+def _preview_log_value(value: object, limit: int = 200) -> str:
+    """Return a compact one-line preview suitable for human logs."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, sort_keys=True)
+        except TypeError:
+            text = str(value)
+    return re.sub(r"\s+", " ", text).strip()[:limit]
+
+
+def _tool_input_preview(raw_input: object) -> str:
+    if not isinstance(raw_input, dict):
+        return _preview_log_value(raw_input)
+    preview = raw_input.get("command") or raw_input.get("path") or raw_input.get("url")
+    if not preview:
+        preview = raw_input.get("query") or raw_input.get("prompt")
+    if not preview and raw_input:
+        preview = next(iter(raw_input.values()))
+    return _preview_log_value(preview)
+
+
 @dataclass
 class _TerminalRecord:
     process: subprocess.Popen[str]
@@ -271,8 +322,9 @@ class _CopilotACPClient:
         self._runtime = runtime
         self._terminals = _TerminalManager() if terminals is None else terminals
 
-    async def on_connect(self, conn: acp.Agent) -> None:
-        return None
+    def on_connect(self, conn: acp.Agent) -> None:
+        del conn
+        self._runtime.log_info("copilot system: connected")
 
     async def read_text_file(
         self,
@@ -412,6 +464,7 @@ class CopilotACPRuntime:
         self,
         *,
         work_dir: Path,
+        repo_name: str | None = None,
         command: Sequence[str] = _COPILOT_COMMAND,
         spawn_agent_process: Callable[..., AbstractAsyncContextManager[Any]] = (
             acp.spawn_agent_process
@@ -422,6 +475,7 @@ class CopilotACPRuntime:
         client_info: Implementation | None = None,
     ) -> None:
         self._work_dir = work_dir
+        self._repo_name = repo_name
         self._command_base = tuple(command)
         self._spawn_agent_process = spawn_agent_process
         self._client_factory = (
@@ -452,6 +506,8 @@ class CopilotACPRuntime:
         self._current_effort: ReasoningEffort | None = None
         self._active_prompt_session_id: str | None = None
         self._prompt_chunks: list[str] = []
+        self._tool_starts_logged: set[str] = set()
+        self._tool_results_logged: set[str] = set()
         self._thread = threading.Thread(
             target=self._run_loop,
             name=f"copilot-acp-{work_dir.name}",
@@ -464,6 +520,12 @@ class CopilotACPRuntime:
         self, runtime: "CopilotACPRuntime"
     ) -> _CopilotACPClient:
         return _CopilotACPClient(runtime)
+
+    def log_info(self, message: str, *args: object) -> None:
+        _log_for_repo(logging.INFO, self._repo_name, message, *args)
+
+    def log_warning(self, message: str, *args: object) -> None:
+        _log_for_repo(logging.WARNING, self._repo_name, message, *args)
 
     def _command_for_effort(self, effort: ReasoningEffort | None) -> tuple[str, ...]:
         if effort is None:
@@ -518,12 +580,62 @@ class CopilotACPRuntime:
     def record_session_update(self, session_id: str, update: Any) -> None:
         if session_id != self._active_prompt_session_id:
             return
-        if getattr(update, "session_update", "") != "agent_message_chunk":
+        update_type = getattr(update, "session_update", "")
+        if update_type == "agent_message_chunk":
+            content = getattr(update, "content", None)
+            text = getattr(content, "text", None)
+            if isinstance(text, str):
+                self._prompt_chunks.append(text)
             return
-        content = getattr(update, "content", None)
-        text = getattr(content, "text", None)
-        if isinstance(text, str):
-            self._prompt_chunks.append(text)
+        if update_type == "tool_call":
+            self._log_tool_call(update)
+            return
+        if update_type == "tool_call_update":
+            self._log_tool_result(update)
+
+    def _log_tool_call(self, update: Any) -> None:
+        tool_call_id = getattr(update, "tool_call_id", None)
+        if (
+            not isinstance(tool_call_id, str)
+            or tool_call_id in self._tool_starts_logged
+        ):
+            return
+        self._tool_starts_logged.add(tool_call_id)
+        title = str(
+            getattr(update, "title", None) or getattr(update, "kind", None) or "?"
+        )
+        preview = _tool_input_preview(getattr(update, "raw_input", None))
+        if preview:
+            self.log_info("copilot tool: %s — %s", title, preview)
+            return
+        self.log_info("copilot tool: %s", title)
+
+    def _log_tool_result(self, update: Any) -> None:
+        tool_call_id = getattr(update, "tool_call_id", None)
+        if (
+            not isinstance(tool_call_id, str)
+            or tool_call_id in self._tool_results_logged
+        ):
+            return
+        status = getattr(update, "status", None)
+        raw_output = getattr(update, "raw_output", None)
+        if raw_output is None and status not in {"completed", "failed"}:
+            return
+        self._tool_results_logged.add(tool_call_id)
+        title = str(
+            getattr(update, "title", None) or getattr(update, "kind", None) or "?"
+        )
+        preview = _preview_log_value(raw_output)
+        if status == "failed":
+            if preview:
+                self.log_warning("copilot tool failed: %s — %s", title, preview)
+                return
+            self.log_warning("copilot tool failed: %s", title)
+            return
+        if preview:
+            self.log_info("copilot tool result: %s — %s", title, preview)
+            return
+        self.log_info("copilot tool result: %s", title)
 
     async def _ensure_session_async(
         self, session_id: str | None, model: ProviderModel | str | None
@@ -558,6 +670,8 @@ class CopilotACPRuntime:
             raise RuntimeError("Copilot ACP connection is not available")
         self._active_prompt_session_id = target_session_id
         self._prompt_chunks = []
+        self._tool_starts_logged = set()
+        self._tool_results_logged = set()
         response = await connection.prompt(
             prompt=[acp.text_block(content)],
             session_id=target_session_id,
@@ -565,6 +679,8 @@ class CopilotACPRuntime:
         text = "".join(self._prompt_chunks)
         self._active_prompt_session_id = None
         self._prompt_chunks = []
+        self._tool_starts_logged = set()
+        self._tool_results_logged = set()
         return text, response.stop_reason, target_session_id
 
     async def _cancel_async(self, session_id: str) -> None:
@@ -658,6 +774,8 @@ class CopilotACPRuntime:
         self._current_effort = None
         self._active_prompt_session_id = None
         self._prompt_chunks = []
+        self._tool_starts_logged = set()
+        self._tool_results_logged = set()
         if agent_cm is not None:
             await agent_cm.__aexit__(None, None, None)
 
@@ -713,7 +831,7 @@ class CopilotCLISession:
             self._runtime = runtime
         else:
             factory = CopilotACPRuntime if runtime_factory is None else runtime_factory
-            self._runtime = factory(work_dir=self._work_dir)
+            self._runtime = factory(work_dir=self._work_dir, repo_name=repo_name)
         self._lock = threading.Lock()
         self._owner_lock = threading.Lock()
         self._owner: str | None = None
@@ -833,6 +951,12 @@ class CopilotCLISession:
             base_system_prompt=self._base_system_prompt,
             system_prompt=system_prompt,
         )
+        _log_for_repo(
+            logging.INFO,
+            self._repo_name,
+            "%s",
+            _transcript_block("copilot prompt", prompt),
+        )
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
             prompt,
@@ -842,6 +966,12 @@ class CopilotCLISession:
         if model is not None:
             self._model = coerce_provider_model(model)
         self._last_turn_cancelled = stop_reason == "cancelled"
+        _log_for_repo(
+            logging.INFO,
+            self._repo_name,
+            "%s",
+            _transcript_block("copilot result", result),
+        )
         return result
 
 
@@ -1003,6 +1133,12 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     ) -> str:
         normalized = _normalize_model(model)
         assert normalized is not None
+        _log_for_repo(
+            logging.INFO,
+            self._repo_name,
+            "%s",
+            _transcript_block("copilot prompt", prompt),
+        )
         efforts = normalized.efforts or (None,)
         for effort in efforts:
             cmd = ["--model", normalized.model]
@@ -1019,6 +1155,13 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
                 runner=self._runner,
             )
             if result.returncode == 0:
+                text = extract_result_text(result.stdout.strip())
+                _log_for_repo(
+                    logging.INFO,
+                    self._repo_name,
+                    "%s",
+                    _transcript_block("copilot result", text),
+                )
                 return result.stdout.strip()
         return ""
 

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -675,6 +675,14 @@ def _styled_provider_status(status: ProviderPressureStatus) -> str:
     return color(_provider_status_style(status), _provider_status_summary(status))
 
 
+def _styled_repo_provider(repo: RepoStatus) -> str:
+    """Render the repo's provider label without repeating global limits details."""
+    provider_status = repo.provider_status
+    if provider_status is None:
+        return str(repo.provider)
+    return color(_provider_status_style(provider_status), str(provider_status.provider))
+
+
 def _format_provider_summary_line(statuses: list[ProviderPressureStatus]) -> str | None:
     if not statuses:
         return None
@@ -694,11 +702,7 @@ def _format_repo_header(repo: RepoStatus) -> str:
     """
     state_word = "running" if repo.fido_running else "idle"
     state_style = GREEN if repo.fido_running else DIM
-    stats: list[str] = []
-    if repo.provider_status is not None:
-        stats.append(_styled_provider_status(repo.provider_status))
-    else:
-        stats.append(str(repo.provider))
+    stats: list[str] = [_styled_repo_provider(repo)]
     if repo.crash_count > 0:
         stats.append(color(RED_BOLD, f"crashes {repo.crash_count}"))
     if repo.worker_uptime is not None:
@@ -736,12 +740,12 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
         body.append("  no assigned issues")
         return body
 
-    issue_line = f"  {color(BOLD, 'Issue:')}  {color(CYAN, f'#{repo.issue}')}"
+    issue_line = f"  {color(BOLD, 'Issue:')} {color(CYAN, f'#{repo.issue}')}"
     if repo.issue_title:
         issue_line += f" {color(DIM, '—')} {repo.issue_title}"
     if repo.issue_elapsed_seconds is not None:
         issue_line += (
-            f"  {color(DIM, f'(elapsed {_format_uptime(repo.issue_elapsed_seconds)})')}"
+            f" {color(DIM, f'(elapsed {_format_uptime(repo.issue_elapsed_seconds)})')}"
         )
     body.append(issue_line)
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -53,7 +53,8 @@ class RepoContextFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        record.repo_name = getattr(_thread_repo, "repo_name", "-")  # type: ignore[attr-defined]
+        if not isinstance(getattr(record, "repo_name", None), str):
+            record.repo_name = getattr(_thread_repo, "repo_name", "-")  # type: ignore[attr-defined]
         return True
 
 

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import signal
 import subprocess
 import threading
@@ -24,7 +25,9 @@ from kennel.copilotcli import (
     _combine_prompt,
     _CopilotACPClient,
     _normalize_model,
+    _preview_log_value,
     _TerminalManager,
+    _tool_input_preview,
     extract_result_text,
     extract_session_id,
 )
@@ -221,6 +224,19 @@ def _spawn_factory(*connections: FakeConnection):
 
 
 class TestHelpers:
+    def test_preview_log_value_falls_back_to_str(self) -> None:
+        class Unserializable:
+            def __str__(self) -> str:
+                return "weird object"
+
+        assert _preview_log_value(Unserializable()) == "weird object"
+
+    def test_tool_input_preview_branches(self) -> None:
+        assert _tool_input_preview("plain text") == "plain text"
+        assert _tool_input_preview({"query": "find this"}) == "find this"
+        assert _tool_input_preview({"prompt": "say hi"}) == "say hi"
+        assert _tool_input_preview({"other": "value"}) == "value"
+
     def test_extract_helpers_ignore_invalid_lines(self) -> None:
         output = "\n".join(
             [
@@ -437,9 +453,10 @@ class TestCopilotACPClient:
         runtime.record_session_update.assert_called_once_with("sess", update)
 
     def test_on_connect_is_noop(self) -> None:
-        assert (
-            asyncio.run(_CopilotACPClient(MagicMock()).on_connect(MagicMock())) is None
-        )
+        runtime = MagicMock()
+        client = _CopilotACPClient(runtime)
+        assert client.on_connect(MagicMock()) is None
+        runtime.log_info.assert_called_once_with("copilot system: connected")
 
 
 class TestCopilotACPRuntime:
@@ -591,6 +608,133 @@ class TestCopilotACPRuntime:
         with pytest.raises(RuntimeError, match="runtime is stopped"):
             runtime._run_async(object())  # pyright: ignore[reportPrivateUsage]
 
+    def test_logs_tool_activity_with_repo_name(self, tmp_path: Path, caplog) -> None:
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            repo_name="owner/orly",
+            spawn_agent_process=_spawn_factory(FakeConnection()),
+        )
+        try:
+            runtime._active_prompt_session_id = "sess"  # pyright: ignore[reportPrivateUsage]
+            with caplog.at_level(logging.INFO):
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call",
+                        tool_call_id="tool-1",
+                        title="run shell command",
+                        raw_input={"command": "make test"},
+                    ),
+                )
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call_update",
+                        tool_call_id="tool-1",
+                        title="run shell command",
+                        status="completed",
+                        raw_output={"stdout": "ok"},
+                    ),
+                )
+            assert "copilot tool: run shell command — make test" in caplog.text
+            assert (
+                'copilot tool result: run shell command — {"stdout": "ok"}'
+                in caplog.text
+            )
+            assert all(record.repo_name == "orly" for record in caplog.records)
+        finally:
+            runtime.stop()
+
+    def test_logs_tool_fallback_branches(self, tmp_path: Path, caplog) -> None:
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            repo_name="owner/orly",
+            spawn_agent_process=_spawn_factory(FakeConnection()),
+        )
+        try:
+            runtime._active_prompt_session_id = "sess"  # pyright: ignore[reportPrivateUsage]
+            with caplog.at_level(logging.INFO):
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call",
+                        tool_call_id="tool-1",
+                        title="bare tool",
+                        raw_input=None,
+                    ),
+                )
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call_update",
+                        tool_call_id="tool-1",
+                        title="bare tool",
+                        status="completed",
+                        raw_output=None,
+                    ),
+                )
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call_update",
+                        tool_call_id="tool-2",
+                        title="failed tool",
+                        status="failed",
+                        raw_output=None,
+                    ),
+                )
+                runtime.record_session_update(
+                    "sess",
+                    SimpleNamespace(
+                        session_update="tool_call_update",
+                        tool_call_id="tool-3",
+                        title="failed tool with output",
+                        status="failed",
+                        raw_output={"stderr": "boom"},
+                    ),
+                )
+            assert "copilot tool: bare tool" in caplog.text
+            assert "copilot tool result: bare tool" in caplog.text
+            assert "copilot tool failed: failed tool" in caplog.text
+            assert (
+                'copilot tool failed: failed tool with output — {"stderr": "boom"}'
+                in caplog.text
+            )
+        finally:
+            runtime.stop()
+
+    def test_ignores_duplicate_and_incomplete_tool_results(
+        self, tmp_path: Path
+    ) -> None:
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            repo_name="owner/orly",
+            spawn_agent_process=_spawn_factory(FakeConnection()),
+        )
+        try:
+            runtime._active_prompt_session_id = "sess"  # pyright: ignore[reportPrivateUsage]
+            runtime._tool_results_logged.add("tool-1")  # pyright: ignore[reportPrivateUsage]
+            runtime.record_session_update(
+                "sess",
+                SimpleNamespace(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-1",
+                    status="completed",
+                    raw_output={"stdout": "ignored"},
+                ),
+            )
+            runtime.record_session_update(
+                "sess",
+                SimpleNamespace(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-2",
+                    status="in_progress",
+                    raw_output=None,
+                ),
+            )
+        finally:
+            runtime.stop()
+
     def test_connection_start_failure_closes_context(self, tmp_path: Path) -> None:
         class BrokenConnection(FakeConnection):
             async def initialize(
@@ -726,6 +870,29 @@ class TestCopilotCLISession:
         acquired.wait(timeout=1.0)
         thread.join(timeout=1.0)
         assert runtime.cancel_calls == []
+
+    def test_prompt_logs_transcript(self, tmp_path: Path, caplog) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("persona")
+        runtime = FakeRuntime()
+        runtime.next_prompt = ("done", "end_turn", "sess-2")
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+            repo_name="owner/orly",
+        )
+        with caplog.at_level(logging.INFO):
+            assert (
+                session.prompt(
+                    "task", model=CopilotCLIClient.voice_model, system_prompt="system"
+                )
+                == "done"
+            )
+        assert "copilot prompt >>>" in caplog.text
+        assert "persona\n\n---\n\nsystem\n\n---\n\ntask" in caplog.text
+        assert "copilot result >>>\ndone\n<<< copilot result" in caplog.text
 
 
 class TestCopilotCLIAPI:
@@ -1013,6 +1180,19 @@ class TestCopilotCLIClient:
         runner = MagicMock(return_value=_completed("", returncode=1))
         client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
         assert client._run_cli_prompt("body", model="claude-opus-4-6", timeout=1) == ""
+
+    def test_cli_prompt_logs_transcript(self, tmp_path: Path, caplog) -> None:
+        runner = MagicMock(return_value=_completed(_copilot_output("cli result")))
+        client = CopilotCLIClient(
+            runner=runner,
+            work_dir=tmp_path,
+            repo_name="owner/orly",
+        )
+        with caplog.at_level(logging.INFO):
+            output = client._run_cli_prompt("body", model="gpt-5.4", timeout=1)
+        assert extract_result_text(output) == "cli result"
+        assert "copilot prompt >>>\nbody\n<<< copilot prompt" in caplog.text
+        assert "copilot result >>>\ncli result\n<<< copilot result" in caplog.text
 
 
 class TestCopilotCLI:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1323,7 +1323,7 @@ class TestFormatStatus:
         output = format_status(status)
         assert output == "kennel: UP (pid 12345, uptime 2h13m)"
 
-    def test_includes_provider_limits_summary_and_repo_pressure(self) -> None:
+    def test_includes_provider_limits_summary_and_repo_provider(self) -> None:
         provider_status = ProviderPressureStatus(
             provider=ProviderID.CLAUDE_CODE,
             pressure=0.91,
@@ -1337,7 +1337,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "limits: claude-code 91% (five hour)" in output
-        assert "owner/repo: fido idle — claude-code 91% (five hour)" in output
+        assert "owner/repo: fido idle — claude-code" in output
+        assert "owner/repo: fido idle — claude-code 91% (five hour)" not in output
 
     def test_includes_provider_reset_time_in_summary(self) -> None:
         provider_status = ProviderPressureStatus(
@@ -1379,6 +1380,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "claude-code limits unknown" in output
+        assert "owner/repo: fido idle — claude-code" in output
+        assert "owner/repo: fido idle — claude-code limits unknown" not in output
 
     def test_includes_copilot_unknown_summary(self) -> None:
         provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
@@ -1394,6 +1397,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "copilot-cli limits unknown" in output
+        assert "owner/repo: fido idle — copilot-cli" in output
+        assert "owner/repo: fido idle — copilot-cli limits unknown" not in output
 
     def test_kennel_up_no_uptime(self) -> None:
         status = KennelStatus(kennel_pid=12345, kennel_uptime=None, repos=[])
@@ -1438,7 +1443,7 @@ class TestFormatStatus:
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "Issue:  #42 — Add widget" in output
+        assert "Issue: #42 — Add widget" in output
         assert "Worker: task 3/3 — Do the thing" in output
 
     def test_paused_provider_overrides_worker_state(self) -> None:
@@ -1491,14 +1496,14 @@ class TestFormatStatus:
         repo = self._repo(issue=5, pending=2, completed=0, task_number=1, task_total=2)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "Issue:  #5" in output
+        assert "Issue: #5" in output
         assert "Worker: task 1/2" in output
 
     def test_repo_issue_no_tasks(self) -> None:
         repo = self._repo(issue=3)
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
-        assert "Issue:  #3" in output
+        assert "Issue: #3" in output
         # No task → Worker line shows idle
         assert "Worker: idle" in output
 
@@ -1848,6 +1853,8 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", self._color_env(), clear=True):
             output = format_status(status)
         assert f"{_CODES['dim']}(elapsed 2m)" in output
+        assert f"  {_CODES['dim']}(elapsed 2m)" not in output
+        assert f" {_CODES['dim']}(elapsed 2m)" in output
 
     def test_busy_red(self) -> None:
         repo = self._repo(worker_stuck=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -170,6 +170,16 @@ class TestRepoContextFilter:
         record = logging.LogRecord("", logging.WARNING, "", 0, "", (), None)
         assert RepoContextFilter().filter(record) is True
 
+    def test_filter_preserves_explicit_repo_name(self) -> None:
+        _thread_repo.repo_name = "confusio"
+        record = logging.LogRecord("", logging.INFO, "", 0, "", (), None)
+        record.repo_name = "orly"  # type: ignore[attr-defined]
+        try:
+            assert RepoContextFilter().filter(record) is True
+            assert record.repo_name == "orly"  # type: ignore[attr-defined]
+        finally:
+            del _thread_repo.repo_name
+
 
 class TestRepoNameFilter:
     def _record_with_repo(self, repo_name: str) -> logging.LogRecord:


### PR DESCRIPTION
## Summary
- keep detailed provider limits on the global `limits:` line only
- fix extra spacing in issue status lines
- make Copilot ACP `on_connect` match the library's synchronous callback contract
- add repo-tagged Copilot prompt/result transcript logs plus ACP tool activity logs

## Testing
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest --cov --cov-report=term-missing --cov-fail-under=100
