### PR TITLE
Mark draft PRs ready before re-requesting review

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2014,25 +2014,33 @@ class Worker:
                     pr_number,
                 )
                 return 0
+            checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
+            required = self.gh.get_required_checks(
+                repo_ctx.repo, repo_ctx.default_branch
+            )
+            if not ci_ready_for_review(checks, required):
+                log.info(
+                    "PR #%s: changes requested — all addressed, but CI not yet passing — deferring re-request",
+                    pr_number,
+                )
+                return 0
+            promoted_from_draft = False
+            if is_draft:
+                log.info(
+                    "PR #%s: changes requested — all addressed, CI passing — marking ready",
+                    pr_number,
+                )
+                self.gh.pr_ready(repo_ctx.repo, pr_number)
+                promoted_from_draft = True
             missing = sorted(repo_ctx.collaborators - set(requested_reviewers))
             if missing:
-                checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
-                required = self.gh.get_required_checks(
-                    repo_ctx.repo, repo_ctx.default_branch
+                log.info(
+                    "PR #%s: changes requested — all addressed, CI passing — re-requesting review from %s",
+                    pr_number,
+                    ", ".join(missing),
                 )
-                if ci_ready_for_review(checks, required):
-                    log.info(
-                        "PR #%s: changes requested — all addressed, CI passing — re-requesting review from %s",
-                        pr_number,
-                        ", ".join(missing),
-                    )
-                    self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
-                else:
-                    log.info(
-                        "PR #%s: changes requested — all addressed, but CI not yet passing — deferring re-request",
-                        pr_number,
-                    )
-            return 0
+                self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
+            return 1 if promoted_from_draft else 0
 
         if is_draft:
             completed = [

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 
 import pytest
 
@@ -7905,6 +7905,48 @@ class TestHandlePromoteMerge:
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
         assert result == 0
+
+    def test_changes_requested_draft_marks_ready_before_rerequest(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(
+            state="CHANGES_REQUESTED", is_draft=True
+        )
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        assert result == 1
+        ready_call = call.pr_ready("rhencke/myrepo", 9)
+        rerequest_call = call.add_pr_reviewers("rhencke/myrepo", 9, ["rhencke"])
+        assert ready_call in gh.mock_calls
+        assert rerequest_call in gh.mock_calls
+        assert gh.mock_calls.index(ready_call) < gh.mock_calls.index(rerequest_call)
+
+    def test_changes_requested_draft_marks_ready_without_readding_reviewer(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [{"author": {"login": "rhencke"}, "state": "CHANGES_REQUESTED"}],
+            "commits": [],
+            "isDraft": True,
+            "requestedReviewers": ["rhencke"],
+        }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        with patch("kennel.tasks.Tasks.list", return_value=[]):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        assert result == 1
+        gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
+        gh.add_pr_reviewers.assert_not_called()
 
     def test_changes_requested_does_not_merge(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)


### PR DESCRIPTION
## Summary
- mark draft PRs ready before the CHANGES_REQUESTED re-request path asks for review again
- keep the CI gate on the re-request path in one place
- cover both the fresh re-request and already-requested reviewer cases

## Testing
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest --cov --cov-report=term-missing --cov-fail-under=100
