### PR TITLE
Recover from dropped Copilot sessions

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -811,6 +811,11 @@ class ClaudeSession:
         """Durable Claude conversation id, if one has been established."""
         return self._session_id or None
 
+    @property
+    def dropped_session_count(self) -> int:
+        """Claude stream-json sessions do not track dropped resume tokens."""
+        return 0
+
     def _respawn(self, *, clear_session_id: bool, reason: str) -> None:
         """Stop the current subprocess and spawn a replacement."""
         log.info("ClaudeSession: %s (model=%s)", reason, self._model)

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import acp
+from acp.exceptions import RequestError
 from acp.schema import (
     AllowedOutcome,
     ClientCapabilities,
@@ -57,6 +58,11 @@ _COPILOT_JSON_BASE_ARGS = (
     "--allow-all",
     "-s",
 )
+
+
+def _is_missing_session_error(exc: RequestError) -> bool:
+    """Return True when ACP reports that a session id no longer exists."""
+    return "Resource not found: Session " in str(exc) and " not found" in str(exc)
 
 
 def _iter_jsonl(output: str) -> list[dict[str, Any]]:
@@ -124,6 +130,20 @@ def _combine_prompt(
         if part is not None and part.strip()
     ]
     return "\n\n---\n\n".join(parts)
+
+
+def _unexpected_new_session_prompt(content: str) -> str:
+    """Prepend a recovery nudge after ACP unexpectedly drops a stale session."""
+    return (
+        "IMPORTANT: Your previous persistent Copilot session was unexpectedly lost, "
+        "so you are now continuing in a brand new session.\n\n"
+        "Re-orient from the current repository state before acting. Do not rely on "
+        "memory from the lost session. Treat the prompt below as the authoritative "
+        "current task context, verify the live repo/branch/task state as needed, "
+        "and continue the work without duplicating already-completed steps.\n\n"
+        "---\n\n"
+        f"{content}"
+    )
 
 
 def _copilot(
@@ -508,6 +528,9 @@ class CopilotACPRuntime:
         self._prompt_chunks: list[str] = []
         self._tool_starts_logged: set[str] = set()
         self._tool_results_logged: set[str] = set()
+        self._metrics_lock = threading.Lock()
+        self._dropped_session_count = 0
+        self._needs_session_recovery_nudge = False
         self._thread = threading.Thread(
             target=self._run_loop,
             name=f"copilot-acp-{work_dir.name}",
@@ -547,6 +570,11 @@ class CopilotACPRuntime:
     def is_alive(self) -> bool:
         process = self._process
         return process is not None and process.returncode is None
+
+    @property
+    def dropped_session_count(self) -> int:
+        with self._metrics_lock:
+            return self._dropped_session_count
 
     def ensure_session(
         self, session_id: str | None, model: ProviderModel | str | None
@@ -657,6 +685,7 @@ class CopilotACPRuntime:
     async def _reset_session_async(self, model: ProviderModel | str | None) -> str:
         normalized = _normalize_model(model)
         await self._ensure_connection_async(normalized)
+        self._needs_session_recovery_nudge = False
         target_session_id = await self._attach_session_async(None)
         await self._set_model_async(target_session_id, normalized)
         return target_session_id
@@ -668,12 +697,18 @@ class CopilotACPRuntime:
         connection = self._connection
         if connection is None:
             raise RuntimeError("Copilot ACP connection is not available")
+        prompt_content = (
+            _unexpected_new_session_prompt(content)
+            if self._needs_session_recovery_nudge
+            else content
+        )
+        self._needs_session_recovery_nudge = False
         self._active_prompt_session_id = target_session_id
         self._prompt_chunks = []
         self._tool_starts_logged = set()
         self._tool_results_logged = set()
         response = await connection.prompt(
-            prompt=[acp.text_block(content)],
+            prompt=[acp.text_block(prompt_content)],
             session_id=target_session_id,
         )
         text = "".join(self._prompt_chunks)
@@ -739,14 +774,28 @@ class CopilotACPRuntime:
             response = await connection.new_session(cwd=str(self._work_dir))
             self._attached_session_id = response.session_id
             return response.session_id
-        if self._supports_load_session():
-            await connection.load_session(
-                cwd=str(self._work_dir), session_id=session_id
+        try:
+            if self._supports_load_session():
+                await connection.load_session(
+                    cwd=str(self._work_dir), session_id=session_id
+                )
+            else:
+                await connection.resume_session(
+                    cwd=str(self._work_dir), session_id=session_id
+                )
+        except RequestError as exc:
+            if not _is_missing_session_error(exc):
+                raise
+            self.log_warning(
+                "copilot session dropped: %s not found — starting fresh",
+                session_id,
             )
-        else:
-            await connection.resume_session(
-                cwd=str(self._work_dir), session_id=session_id
-            )
+            with self._metrics_lock:
+                self._dropped_session_count += 1
+            self._needs_session_recovery_nudge = True
+            response = await connection.new_session(cwd=str(self._work_dir))
+            self._attached_session_id = response.session_id
+            return response.session_id
         self._attached_session_id = session_id
         return session_id
 
@@ -855,6 +904,10 @@ class CopilotCLISession:
     @property
     def session_id(self) -> str | None:
         return self._session_id
+
+    @property
+    def dropped_session_count(self) -> int:
+        return self._runtime.dropped_session_count
 
     @property
     def last_turn_cancelled(self) -> bool:

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -180,6 +180,11 @@ class PromptSession(Protocol):
         """Return the provider-native persistent session identifier, if any."""
         ...
 
+    @property
+    def dropped_session_count(self) -> int:
+        """Return how many stale persistent session ids were dropped, if tracked."""
+        ...
+
     def prompt(
         self,
         content: str,
@@ -266,6 +271,11 @@ class ProviderAgent(Protocol):
     @property
     def session_id(self) -> str | None:
         """Return the provider-native persistent session identifier, if any."""
+        ...
+
+    @property
+    def session_dropped_count(self) -> int:
+        """Return the attached session's dropped-session count, if available."""
         ...
 
     voice_model: ProviderModel

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -305,6 +305,11 @@ class WorkerRegistry:
         thread = self._threads.get(repo_name)
         return thread.session_pid if thread is not None else None
 
+    def get_session_dropped_count(self, repo_name: str) -> int:
+        """Return how many stale persistent session ids were dropped for *repo_name*."""
+        thread = self._threads.get(repo_name)
+        return thread.session_dropped_count if thread is not None else 0
+
     def set_rescoping(self, repo_name: str, active: bool) -> None:
         """Set the rescoping-active flag for *repo_name*.
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -757,6 +757,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             crash = self.registry.get_crash_info(a.repo_name)
             started_at = self.registry.thread_started_at(a.repo_name)
             repo_cfg = self.config.repos.get(a.repo_name)
+            dropped_count = int(self.registry.get_session_dropped_count(a.repo_name))
             worker_uptime = (
                 (now - started_at).total_seconds() if started_at is not None else None
             )
@@ -787,6 +788,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "session_owner": self.registry.get_session_owner(a.repo_name),
                     "session_alive": self.registry.get_session_alive(a.repo_name),
                     "session_pid": self.registry.get_session_pid(a.repo_name),
+                    "session_dropped_count": dropped_count,
                     "claude_talker": _serialize_talker(claude.get_talker(a.repo_name)),
                     "rescoping": self.registry.is_rescoping(a.repo_name),
                 }

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -77,6 +77,15 @@ class SessionBackedAgent:
         session_id = getattr(session, "session_id")
         return session_id if isinstance(session_id, str) and session_id else None
 
+    @property
+    def session_dropped_count(self) -> int:
+        with self._session_lock:
+            session = self._session
+        if session is None or not hasattr(session, "dropped_session_count"):
+            return 0
+        dropped = getattr(session, "dropped_session_count")
+        return dropped if isinstance(dropped, int) and dropped >= 0 else 0
+
     def ensure_session(self, model: ProviderModel | None = None) -> None:
         with self._session_lock:
             session = self._session

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -83,6 +83,7 @@ class RepoStatus:
     webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
     session_owner: str | None = None
     session_alive: bool = False
+    session_dropped_count: int = 0
     claude_talker: ClaudeTalkerInfo | None = None
     rescoping: bool = False  # True while a background Opus reorder is in flight
 
@@ -315,6 +316,7 @@ def _fetch_activities(
                 "session_owner": item.get("session_owner"),
                 "session_alive": item.get("session_alive", False),
                 "session_pid": item.get("session_pid"),
+                "session_dropped_count": item.get("session_dropped_count", 0),
                 "claude_talker": item.get("claude_talker"),
                 "provider_status": _parse_provider_status(item.get("provider_status")),
                 "rescoping": item.get("rescoping", False),
@@ -435,6 +437,7 @@ def repo_status(
     session_owner: str | None = None,
     session_alive: bool = False,
     session_pid: int | None = None,
+    session_dropped_count: int = 0,
     claude_talker: ClaudeTalkerInfo | None = None,
     rescoping: bool = False,
     provider_status: ProviderPressureStatus | None = None,
@@ -468,6 +471,7 @@ def repo_status(
             webhook_activities=webhook_activities,
             session_owner=session_owner,
             session_alive=session_alive,
+            session_dropped_count=session_dropped_count,
             claude_talker=claude_talker,
             rescoping=rescoping,
         )
@@ -522,6 +526,7 @@ def repo_status(
         webhook_activities=webhook_activities,
         session_owner=session_owner,
         session_alive=session_alive,
+        session_dropped_count=session_dropped_count,
         claude_talker=claude_talker,
         rescoping=rescoping,
     )
@@ -586,6 +591,9 @@ def collect() -> KennelStatus:
                 session_owner=info.get("session_owner") if info else None,
                 session_alive=bool(info.get("session_alive")) if info else False,
                 session_pid=session_pid_val,
+                session_dropped_count=int(info.get("session_dropped_count", 0))
+                if info
+                else 0,
                 claude_talker=talker_info,
                 rescoping=bool(info.get("rescoping")) if info else False,
                 provider_status=provider_status,
@@ -623,6 +631,9 @@ def _agent_runtime_suffix(repo: RepoStatus) -> str:
         and repo.claude_talker is None
     ):
         parts.append(color(DIM, "session idle"))
+    if repo.session_dropped_count > 0:
+        noun = "session" if repo.session_dropped_count == 1 else "sessions"
+        parts.append(color(RED_BOLD, f"dropped {noun} {repo.session_dropped_count}"))
     pid_str = (
         color(DIM, f"pid {repo.claude_pid}")
         if repo.claude_pid is not None

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2432,6 +2432,13 @@ class WorkerThread(threading.Thread):
             provider = self._provider
         return provider.agent.session_pid if provider is not None else None
 
+    @property
+    def session_dropped_count(self) -> int:
+        """Number of stale provider session ids dropped by the live session."""
+        with self._provider_lock:
+            provider = self._provider
+        return provider.agent.session_dropped_count if provider is not None else 0
+
     def wake(self) -> None:
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -796,6 +796,12 @@ class TestClaudeSessionWakeupPipe:
         session._drain_wakeup()  # should not raise
         session.stop()
 
+    def test_dropped_session_count_is_zero(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert session.dropped_session_count == 0
+        session.stop()
+
 
 class TestClaudeSessionSend:
     def test_writes_json_user_message_to_stdin(self, tmp_path: Path) -> None:

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from acp.exceptions import RequestError
 
 from kennel import claude
 from kennel.copilotcli import (
@@ -100,6 +101,7 @@ class FakeRuntime:
         self.pid = 111
         self.alive = True
         self.next_prompt = ("done", "end_turn", "sess-next")
+        self.dropped_session_count = 0
 
     def ensure_session(self, session_id: str | None, model: str | None) -> str:
         self.ensure_calls.append((session_id, model))
@@ -130,8 +132,16 @@ class FakeRuntime:
 
 
 class FakeConnection:
-    def __init__(self, *, load_supported: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        load_supported: bool = True,
+        fail_load_session: bool = False,
+        fail_resume_session: bool = False,
+    ) -> None:
         self.load_supported = load_supported
+        self.fail_load_session = fail_load_session
+        self.fail_resume_session = fail_resume_session
         self.initialize_calls: list[tuple[int, object, object]] = []
         self.new_session_calls: list[str] = []
         self.load_session_calls: list[tuple[str, str]] = []
@@ -164,10 +174,18 @@ class FakeConnection:
 
     async def load_session(self, cwd: str, session_id: str) -> object:
         self.load_session_calls.append((cwd, session_id))
+        if self.fail_load_session:
+            raise RequestError(
+                404, f"Resource not found: Session {session_id} not found"
+            )
         return SimpleNamespace()
 
     async def resume_session(self, cwd: str, session_id: str) -> object:
         self.resume_session_calls.append((cwd, session_id))
+        if self.fail_resume_session:
+            raise RequestError(
+                404, f"Resource not found: Session {session_id} not found"
+            )
         return SimpleNamespace()
 
     async def set_session_model(self, model_id: str, session_id: str) -> object:
@@ -548,6 +566,75 @@ class TestCopilotACPRuntime:
         finally:
             runtime.stop()
 
+    def test_missing_loaded_session_starts_fresh_and_counts_drop(
+        self, tmp_path: Path
+    ) -> None:
+        connection = FakeConnection(load_supported=True, fail_load_session=True)
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            assert runtime.ensure_session("persisted", None) == "sess-1"
+            assert connection.load_session_calls == [(str(tmp_path), "persisted")]
+            assert connection.new_session_calls == [str(tmp_path)]
+            assert runtime.dropped_session_count == 1
+        finally:
+            runtime.stop()
+
+    def test_missing_loaded_session_nudges_next_prompt(self, tmp_path: Path) -> None:
+        connection = FakeConnection(load_supported=True, fail_load_session=True)
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            session_id = runtime.ensure_session("persisted", None)
+            runtime.prompt(session_id, "hello", None)
+            prompt_block = connection.prompt_calls[0][1][0]
+            assert "previous persistent Copilot session was unexpectedly lost" in (
+                prompt_block.text
+            )
+            assert prompt_block.text.endswith("hello")
+        finally:
+            runtime.stop()
+
+    def test_missing_resumed_session_starts_fresh_and_counts_drop(
+        self, tmp_path: Path
+    ) -> None:
+        connection = FakeConnection(load_supported=False, fail_resume_session=True)
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            assert runtime.ensure_session("persisted", None) == "sess-1"
+            assert connection.resume_session_calls == [(str(tmp_path), "persisted")]
+            assert connection.new_session_calls == [str(tmp_path)]
+            assert runtime.dropped_session_count == 1
+        finally:
+            runtime.stop()
+
+    def test_non_missing_load_session_error_is_not_swallowed(
+        self, tmp_path: Path
+    ) -> None:
+        connection = FakeConnection(load_supported=True)
+
+        async def broken_load_session(cwd: str, session_id: str) -> object:
+            del cwd, session_id
+            raise RequestError(500, "boom")
+
+        connection.load_session = broken_load_session
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            with pytest.raises(RequestError, match="boom"):
+                runtime.ensure_session("persisted", None)
+        finally:
+            runtime.stop()
+
     def test_cancel_without_connection_is_noop(self, tmp_path: Path) -> None:
         runtime = CopilotACPRuntime(
             work_dir=tmp_path,
@@ -793,6 +880,7 @@ class TestCopilotCLISession:
         session.recover()
         session.reset(CopilotCLIClient.voice_model)
         assert session.session_id == "sess-reset"
+        assert session.dropped_session_count == 0
         assert session.pid == 111
         assert session.is_alive() is True
         session.stop()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -216,6 +216,18 @@ class TestWorkerRegistry:
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_pid("foo/bar") == 77777
 
+    def test_get_session_dropped_count_returns_zero_for_unknown_repo(self) -> None:
+        reg, _ = self._make_registry()
+        assert reg.get_session_dropped_count("unknown/repo") == 0
+
+    def test_get_session_dropped_count_delegates_to_thread(
+        self, tmp_path: Path
+    ) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.session_dropped_count = 4
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.get_session_dropped_count("foo/bar") == 4
+
     def test_get_session_returns_none_for_unknown_repo(self) -> None:
         reg, _ = self._make_registry()
         assert reg.get_session("unknown/repo") is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -217,6 +217,7 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.get_session_dropped_count.return_value = 0
         WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
@@ -232,6 +233,7 @@ class TestGetEndpoint:
         assert entry["worker_uptime_seconds"] is None
         assert entry["webhook_activities"] == []
         assert entry["session_owner"] is None
+        assert entry["session_dropped_count"] == 0
 
     def test_status_endpoint_includes_session_owner(self, server: tuple) -> None:
         from datetime import datetime, timezone
@@ -254,10 +256,12 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.get_session_dropped_count.return_value = 3
         WebhookHandler.registry.is_rescoping.return_value = False
         resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data[0]["session_owner"] == "worker-home"
+        assert data[0]["session_dropped_count"] == 3
 
     def test_status_endpoint_includes_session_alive(self, server: tuple) -> None:
         from datetime import datetime, timezone

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -86,7 +86,12 @@ class TestSessionBackedAgent:
             agent._spawn_owned_session(ProviderModel("model"))
 
     def test_session_properties_attach_and_detach(self) -> None:
-        session = MagicMock(owner="worker", pid=123, session_id="sess-1")
+        session = MagicMock(
+            owner="worker",
+            pid=123,
+            session_id="sess-1",
+            dropped_session_count=2,
+        )
         session.is_alive.return_value = True
         agent = _FakeAgent(session=session)
         assert agent.session is session
@@ -94,6 +99,7 @@ class TestSessionBackedAgent:
         assert agent.session_alive is True
         assert agent.session_pid == 123
         assert agent.session_id == "sess-1"
+        assert agent.session_dropped_count == 2
         assert agent.detach_session() is session
         assert agent.session is None
 
@@ -103,6 +109,7 @@ class TestSessionBackedAgent:
         assert (
             _FakeAgent(session=type("S", (), {"session_id": 123})()).session_id is None
         )
+        assert _FakeAgent().session_dropped_count == 0
 
     def test_ensure_session_requires_factory_inputs(self) -> None:
         with pytest.raises(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -504,6 +504,7 @@ class TestFetchActivities:
                 "session_owner": None,
                 "session_alive": False,
                 "session_pid": None,
+                "session_dropped_count": 0,
                 "claude_talker": None,
                 "provider_status": None,
                 "rescoping": False,
@@ -543,6 +544,7 @@ class TestFetchActivities:
                 "session_owner": None,
                 "session_alive": False,
                 "session_pid": None,
+                "session_dropped_count": 0,
                 "claude_talker": None,
                 "provider_status": None,
                 "rescoping": False,
@@ -557,6 +559,7 @@ class TestFetchActivities:
                 "session_owner": None,
                 "session_alive": False,
                 "session_pid": None,
+                "session_dropped_count": 0,
                 "claude_talker": None,
                 "provider_status": None,
                 "rescoping": False,
@@ -1116,6 +1119,7 @@ class TestCollect:
             session_owner=None,
             session_alive=False,
             session_pid=None,
+            session_dropped_count=0,
             claude_talker=None,
             rescoping=False,
         )
@@ -1152,6 +1156,7 @@ class TestCollect:
             session_owner=None,
             session_alive=False,
             session_pid=None,
+            session_dropped_count=0,
             claude_talker=None,
             rescoping=False,
         )
@@ -1181,6 +1186,7 @@ class TestCollect:
             session_owner=None,
             session_alive=False,
             session_pid=None,
+            session_dropped_count=0,
             claude_talker=None,
             rescoping=False,
         )
@@ -1258,6 +1264,7 @@ class TestCollect:
             session_owner=None,
             session_alive=False,
             session_pid=None,
+            session_dropped_count=0,
             claude_talker=None,
             rescoping=False,
         )
@@ -1574,6 +1581,17 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "→ agent (session idle)" in output
+
+    def test_agent_runtime_suffix_shows_dropped_session_count(self) -> None:
+        repo = self._repo(
+            issue=1,
+            claude_pid=9999,
+            claude_uptime=60,
+            session_dropped_count=2,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        output = format_status(status)
+        assert "→ pid 9999 (running 1m, dropped sessions 2)" in output
 
     def test_multiple_repos(self) -> None:
         # Each repo emits a header + "no assigned issues" body line.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10166,6 +10166,18 @@ class TestWorkerThread:
         mock_session.is_alive.return_value = False
         assert wt.session_alive is False
 
+    def test_session_dropped_count_defaults_to_zero(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt.session_dropped_count == 0
+
+    def test_session_dropped_count_delegates_to_provider_agent(
+        self, tmp_path: Path
+    ) -> None:
+        provider = MagicMock()
+        provider.agent.session_dropped_count = 4
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        assert wt.session_dropped_count == 4
+
     def test_run_halts_on_claude_leak_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- recover cleanly when ACP says a persisted Copilot session no longer exists
- count dropped sessions and surface that count in kennel status and /status.json
- prepend a one-shot recovery nudge on unexpected fresh sessions so the next turn re-orients from live repo state

## Testing
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright
- uv run pytest --cov --cov-report=term-missing --cov-fail-under=100