### PR TITLE
Fix lingering webhook triage status

### DIFF
--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -63,6 +63,21 @@ class WebhookActivity:
     thread_id: int
 
 
+@dataclass(frozen=True)
+class WebhookActivityHandle:
+    """Opaque handle for updating one in-flight webhook activity safely."""
+
+    repo_name: str
+    handle_id: int
+    registry: "WorkerRegistry"
+
+    def set_description(self, description: str) -> None:
+        """Update the displayed description for this webhook activity."""
+        self.registry.set_webhook_description(
+            self.repo_name, self.handle_id, description
+        )
+
+
 class WorkerRegistry:
     """Owns and manages one :class:`~kennel.worker.WorkerThread` per repo.
 
@@ -204,7 +219,7 @@ class WorkerRegistry:
         description: str,
         *,
         _now: Callable[[], datetime] = _utcnow,
-    ) -> Generator[None, None, None]:
+    ) -> Generator[WebhookActivityHandle, None, None]:
         """Register an in-flight webhook handler for the duration of the block.
 
         Usage::
@@ -221,10 +236,11 @@ class WorkerRegistry:
             started_at=_now(),
             thread_id=threading.get_ident(),
         )
+        handle = WebhookActivityHandle(repo_name, activity.handle_id, self)
         with self._webhook_lock:
             self._webhook_activities.setdefault(repo_name, []).append(activity)
         try:
-            yield
+            yield handle
         finally:
             with self._webhook_lock:
                 items = self._webhook_activities.get(repo_name)
@@ -232,6 +248,25 @@ class WorkerRegistry:
                     self._webhook_activities[repo_name] = [
                         a for a in items if a.handle_id != activity.handle_id
                     ]
+
+    def set_webhook_description(
+        self, repo_name: str, handle_id: int, description: str
+    ) -> None:
+        """Replace one webhook activity entry with an updated description."""
+        with self._webhook_lock:
+            items = self._webhook_activities.get(repo_name)
+            if items is None:
+                return
+            for i, activity in enumerate(items):
+                if activity.handle_id != handle_id:
+                    continue
+                items[i] = WebhookActivity(
+                    handle_id=activity.handle_id,
+                    description=description,
+                    started_at=activity.started_at,
+                    thread_id=activity.thread_id,
+                )
+                return
 
     def get_webhook_activities(self, repo_name: str) -> list[WebhookActivity]:
         """Return a snapshot of in-flight webhook activities for *repo_name*."""

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -40,7 +40,7 @@ from kennel.infra import (
     real_infra,
 )
 from kennel.provider_factory import DefaultProviderFactory
-from kennel.registry import WorkerRegistry, make_registry
+from kennel.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from kennel.static_files import StaticFiles
 from kennel.status import provider_statuses_for_repo_configs
 from kennel.watchdog import (  # noqa: PLC2701
@@ -529,8 +529,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         description = self._describe_action(action)
         claude.set_thread_repo(repo_cfg.name)
         try:
-            with self.registry.webhook_activity(repo_cfg.name, description):
-                self._process_action_inner(action, repo_cfg)
+            with self.registry.webhook_activity(repo_cfg.name, description) as activity:
+                self._process_action_inner(action, repo_cfg, activity)
         except claude.ClaudeLeakError:
             # A webhook and a worker tried to talk to the same repo's claude
             # at the same time — the only safe action is to halt the whole
@@ -546,12 +546,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
     def _describe_action(self, action: Action) -> str:
         """Short label for status display — what this webhook handler is doing."""
         if action.reply_to:
-            cid = action.reply_to.get("comment_id")
-            return f"replying to review comment {cid}" if cid else "replying to review"
+            return "handling review comment"
         if action.review_comments:
-            return "replying to review thread"
+            return "handling review thread"
         if action.comment_body:
-            return "triaging PR comment"
+            return "handling PR comment"
         return "handling webhook action"
 
     def _reply_promise(self, action: Action) -> tuple[str, int] | None:
@@ -567,7 +566,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
             raise TypeError(f"invalid reply promise comment id: {comment_id!r}")
         return comment_type, comment_id
 
-    def _process_action_inner(self, action: Action, repo_cfg: RepoConfig) -> None:
+    def _process_action_inner(
+        self,
+        action: Action,
+        repo_cfg: RepoConfig,
+        activity: WebhookActivityHandle,
+    ) -> None:
         # The worker thread's own ``worker_what`` is not touched here — this
         # handler runs on a separate webhook thread and its activity is
         # surfaced in the repo's :class:`~kennel.registry.WebhookActivity`
@@ -586,6 +590,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     handled = True
                     category, titles = None, []
                 else:
+                    activity.set_description("triaging review comment")
                     try:
                         category, titles = type(self)._fn_reply_to_comment(
                             action, self.config, repo_cfg, gh
@@ -615,6 +620,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 # DEFER files a GitHub issue (handled in reply_to_comment) — no tasks.json entry.
                 # ACT, DO → add each task title to work queue.
                 if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):
+                    activity.set_description(
+                        "queuing review comment tasks"
+                        if len(titles or []) != 1
+                        else "queuing review comment task"
+                    )
                     for title in titles or []:
                         type(self)._fn_create_task(
                             title,
@@ -626,6 +636,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         )
 
             if action.review_comments:
+                activity.set_description("replying to review thread")
                 type(self)._fn_reply_to_review(
                     action, self.config, repo_cfg, gh, already_replied=_replied_comments
                 )
@@ -639,6 +650,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     log.info("already replied to comment %s — skipping", cid)
                     category, titles = None, []
                 else:
+                    activity.set_description("triaging PR comment")
                     try:
                         category, titles = type(self)._fn_reply_to_issue_comment(
                             action, self.config, repo_cfg, gh
@@ -666,6 +678,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 handled = True
                 # DEFER files a GitHub issue — no tasks.json entry.
                 if category not in ("DUMP", "ANSWER", "ASK", "DEFER"):
+                    activity.set_description(
+                        "queuing PR comment tasks"
+                        if len(titles) != 1
+                        else "queuing PR comment task"
+                    )
                     for title in titles:
                         type(self)._fn_create_task(
                             title,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -693,6 +693,31 @@ class TestWebhookActivity:
         reg = WorkerRegistry(MagicMock())
         assert reg.get_webhook_activities("ghost/repo") == []
 
+    def test_handle_can_update_description(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        with reg.webhook_activity("foo/bar", "handling") as activity:
+            assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
+            activity.set_description("triaging")
+            assert reg.get_webhook_activities("foo/bar")[0].description == "triaging"
+
+    def test_handle_update_after_exit_is_noop(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        with reg.webhook_activity("foo/bar", "handling") as activity:
+            pass
+        activity.set_description("triaging")
+        assert reg.get_webhook_activities("foo/bar") == []
+
+    def test_unknown_handle_update_is_noop(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        with reg.webhook_activity("foo/bar", "handling"):
+            reg.set_webhook_description("foo/bar", -1, "triaging")
+            assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
+
+    def test_unknown_repo_handle_update_is_noop(self) -> None:
+        reg = WorkerRegistry(MagicMock())
+        reg.set_webhook_description("ghost/repo", 1, "triaging")
+        assert reg.get_webhook_activities("ghost/repo") == []
+
 
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1690,6 +1690,55 @@ class TestProcessAction:
         assert status == 200
         mock_gh.add_reaction.assert_called_once()
 
+    def test_issue_comment_webhook_activity_tracks_phase(self, tmp_path: Path) -> None:
+        from kennel.events import Action
+        from kennel.registry import WorkerRegistry
+        from kennel.server import _replied_comments
+
+        cfg = _config(tmp_path)
+        handler = WebhookHandler.__new__(WebhookHandler)
+        handler.config = cfg
+        handler.registry = WorkerRegistry(MagicMock())
+        handler.gh = MagicMock()
+        phases: list[str] = []
+
+        def reply_to_issue_comment(*args: object) -> tuple[str, list[str]]:
+            del args
+            phases.append(
+                handler.registry.get_webhook_activities("owner/repo")[0].description
+            )
+            return "ACT", ["do it"]
+
+        def create_task(*args: object, **kwargs: object) -> None:
+            del args, kwargs
+            phases.append(
+                handler.registry.get_webhook_activities("owner/repo")[0].description
+            )
+
+        WebhookHandler._fn_reply_to_issue_comment = reply_to_issue_comment
+        WebhookHandler._fn_create_task = create_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        action = Action(
+            prompt="test",
+            comment_body="please fix",
+            thread={
+                "repo": "owner/repo",
+                "pr": 11,
+                "comment_id": 9300,
+                "url": "https://github.com/owner/repo/pull/11#issuecomment-9300",
+                "author": "owner",
+                "comment_type": "issues",
+            },
+        )
+
+        try:
+            handler._process_action(action, cfg.repos["owner/repo"])
+        finally:
+            _replied_comments.discard(9300)
+
+        assert phases == ["triaging PR comment", "queuing PR comment task"]
+        assert handler.registry.get_webhook_activities("owner/repo") == []
+
     def test_dispatch_error_returns_500(self, server: tuple) -> None:
         """When dispatch raises, return 500 so GitHub retries the delivery."""
         url, cfg = server


### PR DESCRIPTION
## Summary
- investigate misleading lingering webhook triage status
- tighten webhook activity lifecycle/status reporting
- add regressions for the orly false-positive incident

## Testing
- not run yet
