### PR TITLE
Webhook reply pipeline silently swallows comments after needs_more_context returns NO (closes #524)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -901,7 +901,12 @@ def reply_to_issue_comment(
                     "\n\nFull conversation on this issue/PR:\n" + "\n".join(lines)
                 )
         except Exception:
-            pass  # best-effort
+            log.warning(
+                "reply_to_issue_comment: failed to fetch conversation history for PR #%s"
+                " — proceeding without it",
+                number,
+                exc_info=True,
+            )
 
     # Merge conversation context into triage context
     context = dict(action.context) if action.context else {}

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -557,7 +557,9 @@ def reply_to_comment(
         except OSError:
             log.info("comment %s locked by another process — skipping", cid)
             lock_fd.close()
-            return ("ACT", [action.comment_body[:80]])
+            # Return empty titles so the caller creates no phantom tasks.
+            # Another process holds the lock and will handle reply + task creation.
+            return ("ACT", [])
     else:
         lock_fd = None
 

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -620,7 +620,7 @@ def reply_to_comment(
     )
 
     log.info(
-        "generating %s reply for PR #%s comment %s",
+        "reply generator: requesting %s reply for PR #%s comment %s",
         category,
         info["pr"],
         info["comment_id"],
@@ -629,6 +629,11 @@ def reply_to_comment(
         prompts.persona_wrap(instr),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
+    )
+    log.info(
+        "reply generator: returned %d chars (preview=%r)",
+        len(body or ""),
+        (body or "")[:80],
     )
     if not body:
         raise ValueError(
@@ -743,7 +748,13 @@ def needs_more_context(
         "to act on alone)?\n\n"
         "Reply with exactly YES or NO."
     )
+    log.info("needs-more-context check: requesting haiku")
     answer = agent.run_turn(prompt, model=agent.brief_model).upper()
+    log.info(
+        "needs-more-context check: returned %d chars (answer=%r)",
+        len(answer),
+        answer[:20],
+    )
     return answer.startswith("YES")
 
 
@@ -766,16 +777,31 @@ def _summarize_as_action_item(
         "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
         f"Comment: {comment_body}"
     )
+    log.info("summarize-action-item: requesting initial title from opus")
     result = agent.run_turn(prompt, model=agent.voice_model).strip()
+    log.info(
+        "summarize-action-item: returned %d chars (preview=%r)",
+        len(result),
+        result[:60],
+    )
     for _ in range(3):
         if not result or len(result) <= _MAX_TITLE_LEN:
             break
+        log.info(
+            "summarize-action-item: title too long (%d chars), requesting shorten",
+            len(result),
+        )
         result = agent.run_turn(
             f"{NO_TOOLS_CLAUSE}\n\n"
             f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
             f"Reply with ONLY the shortened title.\n\nTitle: {result}",
             model=agent.voice_model,
         ).strip()
+        log.info(
+            "summarize-action-item: shorten returned %d chars (preview=%r)",
+            len(result),
+            result[:60],
+        )
     if not result:
         raise ValueError("_summarize_as_action_item: run_turn returned empty")
     return result[:_MAX_TITLE_LEN]

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -581,6 +581,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         try:
             gh = cast(GitHub, self.gh)  # always set by serve() before first request
             handled = False
+            category: str | None = None
+            titles: list[str] = []
 
             if action.reply_to:
                 promise = self._reply_promise(action)
@@ -693,6 +695,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
                             registry=self.registry,
                         )
 
+            log.info(
+                "action outcome: handled=%s category=%s tasks=%d",
+                handled,
+                category,
+                len(titles),
+            )
             # Non-comment events just trigger kennel worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)
         except claude.ClaudeLeakError:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1999,7 +1999,13 @@ class TestReplyToIssueComment:
         assert "alice: first comment" in triage_ctx["conversation"]
         assert "bob: second comment" in triage_ctx["conversation"]
 
-    def test_conversation_context_exception_is_swallowed(self, tmp_path: Path) -> None:
+    def test_conversation_context_fetch_failure_logs_and_continues(
+        self, tmp_path: Path
+    ) -> None:
+        """Conversation fetch failure logs a warning and proceeds without context.
+
+        The reply pipeline must not be blocked by a best-effort history fetch.
+        """
         cfg = self._cfg(tmp_path)
         action = self._action()
         mock_gh = MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1435,8 +1435,12 @@ class TestReplyToComment:
                 agent=_client(side_effect=fake_pp),
             )
 
-    def test_lock_race_returns_act(self, tmp_path: Path) -> None:
-        """Second call with same comment_id is blocked by lock."""
+    def test_lock_race_returns_act_with_no_titles(self, tmp_path: Path) -> None:
+        """Second call with same comment_id is blocked by lock.
+
+        Must return empty titles so the server creates no phantom tasks —
+        the process that holds the lock will handle reply and task creation.
+        """
         import fcntl
 
         cfg = self._cfg(tmp_path)
@@ -1456,6 +1460,7 @@ class TestReplyToComment:
                 action, cfg, self._repo_cfg(tmp_path), MagicMock()
             )
             assert cat == "ACT"  # returns without posting
+            assert titles == []  # no phantom tasks — other process handles it
         finally:
             lock_fd.close()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1153,6 +1153,83 @@ class TestProcessAction:
         finally:
             ks._replied_comments.discard(203)
 
+    def test_preempted_review_comment_creates_no_phantom_task(
+        self, server: tuple
+    ) -> None:
+        """When reply_to_comment returns ('ACT', []) due to per-comment lock
+        contention (preempted reply), _process_action_inner must not enqueue any
+        tasks — the process that holds the lock is responsible for reply and task
+        creation."""
+        import kennel.server as ks
+
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 510,
+                "body": "please rename this variable",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "foo.py",
+                "line": 3,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 51, "title": "My PR", "body": ""},
+        }
+        mock_task = MagicMock()
+        # Simulate lock-contention: another process holds the lock, so
+        # reply_to_comment returns ACT with empty titles instead of a task title.
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ACT", []))
+        WebhookHandler._fn_create_task = mock_task
+        WebhookHandler._fn_launch_worker = MagicMock()
+        try:
+            status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
+            assert status == 200
+            mock_task.assert_not_called()
+        finally:
+            ks._replied_comments.discard(510)
+
+    def test_swallowed_comment_outcome_is_logged(
+        self, server: tuple, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """_process_action_inner must emit an 'action outcome:' summary log for
+        every processed comment.  Without this log a comment could be silently
+        swallowed — consumed by the webhook handler without any visible trace."""
+        import logging
+
+        import kennel.server as ks
+
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 511,
+                "body": "looks good to me",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/52#issuecomment-511",
+            },
+            "issue": {
+                "number": 52,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            return_value=("ANSWER", [])
+        )
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+        try:
+            with caplog.at_level(logging.INFO, logger="kennel.server"):
+                status = _post_webhook(url, cfg, "issue_comment", payload)
+            assert status == 200
+            assert "action outcome:" in caplog.text
+        finally:
+            ks._replied_comments.discard(511)
+
     def test_duplicate_issue_comment_delivery_skips_second_reply(
         self, server: tuple
     ) -> None:


### PR DESCRIPTION
Fixes #524.

The webhook reply pipeline silently swallows comments when sequential `run_turn` calls get preempted by the worker re-acquiring the session lock. This PR fixes phantom task creation from lock-contention early returns, replaces silent exception swallowing with logging, adds bracketing and outcome logging throughout the reply pipeline and `_process_action_inner`, enables `retry_on_preempt` for webhook reply calls, adds a fail-closed guard so `reply_to_comment` can never exit without posting a reply or raising, and covers the preempted-reply and swallowed-comment scenarios with tests.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (18)</summary>

- [x] Add outcome summary logging to _process_action_inner <!-- type:spec -->
- [x] Add tests for preempted-reply and swallowed-comment scenarios <!-- type:spec -->
- [x] Fix lock-contention early return creating phantom tasks for already-handled comments <!-- type:spec -->
- [x] Fix iter_events preemption race: check _preempt_pending in poll loop <!-- type:spec -->
- [x] Add pipeline observability to reply_to_comment and session.prompt <!-- type:spec -->
- [x] Instrument reply pipeline with per-step logging and preempt detection <!-- type:spec -->
- [x] Fail loud on cancelled/empty webhook run_turn results in reply pipeline <!-- type:spec -->
- [x] Add exit guard to reply_to_comment and reply_to_issue_comment <!-- type:spec -->
- [x] Add instrumentation logging to reply_to_comment pipeline <!-- type:spec -->
- [x] Make webhook agent run_turn calls retry on preemption <!-- type:spec -->
- [x] Add fail-closed guard when webhook reply exits without posting <!-- type:spec -->
- [x] Add bracket logging around every run_turn call in reply_to_comment <!-- type:spec -->
- [x] Add bracketing log lines around every run_turn call in reply pipeline <!-- type:spec -->
- [x] Add outcome summary log to reply_to_comment and reply_to_issue_comment exits <!-- type:spec -->
- [x] Replace silent except-pass in reply_to_issue_comment conversation fetch with logging <!-- type:spec -->
- [x] Add guaranteed exit logging to reply_to_comment and reply_to_issue_comment <!-- type:spec -->
- [x] Enable retry_on_preempt for webhook reply run_turn calls <!-- type:spec -->
- [x] Guard reply_to_comment: every exit path must post a reply or raise <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->