### PR TITLE
Keep task bookkeeping aligned with PR state

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1189,6 +1189,7 @@ def _make_reorder_kwargs(
     agent: ProviderAgent,
     prompts: Prompts,
     rewrite_fn: Callable[..., None],
+    sync_fn: Callable[[Path, Any], None] | None = None,
 ) -> dict[str, Any]:
     """Build the kwargs dict for a :func:`~kennel.tasks.reorder_tasks` call."""
 
@@ -1197,6 +1198,12 @@ def _make_reorder_kwargs(
             _notify_thread_change(change, config, gh, agent=None, prompts=None)
 
     def on_done() -> None:
+        if sync_fn is None:
+            from kennel.tasks import sync_tasks
+
+            sync_tasks(work_dir, gh)
+        else:
+            sync_fn(work_dir, gh)
         rewrite_fn(
             work_dir,
             gh,
@@ -1237,6 +1244,7 @@ def _reorder_tasks_background(
     prompts: Prompts | None = None,
     _rewrite_fn: Callable[..., None] | None = None,
     _reorder_fn: Callable[..., None] | None = None,
+    _sync_fn: Callable[[Path, Any], None] | None = None,
     _coalesce_state: dict[str, Any] | None = None,
 ) -> None:
     """Run :func:`~kennel.tasks.reorder_tasks` in a daemon background thread.
@@ -1276,7 +1284,7 @@ def _reorder_tasks_background(
 
     key = str(work_dir)
     kwargs = _make_reorder_kwargs(
-        work_dir, config, repo_cfg, registry, gh, agent, prompts, rewrite_fn
+        work_dir, config, repo_cfg, registry, gh, agent, prompts, rewrite_fn, _sync_fn
     )
 
     with _reorder_coalesce_lock:

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -77,8 +77,8 @@ class RepoStatus:
     issue_elapsed_seconds: int | None = None
     pr_number: int | None = None
     pr_title: str | None = None
-    task_number: int | None = None  # position counting all tasks (X in "X/Y")
-    task_total: int | None = None  # total task count including completed (Y in "X/Y")
+    task_number: int | None = None  # active task position within the current queue
+    task_total: int | None = None  # current queue length (pending + in_progress)
     worker_uptime: int | None = None
     webhook_activities: list[WebhookActivityInfo] = field(default_factory=list)
     session_owner: str | None = None
@@ -396,20 +396,19 @@ def _current_task(task_list: list[dict[str, Any]]) -> str | None:
 def _task_position(task_list: list[dict[str, Any]]) -> tuple[int | None, int | None]:
     """Return (task_number, total) for display.
 
-    task_number counts up across the full list: completed tasks contribute
-    to the offset so the display reads 1/7 → 2/7 → 3/7 rather than
-    shrinking as tasks are completed.  total is the count of all tasks.
+    Reports the active task's position within the current queue (pending +
+    in-progress tasks only). Completed historical tasks do not offset the
+    position because status should describe what remains to do right now.
     Returns (None, None) when there are no non-completed tasks.
     """
-    total = len(task_list)
     non_completed = [t for t in task_list if t["status"] != "completed"]
     if not non_completed:
         return (None, None)
-    completed_count = total - len(non_completed)
+    total = len(non_completed)
     for idx, t in enumerate(non_completed, start=1):
         if t["status"] == "in_progress":
-            return (completed_count + idx, total)
-    return (completed_count + 1, total)
+            return (idx, total)
+    return (1, total)
 
 
 def _elapsed_since_iso(

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1933,6 +1933,35 @@ class Worker:
         self.gh.comment_issue(repo, issue, msg)
         log.info("posted pickup comment on issue #%s", issue)
 
+    def _has_substantive_branch_commits(
+        self,
+        commits: list[dict[str, Any]],
+        remote: str,
+        default_branch: str,
+    ) -> bool:
+        """Return True when the branch has work beyond the empty wip sentinel."""
+        if len(commits) > 1:
+            return True
+        if not commits:
+            return False
+        base = self._git(
+            ["merge-base", "HEAD", f"{remote}/{default_branch}"],
+            check=False,
+        )
+        if base.returncode != 0:
+            return False
+        base_sha = base.stdout.strip()
+        log_result = self._git(
+            ["log", "--format=%s", f"{base_sha}..HEAD", "--reverse"],
+            check=False,
+        )
+        if log_result.returncode != 0:
+            return False
+        subjects = [
+            line.strip() for line in log_result.stdout.splitlines() if line.strip()
+        ]
+        return any(subject != "wip: start" for subject in subjects)
+
     def handle_promote_merge(
         self,
         fido_dir: Path,
@@ -2052,13 +2081,22 @@ class Worker:
                     pr_number,
                 )
                 return 0
-            if pending:
+            has_real_branch_work = self._has_substantive_branch_commits(
+                commits, "origin", repo_ctx.default_branch
+            )
+            if pending and not has_real_branch_work:
                 log.info(
                     "PR #%s: %d tasks still pending — not promoting yet",
                     pr_number,
                     len(pending),
                 )
                 return 0
+            if pending:
+                log.info(
+                    "PR #%s: %d tasks still pending, but branch has real commits — continuing promote checks",
+                    pr_number,
+                    len(pending),
+                )
             checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
             required = self.gh.get_required_checks(
                 repo_ctx.repo, repo_ctx.default_branch

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2909,10 +2909,14 @@ class TestReorderTasksBackground:
     def test_on_done_kwarg_calls_rewrite_fn(self, tmp_path: Path) -> None:
         started: list = []
         rewrite_calls: list = []
+        sync_calls: list = []
         calls, mock_reorder = self._capture_reorder_calls()
 
         def mock_rewrite(*a, **kw):
             rewrite_calls.append((a, kw))
+
+        def mock_sync(*a, **kw):
+            sync_calls.append((a, kw))
 
         _reorder_tasks_background(
             tmp_path,
@@ -2922,11 +2926,13 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
+            _sync_fn=mock_sync,
             _coalesce_state={},
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
         on_done()
+        assert len(sync_calls) == 1
         assert len(rewrite_calls) == 1
         args, kwargs = rewrite_calls[0]
         assert args[0] == tmp_path
@@ -2947,6 +2953,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
+            _sync_fn=lambda *a, **kw: None,
             agent=fake_client,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
@@ -2955,6 +2962,55 @@ class TestReorderTasksBackground:
         on_done = calls[0][2]["_on_done"]
         on_done()
         assert rewrite_calls[0].get("agent") is fake_client
+
+    def test_on_done_syncs_before_rewrite(self, tmp_path: Path) -> None:
+        started: list = []
+        order: list[str] = []
+        calls, mock_reorder = self._capture_reorder_calls()
+
+        def mock_sync(*a, **kw):
+            order.append("sync")
+
+        def mock_rewrite(*a, **kw):
+            order.append("rewrite")
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _rewrite_fn=mock_rewrite,
+            _reorder_fn=mock_reorder,
+            _sync_fn=mock_sync,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        on_done = calls[0][2]["_on_done"]
+        on_done()
+        assert order == ["sync", "rewrite"]
+
+    def test_on_done_uses_default_sync_tasks_when_no_sync_fn(
+        self, tmp_path: Path
+    ) -> None:
+        started: list = []
+        calls, mock_reorder = self._capture_reorder_calls()
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _rewrite_fn=lambda *a, **kw: None,
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        on_done = calls[0][2]["_on_done"]
+        with patch("kennel.tasks.sync_tasks") as mock_sync:
+            on_done()
+        mock_sync.assert_called_once()
 
     def test_coalesces_when_already_running(self, tmp_path: Path) -> None:
         """Second call while first is running marks pending, does not spawn thread."""

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -361,19 +361,19 @@ class TestTaskPosition:
     def test_counts_up_past_completed_tasks(self) -> None:
         from kennel.status import _task_position
 
-        # 2 done, 1 in_progress, 1 pending → "3/4" not "1/2"
+        # Completed tasks do not offset the active queue position.
         tasks = [
             {"status": "completed"},
             {"status": "completed"},
             {"status": "in_progress"},
             {"status": "pending"},
         ]
-        assert _task_position(tasks) == (3, 4)
+        assert _task_position(tasks) == (1, 2)
 
     def test_pending_offsets_past_completed(self) -> None:
         from kennel.status import _task_position
 
-        # 3 done, 2 pending, no in_progress → "4/5"
+        # Completed tasks do not count toward the current queue length.
         tasks = [
             {"status": "completed"},
             {"status": "completed"},
@@ -381,7 +381,7 @@ class TestTaskPosition:
             {"status": "pending"},
             {"status": "pending"},
         ]
-        assert _task_position(tasks) == (4, 5)
+        assert _task_position(tasks) == (1, 2)
 
 
 class TestElapsedSinceIso:
@@ -1444,14 +1444,14 @@ class TestFormatStatus:
             pending=1,
             completed=2,
             current_task="Do the thing",
-            task_number=3,
-            task_total=3,
+            task_number=1,
+            task_total=1,
             issue_title="Add widget",
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue: #42 — Add widget" in output
-        assert "Worker: task 3/3 — Do the thing" in output
+        assert "Worker: task 1/1 — Do the thing" in output
 
     def test_paused_provider_overrides_worker_state(self) -> None:
         provider_status = ProviderPressureStatus(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8529,7 +8529,7 @@ class TestHandlePromoteMerge:
         gh.add_pr_reviewers.assert_not_called()
 
     def test_draft_pending_tasks_block_promote(self, tmp_path: Path) -> None:
-        """Pending tasks prevent promote — all tasks must be complete."""
+        """Pending tasks still block promote when the branch has no real commits."""
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
@@ -8543,6 +8543,102 @@ class TestHandlePromoteMerge:
             )
         assert result == 0
         gh.pr_ready.assert_not_called()
+
+    def test_draft_pending_tasks_with_real_commits_can_promote(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [],
+            "commits": [{}, {}],
+            "isDraft": True,
+        }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        tasks_list = [
+            {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
+            {"id": "t2", "title": "Next", "status": "pending", "type": "spec"},
+        ]
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        assert result == 1
+        gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
+
+    def test_draft_pending_tasks_with_real_commits_requests_review(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [],
+            "commits": [{}, {}],
+            "isDraft": True,
+        }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        tasks_list = [
+            {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
+            {"id": "t2", "title": "Next", "status": "pending", "type": "spec"},
+        ]
+        with patch("kennel.tasks.Tasks.list", return_value=tasks_list):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
+
+    def test_has_substantive_branch_commits_true_for_multiple_commits(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        assert (
+            worker._has_substantive_branch_commits([{}, {}], "origin", "main") is True
+        )
+
+    def test_has_substantive_branch_commits_false_when_merge_base_fails(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        failed = MagicMock(returncode=1, stdout="")
+        with patch.object(worker, "_git", return_value=failed):
+            assert (
+                worker._has_substantive_branch_commits([{}], "origin", "main") is False
+            )
+
+    def test_has_substantive_branch_commits_false_when_log_fails(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        merge_base = MagicMock(returncode=0, stdout="base000\n")
+        failed_log = MagicMock(returncode=1, stdout="")
+        with patch.object(worker, "_git", side_effect=[merge_base, failed_log]):
+            assert (
+                worker._has_substantive_branch_commits([{}], "origin", "main") is False
+            )
+
+    def test_has_substantive_branch_commits_false_for_only_wip(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        merge_base = MagicMock(returncode=0, stdout="base000\n")
+        log_result = MagicMock(returncode=0, stdout="wip: start\n")
+        with patch.object(worker, "_git", side_effect=[merge_base, log_result]):
+            assert (
+                worker._has_substantive_branch_commits([{}], "origin", "main") is False
+            )
+
+    def test_has_substantive_branch_commits_true_for_single_real_commit(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        merge_base = MagicMock(returncode=0, stdout="base000\n")
+        log_result = MagicMock(returncode=0, stdout="feat: real work\n")
+        with patch.object(worker, "_git", side_effect=[merge_base, log_result]):
+            assert (
+                worker._has_substantive_branch_commits([{}], "origin", "main") is True
+            )
 
     # --- CI gate on draft promotion ---
 


### PR DESCRIPTION
Fixes #633.

This keeps the three task-progress signals aligned:
- rescope now syncs PR work-queue markers before rewriting the PR summary
- status reports the active queue position instead of offsetting past completed tasks
- draft promotion can continue when branch history shows real work commits even if task bookkeeping is lagging
