### PR TITLE
Stop guarddog from killing its own Claude Code

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -73,8 +73,46 @@ Update the status again after each major step (diagnosis, fix, PR, restart) — 
 Do NOT clear the status when done. Kennel handles that on restart.
 
 ### Step 2: Stop kennel
+Never use a broad `ps | grep claude | kill` pattern — it will kill the `claude-code` running this very skill (suicide) or other unrelated claude processes. Instead, look up kennel's PID from its own status and kill only kennel plus its descendant tree.
+
 ```bash
-MY_PID=$PPID; ps aux | grep -E "kennel|claude" | grep -v grep | grep -v "claude -c" | awk -v me="$MY_PID" '$2 != me {print $2}' | xargs kill 2>/dev/null
+# Parse kennel PID from status output.
+KENNEL_PID=$(cd /home/rhencke/workspace/home && uv run kennel status 2>/dev/null \
+    | awk '/^kennel: UP/ { for (i=1; i<=NF; i++) if ($i == "pid") { gsub(/[^0-9]/,"",$(i+1)); print $(i+1); exit } }')
+
+if [ -z "$KENNEL_PID" ]; then
+    echo "kennel: not running (no PID in status) — nothing to stop"
+else
+    # Safety: refuse if kennel is somehow an ancestor of this shell.
+    _pid=$$
+    while [ -n "$_pid" ] && [ "$_pid" != "1" ] && [ "$_pid" != "0" ]; do
+        if [ "$_pid" = "$KENNEL_PID" ]; then
+            echo "refusing: kennel PID $KENNEL_PID is an ancestor of this shell" >&2
+            exit 1
+        fi
+        _pid=$(awk '{print $4}' "/proc/$_pid/stat" 2>/dev/null)
+    done
+
+    # Recursively collect descendants (leaf-first).
+    _descendants() {
+        for child in $(pgrep -P "$1" 2>/dev/null); do
+            _descendants "$child"
+            echo "$child"
+        done
+    }
+    pids=$(_descendants "$KENNEL_PID")
+
+    # TERM children first, then kennel itself; give it up to 5s; then KILL stragglers.
+    for p in $pids; do kill -TERM "$p" 2>/dev/null; done
+    kill -TERM "$KENNEL_PID" 2>/dev/null
+    for _ in 1 2 3 4 5; do
+        kill -0 "$KENNEL_PID" 2>/dev/null || break
+        sleep 1
+    done
+    for p in $pids; do kill -KILL "$p" 2>/dev/null; done
+    kill -KILL "$KENNEL_PID" 2>/dev/null
+    echo "kennel stopped (pid $KENNEL_PID)"
+fi
 ```
 
 ### Step 3: Diagnose


### PR DESCRIPTION
## Summary

The guarddog skill's **Step 2: Stop kennel** command was:

```bash
MY_PID=$PPID; ps aux | grep -E "kennel|claude" | grep -v grep | grep -v "claude -c" | awk -v me="$MY_PID" '$2 != me {print $2}' | xargs kill 2>/dev/null
```

That `grep -E "kennel|claude"` matches **every** `claude` process — including the `claude-code` running the guarddog skill itself. The `$PPID` safeguard only excludes the immediate parent shell (the `bash -c` spawned by the Bash tool), not the actual Claude Code process higher up the tree. Net result: running Step 2 would kill the Claude Code driving the skill mid-workflow.

## Fix

Replace the broad `ps | grep` with a targeted kill:

1. Parse kennel's PID from its own `kennel status` output.
2. Refuse to run if kennel's PID is an ancestor of the current shell (defense-in-depth).
3. Recursively walk `pgrep -P` from kennel's PID to collect its descendant tree.
4. `SIGTERM` children first, then kennel; give a 5-second grace window; `SIGKILL` anything still alive.

Nothing outside kennel's descendant tree is touched.

## Test plan

- [x] `uv run ruff format --check . && uv run ruff check . && uv run pytest --cov --cov-fail-under=100` — all 2203 tests pass, 100% coverage.
- [ ] After merge, run guarddog vet and confirm Step 2 terminates kennel without killing Claude Code.