### PR TITLE
Fix pickup comment false-skip when issue author is Fido (#636)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -39,6 +39,11 @@ from kennel.types import TaskStatus, TaskType
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
 
+# Invisible HTML marker appended to pickup comments so future runs can
+# distinguish a genuine pickup comment from other things Fido's account may
+# have commented on its own issue (fix for #636).
+_PICKUP_COMMENT_MARKER = "<!-- fido:pickup -->"
+
 log = logging.getLogger(__name__)
 
 _thread_repo: threading.local = threading.local()
@@ -1898,14 +1903,14 @@ class Worker:
     ) -> None:
         """Post a Fido-flavoured pickup comment on the issue if not already posted.
 
-        Checks whether gh_user has commented since the issue was last opened
-        (handles reopened issues). Otherwise generates the comment via the
-        provider agent (using the Fido persona) and posts it. Falls back to a
-        plain-text comment if the provider returns nothing.
+        Detects a prior pickup comment by looking for
+        :data:`_PICKUP_COMMENT_MARKER` in a gh_user comment created after the
+        issue was last opened (handles reopened issues). Without the marker
+        we can't tell a pickup comment apart from other things Fido's account
+        may have said on its own issue (fix for #636).
         """
         issue_data = self.gh.view_issue(repo, issue)
         issue_created = issue_data.get("created_at", "")
-        # For reopened issues, use the most recent open event
         events = self.gh.get_issue_events(repo, issue)
         last_opened = issue_created
         for e in events:
@@ -1913,12 +1918,13 @@ class Worker:
                 last_opened = e.get("created_at", last_opened)
 
         comments = self.gh.get_issue_comments(repo, issue)
-        has_recent_comment = any(
+        has_pickup_comment = any(
             c.get("user", {}).get("login") == gh_user
             and c.get("created_at", "") >= last_opened
+            and _PICKUP_COMMENT_MARKER in c.get("body", "")
             for c in comments
         )
-        if has_recent_comment:
+        if has_pickup_comment:
             log.info("issue #%s: pickup comment already exists — skipping", issue)
             return
 
@@ -1930,7 +1936,8 @@ class Worker:
         if not msg:
             msg = f"Picking up issue: {issue_title}"
 
-        self.gh.comment_issue(repo, issue, msg)
+        body = f"{msg}\n\n{_PICKUP_COMMENT_MARKER}"
+        self.gh.comment_issue(repo, issue, body)
         log.info("posted pickup comment on issue #%s", issue)
 
     def _has_substantive_branch_commits(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2139,17 +2139,37 @@ class TestWorkerPostPickupComment:
         gh.get_issue_events.return_value = []
         return Worker(tmp_path, gh, provider_agent=provider_agent), gh
 
-    def test_skips_when_already_commented(self, tmp_path: Path) -> None:
+    def test_skips_when_pickup_marker_present(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         gh.get_issue_comments.return_value = [
             {
                 "user": {"login": "fido-bot"},
-                "body": "Woof!",
+                "body": "Woof! On it!\n\n<!-- fido:pickup -->",
                 "created_at": "2024-02-01T00:00:00Z",
             }
         ]
         worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
         gh.comment_issue.assert_not_called()
+
+    def test_posts_when_previous_comment_lacks_marker(self, tmp_path: Path) -> None:
+        """#636 regression: a fido-bot comment without the pickup marker
+        (e.g. a clarifying follow-up Fido added to its own issue) must not
+        suppress the pickup comment."""
+        mock_client = _client()
+        mock_client.generate_reply.return_value = "Woof! On it!"
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
+        worker._prompts = Prompts("I am Fido.")
+        gh.get_issue_comments.return_value = [
+            {
+                "user": {"login": "fido-bot"},
+                "body": "Some clarification, not a pickup comment.",
+                "created_at": "2024-02-01T00:00:00Z",
+            }
+        ]
+        worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
+        gh.comment_issue.assert_called_once_with(
+            "owner/repo", 1, "Woof! On it!\n\n<!-- fido:pickup -->"
+        )
 
     def test_posts_comment_when_no_previous_comment(self, tmp_path: Path) -> None:
         mock_client = _client()
@@ -2160,7 +2180,9 @@ class TestWorkerPostPickupComment:
             {"user": {"login": "other-user"}, "body": "Hi"}
         ]
         worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
-        gh.comment_issue.assert_called_once_with("owner/repo", 1, "Woof! On it!")
+        gh.comment_issue.assert_called_once_with(
+            "owner/repo", 1, "Woof! On it!\n\n<!-- fido:pickup -->"
+        )
 
     def test_posts_comment_when_no_existing_comments(self, tmp_path: Path) -> None:
         mock_client = _client()
@@ -2181,7 +2203,7 @@ class TestWorkerPostPickupComment:
         gh.get_issue_comments.return_value = []
         worker.post_pickup_comment("owner/repo", 5, "A task", "fido-bot")
         gh.comment_issue.assert_called_once_with(
-            "owner/repo", 5, "Picking up issue: A task"
+            "owner/repo", 5, "Picking up issue: A task\n\n<!-- fido:pickup -->"
         )
 
     def test_uses_persona_from_sub_dir(self, tmp_path: Path) -> None:
@@ -2232,7 +2254,7 @@ class TestWorkerPostPickupComment:
         gh.get_issue_comments.return_value = [
             {
                 "user": {"login": "fido-bot"},
-                "body": "Woof!",
+                "body": "Woof!\n\n<!-- fido:pickup -->",
                 "created_at": "2024-02-01T00:00:00Z",
             }
         ]
@@ -2241,7 +2263,8 @@ class TestWorkerPostPickupComment:
         assert "already exists" in caplog.text
 
     def test_posts_comment_on_reopened_issue(self, tmp_path: Path) -> None:
-        """Old comment predates reopen, so a new pickup comment is posted."""
+        """Old pickup-marked comment predates reopen, so a new pickup comment
+        is posted after reopen."""
         mock_client = _client()
         mock_client.generate_reply.return_value = "Back on it!"
         worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
@@ -2251,13 +2274,15 @@ class TestWorkerPostPickupComment:
         gh.get_issue_comments.return_value = [
             {
                 "user": {"login": "fido-bot"},
-                "body": "Woof!",
+                "body": "Woof!\n\n<!-- fido:pickup -->",
                 "created_at": "2024-02-01T00:00:00Z",
             }
         ]
         worker._prompts = Prompts("I am Fido.")
         worker.post_pickup_comment("owner/repo", 1, "Fix bug", "fido-bot")
-        gh.comment_issue.assert_called_once_with("owner/repo", 1, "Back on it!")
+        gh.comment_issue.assert_called_once_with(
+            "owner/repo", 1, "Back on it!\n\n<!-- fido:pickup -->"
+        )
 
 
 class TestRun:


### PR DESCRIPTION
## Summary

Closes #636.

When Fido's own account opens an issue and leaves a clarifying follow-up comment, the worker's `post_pickup_comment` was silently skipping the pickup comment because its existence check matched **any** gh_user comment with `created_at >= last_opened` — not specifically a pickup comment.

Fix: append an invisible `<!-- fido:pickup -->` HTML marker to every pickup comment, and change the existence check to match that marker instead of the time-only heuristic. Now only a gh_user comment that actually carries the marker suppresses the next pickup.

Backfill-safe — for legacy pickup comments without the marker, the worker will post one new pickup comment. A one-time duplicate is acceptable.

## Test plan

- [x] `uv run ruff format --check . && uv run ruff check . && uv run pytest --cov --cov-fail-under=100` — 2204 tests pass, 100% coverage
- [x] New regression test `test_posts_when_previous_comment_lacks_marker` covers the #636 scenario
- [x] `test_skips_when_pickup_marker_present` covers the intended skip path
- [x] `test_posts_comment_on_reopened_issue` still passes — marker-bearing comment before reopen does not suppress a fresh pickup after reopen