### PR TITLE
Worker starts ClaudeSession before the first real turn and leaves it idle during pickup work (closes #502)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1551,6 +1551,30 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
     def _json_parse_candidates(self, raw: str) -> tuple[str, ...]:
         return (raw, *(m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)))
 
+    def _run_one_shot_text(self, prompt: str, model: ProviderModel) -> str:
+        """Run ``claude --print`` with *prompt* on stdin; no persistent session created."""
+        cmd = [
+            "claude",
+            "--model",
+            model_name(model),
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--dangerously-skip-permissions",
+            "--print",
+        ]
+        result = self._runner(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=self._work_dir,
+        )
+        output = result.stdout.strip()
+        raise_for_provider_error_output(output)
+        return extract_result_text(output)
+
     def run_turn(
         self,
         content: str,

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -1116,6 +1116,11 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     def _dead_prompt_error_message(self) -> str:
         return "Copilot CLI session died during prompt"
 
+    def _run_one_shot_text(self, prompt: str, model: ProviderModel) -> str:
+        """Run a one-shot Copilot prompt without creating a persistent session."""
+        raw = self._run_cli_prompt(prompt, model=model, timeout=30)
+        return extract_result_text(raw)
+
     def run_turn(
         self,
         content: str,

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -318,6 +318,17 @@ class SessionBackedAgent:
             system_prompt=system_prompt,
         )
 
+    def _run_one_shot_text(self, prompt: str, model: ProviderModel) -> str:
+        """Run a one-shot prompt without creating a persistent session.
+
+        Subclasses with a subprocess backend (e.g. :class:`~kennel.claude.ClaudeClient`)
+        override this to avoid spawning a persistent session.  The base
+        implementation falls through to :meth:`_run_shared_turn`, which will
+        resolve or create a session via the normal session-resolution path.
+        """
+        text, _ = self._run_shared_turn(prompt, model=model)
+        return text
+
     def generate_reply(
         self,
         prompt: str,
@@ -325,10 +336,10 @@ class SessionBackedAgent:
         timeout: int = 30,
     ) -> str:
         del timeout
-        text, _ = self._run_shared_turn(
-            prompt,
-            model=self.voice_model if model is None else model,
-        )
+        m = self.voice_model if model is None else model
+        if self.session is None:
+            return self._run_one_shot_text(prompt, m).strip()
+        text, _ = self._run_shared_turn(prompt, model=m)
         return text.strip()
 
     def generate_branch_name(
@@ -338,10 +349,11 @@ class SessionBackedAgent:
         timeout: int = 15,
     ) -> str:
         del timeout
-        text, _ = self._run_shared_turn(
-            prompt,
-            model=self.brief_model if model is None else model,
-        )
+        m = self.brief_model if model is None else model
+        if self.session is None:
+            stripped = self._run_one_shot_text(prompt, m).strip()
+            return stripped.splitlines()[0] if stripped else ""
+        text, _ = self._run_shared_turn(prompt, model=m)
         stripped = text.strip()
         return stripped.splitlines()[0] if stripped else ""
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2235,8 +2235,6 @@ class Worker:
 
             compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
             session_fresh = self._session is None
-            if session_fresh:
-                self.create_session()
             try:
                 issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
                 if issue is None:
@@ -2259,6 +2257,7 @@ class Worker:
                 self.post_pickup_comment(
                     repo_ctx.repo, issue, issue_title, repo_ctx.gh_user
                 )
+                self.create_session()
                 pr_number, slug, pr_is_fresh = self.find_or_create_pr(
                     ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
                 )
@@ -2349,8 +2348,8 @@ class WorkerThread(threading.Thread):
 
     Neither ``_provider`` nor ``_session_issue`` survive a kennel/home restart
     — ``os.execvp`` replaces the process, so a new ``WorkerThread`` starts
-    with no provider-attached session and creates a fresh session on its first
-    iteration.
+    with no provider-attached session; the session is created lazily by
+    :class:`Worker` immediately before the first real provider turn.
     """
 
     def __init__(
@@ -2516,15 +2515,6 @@ class WorkerThread(threading.Thread):
                 self._provider = provider
             return provider
 
-    def _create_session(self) -> PromptSession:
-        """Eagerly create the persistent provider session for this thread."""
-        provider = self._ensure_provider()
-        provider.agent.ensure_session(provider.agent.voice_model)
-        session = provider.agent.session
-        if session is None:
-            raise RuntimeError("provider.ensure_session() returned no session")
-        return session
-
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
@@ -2534,11 +2524,6 @@ class WorkerThread(threading.Thread):
                 if self._registry is not None:
                     self._registry.report_activity(self._repo_name, "idle", busy=False)
                 provider = self._ensure_provider()
-                session = provider.agent.session
-                if session is None:
-                    session = self._create_session()
-                    if provider.agent.session is not session:
-                        provider.agent.attach_session(session)
                 worker = Worker(
                     self.work_dir,
                     self._gh,
@@ -2546,7 +2531,6 @@ class WorkerThread(threading.Thread):
                     self._repo_name,
                     self._registry,
                     self._membership,
-                    session=session,
                     session_issue=self._session_issue,
                     config=self._config,
                     repo_cfg=self._repo_cfg,

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -3032,3 +3032,29 @@ class TestClaudeClientSharedHelpers:
         client = ClaudeClient(session=session)
         with pytest.raises(RuntimeError, match="matching live session"):
             client.resume_status("sess-42", "please shorten")
+
+    def test_run_one_shot_text_calls_runner_and_returns_extracted_text(self) -> None:
+        output = '{"type":"result","result":"pickup reply"}'
+        mock_runner = MagicMock(return_value=_completed(stdout=output))
+        client = ClaudeClient(runner=mock_runner)
+        result = client._run_one_shot_text("pick up issue", client.voice_model)
+        assert result == "pickup reply"
+        cmd = mock_runner.call_args[0][0]
+        assert "--print" in cmd
+        assert "--model" in cmd
+
+    def test_generate_reply_no_session_uses_runner(self) -> None:
+        output = '{"type":"result","result":"  woof, on it!  "}'
+        mock_runner = MagicMock(return_value=_completed(stdout=output))
+        client = ClaudeClient(runner=mock_runner)
+        assert client.generate_reply("please pick up this issue") == "woof, on it!"
+        mock_runner.assert_called_once()
+
+    def test_generate_branch_name_no_session_uses_runner(self) -> None:
+        import json as _json
+
+        output = _json.dumps({"type": "result", "result": "fix-thing\nextra"})
+        mock_runner = MagicMock(return_value=_completed(stdout=output))
+        client = ClaudeClient(runner=mock_runner)
+        assert client.generate_branch_name("name this issue") == "fix-thing"
+        mock_runner.assert_called_once()

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1313,6 +1313,29 @@ class TestCopilotCLIClient:
         client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
         assert client._run_cli_prompt("body", model="claude-opus-4-6", timeout=1) == ""
 
+    def test_run_one_shot_text_delegates_to_run_cli_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = MagicMock(return_value=_completed(_copilot_output("assistant reply")))
+        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
+        result = client._run_one_shot_text("hello", client.voice_model)
+        assert result == "assistant reply"
+        runner.assert_called_once()
+
+    def test_generate_reply_no_session_uses_run_cli_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = MagicMock(return_value=_completed(_copilot_output("  woof, on it!  ")))
+        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
+        assert client.generate_reply("pick up issue") == "woof, on it!"
+
+    def test_generate_branch_name_no_session_uses_run_cli_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        runner = MagicMock(return_value=_completed(_copilot_output("fix-thing\nextra")))
+        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
+        assert client.generate_branch_name("name it") == "fix-thing"
+
     def test_cli_prompt_logs_transcript(self, tmp_path: Path, caplog) -> None:
         runner = MagicMock(return_value=_completed(_copilot_output("cli result")))
         client = CopilotCLIClient(

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -241,6 +241,13 @@ class TestSessionBackedAgent:
         agent = _FakeAgent(session_fn=lambda: session)
         assert agent.resume_status("sess-1", "resume") == "resumed status"
 
+    def test_generate_branch_name_no_session_uses_one_shot_fallback(self) -> None:
+        session = MagicMock(session_id="sess")
+        session.prompt.return_value = "fix-bug-123\nextra lines"
+        agent = _FakeAgent(session_fn=lambda: session)
+        # no attached session → uses _run_one_shot_text fallback path
+        assert agent.generate_branch_name("name a branch") == "fix-bug-123"
+
     def test_prompt_with_recovery_recovers_after_dead_prompt_failure(self) -> None:
         session = MagicMock()
         session.prompt.side_effect = [BrokenPipeError("boom"), "done"]

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -248,6 +248,18 @@ class TestSessionBackedAgent:
         # no attached session → uses _run_one_shot_text fallback path
         assert agent.generate_branch_name("name a branch") == "fix-bug-123"
 
+    def test_generate_reply_no_session_uses_one_shot_fallback(self) -> None:
+        """generate_reply falls through to _run_one_shot_text when no session attached.
+
+        This mirrors the branch-name fallback: both voice ops avoid creating a
+        persistent session and instead rely on a transient one-shot call.
+        """
+        session = MagicMock(session_id="sess")
+        session.prompt.return_value = "woof, on it!"
+        agent = _FakeAgent(session_fn=lambda: session)
+        # no attached session → uses _run_one_shot_text fallback path
+        assert agent.generate_reply("write a pickup reply") == "woof, on it!"
+
     def test_prompt_with_recovery_recovers_after_dead_prompt_failure(self) -> None:
         session = MagicMock()
         session.prompt.side_effect = [BrokenPipeError("boom"), "done"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -915,7 +915,8 @@ class TestWorker:
         assert worker._session is None
         worker.stop_session()  # must not raise
 
-    def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
+    def test_run_does_not_create_session_when_no_issue(self, tmp_path: Path) -> None:
+        """create_session is deferred — no call when there is no issue to work on."""
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         worker = Worker(tmp_path, gh)
@@ -928,12 +929,47 @@ class TestWorker:
             patch.object(worker, "setup_hooks", return_value=("c", "s")),
             patch.object(worker, "teardown_hooks"),
             patch.object(worker, "create_session", mock_create),
-            patch.object(worker, "stop_session"),
             patch.object(worker, "get_current_issue", return_value=None),
             patch.object(worker, "find_next_issue", return_value=None),
         ):
             worker.run()
-        mock_create.assert_called_once_with()
+        mock_create.assert_not_called()
+
+    def test_run_creates_session_just_before_find_or_create_pr(
+        self, tmp_path: Path
+    ) -> None:
+        """create_session is called exactly once, just before find_or_create_pr."""
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        call_order: list[str] = []
+
+        def record_create() -> None:
+            call_order.append("create_session")
+
+        def record_focp(*_a: object, **_kw: object) -> tuple[int, str, bool]:
+            call_order.append("find_or_create_pr")
+            return (42, "fix-bug", True)
+
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(worker, "create_session", side_effect=record_create),
+            patch.object(worker, "find_or_create_pr", side_effect=record_focp),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+
+        assert call_order == ["create_session", "find_or_create_pr"]
 
     def test_run_recovers_reply_promises_before_normal_handlers(
         self, tmp_path: Path
@@ -1063,7 +1099,11 @@ class TestWorker:
             worker.run()
         assert worker._session_issue == 7
 
-    def test_run_does_not_create_session_when_provided(self, tmp_path: Path) -> None:
+    def test_run_does_not_create_session_when_no_issue_even_with_prior_session(
+        self, tmp_path: Path
+    ) -> None:
+        """create_session is not called when there is nothing to do, even with a
+        prior session already attached (no issue → early return before session call)."""
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         mock_session = MagicMock()
@@ -10012,12 +10052,19 @@ class TestWorkerThread:
     # ── session lifecycle ─────────────────────────────────────────────────
 
     def test_session_carried_to_next_iteration(self, tmp_path: Path) -> None:
-        """Session pre-created by WorkerThread on first iteration is carried forward."""
+        """Session created lazily by Worker is carried to subsequent Workers via provider.
+
+        WorkerThread no longer pre-creates the session.  The first Worker
+        creates it (attaches to provider.agent) during its run(); WorkerThread
+        then reclaims the provider, so the second Worker sees the session
+        already attached via provider.agent.session.
+        """
         wt = self._make_thread(tmp_path)
         wt._wake = MagicMock()
-        pre_session = MagicMock()
-        wt._create_session = MagicMock(return_value=pre_session)
-        sessions_received: list = []
+
+        lazy_session = MagicMock()
+        sessions_at_run_start: list = []
+        call_count = 0
 
         def fake_worker_init(
             self_w,
@@ -10037,16 +10084,17 @@ class TestWorkerThread:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
-            self_w._session = session
             self_w._session_issue = session_issue
-            sessions_received.append(session)
-
-        call_count = 0
+            # Do NOT capture session= — it is always None after the change.
+            # Real session access goes through _provider (set by WorkerThread).
 
         def fake_worker_run(self_w) -> int:
             nonlocal call_count
             call_count += 1
+            sessions_at_run_start.append(self_w._provider.agent.session)
             if call_count == 1:
+                # Simulate Worker lazily creating a session during its run().
+                self_w._provider.agent.attach_session(lazy_session)
                 return 1
             wt._stop = True
             return 0
@@ -10057,13 +10105,11 @@ class TestWorkerThread:
         ):
             self._run_thread(wt)
 
-        assert len(sessions_received) == 2
-        # WorkerThread pre-creates the session before the first Worker runs,
-        # so the first Worker already inherits it, and subsequent Workers
-        # continue to inherit it (no carry-over / re-create on iteration 2).
-        assert sessions_received[0] is pre_session
-        assert sessions_received[1] is pre_session
-        wt._create_session.assert_called_once()
+        assert len(sessions_at_run_start) == 2
+        # Before first Worker runs, no session exists yet.
+        assert sessions_at_run_start[0] is None
+        # Second Worker inherits the session the first Worker created.
+        assert sessions_at_run_start[1] is lazy_session
 
     def test_session_issue_carried_to_next_iteration(self, tmp_path: Path) -> None:
         """session_issue set by one Worker.run() is passed to the next."""
@@ -10113,18 +10159,6 @@ class TestWorkerThread:
         assert len(issues_received) == 2
         assert issues_received[0] is None  # no carry-over on first iteration
         assert issues_received[1] == 42  # carried forward
-
-    def test_create_session_raises_when_provider_does_not_attach_one(
-        self, tmp_path: Path
-    ) -> None:
-        wt = self._make_thread(tmp_path)
-        provider = MagicMock()
-        provider.agent.session = None
-        wt._provider = provider
-        with pytest.raises(
-            RuntimeError, match="provider.ensure_session\\(\\) returned no session"
-        ):
-            wt._create_session()
 
     def test_session_stopped_when_thread_exits(self, tmp_path: Path) -> None:
         """WorkerThread stops the session when its loop finishes."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1020,6 +1020,47 @@ class TestWorker:
             "find_or_create_pr",
         ]
 
+    def test_provider_agent_session_is_none_during_post_pickup_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """_provider_agent.session is None when post_pickup_comment is invoked.
+
+        create_session() hasn't been called yet at that point, so the pickup
+        comment is generated via the one-shot fallback path rather than a live
+        persistent session.  Any code path that eagerly creates a session before
+        the pickup comment would cause this assertion to fail.
+        """
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        session_during_pickup: list = []
+
+        def record_session(*_a: object) -> None:
+            session_during_pickup.append(worker._provider_agent.session)
+
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment", side_effect=record_session),
+            patch.object(worker, "create_session"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", True)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+
+        assert len(session_during_pickup) == 1
+        assert session_during_pickup[0] is None
+
     def test_run_recovers_reply_promises_before_normal_handlers(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -971,6 +971,55 @@ class TestWorker:
 
         assert call_order == ["create_session", "find_or_create_pr"]
 
+    def test_run_pickup_comment_fires_before_session_creation(
+        self, tmp_path: Path
+    ) -> None:
+        """post_pickup_comment runs before create_session — no session during pickup work.
+
+        The whole point of deferring session startup is that pickup operations
+        (posting the "on it!" comment) happen without a live session, using the
+        one-shot fallback path instead.  This test pins that ordering so any
+        regression that eagerly starts the session before pickup is caught.
+        """
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh)
+        call_order: list[str] = []
+
+        def record_pickup(*_a: object, **_kw: object) -> None:
+            call_order.append("post_pickup_comment")
+
+        def record_create() -> None:
+            call_order.append("create_session")
+
+        def record_focp(*_a: object, **_kw: object) -> tuple[int, str, bool]:
+            call_order.append("find_or_create_pr")
+            return (42, "fix-bug", True)
+
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment", side_effect=record_pickup),
+            patch.object(worker, "create_session", side_effect=record_create),
+            patch.object(worker, "find_or_create_pr", side_effect=record_focp),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "execute_task", return_value=False),
+            patch.object(worker, "handle_promote_merge", return_value=0),
+        ):
+            worker.run()
+
+        assert call_order == [
+            "post_pickup_comment",
+            "create_session",
+            "find_or_create_pr",
+        ]
+
     def test_run_recovers_reply_promises_before_normal_handlers(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #502.

Voice-only operations (pickup comments, branch name generation) already have one-shot fallbacks when no persistent session exists. With that in place, the eager `_create_session()` call moves out of `WorkerThread.run()` entirely — `Worker` now defers session creation to just before the first real provider turn, eliminating the idle subprocess window during pickup work. The thread still reclaims the session from the worker after each iteration for cross-iteration persistence.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add test coverage for deferred session creation during worker pickup <!-- type:spec -->
- [x] Move session creation from WorkerThread loop to Worker just before first real turn <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->