### PR TITLE
Make webhook preempt actually preempt (#637)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -157,6 +157,30 @@ def current_repo() -> str | None:
     return getattr(_thread_local, "repo_name", None)
 
 
+def set_thread_kind(kind: Literal["worker", "webhook"] | None) -> None:
+    """Set (or clear, with ``None``) the caller kind for this thread.
+
+    Workers call this with ``"worker"`` at :meth:`WorkerThread.run` entry; the
+    webhook handler calls it with ``"webhook"`` at ``_process_action`` entry.
+    :meth:`ClaudeSession.prompt` consults it to decide whether its preempt
+    signal (cancel + ``control_request``) should fire: webhooks preempt
+    workers, workers and webhooks never preempt a running webhook (fix for
+    #637 — without this guard a burst of webhooks cancel each other and
+    nobody's reply lands).
+    """
+    if kind is None:
+        if hasattr(_thread_local, "kind"):
+            del _thread_local.kind
+    else:
+        _thread_local.kind = kind
+
+
+def current_thread_kind() -> Literal["worker", "webhook"]:
+    """Return the caller kind for this thread.  Defaults to ``"worker"``
+    when not set (non-entry code paths and tests)."""
+    return getattr(_thread_local, "kind", "worker")
+
+
 def register_talker(talker: ClaudeTalker) -> None:
     """Register *talker* as the active claude driver for its repo.
 
@@ -674,6 +698,10 @@ class ClaudeSession:
         # :attr:`_cancel` — starving the preempter for a full worker turn.
         # See yield-starvation discussion in #499 comments.
         self._preempt_pending = threading.Event()
+        # Set by :meth:`prompt` just before entering the lock context so
+        # :meth:`__enter__` can register the talker with the correct kind
+        # (``"worker"`` vs ``"webhook"``).  Cleared inside :meth:`__enter__`.
+        self._pending_talker_kind: Literal["worker", "webhook"] | None = None
         # Wakeup pipe: writing a byte to _wakeup_w kicks select() out of its
         # blocking wait in iter_events() so the cancel signal is noticed
         # immediately instead of waiting up to _SELECT_POLL_INTERVAL.
@@ -867,11 +895,16 @@ class ClaudeSession:
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
 
-        Registers a ``worker``-kind :class:`ClaudeTalker` so status surfaces
-        this thread as the one driving claude.  Does *not* clear the cancel
-        event — that is deferred to :meth:`iter_events` so a signal that
-        lands between one holder's :meth:`__exit__` and the next holder's
-        :meth:`iter_events` is not silently dropped.
+        Registers a :class:`ClaudeTalker` with the kind set by :meth:`prompt`
+        via :attr:`_pending_talker_kind` (falling back to the thread-local
+        kind otherwise).  The talker kind lets other threads tell — via
+        :func:`get_talker` — whether they may preempt (fix for #637:
+        webhooks must not preempt each other).
+
+        Does *not* clear the cancel event — that is deferred to
+        :meth:`iter_events` so a signal that lands between one holder's
+        :meth:`__exit__` and the next holder's :meth:`iter_events` is not
+        silently dropped.
 
         Raises :class:`ClaudeLeakError` if another thread is already
         registered as the talker for this repo — indicates a sub-claude is
@@ -882,13 +915,15 @@ class ClaudeSession:
         # We hold the lock now; any preempter waiting on this
         # (wait_for_pending_preempt) can wake.
         self._preempt_pending.clear()
+        kind = self._pending_talker_kind or current_thread_kind()
+        self._pending_talker_kind = None
         if self._repo_name is not None:
             try:
                 register_talker(
                     ClaudeTalker(
                         repo_name=self._repo_name,
                         thread_id=threading.get_ident(),
-                        kind="worker",
+                        kind=kind,
                         description="persistent session turn",
                         claude_pid=self._proc.pid,
                         started_at=_talker_now(),
@@ -1039,42 +1074,64 @@ class ClaudeSession:
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
     ) -> str:
-        """Steal the session, send *content* as a user message, return the result.
+        """Send *content* as a user message on the persistent session and
+        return the result.
 
-        Intended as the session-aware replacement for one-shot
-        client turn helpers on webhook-
-        handler threads.  Runs one full turn on the persistent session:
+        The preempt path is kind-aware (fix for #637):
 
-        1. Signal cancel to wake any current holder out of
-           :meth:`iter_events`.  They exit their turn early, their context
-           manager releases the lock and unregisters their talker.
-        2. Acquire ``self`` as a context manager — blocks while the previous
-           holder is winding down.  Registers a fresh :class:`ClaudeTalker`
-           so status display attributes claude to this thread.
-        3. Switch model if *model* is provided and differs from the session
-           default.
-        4. Send *content* (optionally prefixed with *system_prompt*) and
-           consume until the result boundary, returning the text.
+        - **Webhook caller + worker currently holding the session** — set the
+          cancel event, wake the worker's ``select()``, and send a stream-json
+          ``control_request`` interrupt so claude aborts the running tool
+          immediately instead of completing it first.  This converts the old
+          yield-at-boundary behaviour (which waited for the current tool — a
+          pytest or long ``rg`` — to finish) into genuine mid-tool preemption.
+        - **Webhook caller + another webhook currently holding the session**
+          — do NOT cancel.  Webhooks never preempt each other; the second
+          webhook queues on the lock.  Without this guard a bursty webhook
+          stream makes every handler cancel the previous one and nobody's
+          reply lands.
+        - **Worker caller (its own retry after being preempted, etc.)** —
+          also do NOT cancel.  Workers wait on the lock naturally rather
+          than cancelling whichever webhook is serving a reply.
 
-        Does **not** send a ``control_request`` interrupt to the subprocess
-        before the user message.  On a fresh subprocess with no in-flight
-        turn, claude ignores the control_request and never emits a
-        ``type=result``, so ``consume_until_result`` would hang
-        indefinitely.  The :attr:`_cancel` signal + lock hand-off already
-        ensures the previous holder's :meth:`iter_events` has exited, so
-        there is nothing in-flight to interrupt.
+        After the preempt decision, acquires the session lock and runs one
+        turn: optional :meth:`switch_model`, :meth:`send` (which drains any
+        lingering boundary events from the aborted turn), and
+        :meth:`consume_until_result`.
         """
-        self._cancel.set()
-        self._wake()
-        # Mark that a preempter is queued so the current lock holder (a
-        # worker) can wait_for_pending_preempt and cede the lock fairly
-        # instead of racing to re-acquire after it yields.
-        self._preempt_pending.set()
-        log.info(
-            "session.prompt: preempt requested (tid=%d, model=%s)",
-            threading.get_ident(),
-            self._model if model is None else model_name(model),
-        )
+        caller_kind = current_thread_kind()
+        current = get_talker(self._repo_name) if self._repo_name is not None else None
+        current_kind = current.kind if current is not None else None
+        should_preempt = caller_kind == "webhook" and current_kind == "worker"
+        if should_preempt:
+            self._cancel.set()
+            self._wake()
+            # Kick the subprocess off its in-flight tool.  Without this the
+            # worker's iter_events only notices _cancel between stream-json
+            # events — which don't arrive while claude is running a long
+            # tool (pytest, rg, etc.).  Only send control_request when a
+            # turn is actually in flight; sending to an idle subprocess
+            # never gets a result event back and consume_until_result
+            # would hang indefinitely.
+            if self._in_turn:
+                try:
+                    self._send_control_interrupt()
+                except (BrokenPipeError, OSError) as exc:
+                    log.warning("session.prompt: early control_request failed: %s", exc)
+            self._preempt_pending.set()
+            log.info(
+                "session.prompt: preempting worker (tid=%d, model=%s)",
+                threading.get_ident(),
+                self._model if model is None else model_name(model),
+            )
+        else:
+            log.info(
+                "session.prompt: queuing behind %s holder (tid=%d, model=%s)",
+                current_kind or "none",
+                threading.get_ident(),
+                self._model if model is None else model_name(model),
+            )
+        self._pending_talker_kind = caller_kind
         try:
             with self:
                 if model is not None:

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -528,6 +528,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     def _process_action(self, action: Action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)
         claude.set_thread_repo(repo_cfg.name)
+        claude.set_thread_kind("webhook")
         try:
             with self.registry.webhook_activity(repo_cfg.name, description) as activity:
                 self._process_action_inner(action, repo_cfg, activity)
@@ -541,6 +542,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             )
             os._exit(3)
         finally:
+            claude.set_thread_kind(None)
             claude.set_thread_repo(None)
 
     def _describe_action(self, action: Action) -> str:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2529,6 +2529,7 @@ class WorkerThread(threading.Thread):
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
         claude.set_thread_repo(self._repo_name)
+        claude.set_thread_kind("worker")
         try:
             while not self._stop:
                 if self._registry is not None:
@@ -2582,6 +2583,7 @@ class WorkerThread(threading.Thread):
             log.exception("WorkerThread %s: unexpected error", self.name)
             raise
         finally:
+            claude.set_thread_kind(None)
             claude.set_thread_repo(None)
             # Only stop the session on orderly shutdown — a crashed thread
             # leaves it alive so the registry can hand it to the replacement.

--- a/tests/test_claude_preempt_kind.py
+++ b/tests/test_claude_preempt_kind.py
@@ -1,0 +1,236 @@
+"""Regression tests for kind-aware preempt in ClaudeSession.prompt (#637).
+
+Uses the prompt's log output to distinguish "preempting worker" (cancel +
+early control_request) from "queuing behind X holder" (no cancel).  Direct
+inspection of stdin writes would conflate the early control_request with
+:meth:`ClaudeSession._drain_to_boundary`'s own control_request from the
+regular :meth:`send` path.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from kennel import claude as claude_mod
+from kennel.claude import ClaudeSession, ClaudeTalker, _talker_now
+
+
+def _make_session_proc(lines: list[str]) -> MagicMock:
+    proc = MagicMock()
+    proc.poll = MagicMock(return_value=None)
+    proc.wait = MagicMock(return_value=0)
+    proc.returncode = 0
+    proc.stdin = MagicMock()
+    proc.stdin.closed = False
+    stdout = MagicMock()
+    stdout.readline = MagicMock(side_effect=list(lines) + [""])
+    proc.stdout = stdout
+    proc.stderr = MagicMock()
+    return proc
+
+
+def _setup_session(tmp_path: Path) -> tuple[ClaudeSession, MagicMock]:
+    system_file = tmp_path / "system.md"
+    system_file.write_text("sys")
+    proc = _make_session_proc(['{"type":"result","result":"reply"}\n'])
+    proc.pid = 55555
+    fake_popen = MagicMock(return_value=proc)
+    fake_selector = MagicMock(return_value=([proc.stdout], [], []))
+    session = ClaudeSession(
+        system_file,
+        work_dir=tmp_path,
+        popen=fake_popen,
+        selector=fake_selector,
+        repo_name="owner/repo",
+        model="claude-opus-4-6",
+    )
+    return session, proc
+
+
+def _fake_talker(kind: str) -> ClaudeTalker:
+    return ClaudeTalker(
+        repo_name="owner/repo",
+        thread_id=999_999,
+        kind=kind,  # type: ignore[arg-type]
+        description="fake",
+        claude_pid=55555,
+        started_at=_talker_now(),
+    )
+
+
+def test_webhook_preempting_worker_logs_preempting_and_fires_interrupt(
+    tmp_path: Path, caplog, monkeypatch
+) -> None:
+    """Webhook caller + worker holds the lock + in-flight turn →
+    logs ``preempting worker`` and calls ``_send_control_interrupt`` early
+    (before entering the lock)."""
+    session, _proc = _setup_session(tmp_path)
+    session._in_turn = True
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    # Wrap _send_control_interrupt so we can see when it fired.
+    called_before_lock = []
+    real_interrupt = session._send_control_interrupt
+
+    def tracking_interrupt() -> None:
+        # When the prompt-level interrupt fires, the lock isn't held yet.
+        called_before_lock.append(not session._lock.locked())
+        real_interrupt()
+
+    session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            session.prompt("reply plz")
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "preempting worker" in caplog.text
+    # At least one control_request must have fired while the lock was free
+    # (the "early" interrupt from the preempt path, not the drain inside send).
+    assert any(called_before_lock), (
+        "webhook preempting worker must send control_request BEFORE "
+        "acquiring the lock so claude aborts mid-tool"
+    )
+
+
+def test_webhook_does_not_preempt_another_webhook(
+    tmp_path: Path, caplog, monkeypatch
+) -> None:
+    """Webhook caller + webhook currently holds the lock → no cancel, no
+    early interrupt.  Logs ``queuing behind webhook`` instead."""
+    session, _proc = _setup_session(tmp_path)
+    session._in_turn = False  # avoid the send() drain path muddying the test
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("webhook"))
+    interrupts_before_lock = []
+    real_interrupt = session._send_control_interrupt
+
+    def tracking_interrupt() -> None:
+        interrupts_before_lock.append(not session._lock.locked())
+        real_interrupt()
+
+    session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            session.prompt("reply plz")
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "queuing behind webhook" in caplog.text
+    assert not any(interrupts_before_lock)
+
+
+def test_worker_caller_does_not_preempt(tmp_path: Path, caplog, monkeypatch) -> None:
+    """Worker caller (its own retry) never sets cancel or sends early
+    control_request, even if another webhook currently holds the lock."""
+    session, _proc = _setup_session(tmp_path)
+    session._in_turn = False
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("webhook"))
+    interrupts_before_lock = []
+    real_interrupt = session._send_control_interrupt
+
+    def tracking_interrupt() -> None:
+        interrupts_before_lock.append(not session._lock.locked())
+        real_interrupt()
+
+    session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
+    claude_mod.set_thread_kind("worker")
+    try:
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            session.prompt("keep working")
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "queuing behind webhook" in caplog.text
+    assert not any(interrupts_before_lock)
+
+
+def test_webhook_with_idle_session_skips_early_control_request(
+    tmp_path: Path, caplog, monkeypatch
+) -> None:
+    """When no turn is in flight (_in_turn=False), webhook skips the early
+    control_request but still logs ``preempting worker`` (cancel flag is
+    still set so iter_events bails out on its next poll)."""
+    session, _proc = _setup_session(tmp_path)
+    session._in_turn = False
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    interrupts_before_lock = []
+    real_interrupt = session._send_control_interrupt
+
+    def tracking_interrupt() -> None:
+        interrupts_before_lock.append(not session._lock.locked())
+        real_interrupt()
+
+    session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            session.prompt("reply plz")
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "preempting worker" in caplog.text
+    assert not any(interrupts_before_lock), (
+        "no in-flight turn → no early control_request (would hang on idle "
+        "subprocess waiting for a type=result that never comes)"
+    )
+
+
+def test_early_control_request_error_is_logged_not_fatal(
+    tmp_path: Path, caplog, monkeypatch
+) -> None:
+    """If the early control_request write fails (BrokenPipe etc.), prompt
+    logs a warning and still enters the lock for its own turn."""
+    session, proc = _setup_session(tmp_path)
+    session._in_turn = True
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    # First stdin.write (the early control_request) raises; later writes
+    # succeed so the drain / send path can proceed.
+    proc.stdin.write.side_effect = [
+        BrokenPipeError("pipe closed"),
+        None,
+        None,
+        None,
+    ]
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with caplog.at_level(logging.WARNING, logger="kennel"):
+            try:
+                session.prompt("reply plz")
+            except Exception:
+                pass  # downstream send may raise once stdin is broken
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "early control_request failed" in caplog.text
+
+
+def test_queuing_log_reports_no_holder_when_session_is_free(
+    tmp_path: Path, caplog, monkeypatch
+) -> None:
+    """Webhook caller + no one currently holds the lock → logs
+    ``queuing behind none`` (not ``preempting worker``)."""
+    session, _proc = _setup_session(tmp_path)
+    session._in_turn = False
+    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: None)
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            session.prompt("hi")
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert "queuing behind none" in caplog.text
+
+
+def test_set_thread_kind_roundtrip() -> None:
+    claude_mod.set_thread_kind(None)
+    assert claude_mod.current_thread_kind() == "worker"
+    claude_mod.set_thread_kind("webhook")
+    assert claude_mod.current_thread_kind() == "webhook"
+    claude_mod.set_thread_kind("worker")
+    assert claude_mod.current_thread_kind() == "worker"
+    claude_mod.set_thread_kind(None)
+    assert claude_mod.current_thread_kind() == "worker"


### PR DESCRIPTION
## Summary

Closes #637.

The old \`ClaudeSession.prompt\` unconditionally set \`_cancel\` and relied on the worker's \`iter_events\` to notice between stream-json events. Events don't arrive while claude is running a tool (pytest, long \`rg\`, etc.), so the \"preempt\" was really a cooperative yield at the next natural turn boundary — often 30-60s after the webhook actually arrived. And because every \`prompt\` call did it, webhooks cancelled each other and a bursty stream produced zero-reply pile-ups.

This PR makes the preempt kind-aware:

- New thread-local kind (\`worker\` vs \`webhook\`) set at \`WorkerThread.run\` entry and \`WebhookHandler._process_action\` entry.
- \`prompt()\` only sets \`_cancel\` + sends an early \`control_request\` when the caller is a webhook AND the current lock holder is a worker. That \`control_request\` forces claude to abort its in-flight tool immediately — real mid-tool preemption, not yield-at-boundary.
- Webhook-to-webhook and worker-to-anything prompts skip the cancel and queue on the lock naturally.
- \`__enter__\` registers the talker with the actual caller kind so the next preempt check can see \"this is a webhook, don't cancel.\"

The early \`control_request\` is gated on \`_in_turn=True\` — sending to an idle subprocess would wait for a \`type=result\` that never comes and hang \`consume_until_result\`, the hazard the original docstring called out.

Logs now distinguish \`preempting worker\` (real preempt) from \`queuing behind worker|webhook|none holder\` (cooperative wait).

## Test plan

- [x] \`uv run ruff format --check . && uv run ruff check . && uv run pytest --cov --cov-fail-under=100\` — 2211 tests pass, 100% coverage.
- [x] 7 new regression tests in \`tests/test_claude_preempt_kind.py\` covering:
  - webhook preempts worker (logs + early control_request before lock)
  - webhook does NOT preempt another webhook
  - worker caller does NOT preempt anyone
  - webhook with idle session skips early control_request (gated on \`_in_turn\`)
  - early control_request BrokenPipe is logged and non-fatal
  - \"no holder\" case logs \`queuing behind none\`
  - \`set_thread_kind\` roundtrip
- [ ] After merge: watch a live PR-comment reply and confirm it lands in seconds rather than minutes.