### PR TITLE
Share preempt decision across claude and copilot (#637 follow-up)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -181,6 +181,34 @@ def current_thread_kind() -> Literal["worker", "webhook"]:
     return getattr(_thread_local, "kind", "worker")
 
 
+def try_preempt_worker(
+    repo_name: str | None, cancel_fn: Callable[[], None]
+) -> tuple[bool, Literal["worker", "webhook"] | None]:
+    """Invoke *cancel_fn* iff the calling thread is a webhook AND the
+    session's current lock holder is a worker.  Otherwise do nothing.
+
+    Returns ``(preempted, current_kind)`` — *preempted* is ``True`` only when
+    *cancel_fn* was invoked; *current_kind* is the current holder's kind
+    (``"worker"``, ``"webhook"``, or ``None`` when the session is idle).
+    The caller uses that triple to log the outcome ("preempting worker" vs
+    "queuing behind <kind>").
+
+    Provider-neutral decision gate for #637.  The *mechanism* of cancelling a
+    running turn differs across providers (stream-json ``control_request``
+    for claude, ACP ``cancel(session_id)`` for copilot), but the *decision*
+    is identical and lives here.  Worker callers never preempt anyone;
+    webhooks queue behind other webhooks (FIFO on the session lock) instead
+    of cancelling each other.
+    """
+    caller_kind = current_thread_kind()
+    current = get_talker(repo_name) if repo_name is not None else None
+    current_kind = current.kind if current is not None else None
+    if caller_kind == "webhook" and current_kind == "worker":
+        cancel_fn()
+        return True, current_kind
+    return False, current_kind
+
+
 def register_talker(talker: ClaudeTalker) -> None:
     """Register *talker* as the active claude driver for its repo.
 
@@ -1025,6 +1053,27 @@ class ClaudeSession:
         self._in_turn = False
         self.recover()
 
+    def _fire_worker_cancel(self) -> None:
+        """Provider-specific cancel mechanism handed to
+        :func:`try_preempt_worker`.  Sets the cancel event, wakes the
+        worker's ``select()`` so it exits its turn early, and — when a
+        turn is actually in flight — writes a stream-json
+        ``control_request`` so claude aborts the running tool on its
+        side rather than completing it first.
+
+        Gated on :attr:`_in_turn` because ``control_request`` sent to an
+        idle subprocess never elicits a ``type=result`` back and would
+        hang the next :meth:`consume_until_result` indefinitely (hazard
+        called out in the original :meth:`prompt` docstring).
+        """
+        self._cancel.set()
+        self._wake()
+        if self._in_turn:
+            try:
+                self._send_control_interrupt()
+            except (BrokenPipeError, OSError) as exc:
+                log.warning("session.prompt: early control_request failed: %s", exc)
+
     def _send_control_interrupt(self) -> None:
         """Write a stream-json ``control_request`` interrupt to subprocess stdin.
 
@@ -1099,25 +1148,10 @@ class ClaudeSession:
         lingering boundary events from the aborted turn), and
         :meth:`consume_until_result`.
         """
-        caller_kind = current_thread_kind()
-        current = get_talker(self._repo_name) if self._repo_name is not None else None
-        current_kind = current.kind if current is not None else None
-        should_preempt = caller_kind == "webhook" and current_kind == "worker"
-        if should_preempt:
-            self._cancel.set()
-            self._wake()
-            # Kick the subprocess off its in-flight tool.  Without this the
-            # worker's iter_events only notices _cancel between stream-json
-            # events — which don't arrive while claude is running a long
-            # tool (pytest, rg, etc.).  Only send control_request when a
-            # turn is actually in flight; sending to an idle subprocess
-            # never gets a result event back and consume_until_result
-            # would hang indefinitely.
-            if self._in_turn:
-                try:
-                    self._send_control_interrupt()
-                except (BrokenPipeError, OSError) as exc:
-                    log.warning("session.prompt: early control_request failed: %s", exc)
+        preempted, current_kind = try_preempt_worker(
+            self._repo_name, self._fire_worker_cancel
+        )
+        if preempted:
             self._preempt_pending.set()
             log.info(
                 "session.prompt: preempting worker (tid=%d, model=%s)",
@@ -1131,7 +1165,7 @@ class ClaudeSession:
                 threading.get_ident(),
                 self._model if model is None else model_name(model),
             )
-        self._pending_talker_kind = caller_kind
+        self._pending_talker_kind = current_thread_kind()
         try:
             with self:
                 if model is not None:

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -15,8 +15,9 @@ import uuid
 from collections.abc import Callable, Sequence
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import acp
 from acp.exceptions import RequestError
@@ -900,6 +901,10 @@ class CopilotCLISession:
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
         self._session_id: str | None = self._runtime.ensure_session(None, model)
+        # Kind the current lock holder is registered under in the shared
+        # talker registry (``"worker"`` / ``"webhook"``), or ``None`` when
+        # no one is inside the lock.  Set by :meth:`_register_talker_kind`.
+        self._registered_talker_kind: Literal["worker", "webhook"] | None = None
 
     @property
     def owner(self) -> str | None:
@@ -975,21 +980,67 @@ class CopilotCLISession:
     def stop(self) -> None:
         self._runtime.stop()
 
+    def _fire_worker_cancel(self) -> None:
+        """Provider-specific cancel mechanism handed to
+        :func:`claude.try_preempt_worker`.  Asks the Copilot ACP runtime to
+        cancel the currently-active prompt so the worker's turn returns with
+        ``stop_reason="cancelled"`` and releases the session lock.  No-op if
+        there is no active session id or the runtime is already down.
+        """
+        session_id = self._session_id
+        if session_id is not None and self._runtime.is_alive():
+            self._runtime.cancel(session_id)
+
     def __enter__(self) -> "CopilotCLISession":
         waited = not self._lock.acquire(blocking=False)
         if waited:
             with self._preempt_condition:
                 self._pending_preempts += 1
-            session_id = self._session_id
-            if session_id is not None and self._runtime.is_alive():
-                self._runtime.cancel(session_id)
+            # Only fire the runtime cancel when a webhook is preempting a
+            # worker — matches the shared decision gate used for claude.
+            # Another webhook waiting behind a webhook just queues on the
+            # lock; workers never cancel anyone.
+            claude.try_preempt_worker(self._repo_name, self._fire_worker_cancel)
             self._lock.acquire()
         self._thread_state.waited = waited
         with self._owner_lock:
             self._owner = threading.current_thread().name
+        self._register_talker_kind()
         return self
 
+    def _register_talker_kind(self) -> None:
+        """Register this thread with the shared talker registry so other
+        threads can tell, via :func:`claude.get_talker`, whether the current
+        lock holder is a worker or a webhook.  Matches what
+        :meth:`ClaudeSession.__enter__` does for the claude provider.
+
+        Tracked as :attr:`_registered_talker_kind` so :meth:`__exit__` knows
+        whether to unregister.
+        """
+        if self._repo_name is None:
+            self._registered_talker_kind = None
+            return
+        kind = claude.current_thread_kind()
+        try:
+            claude.register_talker(
+                claude.ClaudeTalker(
+                    repo_name=self._repo_name,
+                    thread_id=threading.get_ident(),
+                    kind=kind,
+                    description="copilot-cli session turn",
+                    claude_pid=0,  # no claude subprocess — ACP runtime
+                    started_at=datetime.now(tz=timezone.utc),
+                )
+            )
+            self._registered_talker_kind = kind
+        except claude.ClaudeLeakError:
+            self._lock.release()
+            raise
+
     def __exit__(self, *args: object) -> None:
+        if self._repo_name is not None and self._registered_talker_kind is not None:
+            claude.unregister_talker(self._repo_name, threading.get_ident())
+            self._registered_talker_kind = None
         with self._owner_lock:
             self._owner = None
         self._lock.release()

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -919,7 +919,11 @@ class TestCopilotCLISession:
         session.stop()
         assert runtime.stop_called is True
 
-    def test_preempt_waits_for_contender(self, tmp_path: Path) -> None:
+    def test_webhook_preempts_worker_cancels_runtime(self, tmp_path: Path) -> None:
+        """Worker holds the session; webhook contender fires the runtime
+        cancel so the worker's turn returns and releases the lock."""
+        from kennel import claude as claude_mod
+
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         runtime = FakeRuntime()
@@ -928,31 +932,167 @@ class TestCopilotCLISession:
             work_dir=tmp_path,
             model=CopilotCLIClient.work_model,
             runtime=runtime,
+            repo_name="owner/repo",
         )
         acquired = threading.Event()
         release = threading.Event()
 
+        # Holder enters as worker so the shared talker registry reports it.
+        claude_mod.set_thread_kind("worker")
         session.__enter__()
 
         def contender() -> None:
-            with session:
-                acquired.set()
-                release.wait()
+            claude_mod.set_thread_kind("webhook")
+            try:
+                with session:
+                    acquired.set()
+                    release.wait()
+            finally:
+                claude_mod.set_thread_kind(None)
 
         thread = threading.Thread(target=contender, daemon=True)
         thread.start()
-        for _ in range(100):
-            if runtime.cancel_calls:
-                break
-            time.sleep(0.01)
-        assert runtime.cancel_calls == ["sess-created"]
-        assert session.wait_for_pending_preempt(timeout=0.01) is False
-        session.__exit__(None, None, None)
-        acquired.wait(timeout=1.0)
-        assert session.wait_for_pending_preempt(timeout=0.01) is False
-        release.set()
-        thread.join(timeout=1.0)
-        assert session.wait_for_pending_preempt(timeout=1.0) is True
+        try:
+            for _ in range(100):
+                if runtime.cancel_calls:
+                    break
+                time.sleep(0.01)
+            assert runtime.cancel_calls == ["sess-created"]
+            assert session.wait_for_pending_preempt(timeout=0.01) is False
+            session.__exit__(None, None, None)
+            acquired.wait(timeout=1.0)
+            assert session.wait_for_pending_preempt(timeout=0.01) is False
+            release.set()
+            thread.join(timeout=1.0)
+            assert session.wait_for_pending_preempt(timeout=1.0) is True
+        finally:
+            claude_mod.set_thread_kind(None)
+
+    def test_webhook_does_not_cancel_another_webhook(self, tmp_path: Path) -> None:
+        """Webhook contender queues behind another webhook without firing
+        the runtime cancel — FIFO on the lock instead of mutual cancellation
+        (#637)."""
+        from kennel import claude as claude_mod
+
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+            repo_name="owner/repo",
+        )
+        acquired = threading.Event()
+        release = threading.Event()
+
+        claude_mod.set_thread_kind("webhook")
+        session.__enter__()
+
+        def contender() -> None:
+            claude_mod.set_thread_kind("webhook")
+            try:
+                with session:
+                    acquired.set()
+                    release.wait()
+            finally:
+                claude_mod.set_thread_kind(None)
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+        try:
+            # Give the contender a chance to queue; no cancel should fire.
+            time.sleep(0.05)
+            assert runtime.cancel_calls == []
+            session.__exit__(None, None, None)
+            acquired.wait(timeout=1.0)
+            release.set()
+            thread.join(timeout=1.0)
+            assert runtime.cancel_calls == []
+        finally:
+            claude_mod.set_thread_kind(None)
+
+    def test_enter_releases_lock_on_claude_leak_error(self, tmp_path: Path) -> None:
+        """If another thread already registered a talker for this repo the
+        session's __enter__ must release the lock before propagating so the
+        existing holder can finish and unregister, not deadlock."""
+        from kennel import claude as claude_mod
+
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+            repo_name="owner/repo",
+        )
+        # Pre-register a different tid as the active talker so the session's
+        # own register_talker inside __enter__ raises ClaudeLeakError.
+        claude_mod.register_talker(
+            claude_mod.ClaudeTalker(
+                repo_name="owner/repo",
+                thread_id=999_999,
+                kind="worker",
+                description="squatter",
+                claude_pid=0,
+                started_at=claude_mod._talker_now(),
+            )
+        )
+        try:
+            with pytest.raises(claude_mod.ClaudeLeakError):
+                session.__enter__()
+            # Lock must have been released on the leak path so a later
+            # legitimate enter (after the squatter clears) still works.
+            assert session._lock.acquire(blocking=False) is True
+            session._lock.release()
+        finally:
+            claude_mod.unregister_talker("owner/repo", 999_999)
+
+    def test_worker_contender_does_not_cancel(self, tmp_path: Path) -> None:
+        """Worker contender (e.g. its own retry) waits on the lock rather
+        than cancelling whichever webhook currently holds it."""
+        from kennel import claude as claude_mod
+
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+            repo_name="owner/repo",
+        )
+        acquired = threading.Event()
+        release = threading.Event()
+
+        claude_mod.set_thread_kind("webhook")
+        session.__enter__()
+
+        def contender() -> None:
+            claude_mod.set_thread_kind("worker")
+            try:
+                with session:
+                    acquired.set()
+                    release.wait()
+            finally:
+                claude_mod.set_thread_kind(None)
+
+        thread = threading.Thread(target=contender, daemon=True)
+        thread.start()
+        try:
+            time.sleep(0.05)
+            assert runtime.cancel_calls == []
+            session.__exit__(None, None, None)
+            acquired.wait(timeout=1.0)
+            release.set()
+            thread.join(timeout=1.0)
+            assert runtime.cancel_calls == []
+        finally:
+            claude_mod.set_thread_kind(None)
 
     def test_missing_system_file_and_runtime_factory_branch(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

Extracts the preempt *decision* into a single shared HOF so both providers use identical semantics — only the provider-specific *cancel mechanism* differs. Fixes #637 on the copilot path, which #641 didn't touch.

**New shared gate in \`kennel.claude\`:**
\`\`\`python
try_preempt_worker(repo_name, cancel_fn) -> (preempted, current_kind)
\`\`\`
Invokes \`cancel_fn\` iff caller_kind == \"webhook\" AND current_holder_kind == \"worker\". Returns the outcome so the caller can log \`preempting worker\` vs \`queuing behind <kind>\`.

**Per-provider cancel_fn:**
- \`ClaudeSession._fire_worker_cancel\` — sets \`_cancel\` + \`_wake\` + (gated on \`_in_turn\`) writes stream-json \`control_request\`
- \`CopilotCLISession._fire_worker_cancel\` — calls \`_runtime.cancel(session_id)\`

\`CopilotCLISession.__enter__\` now also registers a talker with the caller's kind on the shared registry, so the gate can see \"this is a webhook\" for future contenders. No other session behaviour changes — same subprocess, same \`--resume\` / session_id plumbing, same lock.

## Behavioural guarantees (identical for both providers)

- Webhook preempts worker → cancel fires
- Webhook caller + webhook holder → no cancel, FIFO queue on lock (#637 webhook-cancels-webhook bug)
- Worker caller → never cancels anyone (worker retry just waits)

## Test plan

- [x] \`uv run ruff format --check . && uv run ruff check . && uv run pytest --cov --cov-fail-under=100\` — 2214 tests, 100% coverage
- [x] 3 new copilot tests mirroring the claude ones: webhook preempts worker, webhook does not preempt webhook, worker contender does not preempt, plus the leak-on-enter safety path
- [x] Existing \`ClaudeSession.prompt\` tests still pass (refactored to call the shared HOF)
- [ ] After merge: post a comment on an orly PR and verify the reply lands quickly