### PR TITLE
Fall back to immediate merge when repo has auto-merge disabled (#643)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -35,6 +35,26 @@ class GraphQLError(Exception):
         self.errors = errors
 
 
+def _auto_merge_unavailable(exc: GraphQLError) -> bool:
+    """True when *exc* is a GraphQL ``enablePullRequestAutoMerge`` failure
+    caused by the repository having auto-merge disabled.
+
+    GitHub returns ``{'type': 'UNPROCESSABLE', 'message': 'Pull request Auto
+    merge is not allowed for this repository', ...}``.  Callers treat that
+    as a \"fall back to immediate merge\" signal rather than a crash (fix
+    for #643).
+    """
+    for err in exc.errors:
+        if not isinstance(err, dict):
+            continue
+        if err.get("type") != "UNPROCESSABLE":
+            continue
+        message = err.get("message") or ""
+        if "Auto merge is not allowed" in message:
+            return True
+    return False
+
+
 def _gh_token(
     runner: Any = subprocess.run,
     environ: Any = os.environ,
@@ -679,37 +699,66 @@ class GitHub:
         if pr_data.get("merged"):
             log.info("PR %s/#%s already merged — skipping", repo, pr)
             return
-        if auto:
-            node_id = pr_data["node_id"]
-            merge_method = "SQUASH" if squash else "MERGE"
-            query = (
-                "mutation($prId:ID!,$mergeMethod:PullRequestMergeMethod!){"
-                "enablePullRequestAutoMerge(input:{pullRequestId:$prId,"
-                "mergeMethod:$mergeMethod})"
-                "{pullRequest{autoMergeRequest{mergeMethod}}}}"
+        if auto and self._try_enable_auto_merge(repo, pr, pr_data, squash):
+            return
+        merge_method = "squash" if squash else "merge"
+        try:
+            self._put(
+                f"/repos/{repo}/pulls/{pr}/merge",
+                merge_method=merge_method,
             )
+        except _requests.HTTPError as e:
+            # Re-check: if the PR was merged between our initial get_pr and
+            # the merge call (race with webhook-triggered self-restart on
+            # another process), treat 405 as success.
+            if e.response is not None and e.response.status_code == 405:
+                recheck = self._get(f"/repos/{repo}/pulls/{pr}")
+                if recheck.get("merged"):
+                    log.info(
+                        "PR %s/#%s merged concurrently — treating 405 as success",
+                        repo,
+                        pr,
+                    )
+                    return
+            raise
+
+    def _try_enable_auto_merge(
+        self,
+        repo: str,
+        pr: int | str,
+        pr_data: dict[str, Any],
+        squash: bool,
+    ) -> bool:
+        """Try to enable auto-merge on *pr*.
+
+        Returns True on success.  Returns False when the repository has
+        auto-merge disabled (GraphQL UNPROCESSABLE), so the caller can
+        fall back to an immediate REST merge.  Re-raises any other
+        :class:`GraphQLError` — callers are not equipped to continue past
+        a genuine protocol failure.
+        """
+        node_id = pr_data["node_id"]
+        merge_method = "SQUASH" if squash else "MERGE"
+        query = (
+            "mutation($prId:ID!,$mergeMethod:PullRequestMergeMethod!){"
+            "enablePullRequestAutoMerge(input:{pullRequestId:$prId,"
+            "mergeMethod:$mergeMethod})"
+            "{pullRequest{autoMergeRequest{mergeMethod}}}}"
+        )
+        try:
             self._graphql(query, prId=node_id, mergeMethod=merge_method)
-        else:
-            merge_method = "squash" if squash else "merge"
-            try:
-                self._put(
-                    f"/repos/{repo}/pulls/{pr}/merge",
-                    merge_method=merge_method,
-                )
-            except _requests.HTTPError as e:
-                # Re-check: if the PR was merged between our initial get_pr and
-                # the merge call (race with webhook-triggered self-restart on
-                # another process), treat 405 as success.
-                if e.response is not None and e.response.status_code == 405:
-                    recheck = self._get(f"/repos/{repo}/pulls/{pr}")
-                    if recheck.get("merged"):
-                        log.info(
-                            "PR %s/#%s merged concurrently — treating 405 as success",
-                            repo,
-                            pr,
-                        )
-                        return
+            return True
+        except GraphQLError as exc:
+            if not _auto_merge_unavailable(exc):
                 raise
+            log.info(
+                "PR %s/#%s: auto-merge disabled on repo — "
+                "falling back to immediate %s merge",
+                repo,
+                pr,
+                "squash" if squash else "merge",
+            )
+            return False
 
     def get_pr(self, repo: str, pr: int | str) -> dict[str, Any]:
         """Return PR data (reviews, isDraft, mergeStateStatus, body, commits)."""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1481,6 +1481,68 @@ class TestGitHubClass:
         with _pytest.raises(_requests.HTTPError):
             gh.pr_merge("o/r", 10)
 
+    def test_pr_merge_auto_falls_back_on_auto_merge_disabled(self) -> None:
+        """#643: if the repo has auto-merge disabled (GraphQL UNPROCESSABLE),
+        fall back to an immediate squash merge rather than crashing."""
+        gh, mock_s = self._gh()
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        mock_s.get.return_value = pr_resp
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {
+            "data": None,
+            "errors": [
+                {
+                    "type": "UNPROCESSABLE",
+                    "path": ["enablePullRequestAutoMerge"],
+                    "message": "Pull request Auto merge is not allowed for this repository",
+                }
+            ],
+        }
+        mock_s.post.return_value = graphql_resp
+        put_resp = MagicMock()
+        put_resp.raise_for_status = MagicMock()
+        mock_s.put.return_value = put_resp
+        gh.pr_merge("o/r", 10, auto=True)
+        mock_s.put.assert_called_once()
+        # PUT body should request a squash merge via REST.
+        call = mock_s.put.call_args
+        assert "/pulls/10/merge" in call.args[0]
+        assert call.kwargs["json"]["merge_method"] == "squash"
+
+    def test_pr_merge_auto_non_dict_error_entries_skipped(self) -> None:
+        """#643 helper ignores non-dict entries in GraphQLError.errors (GitHub's
+        error list occasionally contains bare strings)."""
+        from kennel.github import GraphQLError, _auto_merge_unavailable
+
+        exc = GraphQLError(["string-error", {"type": "OTHER"}])
+        assert _auto_merge_unavailable(exc) is False
+
+    def test_pr_merge_auto_reraises_other_graphql_errors(self) -> None:
+        """Non-\"auto-merge disabled\" GraphQL errors must not be swallowed."""
+        from kennel.github import GraphQLError
+
+        gh, mock_s = self._gh()
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        mock_s.get.return_value = pr_resp
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {
+            "data": None,
+            "errors": [
+                {
+                    "type": "FORBIDDEN",
+                    "message": "not allowed",
+                }
+            ],
+        }
+        mock_s.post.return_value = graphql_resp
+        import pytest as _pytest
+
+        with _pytest.raises(GraphQLError):
+            gh.pr_merge("o/r", 10, auto=True)
+        mock_s.put.assert_not_called()
+
     def test_pr_merge_non_405_error_reraises(self) -> None:
         """Non-405 errors (e.g. 500) should not be swallowed."""
         import requests as _requests


### PR DESCRIPTION
Closes #643.

\`pr_merge(..., auto=True)\` was calling \`enablePullRequestAutoMerge\` unconditionally and letting any GraphQL failure propagate — including the specific UNPROCESSABLE \"Pull request Auto merge is not allowed for this repository\" error returned by repos that don't have auto-merge enabled (e.g. \`rhencke/orly\`). Each failure killed the worker thread, the watchdog restarted it, and the loop started over (~30s cadence).

Fix: a new \`_auto_merge_unavailable(exc)\` helper recognizes that specific GraphQL error shape, and \`_try_enable_auto_merge\` returns False when it sees it so \`pr_merge\` falls through to the existing REST squash-merge path. Any other GraphQL error still re-raises.

## Test plan

- [x] \`uv run ruff format --check . && uv run ruff check . && uv run pytest --cov --cov-fail-under=100\` — 2217 tests, 100% coverage
- [x] \`test_pr_merge_auto_falls_back_on_auto_merge_disabled\` — the #643 scenario
- [x] \`test_pr_merge_auto_reraises_other_graphql_errors\` — unrelated GraphQL failures still propagate
- [x] \`test_pr_merge_auto_non_dict_error_entries_skipped\` — defensive branch covered
- [ ] Watch orly after merge and confirm the worker no longer loops on PR #49