### PR TITLE
Seed completed tasks from PR body so finished PRs promote (#646)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1853,16 +1853,19 @@ class Worker:
     def seed_tasks_from_pr_body(self, repo: str, pr_number: int) -> None:
         """Seed tasks.json from the PR body work-queue markers if tasks.json is empty.
 
-        Extracts ONLY unchecked task items (``- [ ] ...``) between
-        ``WORK_QUEUE_START`` and ``WORK_QUEUE_END`` markers and adds them via
-        :func:`~kennel.tasks.add_task`.  Completed (``- [x]``) tasks are
-        skipped — the work is already in the git history; re-creating them
-        as pending would send fido into a "no commits produced" retry loop.
+        Extracts **both** unchecked (``- [ ] ...``) and checked
+        (``- [x] ...``) task items between ``WORK_QUEUE_START`` and
+        ``WORK_QUEUE_END`` markers.  Unchecked items are added as pending;
+        checked items are added with status=COMPLETED so the downstream
+        "all tasks done → promote the PR" logic can see them (fix for #646 —
+        previously completed items were skipped, and a PR whose work queue
+        held only completed items looked like a fresh PR needing setup).
+
         Lines without a ``<!-- type:X -->`` comment are skipped with a
         warning (e.g. stale multi-line task bodies from older PR bodies).
 
         No-op if tasks.json is already non-empty, or if no markers /
-        unchecked items are found.
+        items are found.
         """
         if self._tasks.list():
             return  # already have tasks — nothing to seed
@@ -1875,12 +1878,15 @@ class Worker:
         )
         if not match:
             return
-        parsed: list[tuple[str, TaskType]] = []
+        parsed: list[tuple[str, TaskType, TaskStatus]] = []
         for line in match.group(1).splitlines():
-            m = re.match(r"^- \[ \] (.+)$", line)
-            if not m:
+            check = re.match(r"^- \[( |x)\] (.+)$", line)
+            if not check:
                 continue
-            rest = m.group(1)
+            status = (
+                TaskStatus.COMPLETED if check.group(1) == "x" else TaskStatus.PENDING
+            )
+            rest = check.group(2)
             type_match = re.search(r"<!-- type:(\w+) -->", rest)
             if not type_match:
                 log.warning("skipping task line without type marker: %r", line)
@@ -1891,12 +1897,23 @@ class Worker:
             title = re.sub(r"\s*\*\*→ next\*\*\s*", "", title).strip()
             if not title:
                 continue
-            parsed.append((title, task_type))
+            parsed.append((title, task_type, status))
         if not parsed:
             return
-        for title, task_type in parsed:
-            self._tasks.add(title, task_type)
-        log.info("seeded %d tasks from PR body", len(parsed))
+        pending = 0
+        completed = 0
+        for title, task_type, status in parsed:
+            self._tasks.add(title, task_type, status=status)
+            if status == TaskStatus.COMPLETED:
+                completed += 1
+            else:
+                pending += 1
+        log.info(
+            "seeded %d tasks from PR body (%d pending, %d completed)",
+            len(parsed),
+            pending,
+            completed,
+        )
 
     def post_pickup_comment(
         self, repo: str, issue: int, issue_title: str, gh_user: str

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3992,7 +3992,7 @@ class TestSeedTasksFromPrBody:
         mock_add.assert_not_called()
 
     def test_adds_single_task_from_body(self, tmp_path: Path) -> None:
-        from kennel.types import TaskType
+        from kennel.types import TaskStatus, TaskType
 
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = self._pr_with_queue("Fix the bug")
@@ -4001,7 +4001,9 @@ class TestSeedTasksFromPrBody:
             patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
-        mock_add.assert_called_once_with("Fix the bug", TaskType.SPEC)
+        mock_add.assert_called_once_with(
+            "Fix the bug", TaskType.SPEC, status=TaskStatus.PENDING
+        )
 
     def test_adds_multiple_tasks(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -4015,7 +4017,11 @@ class TestSeedTasksFromPrBody:
             worker.seed_tasks_from_pr_body("owner/repo", 1)
         assert mock_add.call_count == 3
 
-    def test_skips_completed_tasks(self, tmp_path: Path) -> None:
+    def test_seeds_completed_tasks_as_completed(self, tmp_path: Path) -> None:
+        """#646: completed tasks are seeded with status=COMPLETED so the
+        downstream 'all tasks done → promote' logic can see them."""
+        from kennel.types import TaskStatus
+
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {
             "body": (
@@ -4031,11 +4037,19 @@ class TestSeedTasksFromPrBody:
             patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
-        # Only the unchecked task should have been added
-        assert mock_add.call_count == 1
-        assert mock_add.call_args.args[0] == "Still pending"
+        assert mock_add.call_count == 3
+        statuses = [c.kwargs["status"] for c in mock_add.call_args_list]
+        assert statuses == [
+            TaskStatus.COMPLETED,
+            TaskStatus.COMPLETED,
+            TaskStatus.PENDING,
+        ]
 
-    def test_skips_all_when_only_completed(self, tmp_path: Path) -> None:
+    def test_seeds_all_completed_queue(self, tmp_path: Path) -> None:
+        """#646: a PR whose work queue is fully completed seeds the completed
+        tasks so the worker can recognize it as ready to promote."""
+        from kennel.types import TaskStatus
+
         worker, gh = self._make_worker(tmp_path)
         gh.get_pr.return_value = {
             "body": (
@@ -4050,7 +4064,9 @@ class TestSeedTasksFromPrBody:
             patch("kennel.tasks.Tasks.add") as mock_add,
         ):
             worker.seed_tasks_from_pr_body("owner/repo", 1)
-        mock_add.assert_not_called()
+        assert mock_add.call_count == 2
+        for c in mock_add.call_args_list:
+            assert c.kwargs["status"] == TaskStatus.COMPLETED
 
     def test_strips_next_marker(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)


### PR DESCRIPTION
Closes #646.

When \`tasks.json\` was empty and the PR body's work queue had only completed (\`- [x]\`) items, \`seed_tasks_from_pr_body\` skipped them all. Empty \`tasks.json\` → \`find_or_create_pr\` ran setup instead of promoting the already-done PR. Symptom on orly PR #49: APPROVED, mergeable, CLEAN, work queue \`Completed (1)\` — kennel re-ran setup every iteration and never merged.

Fix: seed both checked and unchecked items. Unchecked items stay pending; checked items seed with \`status=COMPLETED\`. The downstream \"no pending tasks → promote\" logic then works naturally without new branches elsewhere.

## Test plan

- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2217 tests, 100% coverage
- [x] \`test_seeds_completed_tasks_as_completed\` — mixed queue (2 checked + 1 unchecked) seeds all three with correct statuses
- [x] \`test_seeds_all_completed_queue\` — all-checked queue seeds both as completed (#646 scenario)
- [ ] Watch orly after merge and confirm PR #49 gets promoted/merged