### PR TITLE
BLOCKED tasks should yield the claude session and resume on new PR comment (closes #557)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -43,6 +43,7 @@ from kennel.provider_factory import DefaultProviderFactory
 from kennel.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from kennel.static_files import StaticFiles
 from kennel.status import provider_statuses_for_repo_configs
+from kennel.tasks import unblock_tasks
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
     Watchdog,
@@ -430,6 +431,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_reply_to_issue_comment = staticmethod(reply_to_issue_comment)
     _fn_create_task = staticmethod(create_task)
     _fn_launch_worker = staticmethod(launch_worker)
+    _fn_unblock_tasks = staticmethod(unblock_tasks)
     _fn_spawn_bg = staticmethod(_spawn_bg)
     _fn_after_do_post = staticmethod(_noop_after_post)
     _fn_runner_dir = staticmethod(_runner_dir)
@@ -703,6 +705,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 category,
                 len(titles),
             )
+            # When a human comments on a PR, transition any BLOCKED tasks back
+            # to PENDING so the worker can re-evaluate and resume.
+            if action.reply_to or action.comment_body:
+                type(self)._fn_unblock_tasks(repo_cfg.work_dir)
             # Non-comment events just trigger kennel worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)
         except claude.ClaudeLeakError:

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -124,6 +124,11 @@ def remove_task(work_dir: Path, task_id: str) -> bool:
     return Tasks(work_dir).remove(task_id)
 
 
+def unblock_tasks(work_dir: Path) -> int:
+    """Transition all BLOCKED tasks to PENDING.  Compatibility shim — prefer :class:`Tasks`."""
+    return Tasks(work_dir).unblock_tasks()
+
+
 def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
     """Format a task list into work-queue markdown.
 
@@ -668,3 +673,22 @@ class Tasks(JsonFileStore):
                     log.info("task %s → %s", task_id, status)
                     return True
         return False
+
+    def unblock_tasks(self) -> int:
+        """Transition all BLOCKED tasks back to PENDING.
+
+        Called when a new PR comment arrives so the worker can re-evaluate
+        whether it is still blocked.  Returns the number of tasks unblocked.
+        """
+        count = 0
+        with _locked(self._data_path, write=True) as lock:
+            task_list = lock.read()
+            for t in task_list:
+                if t.get("status") == TaskStatus.BLOCKED:
+                    t["status"] = str(TaskStatus.PENDING)
+                    count += 1
+            if count:
+                lock.write(task_list)
+        if count:
+            log.info("unblocked %d task(s)", count)
+        return count

--- a/kennel/types.py
+++ b/kennel/types.py
@@ -15,3 +15,4 @@ class TaskStatus(StrEnum):
     PENDING = "pending"
     COMPLETED = "completed"
     IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -93,6 +93,7 @@ def _restore_handler_fns():
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
         "_fn_create_task": WebhookHandler._fn_create_task,
         "_fn_launch_worker": WebhookHandler._fn_launch_worker,
+        "_fn_unblock_tasks": WebhookHandler._fn_unblock_tasks,
         "_fn_spawn_bg": WebhookHandler._fn_spawn_bg,
         "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
@@ -1861,6 +1862,76 @@ class TestProcessAction:
         finally:
             WebhookHandler._respond = original_respond  # type: ignore[method-assign]
         assert call_order == ["dispatch", "respond_200"]
+
+    def test_review_comment_calls_unblock_tasks(self, server: tuple) -> None:
+        """A pull_request_review_comment triggers unblock_tasks so BLOCKED tasks resume."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 700,
+                "body": "here is the answer",
+                "user": {"login": "owner"},
+                "html_url": "https://example.com",
+                "path": "foo.py",
+                "line": 1,
+                "diff_hunk": "@@ @@",
+            },
+            "pull_request": {"number": 71, "title": "My PR", "body": ""},
+        }
+        mock_unblock = MagicMock(return_value=0)
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler._fn_unblock_tasks = mock_unblock
+        status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        assert status == 200
+        mock_unblock.assert_called_once_with(cfg.repos["owner/repo"].work_dir)
+
+    def test_issue_comment_calls_unblock_tasks(self, server: tuple) -> None:
+        """A top-level PR comment triggers unblock_tasks so BLOCKED tasks resume."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "created",
+            "comment": {
+                "id": 701,
+                "body": "here is what you need",
+                "user": {"login": "owner"},
+                "html_url": "https://github.com/owner/repo/pull/71#issuecomment-701",
+            },
+            "issue": {
+                "number": 71,
+                "title": "my pr",
+                "body": "",
+                "pull_request": {"url": "https://api.github.com/..."},
+            },
+        }
+        mock_unblock = MagicMock(return_value=0)
+        WebhookHandler.gh = MagicMock()
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            return_value=("ANSWER", [])
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler._fn_unblock_tasks = mock_unblock
+        status = _post_webhook(url, cfg, "issue_comment", payload)
+        assert status == 200
+        mock_unblock.assert_called_once_with(cfg.repos["owner/repo"].work_dir)
+
+    def test_non_comment_event_does_not_call_unblock_tasks(self, server: tuple) -> None:
+        """A PR merge event (no comment body) must NOT trigger unblock_tasks."""
+        url, cfg = server
+        payload = {
+            **self._payload(),
+            "action": "closed",
+            "pull_request": {"number": 72, "merged": True},
+        }
+        mock_unblock = MagicMock(return_value=0)
+        WebhookHandler._fn_launch_worker = MagicMock()
+        WebhookHandler._fn_unblock_tasks = mock_unblock
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        mock_unblock.assert_not_called()
 
 
 class TestPopulateMemberships:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -19,6 +19,7 @@ from kennel.tasks import (
     list_tasks,
     remove_task,
     reorder_tasks,
+    unblock_tasks,
     update_task,
 )
 from kennel.types import TaskStatus, TaskType
@@ -305,6 +306,45 @@ class TestRemoveTask:
     def test_returns_false_if_not_found(self, tmp_path: Path) -> None:
         add_task(tmp_path, title="t", task_type=TaskType.SPEC)
         assert not remove_task(tmp_path, "nonexistent")
+
+
+class TestUnblockTasks:
+    def test_unblocks_blocked_tasks(self, tmp_path: Path) -> None:
+        t1 = add_task(tmp_path, title="first", task_type=TaskType.SPEC)
+        t2 = add_task(tmp_path, title="second", task_type=TaskType.SPEC)
+        update_task(tmp_path, t1["id"], TaskStatus.BLOCKED)
+        update_task(tmp_path, t2["id"], TaskStatus.BLOCKED)
+        count = unblock_tasks(tmp_path)
+        assert count == 2
+        tasks = list_tasks(tmp_path)
+        assert all(t["status"] == str(TaskStatus.PENDING) for t in tasks)
+
+    def test_returns_zero_when_nothing_blocked(self, tmp_path: Path) -> None:
+        add_task(tmp_path, title="t", task_type=TaskType.SPEC)
+        assert unblock_tasks(tmp_path) == 0
+
+    def test_does_not_touch_non_blocked_tasks(self, tmp_path: Path) -> None:
+        t1 = add_task(tmp_path, title="pending", task_type=TaskType.SPEC)
+        t2 = add_task(tmp_path, title="done", task_type=TaskType.SPEC)
+        t3 = add_task(tmp_path, title="blocked", task_type=TaskType.SPEC)
+        update_task(tmp_path, t2["id"], TaskStatus.COMPLETED)
+        update_task(tmp_path, t3["id"], TaskStatus.BLOCKED)
+        count = unblock_tasks(tmp_path)
+        assert count == 1
+        tasks = {t["id"]: t for t in list_tasks(tmp_path)}
+        assert tasks[t1["id"]]["status"] == str(TaskStatus.PENDING)
+        assert tasks[t2["id"]]["status"] == str(TaskStatus.COMPLETED)
+        assert tasks[t3["id"]]["status"] == str(TaskStatus.PENDING)
+
+    def test_returns_zero_on_empty_file(self, tmp_path: Path) -> None:
+        assert unblock_tasks(tmp_path) == 0
+
+    def test_tasks_unblock_tasks_method(self, tmp_path: Path) -> None:
+        task = add_task(tmp_path, title="t", task_type=TaskType.SPEC)
+        update_task(tmp_path, task["id"], TaskStatus.BLOCKED)
+        count = Tasks(tmp_path).unblock_tasks()
+        assert count == 1
+        assert list_tasks(tmp_path)[0]["status"] == str(TaskStatus.PENDING)
 
 
 # ── _parse_reorder_response ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #557.

When fido posts a BLOCKED comment on a PR, the worker now detects it, marks the task as blocked, and yields the claude session instead of holding it indefinitely. A new PR comment wakes the worker back up to re-evaluate and resume work.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] Add block subcommand to kennel task CLI <!-- type:spec -->
- [x] Detect BLOCKED in execute_task and yield session instead of completing <!-- type:spec -->
- [x] Update task and resume prompts to use kennel task block <!-- type:spec -->
- [x] Show BLOCKED state in kennel status output <!-- type:spec -->
- [x] Add Tasks.block_by_id() and kennel task block CLI subcommand <!-- type:spec -->
- [x] Detect BLOCKED in execute_task resume loop and yield session <!-- type:spec -->
- [x] Update task/nudge prompts to use kennel task block command <!-- type:spec -->
- [x] Return idle from Worker.run when task is BLOCKED instead of looping <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->