### PR TITLE
Persist session_id across kennel restarts (#649)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -676,6 +676,7 @@ class ClaudeSession:
         popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
         selector: Callable[..., tuple[list[Any], list[Any], list[Any]]] = select.select,
         repo_name: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -696,9 +697,11 @@ class ClaudeSession:
         # Latest session_id seen in a stream-json event.  Updated inside
         # :meth:`iter_events` so a subsequent :meth:`switch_model` can
         # restart with ``--resume <sid>`` and keep conversation context
-        # across the model swap.  Empty until the first claude event with
-        # a session_id arrives.
-        self._session_id = ""
+        # across the model swap.  Seeded from the *session_id* constructor
+        # kwarg so the first :meth:`_spawn` can ``--resume`` a durable
+        # claude conversation persisted across kennel restarts (#649).
+        # Empty until the first claude event with a session_id arrives.
+        self._session_id = session_id or ""
         # True when the most recent :meth:`iter_events` call exited early
         # because :attr:`_cancel` was set (i.e. another thread preempted the
         # turn via :meth:`prompt`).  Cleared at the start of each turn.
@@ -1592,7 +1595,12 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
     def provider_id(self) -> ProviderID:
         return ProviderID.CLAUDE_CODE
 
-    def _spawn_owned_session(self, model: ProviderModel | None = None) -> PromptSession:
+    def _spawn_owned_session(
+        self,
+        model: ProviderModel | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> PromptSession:
         system_file = self._session_system_file
         work_dir = self._work_dir
         assert system_file is not None
@@ -1602,9 +1610,15 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=self._repo_name,
             model=model,
+            session_id=session_id,
         )
 
-    def ensure_session(self, model: ProviderModel | None = None) -> None:
+    def ensure_session(
+        self,
+        model: ProviderModel | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
         created = False
         with self._session_lock:
             session = self._session
@@ -1617,7 +1631,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
                     raise ValueError(
                         "ClaudeClient.ensure_session requires model when creating a session"
                     )
-                session = self._spawn_owned_session(model)
+                session = self._spawn_owned_session(model, session_id=session_id)
                 self._session = session
                 created = True
         if model is None or (created and model == self.voice_model):

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -879,6 +879,7 @@ class CopilotCLISession:
         repo_name: str | None = None,
         runtime: CopilotACPRuntime | None = None,
         runtime_factory: Callable[..., CopilotACPRuntime] | None = None,
+        session_id: str | None = None,
     ) -> None:
         self._work_dir = Path(work_dir)
         self._repo_name = repo_name
@@ -900,7 +901,11 @@ class CopilotCLISession:
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
-        self._session_id: str | None = self._runtime.ensure_session(None, model)
+        # Resume an existing Copilot ACP session when *session_id* is given
+        # (fix for #649 — persisted across kennel restarts in state.json).
+        # When the id is no longer known to Copilot, ensure_session falls
+        # back to creating a fresh session automatically.
+        self._session_id: str | None = self._runtime.ensure_session(session_id, model)
         # Kind the current lock holder is registered under in the shared
         # talker registry (``"worker"`` / ``"webhook"``), or ``None`` when
         # no one is inside the lock.  Set by :meth:`_register_talker_kind`.
@@ -1136,7 +1141,9 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     def provider_id(self) -> ProviderID:
         return ProviderID.COPILOT_CLI
 
-    def _spawn_owned_session(self, model: ProviderModel) -> PromptSession:
+    def _spawn_owned_session(
+        self, model: ProviderModel, *, session_id: str | None = None
+    ) -> PromptSession:
         system_file = self._session_system_file
         work_dir = self._work_dir
         assert system_file is not None
@@ -1146,6 +1153,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             model=model,
             repo_name=self._repo_name,
+            session_id=session_id,
         )
 
     def _should_retry_prompt_failure(

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -290,8 +290,16 @@ class ProviderAgent(Protocol):
         """Detach and return the current persistent session, if any."""
         ...
 
-    def ensure_session(self, model: ProviderModel | None = None) -> None:
-        """Ensure that a persistent session exists, optionally seeded with *model*."""
+    def ensure_session(
+        self,
+        model: ProviderModel | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Ensure that a persistent session exists, optionally seeded with
+        *model* and resumed from *session_id* (for providers that support
+        durable conversation ids — claude ``--resume``, Copilot ACP
+        ``load_session``)."""
         ...
 
     def stop_session(self) -> None:

--- a/kennel/session_agent.py
+++ b/kennel/session_agent.py
@@ -86,7 +86,20 @@ class SessionBackedAgent:
         dropped = getattr(session, "dropped_session_count")
         return dropped if isinstance(dropped, int) and dropped >= 0 else 0
 
-    def ensure_session(self, model: ProviderModel | None = None) -> None:
+    def ensure_session(
+        self,
+        model: ProviderModel | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Ensure a persistent session exists, optionally resuming *session_id*.
+
+        When *session_id* is provided and no session has been created yet,
+        the new session spawns with that id so the provider can resume the
+        prior conversation (claude ``--resume``, Copilot ACP ``load_session``).
+        Ignored when the session already exists.  Fix for #649 — without
+        this, every kennel self-restart drops the conversation context.
+        """
         with self._session_lock:
             session = self._session
             if session is None:
@@ -98,7 +111,7 @@ class SessionBackedAgent:
                     raise ValueError(
                         f"{type(self).__name__}.ensure_session requires model when creating a session"
                     )
-                self._session = self._spawn_owned_session(model)
+                self._session = self._spawn_owned_session(model, session_id=session_id)
                 return
         if model is not None:
             session.switch_model(model)
@@ -164,7 +177,9 @@ class SessionBackedAgent:
         del content, model, system_prompt, retry_on_preempt, session_mode
         raise NotImplementedError
 
-    def _spawn_owned_session(self, model: ProviderModel) -> PromptSession:
+    def _spawn_owned_session(
+        self, model: ProviderModel, *, session_id: str | None = None
+    ) -> PromptSession:
         raise NotImplementedError
 
     def _run_turn_json_value(

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2534,13 +2534,72 @@ class WorkerThread(threading.Thread):
             return provider
 
     def _create_session(self) -> PromptSession:
-        """Eagerly create the persistent provider session for this thread."""
+        """Eagerly create the persistent provider session for this thread.
+
+        Seeds the provider with the durable session id persisted in
+        ``state.json`` so a kennel self-restart can resume the same
+        provider conversation instead of starting fresh (fix for #649).
+        When the persisted id is no longer recognised by the provider
+        (e.g. evicted server-side), the provider's own stale-session
+        recovery path transparently creates a new one.
+        """
         provider = self._ensure_provider()
-        provider.agent.ensure_session(provider.agent.voice_model)
+        persisted_session_id = self._load_persisted_session_id()
+        provider.agent.ensure_session(
+            provider.agent.voice_model, session_id=persisted_session_id
+        )
         session = provider.agent.session
         if session is None:
             raise RuntimeError("provider.ensure_session() returned no session")
         return session
+
+    def _resolve_fido_dir(self) -> Path | None:
+        """Return the ``.git/fido`` directory for this worker's work_dir,
+        or ``None`` when *work_dir* is not a git worktree (e.g. pytest
+        tmp_path fixtures that don't initialise a repo).  Callers that
+        want to read or write ``state.json`` should treat ``None`` as
+        "no persistence available" rather than raising.
+        """
+        try:
+            return _resolve_git_dir(self.work_dir) / "fido"
+        except subprocess.CalledProcessError, FileNotFoundError, OSError:
+            return None
+
+    def _load_persisted_session_id(self) -> str | None:
+        fido_dir = self._resolve_fido_dir()
+        if fido_dir is None:
+            return None
+        try:
+            data = State(fido_dir).load()
+        except OSError:
+            return None
+        sid = data.get("session_id")
+        return sid if isinstance(sid, str) and sid else None
+
+    def _persist_session_id(self) -> None:
+        """Write the live session's durable id back to ``state.json`` so the
+        next kennel run can resume the same provider conversation.  Silently
+        no-ops when no live session / no session id / no persistence target.
+        """
+        with self._provider_lock:
+            provider = self._provider
+        if provider is None:
+            return
+        session = provider.agent.session
+        if session is None:
+            return
+        sid = getattr(session, "session_id", None)
+        if not isinstance(sid, str) or not sid:
+            return
+        fido_dir = self._resolve_fido_dir()
+        if fido_dir is None:
+            return
+        try:
+            with State(fido_dir).modify() as data:
+                if data.get("session_id") != sid:
+                    data["session_id"] = sid
+        except OSError as exc:
+            log.warning("failed to persist session_id: %s", exc)
 
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
@@ -2578,6 +2637,7 @@ class WorkerThread(threading.Thread):
                     with self._provider_lock:
                         self._provider = worker._provider  # pyright: ignore[reportPrivateUsage]
                     self._session_issue = worker._session_issue  # pyright: ignore[reportPrivateUsage]
+                    self._persist_session_id()
 
                 if result == 1:
                     # Did work — loop immediately without waiting.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2432,6 +2432,7 @@ class TestClaudeClientSessionAttachment:
             work_dir=tmp_path,
             repo_name=None,
             model="claude-opus-4-6",
+            session_id=None,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1272,6 +1272,7 @@ class TestCopilotCLIClient:
             work_dir=tmp_path,
             model=client.voice_model,
             repo_name=None,
+            session_id=None,
         )
         session.reset.assert_called_once_with(client.work_model)
         session.switch_model.assert_not_called()
@@ -1307,6 +1308,7 @@ class TestCopilotCLIClient:
             work_dir=tmp_path,
             model=client.voice_model,
             repo_name=None,
+            session_id=None,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -34,7 +34,8 @@ class _FakeAgent(SessionBackedAgent):
             session=session,
         )
 
-    def _spawn_owned_session(self, model: ProviderModel):
+    def _spawn_owned_session(self, model: ProviderModel, *, session_id=None):
+        self._last_session_id = session_id
         return self._session_factory(model)
 
     def run_turn(

--- a/tests/test_worker_persist_session_id.py
+++ b/tests/test_worker_persist_session_id.py
@@ -1,0 +1,165 @@
+"""Tests for session-id persistence in WorkerThread (#649)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from kennel.github import GitHub
+from kennel.worker import WorkerThread
+
+
+def _make_thread(tmp_path: Path, **kwargs) -> WorkerThread:
+    gh = MagicMock(spec=GitHub)
+    return WorkerThread(
+        tmp_path,
+        "owner/repo",
+        gh=gh,
+        **kwargs,
+    )
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    fido_dir = tmp_path / ".git" / "fido"
+    fido_dir.mkdir(parents=True, exist_ok=True)
+    return fido_dir
+
+
+def test_load_persisted_session_id_returns_value(tmp_path: Path) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(json.dumps({"session_id": "abc-123"}))
+    thread = _make_thread(tmp_path)
+    assert thread._load_persisted_session_id() == "abc-123"
+
+
+def test_load_persisted_session_id_none_when_absent(tmp_path: Path) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(json.dumps({"issue": 5}))
+    thread = _make_thread(tmp_path)
+    assert thread._load_persisted_session_id() is None
+
+
+def test_load_persisted_session_id_none_when_not_a_git_repo(tmp_path: Path) -> None:
+    """tmp_path without `git init` — persistence is unavailable but must
+    not crash callers.  Same shape as test fixtures that construct a worker
+    against a bare directory."""
+    thread = _make_thread(tmp_path)
+    assert thread._resolve_fido_dir() is None
+    assert thread._load_persisted_session_id() is None
+
+
+def test_load_persisted_session_id_handles_state_load_oserror(
+    tmp_path: Path, monkeypatch
+) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(json.dumps({"session_id": "abc"}))
+    thread = _make_thread(tmp_path)
+    from kennel import state as state_mod
+
+    def boom(self):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(state_mod.State, "load", boom)
+    assert thread._load_persisted_session_id() is None
+
+
+def test_persist_session_id_writes_new_value(tmp_path: Path) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    session = MagicMock()
+    session.session_id = "new-sid-456"
+    agent = MagicMock()
+    agent.session = session
+    provider = MagicMock()
+    provider.agent = agent
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._persist_session_id()
+    persisted = json.loads((fido_dir / "state.json").read_text())
+    assert persisted["session_id"] == "new-sid-456"
+
+
+def test_persist_session_id_skips_when_unchanged(tmp_path: Path) -> None:
+    """Avoid rewriting state.json when the id hasn't changed — keeps the
+    file's mtime stable and reduces lock contention under steady state."""
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(
+        json.dumps({"session_id": "same-sid", "issue": 1})
+    )
+    mtime_before = (fido_dir / "state.json").stat().st_mtime_ns
+    session = MagicMock()
+    session.session_id = "same-sid"
+    agent = MagicMock()
+    agent.session = session
+    provider = MagicMock()
+    provider.agent = agent
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._persist_session_id()
+    # mtime should not be bumped beyond what State.modify does on read-only
+    # operations — the file content must stay the same.
+    persisted = json.loads((fido_dir / "state.json").read_text())
+    assert persisted == {"session_id": "same-sid", "issue": 1}
+    assert (fido_dir / "state.json").stat().st_mtime_ns >= mtime_before
+
+
+def test_persist_session_id_noop_when_no_provider(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    thread = _make_thread(tmp_path)
+    thread._provider = None  # pyright: ignore[reportPrivateUsage]
+    thread._persist_session_id()  # must not raise
+
+
+def test_persist_session_id_noop_when_no_session(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    provider = MagicMock()
+    provider.agent.session = None
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._persist_session_id()  # must not raise
+
+
+def test_persist_session_id_noop_when_session_has_empty_id(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    session = MagicMock()
+    session.session_id = ""
+    provider = MagicMock()
+    provider.agent.session = session
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._persist_session_id()  # must not raise and must not write
+
+
+def test_persist_session_id_noop_when_fido_dir_unresolvable(tmp_path: Path) -> None:
+    """Not a git repo → no fido_dir → persistence silently skipped."""
+    session = MagicMock()
+    session.session_id = "some-sid"
+    provider = MagicMock()
+    provider.agent.session = session
+    thread = _make_thread(tmp_path, provider=provider)
+    # No git init — resolving fails
+    thread._persist_session_id()  # must not raise
+
+
+def test_persist_session_id_swallows_state_modify_oserror(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    import logging
+
+    _init_git_repo(tmp_path)
+    session = MagicMock()
+    session.session_id = "sid"
+    provider = MagicMock()
+    provider.agent.session = session
+    thread = _make_thread(tmp_path, provider=provider)
+    from contextlib import contextmanager
+
+    from kennel import state as state_mod
+
+    @contextmanager
+    def boom(self):
+        raise OSError("state.json locked by another process")
+        yield  # unreachable
+
+    monkeypatch.setattr(state_mod.State, "modify", boom)
+    with caplog.at_level(logging.WARNING, logger="kennel"):
+        thread._persist_session_id()
+    assert "failed to persist session_id" in caplog.text


### PR DESCRIPTION
Closes #649.

Every kennel self-restart dropped the per-repo provider conversation because \`session_id\` only lived in memory on the session objects. Persist it in \`state.json\` and feed it back on worker startup so the provider resumes the existing conversation instead of cutting a fresh one.

## Changes

- \`ProviderAgent\`/\`SessionBackedAgent.ensure_session\` + \`_spawn_owned_session\` gain an optional \`session_id=\` kwarg.
- \`ClaudeSession.__init__\` accepts \`session_id\`, seeds \`self._session_id\`; first \`_spawn\` uses \`--resume <sid>\`.
- \`CopilotCLISession.__init__\` accepts \`session_id\`, threads it through \`_runtime.ensure_session\`.
- \`WorkerThread._create_session\` loads \`state.json[\"session_id\"]\` and passes to \`ensure_session\`. After each iteration, \`_persist_session_id\` writes the live session's id back. Defensive against tmp_path / non-git dirs and OSError on state.json I/O.

The stale-id recovery paths already existed in both providers (Copilot ACP \`_is_missing_session_error\`, claude \`--resume\` retry on failure). Persistence just gives the fast path a real chance before falling back.

## Test plan

- [x] 11 new tests in \`tests/test_worker_persist_session_id.py\` covering load/persist/no-op/error paths
- [x] Updated existing \`_spawn_owned_session\` assertions to include the new kwarg
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2228 tests, 100% coverage when run directly
- [ ] Pre-commit hook was flaky during commit — CI will confirm
- [ ] After merge: verify orly's \`dropped session\` counter stays at 0 across a kennel self-restart