### PR TITLE
Commit provider leftovers + webhook diagnostic logging (#654)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -1169,8 +1169,15 @@ class ClaudeSession:
                 self._model if model is None else model_name(model),
             )
         self._pending_talker_kind = current_thread_kind()
+        tid = threading.get_ident()
+        t_start = time.monotonic()
         try:
             with self:
+                log.info(
+                    "session.prompt: lock acquired (tid=%d, waited=%.2fs)",
+                    tid,
+                    time.monotonic() - t_start,
+                )
                 if model is not None:
                     self.switch_model(model)
                 if system_prompt:
@@ -1178,7 +1185,16 @@ class ClaudeSession:
                 else:
                     body = content
                 self.send(body)
-                return self.consume_until_result()
+                result = self.consume_until_result()
+                log.info(
+                    "session.prompt: turn complete (tid=%d, total=%.2fs, "
+                    "result_len=%d, cancelled=%s)",
+                    tid,
+                    time.monotonic() - t_start,
+                    len(result or ""),
+                    self._last_turn_cancelled,
+                )
+                return result
         finally:
             # If an exception blew us out of `with self:` before __enter__
             # could clear the event, do it here so a stuck event doesn't

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -939,6 +939,12 @@ def reply_to_issue_comment(
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
     )
+    log.info(
+        "reply generation returned for PR #%s — body_len=%d preview=%r",
+        number,
+        len(body or ""),
+        (body or "")[:80],
+    )
     if not body:
         raise ValueError(
             f"issue-comment reply: run_turn returned empty for PR #{number}"
@@ -946,11 +952,14 @@ def reply_to_issue_comment(
 
     log.info("posting issue comment reply on PR #%s: %s", number, body[:80])
     gh.comment_issue(repo_full, number, body)
-    log.info("reply posted")
+    log.info("reply posted on PR #%s", number)
 
     # Get comment_id from the dispatch payload (stored in context)
     _cid = (action.context or {}).get("comment_id")
     if _cid:
+        log.info(
+            "reply_to_issue_comment: adding reaction on PR #%s comment %s", number, _cid
+        )
         maybe_react(
             comment,
             _cid,
@@ -961,7 +970,15 @@ def reply_to_issue_comment(
             agent=agent,
             prompts=prompts,
         )
+        log.info(
+            "reply_to_issue_comment: reaction path done on PR #%s comment %s",
+            number,
+            _cid,
+        )
 
+    log.info(
+        "reply_to_issue_comment: complete for PR #%s (category=%s)", number, category
+    )
     return (category, titles)
 
 

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -529,6 +529,13 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _process_action(self, action: Action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)
+        tid = threading.get_ident()
+        log.info(
+            "webhook handler: ENTER repo=%s description=%r tid=%d",
+            repo_cfg.name,
+            description,
+            tid,
+        )
         claude.set_thread_repo(repo_cfg.name)
         claude.set_thread_kind("webhook")
         try:
@@ -544,6 +551,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
             )
             os._exit(3)
         finally:
+            log.info(
+                "webhook handler: EXIT repo=%s tid=%d",
+                repo_cfg.name,
+                tid,
+            )
             claude.set_thread_kind(None)
             claude.set_thread_repo(None)
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1622,6 +1622,44 @@ class Worker:
             return False
         return True
 
+    def _commit_provider_leftovers_if_any(
+        self, task_title: str, head_before: str
+    ) -> str:
+        """Commit any uncommitted worktree changes left behind by the provider.
+
+        Copilot in particular sometimes applies patches via ``apply_patch``
+        but never runs ``git commit`` — the worktree diverges from HEAD and
+        the resume loop spins forever waiting for HEAD to move (#654).  If
+        HEAD hasn't moved since *head_before* but ``git status`` reports a
+        dirty worktree, kennel takes ownership and commits everything with a
+        ``wip: <task_title> (provider didn't commit)`` message so the outer
+        loop makes progress.  Returns the current HEAD sha.
+
+        No-op when HEAD already moved (provider committed on its own) or
+        when the worktree is clean (provider produced nothing).
+        """
+        head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
+        if head_after != head_before:
+            return head_after
+        porcelain = self._git(["status", "--porcelain"], check=False)
+        if porcelain.returncode != 0 or not porcelain.stdout.strip():
+            return head_after
+        log.warning(
+            "task produced uncommitted edits but no commit — committing on "
+            "provider's behalf: %s",
+            task_title,
+        )
+        self._git(["add", "-A"])
+        self._git(
+            [
+                "commit",
+                "-m",
+                f"wip: {task_title} (provider didn't commit)",
+            ],
+            check=False,
+        )
+        return self._git(["rev-parse", "HEAD"]).stdout.strip()
+
     def _squash_wip_commit(self, remote: str, slug: str, default_branch: str) -> bool:
         """Drop the empty 'wip: start' sentinel if it is the branch root.
 
@@ -1763,7 +1801,7 @@ class Worker:
             session_mode=self._consume_turn_session_mode(),
         )
         log.info("task done (session=%s)", session_id)
-        head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
+        head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
         if self._abort_task.is_set():
             self._cleanup_aborted_task(fido_dir, task["id"], task_title)
@@ -1838,7 +1876,7 @@ class Worker:
                 session_mode=session_mode,
             )
             log.info("task resume done (session=%s)", session_id)
-            head_after = self._git(["rev-parse", "HEAD"]).stdout.strip()
+            head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
             if self._abort_task.is_set():
                 self._cleanup_aborted_task(fido_dir, task["id"], task_title)

--- a/tests/test_worker_commit_leftovers.py
+++ b/tests/test_worker_commit_leftovers.py
@@ -1,0 +1,142 @@
+"""Tests for Worker._commit_provider_leftovers_if_any (#654)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from kennel.github import GitHub
+from kennel.worker import Worker
+
+
+def _init_repo(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
+    (tmp_path / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True)
+
+
+def _worker(tmp_path: Path) -> Worker:
+    gh = MagicMock(spec=GitHub)
+    return Worker(tmp_path, gh)
+
+
+def _head(tmp_path: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_noop_when_head_already_moved(tmp_path: Path) -> None:
+    """Provider made its own commit → helper returns current HEAD unchanged."""
+    _init_repo(tmp_path)
+    head_before = _head(tmp_path)
+    (tmp_path / "a.txt").write_text("a\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "real provider commit"],
+        cwd=tmp_path,
+        check=True,
+    )
+    worker = _worker(tmp_path)
+    new_head = worker._commit_provider_leftovers_if_any("Fix thing", head_before)
+    assert new_head != head_before
+    # Only one commit was added (no synthetic wip).
+    log = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "provider didn't commit" not in log
+
+
+def test_noop_when_worktree_clean(tmp_path: Path) -> None:
+    """Provider produced nothing — helper returns HEAD unchanged, no commit."""
+    _init_repo(tmp_path)
+    head_before = _head(tmp_path)
+    worker = _worker(tmp_path)
+    new_head = worker._commit_provider_leftovers_if_any("Empty task", head_before)
+    assert new_head == head_before
+    log = (
+        subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    assert len(log) == 1  # just the seed commit
+
+
+def test_commits_uncommitted_modifications(tmp_path: Path) -> None:
+    """Modified files with no commit → helper commits them itself."""
+    _init_repo(tmp_path)
+    head_before = _head(tmp_path)
+    (tmp_path / "seed.txt").write_text("modified\n")
+    worker = _worker(tmp_path)
+    new_head = worker._commit_provider_leftovers_if_any("Fix seed", head_before)
+    assert new_head != head_before
+    # Commit message includes the synthetic marker.
+    msg = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert msg == "wip: Fix seed (provider didn't commit)"
+
+
+def test_commits_untracked_files(tmp_path: Path) -> None:
+    """Untracked files → helper commits them via ``git add -A``."""
+    _init_repo(tmp_path)
+    head_before = _head(tmp_path)
+    (tmp_path / "new.txt").write_text("brand new\n")
+    worker = _worker(tmp_path)
+    new_head = worker._commit_provider_leftovers_if_any("Add new file", head_before)
+    assert new_head != head_before
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "new.txt" in tracked
+
+
+def test_returns_unchanged_head_when_status_fails(tmp_path: Path, monkeypatch) -> None:
+    """If ``git status --porcelain`` itself fails (transient VFS issue etc.),
+    helper returns head_after without attempting a commit — don't crash on
+    a filesystem hiccup; the resume loop's next iteration tries again."""
+    _init_repo(tmp_path)
+    head_before = _head(tmp_path)
+    worker = _worker(tmp_path)
+
+    real_git = worker._git
+
+    def fake_git(args, check=True, **kwargs):
+        if args[:2] == ["status", "--porcelain"]:
+            result = subprocess.CompletedProcess(args, 1, "", "vfs down")
+            return result
+        return real_git(args, check=check, **kwargs)
+
+    monkeypatch.setattr(worker, "_git", fake_git)
+    new_head = worker._commit_provider_leftovers_if_any("Retry", head_before)
+    assert new_head == head_before


### PR DESCRIPTION
Closes #654.

## Fix

When Copilot (or any provider) edits the worktree via \`apply_patch\` but forgets to run \`git commit\`, \`Worker.execute_task\`'s resume loop spins forever waiting for HEAD to move.  Orly PR #50 sat with only a \`wip: start\` sentinel despite five nudge attempts.

\`_commit_provider_leftovers_if_any\` (called after each turn) checks: if HEAD didn't move but \`git status --porcelain\` is non-empty, kennel runs \`git add -A && git commit -m \"wip: <task> (provider didn't commit)\"\` itself.  HEAD moves, the loop exits, the task completes.

## Diagnostics

Added logging to make the hang-after-release webhook pattern traceable without py-spy:

- \`server._process_action\` — ENTER/EXIT with thread id
- \`events.reply_to_issue_comment\` — per-step: generation length, posting, reaction path, complete
- \`claude.ClaudeSession.prompt\` — lock-acquire elapsed, turn-complete elapsed + cancelled flag

## Test plan

- [x] 5 new tests for \`_commit_provider_leftovers_if_any\` (no-op paths + modifications + untracked files + status failure)
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2244 tests, 100% coverage
- [ ] Watch orly after merge: expect \`wip: <task> (provider didn't commit)\` commits on the PR when Copilot stalls
- [ ] Watch next webhook hang to trace the new log lines