### PR TITLE
Worker status should never show 'idle' — always show what it's doing or waiting for (closes #562)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -117,7 +117,7 @@ def _xml_text(value: object) -> str | None:
 def _repo_status(act: dict[str, Any]) -> str:
     """Derive a single status word from activity flags.
 
-    Priority: paused > stuck > crashed > busy > idle.  Used as the ``dog:status``
+    Priority: paused > stuck > crashed > busy > waiting.  Used as the ``dog:status``
     attribute on ``<repo>`` elements so XSLT and CSS can style by state.
     """
     provider_status = act.get("provider_status")
@@ -129,7 +129,7 @@ def _repo_status(act: dict[str, Any]) -> str:
         return "crashed"
     if act.get("busy"):
         return "busy"
-    return "idle"
+    return "waiting"
 
 
 def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -115,10 +115,13 @@ def _xml_text(value: object) -> str | None:
 
 
 def _repo_status(act: dict[str, Any]) -> str:
-    """Derive a single status word from activity flags.
+    """Derive a status string from activity flags.
 
-    Priority: paused > stuck > crashed > busy > waiting.  Used as the ``dog:status``
-    attribute on ``<repo>`` elements so XSLT and CSS can style by state.
+    Priority: paused > stuck > crashed > busy > what (falling back to
+    "waiting").  Used as the ``dog:status`` attribute on ``<repo>`` elements
+    so XSLT and CSS can style by state.  When the worker is not actively busy,
+    the live ``what`` field (e.g. "waiting: no issues found") is used so the
+    attribute carries the specific reason rather than a generic label.
     """
     provider_status = act.get("provider_status")
     if isinstance(provider_status, dict) and provider_status.get("paused"):
@@ -129,7 +132,7 @@ def _repo_status(act: dict[str, Any]) -> str:
         return "crashed"
     if act.get("busy"):
         return "busy"
-    return "waiting"
+    return act.get("what") or "waiting"
 
 
 def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:

--- a/kennel/static/status.css
+++ b/kennel/static/status.css
@@ -72,7 +72,7 @@ card[dog|status="busy"] {
   border-left: 3px solid #1a7f37;
 }
 
-card[dog|status="idle"] {
+card[dog|status="waiting"] {
   border-left: 3px solid #d8dee4;
 }
 

--- a/kennel/static/status.css
+++ b/kennel/static/status.css
@@ -72,7 +72,7 @@ card[dog|status="busy"] {
   border-left: 3px solid #1a7f37;
 }
 
-card[dog|status="waiting"] {
+card[dog|status^="waiting"] {
   border-left: 3px solid #d8dee4;
 }
 

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -710,7 +710,7 @@ def _format_repo_header(repo: RepoStatus) -> str:
     line when crash_count > 0.  If nobody is currently talking to the agent,
     the generic pid/uptime suffix appears on this line.
     """
-    state_word = "running" if repo.fido_running else "idle"
+    state_word = "running" if repo.fido_running else "waiting"
     state_style = GREEN if repo.fido_running else DIM
     stats: list[str] = [_styled_repo_provider(repo)]
     if repo.crash_count > 0:
@@ -784,7 +784,8 @@ def _worker_thread_state(repo: RepoStatus) -> str:
     """Compact string describing what the worker thread itself is doing.
 
     Prefers the richest descriptor available: current task (with position
-    and title) > PR-but-no-task > the live ``worker_what`` field > ``idle``.
+    and title) > PR-but-no-task > the live ``worker_what`` field >
+    ``waiting for work``.
     Never shows webhook-thread activity — that's surfaced separately.
     """
     provider_status = repo.provider_status
@@ -805,9 +806,9 @@ def _worker_thread_state(repo: RepoStatus) -> str:
     if repo.current_task is not None:
         return f"task: {repo.current_task}"
     what = (repo.worker_what or "").strip()
-    if what and what.lower() != "idle":
+    if what:
         return what
-    return "idle"
+    return "waiting for work"
 
 
 def _format_webhook_lines(repo: RepoStatus) -> list[str]:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2647,7 +2647,9 @@ class WorkerThread(threading.Thread):
         try:
             while not self._stop:
                 if self._registry is not None:
-                    self._registry.report_activity(self._repo_name, "idle", busy=False)
+                    self._registry.report_activity(
+                        self._repo_name, "scanning for work", busy=False
+                    )
                 provider = self._ensure_provider()
                 session = provider.agent.session
                 if session is None:
@@ -2681,6 +2683,15 @@ class WorkerThread(threading.Thread):
                     # Did work — loop immediately without waiting.
                     continue
 
+                if self._registry is not None:
+                    waiting_what = (
+                        "waiting: lock held"
+                        if result == 2
+                        else "waiting: no issues found"
+                    )
+                    self._registry.report_activity(
+                        self._repo_name, waiting_what, busy=False
+                    )
                 timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
                 self._wake.wait(timeout=timeout)
                 self._wake.clear()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -474,9 +474,9 @@ class TestRepoStatus:
             ({"is_stuck": True, "crash_count": 2, "busy": True}, "stuck"),
             ({"is_stuck": False, "crash_count": 3, "busy": True}, "crashed"),
             ({"is_stuck": False, "crash_count": 0, "busy": True}, "busy"),
-            ({"is_stuck": False, "crash_count": 0, "busy": False}, "idle"),
+            ({"is_stuck": False, "crash_count": 0, "busy": False}, "waiting"),
         ],
-        ids=["paused", "stuck", "crashed", "busy", "idle"],
+        ids=["paused", "stuck", "crashed", "busy", "waiting"],
     )
     def test_repo_status_priority(self, act: dict, expected: str) -> None:
         assert _repo_status(act) == expected

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -475,8 +475,34 @@ class TestRepoStatus:
             ({"is_stuck": False, "crash_count": 3, "busy": True}, "crashed"),
             ({"is_stuck": False, "crash_count": 0, "busy": True}, "busy"),
             ({"is_stuck": False, "crash_count": 0, "busy": False}, "waiting"),
+            (
+                {
+                    "is_stuck": False,
+                    "crash_count": 0,
+                    "busy": False,
+                    "what": "waiting: no issues found",
+                },
+                "waiting: no issues found",
+            ),
+            (
+                {
+                    "is_stuck": False,
+                    "crash_count": 0,
+                    "busy": False,
+                    "what": "scanning for work",
+                },
+                "scanning for work",
+            ),
         ],
-        ids=["paused", "stuck", "crashed", "busy", "waiting"],
+        ids=[
+            "paused",
+            "stuck",
+            "crashed",
+            "busy",
+            "waiting",
+            "waiting-what",
+            "scanning",
+        ],
     )
     def test_repo_status_priority(self, act: dict, expected: str) -> None:
         assert _repo_status(act) == expected

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1344,8 +1344,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "limits: claude-code 91% (five hour)" in output
-        assert "owner/repo: fido idle — claude-code" in output
-        assert "owner/repo: fido idle — claude-code 91% (five hour)" not in output
+        assert "owner/repo: fido waiting — claude-code" in output
+        assert "owner/repo: fido waiting — claude-code 91% (five hour)" not in output
 
     def test_includes_provider_reset_time_in_summary(self) -> None:
         provider_status = ProviderPressureStatus(
@@ -1387,8 +1387,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "claude-code limits unknown" in output
-        assert "owner/repo: fido idle — claude-code" in output
-        assert "owner/repo: fido idle — claude-code limits unknown" not in output
+        assert "owner/repo: fido waiting — claude-code" in output
+        assert "owner/repo: fido waiting — claude-code limits unknown" not in output
 
     def test_includes_copilot_unknown_summary(self) -> None:
         provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
@@ -1404,8 +1404,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "copilot-cli limits unknown" in output
-        assert "owner/repo: fido idle — copilot-cli" in output
-        assert "owner/repo: fido idle — copilot-cli limits unknown" not in output
+        assert "owner/repo: fido waiting — copilot-cli" in output
+        assert "owner/repo: fido waiting — copilot-cli limits unknown" not in output
 
     def test_kennel_up_no_uptime(self) -> None:
         status = KennelStatus(kennel_pid=12345, kennel_uptime=None, repos=[])
@@ -1424,7 +1424,7 @@ class TestFormatStatus:
             repos=[self._repo(name="owner/myrepo")],
         )
         output = format_status(status)
-        assert "owner/myrepo: fido idle" in output
+        assert "owner/myrepo: fido waiting" in output
         assert "no assigned issues" in output
 
     def test_repo_fido_running_no_issue(self) -> None:
@@ -1511,8 +1511,8 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue: #3" in output
-        # No task → Worker line shows idle
-        assert "Worker: idle" in output
+        # No task → Worker line shows waiting for work
+        assert "Worker: waiting for work" in output
 
     def test_claude_pid_on_worker_summary_when_no_talker(self) -> None:
         """Runtime stats ride the repo summary when nobody is currently talking."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10064,7 +10064,8 @@ class TestWorkerThread:
         assert captured[0] is wt._abort_task
 
     def test_heartbeat_emitted_each_iteration(self, tmp_path: Path) -> None:
-        """report_activity is called at the top of each loop iteration."""
+        """report_activity is called twice per loop iteration: 'scanning for work'
+        at the top, and 'waiting: no issues found' before the wake wait."""
         mock_registry = MagicMock()
         wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), registry=mock_registry)
         wt._wake = MagicMock()
@@ -10081,10 +10082,34 @@ class TestWorkerThread:
             self._run_thread(wt)
 
         assert call_count == 2
-        assert mock_registry.report_activity.call_count == 2
-        for c in mock_registry.report_activity.call_args_list:
+        # Two calls per iteration: "scanning for work" then "waiting: no issues found"
+        calls = mock_registry.report_activity.call_args_list
+        assert len(calls) == 4
+        for c in calls:
             assert c.args[0] == "owner/repo"
             assert c.kwargs.get("busy") is False or c.args[2] is False
+        assert calls[0].args[1] == "scanning for work"
+        assert calls[1].args[1] == "waiting: no issues found"
+        assert calls[2].args[1] == "scanning for work"
+        assert calls[3].args[1] == "waiting: no issues found"
+
+    def test_waiting_lock_held_reported_on_result_2(self, tmp_path: Path) -> None:
+        """Return 2 (lock held) reports 'waiting: lock held' before the wake wait."""
+        mock_registry = MagicMock()
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), registry=mock_registry)
+        wt._wake = MagicMock()
+
+        def fake_worker_run(self_ignored=None) -> int:
+            wt._stop = True
+            return 2
+
+        with patch.object(Worker, "run", fake_worker_run):
+            self._run_thread(wt)
+
+        calls = mock_registry.report_activity.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args[1] == "scanning for work"
+        assert calls[1].args[1] == "waiting: lock held"
 
     def test_heartbeat_not_emitted_when_no_registry(self, tmp_path: Path) -> None:
         """WorkerThread without a registry must not crash on the heartbeat path."""


### PR DESCRIPTION
Fixes #562.

Replaces all bare "idle" worker status reports with descriptive activity strings so `kennel status` always shows what a worker is actually doing or waiting for. Updates the source (WorkerThread activity reporting), the display layer (status formatting fallbacks), and the server XML `dog:status` attribute to carry the specific waiting reason rather than a generic label.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] PR comment: make server XML dog:status more specific than bare waiting <!-- type:spec -->
- [x] Report descriptive activity from WorkerThread instead of bare idle <!-- type:spec -->
- [x] Replace idle fallbacks in status display and server XML with descriptive states <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->