### PR TITLE
Hold ClaudeSession lock across whole webhook handler (#658)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -12,6 +12,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -733,6 +734,10 @@ class ClaudeSession:
         # :meth:`__enter__` can register the talker with the correct kind
         # (``"worker"`` vs ``"webhook"``).  Cleared inside :meth:`__enter__`.
         self._pending_talker_kind: Literal["worker", "webhook"] | None = None
+        # Per-thread reentrance counter for the ``with self:`` context so
+        # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
+        # without double-registering the talker (fix for #658).
+        self._entry_tls: threading.local = threading.local()
         # Wakeup pipe: writing a byte to _wakeup_w kicks select() out of its
         # blocking wait in iter_events() so the cancel signal is noticed
         # immediately instead of waiting up to _SELECT_POLL_INTERVAL.
@@ -932,6 +937,12 @@ class ClaudeSession:
         :func:`get_talker` — whether they may preempt (fix for #637:
         webhooks must not preempt each other).
 
+        Supports reentrance via :meth:`hold_for_handler` (#658): when the
+        current thread is already inside a hold-for-handler block, the
+        RLock is re-acquired and the talker is NOT re-registered.  The
+        outermost entry owns the registration and unregisters in
+        :meth:`__exit__` when its depth returns to zero.
+
         Does *not* clear the cancel event — that is deferred to
         :meth:`iter_events` so a signal that lands between one holder's
         :meth:`__exit__` and the next holder's :meth:`iter_events` is not
@@ -946,33 +957,66 @@ class ClaudeSession:
         # We hold the lock now; any preempter waiting on this
         # (wait_for_pending_preempt) can wake.
         self._preempt_pending.clear()
-        kind = self._pending_talker_kind or current_thread_kind()
-        self._pending_talker_kind = None
-        if self._repo_name is not None:
-            try:
-                register_talker(
-                    ClaudeTalker(
-                        repo_name=self._repo_name,
-                        thread_id=threading.get_ident(),
-                        kind=kind,
-                        description="persistent session turn",
-                        claude_pid=self._proc.pid,
-                        started_at=_talker_now(),
+        depth = getattr(self._entry_tls, "depth", 0)
+        if depth == 0:
+            kind = self._pending_talker_kind or current_thread_kind()
+            self._pending_talker_kind = None
+            if self._repo_name is not None:
+                try:
+                    register_talker(
+                        ClaudeTalker(
+                            repo_name=self._repo_name,
+                            thread_id=threading.get_ident(),
+                            kind=kind,
+                            description="persistent session turn",
+                            claude_pid=self._proc.pid,
+                            started_at=_talker_now(),
+                        )
                     )
-                )
-            except ClaudeLeakError:
-                self._lock.release()
-                raise
+                except ClaudeLeakError:
+                    self._lock.release()
+                    raise
+        self._entry_tls.depth = depth + 1
         return self
 
     def __exit__(self, *args: object) -> None:
         """Release the session lock.  Unregisters the :class:`ClaudeTalker`
         before releasing the lock so no other thread can race in and see our
-        stale talker entry.
+        stale talker entry.  When called from within a :meth:`hold_for_handler`
+        (#658), only decrements the per-thread reentrance counter — the
+        outermost exit unregisters and fully releases.
         """
-        if self._repo_name is not None:
-            unregister_talker(self._repo_name, threading.get_ident())
+        depth = self._entry_tls.depth - 1
+        if depth == 0:
+            if self._repo_name is not None:
+                unregister_talker(self._repo_name, threading.get_ident())
+            self._entry_tls.depth = 0
+        else:
+            self._entry_tls.depth = depth
         self._lock.release()
+
+    @contextmanager
+    def hold_for_handler(
+        self, *, preempt_worker: bool = False
+    ) -> Iterator["ClaudeSession"]:
+        """Hold the session lock across multiple :meth:`prompt` calls.
+
+        Webhook handlers wrap their entire body in this so the worker can't
+        acquire the lock between individual turns (triage → reply →
+        reaction) and stall the reply behind a long worker turn (#658).
+        Inner :meth:`prompt` / ``with session:`` calls see a non-zero
+        reentrance depth and skip talker re-registration; the RLock handles
+        reentrant acquisition natively.
+
+        When *preempt_worker* is true, the caller's :attr:`_fire_worker_cancel`
+        fires once on entry so a currently-running worker turn is aborted
+        immediately instead of being waited out before the lock is acquired.
+        """
+        if preempt_worker:
+            try_preempt_worker(self._repo_name, self._fire_worker_cancel)
+        self._pending_talker_kind = current_thread_kind()
+        with self:
+            yield self
 
     def send(self, content: str) -> None:
         """Write a user message to the session stdin, flushing immediately.

--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -12,15 +12,16 @@ import threading
 import time
 import uuid
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
 import requests as _requests
 
+from kennel import provider
 from kennel.provider import (
+    OwnedSession,
     PromptSession,
     Provider,
     ProviderAgent,
@@ -95,224 +96,11 @@ def _unregister_child(proc: subprocess.Popen[str]) -> None:
         _active_children.discard(proc)
 
 
-# ── Claude-talker registry ────────────────────────────────────────────────────
-# At most one thread per repo may be "talking to" a claude subprocess at any
-# moment — either via the persistent :class:`ClaudeSession` lock or via a
-# one-shot ``claude --print`` (streaming or batch).  Concurrent registration
-# for the same repo means something is leaking a sub-claude and we halt loud
-# rather than silently proliferate processes.
-
-
-class ClaudeLeakError(RuntimeError):
-    """Raised when a second thread tries to talk to claude for a repo that
-    already has an active talker.  Fatal — kennel halts rather than let
-    sub-claudes multiply silently."""
-
-
-@dataclass(frozen=True)
-class ClaudeTalker:
-    """Snapshot of the thread currently driving a claude subprocess.
-
-    *thread_id* is :func:`threading.get_ident` — a globally-unique integer
-    identifier for the live thread, used to match this talker entry to a
-    specific thread (e.g. a webhook handler's :class:`WebhookActivity`) when
-    rendering status.  The human-readable thread name is looked up at
-    display time rather than cached here.
-
-    *kind* distinguishes between the persistent session path (``"worker"`` —
-    the worker thread is inside a ``with session:`` block) and one-shot
-    ``claude --print`` invocations from a webhook handler (``"webhook"``).
-    *description* is a short human label for status display.
-    """
-
-    repo_name: str
-    thread_id: int
-    kind: Literal["worker", "webhook"]
-    description: str
-    claude_pid: int
-    started_at: datetime
-
-
-_talkers: dict[str, ClaudeTalker] = {}
-_talkers_lock = threading.Lock()
-
-# Thread-local repo_name so downstream one-shot claude calls know which
-# repo they belong to without plumbing repo_name through every helper in
-# :mod:`kennel.events`.  Set at :func:`kennel.server.WebhookHandler._process_action`
-# entry and at :meth:`kennel.worker.WorkerThread.run` entry, cleared on
-# exit.  Reads fall back to ``None`` in tests and tools that do not set it.
-_thread_local: threading.local = threading.local()
-
-
-def set_thread_repo(repo_name: str | None) -> None:
-    """Set (or clear, with ``None``) the repo_name for this thread."""
-    if repo_name is None:
-        if hasattr(_thread_local, "repo_name"):
-            del _thread_local.repo_name
-    else:
-        _thread_local.repo_name = repo_name
-
-
-def current_repo() -> str | None:
-    """Return the repo_name set by :func:`set_thread_repo` on this thread."""
-    return getattr(_thread_local, "repo_name", None)
-
-
-def set_thread_kind(kind: Literal["worker", "webhook"] | None) -> None:
-    """Set (or clear, with ``None``) the caller kind for this thread.
-
-    Workers call this with ``"worker"`` at :meth:`WorkerThread.run` entry; the
-    webhook handler calls it with ``"webhook"`` at ``_process_action`` entry.
-    :meth:`ClaudeSession.prompt` consults it to decide whether its preempt
-    signal (cancel + ``control_request``) should fire: webhooks preempt
-    workers, workers and webhooks never preempt a running webhook (fix for
-    #637 — without this guard a burst of webhooks cancel each other and
-    nobody's reply lands).
-    """
-    if kind is None:
-        if hasattr(_thread_local, "kind"):
-            del _thread_local.kind
-    else:
-        _thread_local.kind = kind
-
-
-def current_thread_kind() -> Literal["worker", "webhook"]:
-    """Return the caller kind for this thread.  Defaults to ``"worker"``
-    when not set (non-entry code paths and tests)."""
-    return getattr(_thread_local, "kind", "worker")
-
-
-def try_preempt_worker(
-    repo_name: str | None, cancel_fn: Callable[[], None]
-) -> tuple[bool, Literal["worker", "webhook"] | None]:
-    """Invoke *cancel_fn* iff the calling thread is a webhook AND the
-    session's current lock holder is a worker.  Otherwise do nothing.
-
-    Returns ``(preempted, current_kind)`` — *preempted* is ``True`` only when
-    *cancel_fn* was invoked; *current_kind* is the current holder's kind
-    (``"worker"``, ``"webhook"``, or ``None`` when the session is idle).
-    The caller uses that triple to log the outcome ("preempting worker" vs
-    "queuing behind <kind>").
-
-    Provider-neutral decision gate for #637.  The *mechanism* of cancelling a
-    running turn differs across providers (stream-json ``control_request``
-    for claude, ACP ``cancel(session_id)`` for copilot), but the *decision*
-    is identical and lives here.  Worker callers never preempt anyone;
-    webhooks queue behind other webhooks (FIFO on the session lock) instead
-    of cancelling each other.
-    """
-    caller_kind = current_thread_kind()
-    current = get_talker(repo_name) if repo_name is not None else None
-    current_kind = current.kind if current is not None else None
-    if caller_kind == "webhook" and current_kind == "worker":
-        cancel_fn()
-        return True, current_kind
-    return False, current_kind
-
-
-def register_talker(talker: ClaudeTalker) -> None:
-    """Register *talker* as the active claude driver for its repo.
-
-    Raises :class:`ClaudeLeakError` if a talker for the same repo is already
-    registered — the guarantee is one claude per repo at a time.
-    """
-    with _talkers_lock:
-        existing = _talkers.get(talker.repo_name)
-        if existing is not None:
-            raise ClaudeLeakError(
-                f"claude leak for repo {talker.repo_name}: "
-                f"tid={existing.thread_id} ({existing.kind}, "
-                f"{existing.description}, pid={existing.claude_pid}) "
-                f"still active when tid={talker.thread_id} ({talker.kind}, "
-                f"{talker.description}, pid={talker.claude_pid}) tried to start"
-            )
-        _talkers[talker.repo_name] = talker
-
-
-def unregister_talker(repo_name: str, thread_id: int) -> None:
-    """Remove the talker entry for *repo_name* if it belongs to *thread_id*.
-
-    Idempotent — safe to call from cleanup paths that may race the registry.
-    Non-matching ``thread_id`` is a no-op (defensive against cross-thread
-    cleanup bugs).
-    """
-    with _talkers_lock:
-        existing = _talkers.get(repo_name)
-        if existing is not None and existing.thread_id == thread_id:
-            del _talkers[repo_name]
-
-
-def get_talker(repo_name: str) -> ClaudeTalker | None:
-    """Return the active talker for *repo_name*, or ``None`` if idle."""
-    with _talkers_lock:
-        return _talkers.get(repo_name)
-
-
-def _talker_now() -> datetime:
-    """Seam for tests — override this module attribute to freeze time."""
-    return datetime.now(tz=timezone.utc)
-
-
-_session_resolver: Callable[[str], PromptSession | None] | None = None
-"""Callback the event/webhook layer uses to find its repo's persistent
-:class:`ClaudeSession` — installed once by :mod:`kennel.server` at startup.
-
-Every in-process prompt call goes through the persistent session, so
-this is a required piece of wiring.  Callers (:meth:`ClaudeClient.run_turn`) fail
-loud if it's missing — the only time that should happen is a forgotten
-resolver install, not a real production path."""
-
-
-def set_session_resolver(
-    resolver: Callable[[str], PromptSession | None] | None,
-) -> None:
-    """Install (or clear) the session resolver callback."""
-    global _session_resolver
-    _session_resolver = resolver
-
-
-def current_repo_session() -> PromptSession:
-    """Return the live :class:`ClaudeSession` driving the current thread's repo.
-
-    Production always has both a thread-local ``repo_name`` (set by
-    :func:`set_thread_repo` in the worker thread and webhook handler
-    entrypoints) and an installed :func:`set_session_resolver` callback,
-    and every worker reaches this code after :meth:`Worker.create_session`
-    has populated the session.  So this raises rather than falling back —
-    a missing session is a wiring bug, not a condition callers should
-    paper over.
-    """
-    repo = current_repo()
-    if repo is None:
-        raise RuntimeError(
-            "ClaudeClient.run_turn called without a thread-local repo_name"
-            " — server.WebhookHandler._process_action and WorkerThread.run"
-            " both set it; this caller is missing the install."
-        )
-    if _session_resolver is None:
-        raise RuntimeError(
-            "ClaudeClient.run_turn called before set_session_resolver — "
-            "server._run() installs it at startup; nothing should run before."
-        )
-    session = _session_resolver(repo)
-    if session is None:
-        raise RuntimeError(
-            f"no ClaudeSession registered for repo {repo} — worker thread "
-            "has not yet created its session"
-        )
-    if not session.is_alive():
-        raise RuntimeError(
-            f"ClaudeSession for repo {repo} is not alive — watchdog should "
-            "have restarted the worker thread"
-        )
-    return session
-
-
 def _thread_name_for_id(thread_id: int) -> str | None:
     """Return the human-readable name of the live thread with *thread_id*,
     or ``None`` if that thread has exited.
 
-    Used by status display to render a :class:`ClaudeTalker`'s thread
+    Used by status display to render a :class:`provider.SessionTalker`'s thread
     without caching the name in the registry — a dead thread's entry is
     already being cleaned up and the name would be stale.
     """
@@ -589,18 +377,18 @@ def _run_streaming(
     )
     _register_child(proc)
     assert proc.stdout is not None  # guaranteed by stdout=PIPE
-    repo_name = current_repo()
+    repo_name = provider.current_repo()
     thread_id = threading.get_ident()
     talker_registered = False
     if repo_name is not None:
-        register_talker(
-            ClaudeTalker(
+        provider.register_talker(
+            provider.SessionTalker(
                 repo_name=repo_name,
                 thread_id=thread_id,
                 kind="webhook",
                 description=f"one-shot claude --print (pid {proc.pid})",
                 claude_pid=proc.pid,
-                started_at=_talker_now(),
+                started_at=provider.talker_now(),
             )
         )
         talker_registered = True
@@ -634,14 +422,14 @@ def _run_streaming(
             raise ClaudeStreamError(proc.returncode)
     finally:
         if talker_registered and repo_name is not None:
-            unregister_talker(repo_name, thread_id)
+            provider.unregister_talker(repo_name, thread_id)
         _unregister_child(proc)
 
 
 # ── Persistent bidirectional session ─────────────────────────────────────────
 
 
-class ClaudeSession:
+class ClaudeSession(OwnedSession):
     """A long-lived claude process driven via bidirectional stream-json.
 
     Spawns ``claude --input-format stream-json --output-format stream-json``
@@ -737,7 +525,7 @@ class ClaudeSession:
         # Per-thread reentrance counter for the ``with self:`` context so
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).
-        self._entry_tls: threading.local = threading.local()
+        self._init_handler_reentry()
         # Wakeup pipe: writing a byte to _wakeup_w kicks select() out of its
         # blocking wait in iter_events() so the cancel signal is noticed
         # immediately instead of waiting up to _SELECT_POLL_INTERVAL.
@@ -805,7 +593,7 @@ class ClaudeSession:
 
     @property
     def repo_name(self) -> str | None:
-        """Repo this session belongs to, for :class:`ClaudeTalker` registration."""
+        """Repo this session belongs to, for :class:`provider.SessionTalker` registration."""
         return self._repo_name
 
     @property
@@ -915,7 +703,7 @@ class ClaudeSession:
     def owner(self) -> str | None:
         """Name of the thread currently holding the session lock, or ``None``.
 
-        Derived from the global :class:`ClaudeTalker` registry so reads are
+        Derived from the global :class:`provider.SessionTalker` registry so reads are
         always serialized through ``_talkers_lock`` — correct under the
         free-threaded (3.14t) runtime without relying on the GIL.  Returns
         ``None`` for sessions without a ``repo_name`` (unit-test fixtures)
@@ -923,7 +711,7 @@ class ClaudeSession:
         """
         if self._repo_name is None:
             return None
-        talker = get_talker(self._repo_name)
+        talker = provider.get_talker(self._repo_name)
         if talker is None or talker.kind != "worker":
             return None
         return _thread_name_for_id(talker.thread_id)
@@ -931,92 +719,58 @@ class ClaudeSession:
     def __enter__(self) -> "ClaudeSession":
         """Acquire the session lock, serializing send/receive across threads.
 
-        Registers a :class:`ClaudeTalker` with the kind set by :meth:`prompt`
-        via :attr:`_pending_talker_kind` (falling back to the thread-local
-        kind otherwise).  The talker kind lets other threads tell — via
-        :func:`get_talker` — whether they may preempt (fix for #637:
-        webhooks must not preempt each other).
-
-        Supports reentrance via :meth:`hold_for_handler` (#658): when the
-        current thread is already inside a hold-for-handler block, the
-        RLock is re-acquired and the talker is NOT re-registered.  The
-        outermost entry owns the registration and unregisters in
-        :meth:`__exit__` when its depth returns to zero.
+        On the outermost entry (via the :class:`OwnedSession`
+        reentrance counter), registers a :class:`provider.SessionTalker` with the
+        kind set by :meth:`prompt` via :attr:`_pending_talker_kind`
+        (falling back to the thread-local kind otherwise).  Nested entries
+        (from :meth:`hold_for_handler`) re-acquire the RLock and skip the
+        talker re-registration.
 
         Does *not* clear the cancel event — that is deferred to
         :meth:`iter_events` so a signal that lands between one holder's
         :meth:`__exit__` and the next holder's :meth:`iter_events` is not
         silently dropped.
 
-        Raises :class:`ClaudeLeakError` if another thread is already
-        registered as the talker for this repo — indicates a sub-claude is
-        leaking.  On leak, the session lock is released before raising so the
-        holder we would have taken over from does not deadlock.
+        Raises :class:`provider.SessionLeakError` on the outermost entry if another
+        thread is already registered as the talker for this repo.  The
+        session lock is released before raising so the prior holder isn't
+        deadlocked.
         """
         self._lock.acquire()
         # We hold the lock now; any preempter waiting on this
         # (wait_for_pending_preempt) can wake.
         self._preempt_pending.clear()
-        depth = getattr(self._entry_tls, "depth", 0)
-        if depth == 0:
-            kind = self._pending_talker_kind or current_thread_kind()
+        depth = self._bump_entry_depth()
+        if depth == 1:
+            kind = self._pending_talker_kind or provider.current_thread_kind()
             self._pending_talker_kind = None
             if self._repo_name is not None:
                 try:
-                    register_talker(
-                        ClaudeTalker(
+                    provider.register_talker(
+                        provider.SessionTalker(
                             repo_name=self._repo_name,
                             thread_id=threading.get_ident(),
                             kind=kind,
                             description="persistent session turn",
                             claude_pid=self._proc.pid,
-                            started_at=_talker_now(),
+                            started_at=provider.talker_now(),
                         )
                     )
-                except ClaudeLeakError:
+                except provider.SessionLeakError:
+                    self._drop_entry_depth()
                     self._lock.release()
                     raise
-        self._entry_tls.depth = depth + 1
         return self
 
     def __exit__(self, *args: object) -> None:
-        """Release the session lock.  Unregisters the :class:`ClaudeTalker`
-        before releasing the lock so no other thread can race in and see our
-        stale talker entry.  When called from within a :meth:`hold_for_handler`
-        (#658), only decrements the per-thread reentrance counter — the
-        outermost exit unregisters and fully releases.
+        """Release the session lock.  Unregisters the :class:`provider.SessionTalker`
+        before releasing the lock on the outermost exit so no other thread
+        can race in and see our stale talker entry.
         """
-        depth = self._entry_tls.depth - 1
-        if depth == 0:
-            if self._repo_name is not None:
-                unregister_talker(self._repo_name, threading.get_ident())
-            self._entry_tls.depth = 0
-        else:
-            self._entry_tls.depth = depth
+        depth = self._drop_entry_depth()
+        if depth == 0 and self._repo_name is not None:
+            provider.unregister_talker(self._repo_name, threading.get_ident())
         self._lock.release()
-
-    @contextmanager
-    def hold_for_handler(
-        self, *, preempt_worker: bool = False
-    ) -> Iterator["ClaudeSession"]:
-        """Hold the session lock across multiple :meth:`prompt` calls.
-
-        Webhook handlers wrap their entire body in this so the worker can't
-        acquire the lock between individual turns (triage → reply →
-        reaction) and stall the reply behind a long worker turn (#658).
-        Inner :meth:`prompt` / ``with session:`` calls see a non-zero
-        reentrance depth and skip talker re-registration; the RLock handles
-        reentrant acquisition natively.
-
-        When *preempt_worker* is true, the caller's :attr:`_fire_worker_cancel`
-        fires once on entry so a currently-running worker turn is aborted
-        immediately instead of being waited out before the lock is acquired.
-        """
-        if preempt_worker:
-            try_preempt_worker(self._repo_name, self._fire_worker_cancel)
-        self._pending_talker_kind = current_thread_kind()
-        with self:
-            yield self
 
     def send(self, content: str) -> None:
         """Write a user message to the session stdin, flushing immediately.
@@ -1195,7 +949,7 @@ class ClaudeSession:
         lingering boundary events from the aborted turn), and
         :meth:`consume_until_result`.
         """
-        preempted, current_kind = try_preempt_worker(
+        preempted, current_kind = provider.try_preempt_worker(
             self._repo_name, self._fire_worker_cancel
         )
         if preempted:
@@ -1212,7 +966,7 @@ class ClaudeSession:
                 threading.get_ident(),
                 self._model if model is None else model_name(model),
             )
-        self._pending_talker_kind = current_thread_kind()
+        self._pending_talker_kind = provider.current_thread_kind()
         tid = threading.get_ident()
         t_start = time.monotonic()
         try:
@@ -1628,7 +1382,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
     def __init__(
         self,
         runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
-        session_fn: Callable[[], PromptSession] = current_repo_session,
+        session_fn: Callable[[], PromptSession] = provider.current_repo_session,
         streaming_runner: Callable[..., Iterator[str]] = _run_streaming,
         sleep_fn: Callable[[float], None] = time.sleep,
         session_factory: Callable[..., PromptSession] | None = None,

--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -33,8 +33,9 @@ from acp.schema import (
     ToolCallUpdate,
 )
 
-from kennel import claude
+from kennel import provider
 from kennel.provider import (
+    OwnedSession,
     PromptSession,
     Provider,
     ProviderAgent,
@@ -867,7 +868,7 @@ class CopilotACPRuntime:
         self._loop.close()
 
 
-class CopilotCLISession:
+class CopilotCLISession(OwnedSession):
     """Persistent Copilot CLI ACP session."""
 
     def __init__(
@@ -892,7 +893,8 @@ class CopilotCLISession:
         else:
             factory = CopilotACPRuntime if runtime_factory is None else runtime_factory
             self._runtime = factory(work_dir=self._work_dir, repo_name=repo_name)
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._init_handler_reentry()
         self._owner_lock = threading.Lock()
         self._owner: str | None = None
         self._pending_preempts = 0
@@ -987,7 +989,7 @@ class CopilotCLISession:
 
     def _fire_worker_cancel(self) -> None:
         """Provider-specific cancel mechanism handed to
-        :func:`claude.try_preempt_worker`.  Asks the Copilot ACP runtime to
+        :func:`provider.try_preempt_worker`.  Asks the Copilot ACP runtime to
         cancel the currently-active prompt so the worker's turn returns with
         ``stop_reason="cancelled"`` and releases the session lock.  No-op if
         there is no active session id or the runtime is already down.
@@ -997,6 +999,13 @@ class CopilotCLISession:
             self._runtime.cancel(session_id)
 
     def __enter__(self) -> "CopilotCLISession":
+        if getattr(self._reentry_tls, "depth", 0) > 0:
+            # Reentrant call from within :meth:`hold_for_handler` — RLock
+            # handles the nested acquire; owner and talker state stay owned
+            # by the outermost entry.
+            self._lock.acquire()
+            self._bump_entry_depth()
+            return self
         waited = not self._lock.acquire(blocking=False)
         if waited:
             with self._preempt_condition:
@@ -1005,17 +1014,18 @@ class CopilotCLISession:
             # worker — matches the shared decision gate used for claude.
             # Another webhook waiting behind a webhook just queues on the
             # lock; workers never cancel anyone.
-            claude.try_preempt_worker(self._repo_name, self._fire_worker_cancel)
+            provider.try_preempt_worker(self._repo_name, self._fire_worker_cancel)
             self._lock.acquire()
         self._thread_state.waited = waited
         with self._owner_lock:
             self._owner = threading.current_thread().name
         self._register_talker_kind()
+        self._bump_entry_depth()
         return self
 
     def _register_talker_kind(self) -> None:
         """Register this thread with the shared talker registry so other
-        threads can tell, via :func:`claude.get_talker`, whether the current
+        threads can tell, via :func:`provider.get_talker`, whether the current
         lock holder is a worker or a webhook.  Matches what
         :meth:`ClaudeSession.__enter__` does for the claude provider.
 
@@ -1025,10 +1035,10 @@ class CopilotCLISession:
         if self._repo_name is None:
             self._registered_talker_kind = None
             return
-        kind = claude.current_thread_kind()
+        kind = provider.current_thread_kind()
         try:
-            claude.register_talker(
-                claude.ClaudeTalker(
+            provider.register_talker(
+                provider.SessionTalker(
                     repo_name=self._repo_name,
                     thread_id=threading.get_ident(),
                     kind=kind,
@@ -1038,13 +1048,19 @@ class CopilotCLISession:
                 )
             )
             self._registered_talker_kind = kind
-        except claude.ClaudeLeakError:
+        except provider.SessionLeakError:
             self._lock.release()
             raise
 
     def __exit__(self, *args: object) -> None:
+        if self._drop_entry_depth() > 0:
+            # Inner exit of a :meth:`hold_for_handler` nest — only drop
+            # the reentrant RLock acquire; owner / talker / waited state
+            # stays until the outermost exit.
+            self._lock.release()
+            return
         if self._repo_name is not None and self._registered_talker_kind is not None:
-            claude.unregister_talker(self._repo_name, threading.get_ident())
+            provider.unregister_talker(self._repo_name, threading.get_ident())
             self._registered_talker_kind = None
         with self._owner_lock:
             self._owner = None
@@ -1128,7 +1144,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             CopilotCLISession if session_factory is None else session_factory
         )
         super().__init__(
-            session_fn=claude.current_repo_session
+            session_fn=provider.current_repo_session
             if session_fn is None
             else session_fn,
             session_system_file=session_system_file,

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -11,11 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from kennel import reply_promises
-from kennel.claude import ClaudeClient, set_thread_repo
+from kennel.claude import ClaudeClient
 from kennel.config import Config, RepoConfig
 from kennel.github import GitHub
 from kennel.prompts import NO_TOOLS_CLAUSE, Prompts
-from kennel.provider import ProviderAgent
+from kennel.provider import ProviderAgent, set_thread_repo
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.registry import WorkerRegistry
 from kennel.state import State

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -1,9 +1,22 @@
-"""Provider contracts and normalized provider-limit state."""
+"""Provider contracts and normalized provider-limit state.
+
+Also home to provider-neutral session coordination primitives:
+talker registry, thread-kind / thread-repo plumbing, preempt decision
+gate, and :class:`OwnedSession` — the base class both
+:class:`~kennel.claude.ClaudeSession` and
+:class:`~kennel.copilotcli.CopilotCLISession` inherit from.  These all
+used to live in :mod:`kennel.claude` under ``Claude``-prefixed names
+from before the copilot provider existed; they were moved here once both
+providers needed them so the naming stopped lying about scope.
+"""
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import StrEnum
 from pathlib import Path
 from typing import Literal, Protocol, TypeAlias
@@ -238,6 +251,295 @@ class PromptSession(Protocol):
     def __exit__(self, *args: object) -> None:
         """Exit the session's turn-serialization context."""
         ...
+
+    def hold_for_handler(
+        self, *, preempt_worker: bool = False
+    ) -> "contextmanager[PromptSession]":  # type: ignore[type-arg]
+        """Hold the session lock across multiple prompt calls for webhook
+        handlers.  Implemented by :class:`OwnedSession` (fix for
+        #658)."""
+        ...
+
+
+# ── Provider-neutral session coordination ────────────────────────────────────
+# At most one thread per repo may be "talking to" a provider subprocess at any
+# moment — either via the persistent session's lock or via a one-shot
+# provider invocation.  Concurrent registration for the same repo means
+# something is leaking a sub-provider and we halt loud rather than silently
+# proliferate processes.
+
+
+class SessionLeakError(RuntimeError):
+    """Raised when a second thread tries to talk to a provider for a repo
+    that already has an active talker.  Fatal — kennel halts rather than
+    let provider subprocesses multiply silently."""
+
+
+@dataclass(frozen=True)
+class SessionTalker:
+    """Snapshot of the thread currently driving a provider subprocess.
+
+    *thread_id* is :func:`threading.get_ident` — a globally-unique integer
+    identifier for the live thread, used to match this talker entry to a
+    specific thread (e.g. a webhook handler's ``WebhookActivity``) when
+    rendering status.  The human-readable thread name is looked up at
+    display time rather than cached here.
+
+    *kind* distinguishes between the persistent session path (``"worker"`` —
+    the worker thread is inside a ``with session:`` block) and webhook
+    handler invocations (``"webhook"``).  *description* is a short human
+    label for status display.
+    """
+
+    repo_name: str
+    thread_id: int
+    kind: Literal["worker", "webhook"]
+    description: str
+    claude_pid: int
+    started_at: datetime
+
+
+_talkers: dict[str, SessionTalker] = {}
+_talkers_lock = threading.Lock()
+
+# Thread-local coordination state so downstream helpers (events, prompts)
+# know which repo they belong to and whether the caller is a worker or a
+# webhook.  Set at :func:`kennel.server.WebhookHandler._process_action`
+# entry and at :meth:`kennel.worker.WorkerThread.run` entry, cleared on
+# exit.  Reads fall back to sensible defaults for tests that don't set it.
+_thread_local: threading.local = threading.local()
+
+
+def set_thread_repo(repo_name: str | None) -> None:
+    """Set (or clear, with ``None``) the repo_name for this thread."""
+    if repo_name is None:
+        if hasattr(_thread_local, "repo_name"):
+            del _thread_local.repo_name
+    else:
+        _thread_local.repo_name = repo_name
+
+
+def current_repo() -> str | None:
+    """Return the repo_name set by :func:`set_thread_repo` on this thread."""
+    return getattr(_thread_local, "repo_name", None)
+
+
+def set_thread_kind(kind: Literal["worker", "webhook"] | None) -> None:
+    """Set (or clear, with ``None``) the caller kind for this thread.
+
+    Workers call this with ``"worker"`` at :meth:`WorkerThread.run` entry; the
+    webhook handler calls it with ``"webhook"`` at ``_process_action`` entry.
+    :meth:`ClaudeSession.prompt` and :meth:`CopilotCLISession.__enter__`
+    consult it to decide whether their preempt signal should fire —
+    webhooks preempt workers; workers and webhooks never preempt a running
+    webhook (fix for #637).
+    """
+    if kind is None:
+        if hasattr(_thread_local, "kind"):
+            del _thread_local.kind
+    else:
+        _thread_local.kind = kind
+
+
+def current_thread_kind() -> Literal["worker", "webhook"]:
+    """Return the caller kind for this thread.  Defaults to ``"worker"``
+    when not set (non-entry code paths and tests)."""
+    return getattr(_thread_local, "kind", "worker")
+
+
+def try_preempt_worker(
+    repo_name: str | None, cancel_fn: Callable[[], None]
+) -> tuple[bool, Literal["worker", "webhook"] | None]:
+    """Invoke *cancel_fn* iff the calling thread is a webhook AND the
+    session's current lock holder is a worker.  Otherwise do nothing.
+
+    Returns ``(preempted, current_kind)`` — *preempted* is ``True`` only when
+    *cancel_fn* was invoked; *current_kind* is the current holder's kind
+    (``"worker"``, ``"webhook"``, or ``None`` when the session is idle).
+    The caller uses that to log the outcome.
+
+    Provider-neutral decision gate for #637.  The *mechanism* of cancelling
+    a running turn differs across providers (stream-json ``control_request``
+    for claude, ACP ``cancel(session_id)`` for copilot), but the *decision*
+    is identical and lives here.  Worker callers never preempt anyone;
+    webhooks queue behind other webhooks (FIFO on the session lock) instead
+    of cancelling each other.
+    """
+    caller_kind = current_thread_kind()
+    current = get_talker(repo_name) if repo_name is not None else None
+    current_kind = current.kind if current is not None else None
+    if caller_kind == "webhook" and current_kind == "worker":
+        cancel_fn()
+        return True, current_kind
+    return False, current_kind
+
+
+def register_talker(talker: SessionTalker) -> None:
+    """Register *talker* as the active provider driver for its repo.
+
+    Raises :class:`SessionLeakError` if a talker for the same repo is
+    already registered — the guarantee is one provider session per repo
+    at a time.
+    """
+    with _talkers_lock:
+        existing = _talkers.get(talker.repo_name)
+        if existing is not None:
+            raise SessionLeakError(
+                f"provider session leak for repo {talker.repo_name}: "
+                f"tid={existing.thread_id} ({existing.kind}, "
+                f"{existing.description}, pid={existing.claude_pid}) "
+                f"still active when tid={talker.thread_id} ({talker.kind}, "
+                f"{talker.description}, pid={talker.claude_pid}) tried to start"
+            )
+        _talkers[talker.repo_name] = talker
+
+
+def unregister_talker(repo_name: str, thread_id: int) -> None:
+    """Remove the talker entry for *repo_name* if it belongs to *thread_id*.
+
+    Idempotent — safe to call from cleanup paths that may race the registry.
+    Non-matching ``thread_id`` is a no-op (defensive against cross-thread
+    cleanup bugs).
+    """
+    with _talkers_lock:
+        existing = _talkers.get(repo_name)
+        if existing is not None and existing.thread_id == thread_id:
+            del _talkers[repo_name]
+
+
+def get_talker(repo_name: str) -> SessionTalker | None:
+    """Return the active talker for *repo_name*, or ``None`` if idle."""
+    with _talkers_lock:
+        return _talkers.get(repo_name)
+
+
+def talker_now() -> datetime:
+    """Seam for tests — patch this to freeze time in talker timestamps."""
+    return datetime.now(tz=timezone.utc)
+
+
+_session_resolver: Callable[[str], PromptSession | None] | None = None
+"""Callback the event/webhook layer uses to find its repo's persistent
+:class:`PromptSession` — installed once by :mod:`kennel.server` at startup.
+
+Every in-process prompt call goes through the persistent session, so this
+is a required piece of wiring.  Callers fail loud if it's missing — the
+only time that should happen is a forgotten resolver install, not a real
+production path."""
+
+
+def set_session_resolver(
+    resolver: Callable[[str], PromptSession | None] | None,
+) -> None:
+    """Install (or clear) the session resolver callback."""
+    global _session_resolver
+    _session_resolver = resolver
+
+
+def current_repo_session() -> PromptSession:
+    """Return the live :class:`PromptSession` driving the current thread's
+    repo.  Raises when either the thread-local repo_name or the session
+    resolver is missing — those are wiring bugs, not conditions callers
+    should paper over.
+    """
+    repo = current_repo()
+    if repo is None:
+        raise RuntimeError(
+            "current_repo_session called without a thread-local repo_name"
+            " — server.WebhookHandler._process_action and WorkerThread.run"
+            " both set it; this caller is missing the install."
+        )
+    if _session_resolver is None:
+        raise RuntimeError(
+            "current_repo_session called before set_session_resolver — "
+            "server._run() installs it at startup; nothing should run before."
+        )
+    session = _session_resolver(repo)
+    if session is None:
+        raise RuntimeError(
+            f"no provider session registered for repo {repo} — worker thread "
+            "has not yet created its session"
+        )
+    if not session.is_alive():
+        raise RuntimeError(
+            f"provider session for repo {repo} is not alive — watchdog should "
+            "have restarted the worker thread"
+        )
+    return session
+
+
+class OwnedSession:
+    """Base class for :class:`~kennel.claude.ClaudeSession` and
+    :class:`~kennel.copilotcli.CopilotCLISession` providing the shared
+    reentrance counter and :meth:`hold_for_handler` context manager
+    (fix for #658).
+
+    Subclasses own their own lock (must be a :class:`threading.RLock` so
+    nested acquires by the same thread are free) and implement the
+    session-specific first-enter / last-exit work in their own ``__enter__``
+    and ``__exit__``.  This base only handles the per-thread depth
+    bookkeeping and the shared ``hold_for_handler`` wrapper so the two
+    providers don't drift apart.
+
+    Required subclass attributes:
+
+    - ``self._lock`` — :class:`threading.RLock`
+    - ``self._repo_name`` — ``str | None`` (fed to
+      :func:`try_preempt_worker` for the preempt decision)
+    - ``self._fire_worker_cancel()`` — method that aborts whatever turn the
+      current lock-holder's provider subprocess is running
+    """
+
+    _reentry_tls: threading.local
+    _repo_name: str | None
+
+    def _init_handler_reentry(self) -> None:
+        """Subclasses call this from their ``__init__`` to set up the
+        thread-local reentrance counter.  Separate method (not
+        ``__init__``) so the base doesn't compete with the subclass
+        constructor signature."""
+        self._reentry_tls = threading.local()
+
+    def _bump_entry_depth(self) -> int:
+        """Increment and return the new per-thread entry depth (1 at
+        outermost entry, 2 at first nested, etc.)."""
+        depth = getattr(self._reentry_tls, "depth", 0) + 1
+        self._reentry_tls.depth = depth
+        return depth
+
+    def _drop_entry_depth(self) -> int:
+        """Decrement and return the new per-thread entry depth (0 at
+        outermost exit)."""
+        depth = self._reentry_tls.depth - 1
+        self._reentry_tls.depth = depth
+        return depth
+
+    def _fire_worker_cancel(self) -> None:
+        """Abort the current lock-holder's turn.  Subclasses override
+        with their provider-specific cancel mechanism."""
+        raise NotImplementedError  # pragma: no cover — abstract hook
+
+    @contextmanager
+    def hold_for_handler(
+        self, *, preempt_worker: bool = False
+    ) -> Iterator["OwnedSession"]:
+        """Hold the session lock across multiple prompt calls.
+
+        Webhook handlers wrap their entire body in this so the worker
+        can't acquire the lock between individual turns (triage → reply
+        → reaction) and stall the reply behind a long worker turn (#658).
+        Inner ``with session:`` / ``session.prompt`` calls re-acquire the
+        RLock and skip the first-enter setup via the reentrance counter.
+
+        When *preempt_worker* is true, fires the caller's
+        :meth:`_fire_worker_cancel` once upfront (via
+        :func:`try_preempt_worker`) so a currently-running worker turn
+        aborts immediately rather than being waited out.
+        """
+        if preempt_worker:
+            try_preempt_worker(self._repo_name, self._fire_worker_cancel)
+        with self:  # type: ignore[attr-defined]
+            yield self
 
 
 class ProviderAgent(Protocol):

--- a/kennel/registry.py
+++ b/kennel/registry.py
@@ -52,7 +52,7 @@ class WebhookActivity:
 
     *thread_id* is :func:`threading.get_ident` captured at context entry so
     status display can match this webhook to the active
-    :class:`~kennel.claude.ClaudeTalker` (whose ``thread_id`` field is from
+    :class:`~kennel.provider.SessionTalker` (whose ``thread_id`` field is from
     the same call) — letting the CLI attach claude stats to the specific
     webhook line that's driving claude.
     """
@@ -366,7 +366,7 @@ class WorkerRegistry:
     def get_session(self, repo_name: str) -> PromptSession | None:
         """Return the live persistent session for *repo_name*.
 
-        Used by :func:`kennel.claude.set_session_resolver` so webhook-handler
+        Used by :func:`kennel.provider.set_session_resolver` so webhook-handler
         prompt calls can route through the per-repo persistent session
         instead of spawning extra one-shot subprocesses.  Returns ``None``
         when no worker thread is registered for the repo or the thread has

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -541,9 +541,23 @@ class WebhookHandler(BaseHTTPRequestHandler):
         )
         claude.set_thread_repo(repo_cfg.name)
         claude.set_thread_kind("webhook")
+        session = self.registry.get_session(repo_cfg.name)
+        needs_model = self._action_uses_model(action)
         try:
             with self.registry.webhook_activity(repo_cfg.name, description) as activity:
-                self._process_action_inner(action, repo_cfg, activity)
+                if (
+                    session is not None
+                    and needs_model
+                    and hasattr(session, "hold_for_handler")
+                ):
+                    # Hold the session across the whole handler (#658) so the
+                    # worker can't sneak in and acquire the lock between this
+                    # handler's individual turns — that stalled webhook replies
+                    # behind long worker turns.
+                    with session.hold_for_handler(preempt_worker=True):
+                        self._process_action_inner(action, repo_cfg, activity)
+                else:
+                    self._process_action_inner(action, repo_cfg, activity)
         except claude.ClaudeLeakError:
             # A webhook and a worker tried to talk to the same repo's claude
             # at the same time — the only safe action is to halt the whole
@@ -561,6 +575,17 @@ class WebhookHandler(BaseHTTPRequestHandler):
             )
             claude.set_thread_kind(None)
             claude.set_thread_repo(None)
+
+    def _action_uses_model(self, action: Action) -> bool:
+        """True when the webhook action will call ``agent.run_turn``.
+
+        Reply-capable actions (PR comments, review comments, review threads)
+        generate a response through the model and therefore benefit from
+        holding the session lock across their whole handler (#658).  Plain
+        webhook-action events (merges, check_runs) only restart workers and
+        don't touch the model — no point blocking the worker for those.
+        """
+        return bool(action.reply_to or action.review_comments or action.comment_body)
 
     def _describe_action(self, action: Action) -> str:
         """Short label for status display — what this webhook handler is doing."""

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 from urllib.parse import urlparse
 from xml.etree.ElementTree import Element, SubElement, register_namespace, tostring
 
-from kennel import claude, reply_promises
+from kennel import provider, reply_promises
 from kennel.claude import kill_active_children
 from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.events import (
@@ -84,8 +84,8 @@ def _runner_dir() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def _serialize_talker(talker: claude.ClaudeTalker | None) -> dict[str, Any] | None:
-    """Convert a :class:`~kennel.claude.ClaudeTalker` to a JSON-friendly dict.
+def _serialize_talker(talker: provider.SessionTalker | None) -> dict[str, Any] | None:
+    """Convert a :class:`~kennel.provider.SessionTalker` to a JSON-friendly dict.
 
     Returns ``None`` when nobody is talking to claude for the repo.
     """
@@ -539,26 +539,23 @@ class WebhookHandler(BaseHTTPRequestHandler):
             description,
             tid,
         )
-        claude.set_thread_repo(repo_cfg.name)
-        claude.set_thread_kind("webhook")
+        provider.set_thread_repo(repo_cfg.name)
+        provider.set_thread_kind("webhook")
         session = self.registry.get_session(repo_cfg.name)
         needs_model = self._action_uses_model(action)
         try:
             with self.registry.webhook_activity(repo_cfg.name, description) as activity:
-                if (
-                    session is not None
-                    and needs_model
-                    and hasattr(session, "hold_for_handler")
-                ):
+                if session is not None and needs_model:
                     # Hold the session across the whole handler (#658) so the
                     # worker can't sneak in and acquire the lock between this
                     # handler's individual turns — that stalled webhook replies
-                    # behind long worker turns.
+                    # behind long worker turns.  Both ClaudeSession and
+                    # CopilotCLISession implement ``hold_for_handler``.
                     with session.hold_for_handler(preempt_worker=True):
                         self._process_action_inner(action, repo_cfg, activity)
                 else:
                     self._process_action_inner(action, repo_cfg, activity)
-        except claude.ClaudeLeakError:
+        except provider.SessionLeakError:
             # A webhook and a worker tried to talk to the same repo's claude
             # at the same time — the only safe action is to halt the whole
             # process so the supervisor (start-kennel.sh) restarts us fresh.
@@ -573,8 +570,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 repo_cfg.name,
                 tid,
             )
-            claude.set_thread_kind(None)
-            claude.set_thread_repo(None)
+            provider.set_thread_kind(None)
+            provider.set_thread_repo(None)
 
     def _action_uses_model(self, action: Action) -> bool:
         """True when the webhook action will call ``agent.run_turn``.
@@ -751,7 +748,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 type(self)._fn_unblock_tasks(repo_cfg.work_dir)
             # Non-comment events just trigger kennel worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)
-        except claude.ClaudeLeakError:
+        except provider.SessionLeakError:
             # Let the outer _process_action handler halt kennel — we must not
             # swallow a leak into the generic "confused reaction" path below.
             raise
@@ -862,7 +859,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "session_alive": self.registry.get_session_alive(a.repo_name),
                     "session_pid": self.registry.get_session_pid(a.repo_name),
                     "session_dropped_count": dropped_count,
-                    "claude_talker": _serialize_talker(claude.get_talker(a.repo_name)),
+                    "claude_talker": _serialize_talker(
+                        provider.get_talker(a.repo_name)
+                    ),
                     "rescoping": self.registry.is_rescoping(a.repo_name),
                 }
             )
@@ -1045,7 +1044,7 @@ def run(
     WebhookHandler.registry = registry
     # Route webhook-handler prompt calls through the per-repo persistent
     # ClaudeSession (closes #479 — "one claude per repo" invariant).
-    claude.set_session_resolver(registry.get_session)
+    provider.set_session_resolver(registry.get_session)
     _Watchdog(registry, config.repos).start_thread()
 
     server = _HTTPServer(("", config.port), WebhookHandler)

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -37,7 +37,7 @@ class WebhookActivityInfo:
     """Lightweight in-flight webhook handler, used purely for display.
 
     *thread_id* matches the ``thread_id`` stored on
-    :class:`~kennel.claude.ClaudeTalker` so display can identify which
+    :class:`~kennel.provider.SessionTalker` so display can identify which
     webhook (if any) is currently driving claude.
     """
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Protocol
 
-from kennel import claude, hooks, tasks
+from kennel import hooks, tasks
 from kennel.claude import ClaudeCode
 from kennel.config import Config, RepoConfig, RepoMembership
 from kennel.github import GitHub
@@ -27,7 +27,10 @@ from kennel.provider import (
     ProviderAgent,
     ProviderModel,
     ProviderPressureStatus,
+    SessionLeakError,
     TurnSessionMode,
+    set_thread_kind,
+    set_thread_repo,
 )
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.state import (
@@ -2642,8 +2645,8 @@ class WorkerThread(threading.Thread):
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
-        claude.set_thread_repo(self._repo_name)
-        claude.set_thread_kind("worker")
+        set_thread_repo(self._repo_name)
+        set_thread_kind("worker")
         try:
             while not self._stop:
                 if self._registry is not None:
@@ -2695,7 +2698,7 @@ class WorkerThread(threading.Thread):
                 timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
                 self._wake.wait(timeout=timeout)
                 self._wake.clear()
-        except claude.ClaudeLeakError:
+        except SessionLeakError:
             # A worker and webhook tried to talk to the same repo's claude
             # at the same time — halt kennel so the supervisor restarts fresh
             # rather than let sub-claudes multiply silently.
@@ -2709,8 +2712,8 @@ class WorkerThread(threading.Thread):
             log.exception("WorkerThread %s: unexpected error", self.name)
             raise
         finally:
-            claude.set_thread_kind(None)
-            claude.set_thread_repo(None)
+            set_thread_kind(None)
+            set_thread_repo(None)
             # Only stop the session on orderly shutdown — a crashed thread
             # leaves it alive so the registry can hand it to the replacement.
             if self._stop:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 import pytest
 
-from kennel import claude
+from kennel import provider
 
 
 @pytest.fixture(autouse=True)
 def _reset_claude_talker_registry():
-    """Clear the global :class:`~kennel.claude.ClaudeTalker` registry between
+    """Clear the global :class:`~kennel.provider.SessionTalker` registry between
     tests so entries from one test can't leak into the next and cause a
-    spurious :class:`~kennel.claude.ClaudeLeakError`.  Also clears any
+    spurious :class:`~kennel.provider.SessionLeakError`.  Also clears any
     thread-local repo_name the test may have set via
-    :func:`kennel.claude.set_thread_repo`.
+    :func:`kennel.provider.set_thread_repo`.
     """
     yield
-    with claude._talkers_lock:
-        claude._talkers.clear()
-    claude.set_thread_repo(None)
+    with provider._talkers_lock:
+        provider._talkers.clear()
+    provider.set_thread_repo(None)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kennel import provider
 from kennel.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
@@ -175,17 +176,16 @@ def session_resolver():
     repo, and wire the thread-local repo so ``run_turn`` can find it.
     Yields the fake session so tests can assert on ``session.prompt.*``.
     """
-    from kennel import claude as claude_module
 
     fake = MagicMock()
     fake.is_alive.return_value = True
-    claude_module.set_session_resolver(lambda repo: fake)
-    claude_module.set_thread_repo("owner/repo")
+    provider.set_session_resolver(lambda repo: fake)
+    provider.set_thread_repo("owner/repo")
     try:
         yield fake
     finally:
-        claude_module.set_session_resolver(None)
-        claude_module.set_thread_repo(None)
+        provider.set_session_resolver(None)
+        provider.set_thread_repo(None)
 
 
 class TestRunStreaming:
@@ -541,8 +541,7 @@ class TestRunStreamingTracksChildren:
         assert proc not in _active_children
 
     def test_current_repo_session_returns_live_session(self) -> None:
-        from kennel import claude as claude_module
-        from kennel.claude import (
+        from kennel.provider import (
             current_repo_session,
             set_session_resolver,
             set_thread_repo,
@@ -556,55 +555,51 @@ class TestRunStreamingTracksChildren:
             assert current_repo_session() is live
         finally:
             set_thread_repo(None)
-            claude_module.set_session_resolver(None)
+            provider.set_session_resolver(None)
 
     def test_current_repo_session_raises_without_repo(self) -> None:
-        from kennel import claude as claude_module
-        from kennel.claude import current_repo_session
+        from kennel.provider import current_repo_session
 
-        claude_module.set_thread_repo(None)
+        provider.set_thread_repo(None)
         with pytest.raises(RuntimeError, match="thread-local repo_name"):
             current_repo_session()
 
     def test_current_repo_session_raises_without_resolver(self) -> None:
-        from kennel import claude as claude_module
-        from kennel.claude import current_repo_session
+        from kennel.provider import current_repo_session
 
-        claude_module.set_session_resolver(None)
-        claude_module.set_thread_repo("owner/repo")
+        provider.set_session_resolver(None)
+        provider.set_thread_repo("owner/repo")
         try:
             with pytest.raises(RuntimeError, match="set_session_resolver"):
                 current_repo_session()
         finally:
-            claude_module.set_thread_repo(None)
+            provider.set_thread_repo(None)
 
     def test_current_repo_session_raises_when_no_session(self) -> None:
-        from kennel import claude as claude_module
-        from kennel.claude import current_repo_session
+        from kennel.provider import current_repo_session
 
-        claude_module.set_session_resolver(lambda repo: None)
-        claude_module.set_thread_repo("owner/repo")
+        provider.set_session_resolver(lambda repo: None)
+        provider.set_thread_repo("owner/repo")
         try:
-            with pytest.raises(RuntimeError, match="no ClaudeSession registered"):
+            with pytest.raises(RuntimeError, match="no provider session registered"):
                 current_repo_session()
         finally:
-            claude_module.set_thread_repo(None)
-            claude_module.set_session_resolver(None)
+            provider.set_thread_repo(None)
+            provider.set_session_resolver(None)
 
     def test_current_repo_session_raises_when_not_alive(self) -> None:
-        from kennel import claude as claude_module
-        from kennel.claude import current_repo_session
+        from kennel.provider import current_repo_session
 
         dead = MagicMock()
         dead.is_alive.return_value = False
-        claude_module.set_session_resolver(lambda repo: dead)
-        claude_module.set_thread_repo("owner/repo")
+        provider.set_session_resolver(lambda repo: dead)
+        provider.set_thread_repo("owner/repo")
         try:
             with pytest.raises(RuntimeError, match="not alive"):
                 current_repo_session()
         finally:
-            claude_module.set_thread_repo(None)
-            claude_module.set_session_resolver(None)
+            provider.set_thread_repo(None)
+            provider.set_session_resolver(None)
 
     def test_thread_name_for_id_returns_none_when_not_found(self) -> None:
         from kennel.claude import _thread_name_for_id
@@ -616,13 +611,10 @@ class TestRunStreamingTracksChildren:
         self, tmp_path: Path
     ) -> None:
         """When thread-local repo_name is set, _run_streaming registers a
-        webhook-kind ClaudeTalker for the duration of the subprocess and
+        webhook-kind SessionTalker for the duration of the subprocess and
         unregisters it on exit."""
-        from kennel.claude import (
-            _run_streaming,
-            get_talker,
-            set_thread_repo,
-        )
+        from kennel.claude import _run_streaming
+        from kennel.provider import get_talker, set_thread_repo
 
         stdin_file = tmp_path / "in"
         stdin_file.write_text("hi")
@@ -1934,16 +1926,15 @@ class TestClaudeSessionLock:
     def test_enter_raises_on_concurrent_talker_and_releases_lock(
         self, tmp_path: Path
     ) -> None:
-        """__enter__ raises ClaudeLeakError if another talker is registered and
+        """__enter__ raises SessionLeakError if another talker is registered and
         releases the session lock so callers don't deadlock."""
         from datetime import datetime, timezone
 
-        from kennel import claude as claude_module
-        from kennel.claude import ClaudeLeakError, ClaudeTalker, register_talker
+        from kennel.provider import SessionLeakError, SessionTalker, register_talker
 
         session = _make_session(tmp_path, _make_session_proc([]))
         register_talker(
-            ClaudeTalker(
+            SessionTalker(
                 repo_name="owner/repo",
                 thread_id=999,
                 kind="webhook",
@@ -1952,13 +1943,13 @@ class TestClaudeSessionLock:
                 started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
             )
         )
-        with pytest.raises(ClaudeLeakError):
+        with pytest.raises(SessionLeakError):
             session.__enter__()
         # Session lock must be released so we don't deadlock future callers.
         assert session._lock.acquire(blocking=False)
         session._lock.release()
-        with claude_module._talkers_lock:
-            claude_module._talkers.clear()
+        with provider._talkers_lock:
+            provider._talkers.clear()
         session.stop()
 
     def test_context_manager_blocks_second_thread(self, tmp_path: Path) -> None:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -1,0 +1,229 @@
+"""Tests for ClaudeSession.hold_for_handler (#658)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kennel import claude as claude_mod
+from kennel.claude import ClaudeSession, ClaudeTalker, _talker_now
+
+
+def _make_session_proc(lines: list[str]) -> MagicMock:
+    proc = MagicMock()
+    proc.poll = MagicMock(return_value=None)
+    proc.wait = MagicMock(return_value=0)
+    proc.returncode = 0
+    proc.stdin = MagicMock()
+    proc.stdin.closed = False
+    stdout = MagicMock()
+    stdout.readline = MagicMock(side_effect=list(lines) + [""])
+    proc.stdout = stdout
+    proc.stderr = MagicMock()
+    return proc
+
+
+def _setup_session(tmp_path: Path, repo: str = "owner/repo") -> ClaudeSession:
+    system_file = tmp_path / "system.md"
+    system_file.write_text("sys")
+    proc = _make_session_proc(['{"type":"result","result":"reply"}\n'])
+    proc.pid = 55555
+    return ClaudeSession(
+        system_file,
+        work_dir=tmp_path,
+        popen=MagicMock(return_value=proc),
+        selector=MagicMock(return_value=([proc.stdout], [], [])),
+        repo_name=repo,
+        model="claude-opus-4-6",
+    )
+
+
+def test_hold_acquires_lock_and_registers_talker(tmp_path: Path) -> None:
+    session = _setup_session(tmp_path)
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler():
+            talker = claude_mod.get_talker("owner/repo")
+            assert talker is not None
+            assert talker.kind == "webhook"
+            assert session._lock._is_owned()  # type: ignore[attr-defined]
+        # After exit, talker unregistered, lock released.
+        assert claude_mod.get_talker("owner/repo") is None
+        assert not session._lock._is_owned()  # type: ignore[attr-defined]
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+
+
+def test_nested_with_inside_hold_does_not_double_register(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Re-entering ``with session:`` inside ``hold_for_handler`` must not
+    attempt a second talker registration (would raise ClaudeLeakError)."""
+    session = _setup_session(tmp_path)
+    register_calls = []
+    real_register = claude_mod.register_talker
+
+    def counting_register(talker):
+        register_calls.append(talker.kind)
+        real_register(talker)
+
+    monkeypatch.setattr(claude_mod, "register_talker", counting_register)
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler():
+            assert len(register_calls) == 1  # outer entry registered once
+            with session:  # nested re-entry
+                assert len(register_calls) == 1  # not re-registered
+            assert len(register_calls) == 1  # still registered after inner exit
+        # After outer exit, unregistered.
+        assert claude_mod.get_talker("owner/repo") is None
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+
+
+def test_hold_preempt_fires_cancel_when_worker_holds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """hold_for_handler(preempt_worker=True) fires _fire_worker_cancel iff
+    the current lock holder is a worker and the caller is a webhook."""
+    session = _setup_session(tmp_path)
+
+    def fake_talker(kind: str) -> ClaudeTalker:
+        return ClaudeTalker(
+            repo_name="owner/repo",
+            thread_id=999_999,
+            kind=kind,  # type: ignore[arg-type]
+            description="fake",
+            claude_pid=55555,
+            started_at=_talker_now(),
+        )
+
+    monkeypatch.setattr(
+        claude_mod, "get_talker", lambda _repo: fake_talker("worker")
+    )
+    cancel_calls = []
+    monkeypatch.setattr(
+        session, "_fire_worker_cancel", lambda: cancel_calls.append(1)
+    )
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler(preempt_worker=True):
+            pass
+    finally:
+        claude_mod.set_thread_kind(None)
+        session.stop()
+    assert cancel_calls == [1]
+
+
+def test_hold_preempt_skipped_when_no_preempt_worker_flag(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Default preempt_worker=False — no cancel fires even with a worker
+    holder."""
+    session = _setup_session(tmp_path)
+
+    def fake_talker(kind: str) -> ClaudeTalker:
+        return ClaudeTalker(
+            repo_name="owner/repo",
+            thread_id=999_999,
+            kind=kind,  # type: ignore[arg-type]
+            description="fake",
+            claude_pid=55555,
+            started_at=_talker_now(),
+        )
+
+    monkeypatch.setattr(
+        claude_mod, "get_talker", lambda _repo: fake_talker("worker")
+    )
+    cancel_calls = []
+    monkeypatch.setattr(
+        session, "_fire_worker_cancel", lambda: cancel_calls.append(1)
+    )
+    try:
+        with session.hold_for_handler():  # preempt_worker default False
+            pass
+    finally:
+        session.stop()
+    assert cancel_calls == []
+
+
+def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
+    """A different thread trying to ``with session:`` while another thread
+    is inside hold_for_handler must block until the hold exits (#658 —
+    that is the whole point of holding the lock across turns)."""
+    session = _setup_session(tmp_path)
+    holder_entered = threading.Event()
+    release_holder = threading.Event()
+    other_acquired = threading.Event()
+    other_finished = threading.Event()
+
+    def holder() -> None:
+        claude_mod.set_thread_kind("webhook")
+        try:
+            with session.hold_for_handler():
+                holder_entered.set()
+                release_holder.wait(timeout=5.0)
+        finally:
+            claude_mod.set_thread_kind(None)
+
+    def other() -> None:
+        claude_mod.set_thread_kind("worker")
+        try:
+            with session:
+                other_acquired.set()
+            other_finished.set()
+        finally:
+            claude_mod.set_thread_kind(None)
+
+    t1 = threading.Thread(target=holder, daemon=True)
+    t1.start()
+    holder_entered.wait(timeout=2.0)
+    t2 = threading.Thread(target=other, daemon=True)
+    t2.start()
+    # Give t2 a chance — it must NOT have acquired the lock yet.
+    assert not other_acquired.wait(timeout=0.1)
+    # Release the holder; t2 should now acquire.
+    release_holder.set()
+    t1.join(timeout=2.0)
+    assert other_acquired.wait(timeout=2.0), "other thread never acquired"
+    assert other_finished.wait(timeout=2.0)
+    session.stop()
+
+
+def test_hold_reraises_leak_error_and_releases_lock(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If register_talker raises ClaudeLeakError inside hold, the lock must
+    be released before the exception propagates so we don't deadlock."""
+    session = _setup_session(tmp_path)
+    # Pre-register a talker for the same repo from a different thread id so
+    # the hold's register_talker collides.
+    claude_mod.register_talker(
+        ClaudeTalker(
+            repo_name="owner/repo",
+            thread_id=111_111,  # different tid — triggers leak
+            kind="worker",
+            description="squatter",
+            claude_pid=0,
+            started_at=_talker_now(),
+        )
+    )
+    claude_mod.set_thread_kind("webhook")
+    try:
+        with pytest.raises(claude_mod.ClaudeLeakError):
+            with session.hold_for_handler():
+                pass  # should not reach here
+        # Lock must be released so other threads can acquire.
+        acquired = session._lock.acquire(blocking=False)
+        assert acquired
+        session._lock.release()
+    finally:
+        claude_mod.set_thread_kind(None)
+        claude_mod.unregister_talker("owner/repo", 111_111)
+        session.stop()

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import threading
-import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from kennel import claude as claude_mod
-from kennel.claude import ClaudeSession, ClaudeTalker, _talker_now
+from kennel import provider
+from kennel.claude import ClaudeSession
+from kennel.provider import SessionTalker, talker_now
 
 
 def _make_session_proc(lines: list[str]) -> MagicMock:
@@ -44,18 +44,18 @@ def _setup_session(tmp_path: Path, repo: str = "owner/repo") -> ClaudeSession:
 
 def test_hold_acquires_lock_and_registers_talker(tmp_path: Path) -> None:
     session = _setup_session(tmp_path)
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
         with session.hold_for_handler():
-            talker = claude_mod.get_talker("owner/repo")
+            talker = provider.get_talker("owner/repo")
             assert talker is not None
             assert talker.kind == "webhook"
             assert session._lock._is_owned()  # type: ignore[attr-defined]
         # After exit, talker unregistered, lock released.
-        assert claude_mod.get_talker("owner/repo") is None
+        assert provider.get_talker("owner/repo") is None
         assert not session._lock._is_owned()  # type: ignore[attr-defined]
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
 
 
@@ -63,17 +63,17 @@ def test_nested_with_inside_hold_does_not_double_register(
     tmp_path: Path, monkeypatch
 ) -> None:
     """Re-entering ``with session:`` inside ``hold_for_handler`` must not
-    attempt a second talker registration (would raise ClaudeLeakError)."""
+    attempt a second talker registration (would raise SessionLeakError)."""
     session = _setup_session(tmp_path)
     register_calls = []
-    real_register = claude_mod.register_talker
+    real_register = provider.register_talker
 
     def counting_register(talker):
         register_calls.append(talker.kind)
         real_register(talker)
 
-    monkeypatch.setattr(claude_mod, "register_talker", counting_register)
-    claude_mod.set_thread_kind("webhook")
+    monkeypatch.setattr(provider, "register_talker", counting_register)
+    provider.set_thread_kind("webhook")
     try:
         with session.hold_for_handler():
             assert len(register_calls) == 1  # outer entry registered once
@@ -81,9 +81,9 @@ def test_nested_with_inside_hold_does_not_double_register(
                 assert len(register_calls) == 1  # not re-registered
             assert len(register_calls) == 1  # still registered after inner exit
         # After outer exit, unregistered.
-        assert claude_mod.get_talker("owner/repo") is None
+        assert provider.get_talker("owner/repo") is None
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
 
 
@@ -94,29 +94,25 @@ def test_hold_preempt_fires_cancel_when_worker_holds(
     the current lock holder is a worker and the caller is a webhook."""
     session = _setup_session(tmp_path)
 
-    def fake_talker(kind: str) -> ClaudeTalker:
-        return ClaudeTalker(
+    def fake_talker(kind: str) -> SessionTalker:
+        return SessionTalker(
             repo_name="owner/repo",
             thread_id=999_999,
             kind=kind,  # type: ignore[arg-type]
             description="fake",
             claude_pid=55555,
-            started_at=_talker_now(),
+            started_at=talker_now(),
         )
 
-    monkeypatch.setattr(
-        claude_mod, "get_talker", lambda _repo: fake_talker("worker")
-    )
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: fake_talker("worker"))
     cancel_calls = []
-    monkeypatch.setattr(
-        session, "_fire_worker_cancel", lambda: cancel_calls.append(1)
-    )
-    claude_mod.set_thread_kind("webhook")
+    monkeypatch.setattr(session, "_fire_worker_cancel", lambda: cancel_calls.append(1))
+    provider.set_thread_kind("webhook")
     try:
         with session.hold_for_handler(preempt_worker=True):
             pass
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert cancel_calls == [1]
 
@@ -128,23 +124,19 @@ def test_hold_preempt_skipped_when_no_preempt_worker_flag(
     holder."""
     session = _setup_session(tmp_path)
 
-    def fake_talker(kind: str) -> ClaudeTalker:
-        return ClaudeTalker(
+    def fake_talker(kind: str) -> SessionTalker:
+        return SessionTalker(
             repo_name="owner/repo",
             thread_id=999_999,
             kind=kind,  # type: ignore[arg-type]
             description="fake",
             claude_pid=55555,
-            started_at=_talker_now(),
+            started_at=talker_now(),
         )
 
-    monkeypatch.setattr(
-        claude_mod, "get_talker", lambda _repo: fake_talker("worker")
-    )
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: fake_talker("worker"))
     cancel_calls = []
-    monkeypatch.setattr(
-        session, "_fire_worker_cancel", lambda: cancel_calls.append(1)
-    )
+    monkeypatch.setattr(session, "_fire_worker_cancel", lambda: cancel_calls.append(1))
     try:
         with session.hold_for_handler():  # preempt_worker default False
             pass
@@ -164,22 +156,22 @@ def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
     other_finished = threading.Event()
 
     def holder() -> None:
-        claude_mod.set_thread_kind("webhook")
+        provider.set_thread_kind("webhook")
         try:
             with session.hold_for_handler():
                 holder_entered.set()
                 release_holder.wait(timeout=5.0)
         finally:
-            claude_mod.set_thread_kind(None)
+            provider.set_thread_kind(None)
 
     def other() -> None:
-        claude_mod.set_thread_kind("worker")
+        provider.set_thread_kind("worker")
         try:
             with session:
                 other_acquired.set()
             other_finished.set()
         finally:
-            claude_mod.set_thread_kind(None)
+            provider.set_thread_kind(None)
 
     t1 = threading.Thread(target=holder, daemon=True)
     t1.start()
@@ -199,24 +191,24 @@ def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
 def test_hold_reraises_leak_error_and_releases_lock(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """If register_talker raises ClaudeLeakError inside hold, the lock must
+    """If register_talker raises SessionLeakError inside hold, the lock must
     be released before the exception propagates so we don't deadlock."""
     session = _setup_session(tmp_path)
     # Pre-register a talker for the same repo from a different thread id so
     # the hold's register_talker collides.
-    claude_mod.register_talker(
-        ClaudeTalker(
+    provider.register_talker(
+        SessionTalker(
             repo_name="owner/repo",
             thread_id=111_111,  # different tid — triggers leak
             kind="worker",
             description="squatter",
             claude_pid=0,
-            started_at=_talker_now(),
+            started_at=talker_now(),
         )
     )
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
-        with pytest.raises(claude_mod.ClaudeLeakError):
+        with pytest.raises(provider.SessionLeakError):
             with session.hold_for_handler():
                 pass  # should not reach here
         # Lock must be released so other threads can acquire.
@@ -224,6 +216,6 @@ def test_hold_reraises_leak_error_and_releases_lock(
         assert acquired
         session._lock.release()
     finally:
-        claude_mod.set_thread_kind(None)
-        claude_mod.unregister_talker("owner/repo", 111_111)
+        provider.set_thread_kind(None)
+        provider.unregister_talker("owner/repo", 111_111)
         session.stop()

--- a/tests/test_claude_preempt_kind.py
+++ b/tests/test_claude_preempt_kind.py
@@ -13,8 +13,9 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from kennel import claude as claude_mod
-from kennel.claude import ClaudeSession, ClaudeTalker, _talker_now
+from kennel import provider
+from kennel.claude import ClaudeSession
+from kennel.provider import SessionTalker, talker_now
 
 
 def _make_session_proc(lines: list[str]) -> MagicMock:
@@ -49,14 +50,14 @@ def _setup_session(tmp_path: Path) -> tuple[ClaudeSession, MagicMock]:
     return session, proc
 
 
-def _fake_talker(kind: str) -> ClaudeTalker:
-    return ClaudeTalker(
+def _fake_talker(kind: str) -> SessionTalker:
+    return SessionTalker(
         repo_name="owner/repo",
         thread_id=999_999,
         kind=kind,  # type: ignore[arg-type]
         description="fake",
         claude_pid=55555,
-        started_at=_talker_now(),
+        started_at=talker_now(),
     )
 
 
@@ -68,7 +69,7 @@ def test_webhook_preempting_worker_logs_preempting_and_fires_interrupt(
     (before entering the lock)."""
     session, _proc = _setup_session(tmp_path)
     session._in_turn = True
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: _fake_talker("worker"))
     # Wrap _send_control_interrupt so we can see when it fired.
     called_before_lock = []
     real_interrupt = session._send_control_interrupt
@@ -79,12 +80,12 @@ def test_webhook_preempting_worker_logs_preempting_and_fires_interrupt(
         real_interrupt()
 
     session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
         with caplog.at_level(logging.INFO, logger="kennel"):
             session.prompt("reply plz")
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "preempting worker" in caplog.text
     # At least one control_request must have fired while the lock was free
@@ -102,7 +103,7 @@ def test_webhook_does_not_preempt_another_webhook(
     early interrupt.  Logs ``queuing behind webhook`` instead."""
     session, _proc = _setup_session(tmp_path)
     session._in_turn = False  # avoid the send() drain path muddying the test
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("webhook"))
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: _fake_talker("webhook"))
     interrupts_before_lock = []
     real_interrupt = session._send_control_interrupt
 
@@ -111,12 +112,12 @@ def test_webhook_does_not_preempt_another_webhook(
         real_interrupt()
 
     session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
         with caplog.at_level(logging.INFO, logger="kennel"):
             session.prompt("reply plz")
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "queuing behind webhook" in caplog.text
     assert not any(interrupts_before_lock)
@@ -127,7 +128,7 @@ def test_worker_caller_does_not_preempt(tmp_path: Path, caplog, monkeypatch) -> 
     control_request, even if another webhook currently holds the lock."""
     session, _proc = _setup_session(tmp_path)
     session._in_turn = False
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("webhook"))
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: _fake_talker("webhook"))
     interrupts_before_lock = []
     real_interrupt = session._send_control_interrupt
 
@@ -136,12 +137,12 @@ def test_worker_caller_does_not_preempt(tmp_path: Path, caplog, monkeypatch) -> 
         real_interrupt()
 
     session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
-    claude_mod.set_thread_kind("worker")
+    provider.set_thread_kind("worker")
     try:
         with caplog.at_level(logging.INFO, logger="kennel"):
             session.prompt("keep working")
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "queuing behind webhook" in caplog.text
     assert not any(interrupts_before_lock)
@@ -155,7 +156,7 @@ def test_webhook_with_idle_session_skips_early_control_request(
     still set so iter_events bails out on its next poll)."""
     session, _proc = _setup_session(tmp_path)
     session._in_turn = False
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: _fake_talker("worker"))
     interrupts_before_lock = []
     real_interrupt = session._send_control_interrupt
 
@@ -164,12 +165,12 @@ def test_webhook_with_idle_session_skips_early_control_request(
         real_interrupt()
 
     session._send_control_interrupt = tracking_interrupt  # type: ignore[method-assign]
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
         with caplog.at_level(logging.INFO, logger="kennel"):
             session.prompt("reply plz")
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "preempting worker" in caplog.text
     assert not any(interrupts_before_lock), (
@@ -185,7 +186,7 @@ def test_early_control_request_error_is_logged_not_fatal(
     logs a warning and still enters the lock for its own turn."""
     session, proc = _setup_session(tmp_path)
     session._in_turn = True
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: _fake_talker("worker"))
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: _fake_talker("worker"))
     # First stdin.write (the early control_request) raises; later writes
     # succeed so the drain / send path can proceed.
     proc.stdin.write.side_effect = [
@@ -194,7 +195,7 @@ def test_early_control_request_error_is_logged_not_fatal(
         None,
         None,
     ]
-    claude_mod.set_thread_kind("webhook")
+    provider.set_thread_kind("webhook")
     try:
         with caplog.at_level(logging.WARNING, logger="kennel"):
             try:
@@ -202,7 +203,7 @@ def test_early_control_request_error_is_logged_not_fatal(
             except Exception:
                 pass  # downstream send may raise once stdin is broken
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "early control_request failed" in caplog.text
 
@@ -214,23 +215,23 @@ def test_queuing_log_reports_no_holder_when_session_is_free(
     ``queuing behind none`` (not ``preempting worker``)."""
     session, _proc = _setup_session(tmp_path)
     session._in_turn = False
-    monkeypatch.setattr(claude_mod, "get_talker", lambda _repo: None)
-    claude_mod.set_thread_kind("webhook")
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: None)
+    provider.set_thread_kind("webhook")
     try:
         with caplog.at_level(logging.INFO, logger="kennel"):
             session.prompt("hi")
     finally:
-        claude_mod.set_thread_kind(None)
+        provider.set_thread_kind(None)
         session.stop()
     assert "queuing behind none" in caplog.text
 
 
 def test_set_thread_kind_roundtrip() -> None:
-    claude_mod.set_thread_kind(None)
-    assert claude_mod.current_thread_kind() == "worker"
-    claude_mod.set_thread_kind("webhook")
-    assert claude_mod.current_thread_kind() == "webhook"
-    claude_mod.set_thread_kind("worker")
-    assert claude_mod.current_thread_kind() == "worker"
-    claude_mod.set_thread_kind(None)
-    assert claude_mod.current_thread_kind() == "worker"
+    provider.set_thread_kind(None)
+    assert provider.current_thread_kind() == "worker"
+    provider.set_thread_kind("webhook")
+    assert provider.current_thread_kind() == "webhook"
+    provider.set_thread_kind("worker")
+    assert provider.current_thread_kind() == "worker"
+    provider.set_thread_kind(None)
+    assert provider.current_thread_kind() == "worker"

--- a/tests/test_copilot_hold_for_handler.py
+++ b/tests/test_copilot_hold_for_handler.py
@@ -1,0 +1,111 @@
+"""Reentrance + hold_for_handler tests for CopilotCLISession (#658)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kennel import provider
+from kennel.copilotcli import CopilotCLIClient, CopilotCLISession
+
+
+class FakeRuntime:
+    def __init__(self) -> None:
+        self._session_id = "sess-created"
+        self.cancel_calls: list[str] = []
+        self.dropped_session_count = 0
+        self.pid = None
+
+    def ensure_session(self, session_id, model):  # noqa: ARG002
+        return self._session_id
+
+    def recover_session(self, session_id, model):  # noqa: ARG002
+        return self._session_id
+
+    def reset_session(self, model):  # noqa: ARG002
+        return self._session_id
+
+    def cancel(self, session_id: str) -> None:
+        self.cancel_calls.append(session_id)
+
+    def is_alive(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        pass
+
+    def prompt(self, session_id, content, model):  # noqa: ARG002
+        return "ok", "completed", session_id
+
+
+def _session(tmp_path: Path) -> CopilotCLISession:
+    sys_file = tmp_path / "persona.md"
+    sys_file.write_text("")
+    return CopilotCLISession(
+        sys_file,
+        work_dir=tmp_path,
+        model=CopilotCLIClient.work_model,
+        runtime=FakeRuntime(),
+        repo_name="owner/repo",
+    )
+
+
+def test_hold_for_handler_allows_nested_with(tmp_path: Path) -> None:
+    """Copilot's hold_for_handler + inner ``with session:`` work as a
+    single talker registration across both entries (mirrors the claude
+    behaviour in #658)."""
+    session = _session(tmp_path)
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler():
+            assert provider.get_talker("owner/repo") is not None
+            with session:
+                # Reentrant — still the single outer talker.
+                assert provider.get_talker("owner/repo") is not None
+        assert provider.get_talker("owner/repo") is None
+    finally:
+        provider.set_thread_kind(None)
+
+
+def test_hold_for_handler_does_not_fire_runtime_cancel_when_free(
+    tmp_path: Path,
+) -> None:
+    """No holder + no ``preempt_worker=True`` → no runtime cancel."""
+    session = _session(tmp_path)
+    assert isinstance(session._runtime, FakeRuntime)
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler():
+            pass
+    finally:
+        provider.set_thread_kind(None)
+    assert session._runtime.cancel_calls == []
+
+
+def test_hold_for_handler_preempt_fires_runtime_cancel_on_worker_holder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Webhook caller + worker currently holding (per talker registry)
+    + ``preempt_worker=True`` → runtime cancel fires once."""
+    session = _session(tmp_path)
+    assert isinstance(session._runtime, FakeRuntime)
+
+    def fake_talker(_repo: str) -> provider.SessionTalker:
+        return provider.SessionTalker(
+            repo_name="owner/repo",
+            thread_id=999_999,
+            kind="worker",
+            description="fake-worker",
+            claude_pid=0,
+            started_at=provider.talker_now(),
+        )
+
+    monkeypatch.setattr(provider, "get_talker", fake_talker)
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler(preempt_worker=True):
+            pass
+    finally:
+        provider.set_thread_kind(None)
+    assert session._runtime.cancel_calls == ["sess-created"]

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 from acp.exceptions import RequestError
 
-from kennel import claude
+from kennel import provider
 from kennel.copilotcli import (
     _ACP_STREAM_LIMIT,
     CopilotACPRuntime,
@@ -922,7 +922,6 @@ class TestCopilotCLISession:
     def test_webhook_preempts_worker_cancels_runtime(self, tmp_path: Path) -> None:
         """Worker holds the session; webhook contender fires the runtime
         cancel so the worker's turn returns and releases the lock."""
-        from kennel import claude as claude_mod
 
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
@@ -938,17 +937,17 @@ class TestCopilotCLISession:
         release = threading.Event()
 
         # Holder enters as worker so the shared talker registry reports it.
-        claude_mod.set_thread_kind("worker")
+        provider.set_thread_kind("worker")
         session.__enter__()
 
         def contender() -> None:
-            claude_mod.set_thread_kind("webhook")
+            provider.set_thread_kind("webhook")
             try:
                 with session:
                     acquired.set()
                     release.wait()
             finally:
-                claude_mod.set_thread_kind(None)
+                provider.set_thread_kind(None)
 
         thread = threading.Thread(target=contender, daemon=True)
         thread.start()
@@ -966,13 +965,12 @@ class TestCopilotCLISession:
             thread.join(timeout=1.0)
             assert session.wait_for_pending_preempt(timeout=1.0) is True
         finally:
-            claude_mod.set_thread_kind(None)
+            provider.set_thread_kind(None)
 
     def test_webhook_does_not_cancel_another_webhook(self, tmp_path: Path) -> None:
         """Webhook contender queues behind another webhook without firing
         the runtime cancel — FIFO on the lock instead of mutual cancellation
         (#637)."""
-        from kennel import claude as claude_mod
 
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
@@ -987,17 +985,17 @@ class TestCopilotCLISession:
         acquired = threading.Event()
         release = threading.Event()
 
-        claude_mod.set_thread_kind("webhook")
+        provider.set_thread_kind("webhook")
         session.__enter__()
 
         def contender() -> None:
-            claude_mod.set_thread_kind("webhook")
+            provider.set_thread_kind("webhook")
             try:
                 with session:
                     acquired.set()
                     release.wait()
             finally:
-                claude_mod.set_thread_kind(None)
+                provider.set_thread_kind(None)
 
         thread = threading.Thread(target=contender, daemon=True)
         thread.start()
@@ -1011,13 +1009,12 @@ class TestCopilotCLISession:
             thread.join(timeout=1.0)
             assert runtime.cancel_calls == []
         finally:
-            claude_mod.set_thread_kind(None)
+            provider.set_thread_kind(None)
 
     def test_enter_releases_lock_on_claude_leak_error(self, tmp_path: Path) -> None:
         """If another thread already registered a talker for this repo the
         session's __enter__ must release the lock before propagating so the
         existing holder can finish and unregister, not deadlock."""
-        from kennel import claude as claude_mod
 
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
@@ -1030,31 +1027,30 @@ class TestCopilotCLISession:
             repo_name="owner/repo",
         )
         # Pre-register a different tid as the active talker so the session's
-        # own register_talker inside __enter__ raises ClaudeLeakError.
-        claude_mod.register_talker(
-            claude_mod.ClaudeTalker(
+        # own register_talker inside __enter__ raises SessionLeakError.
+        provider.register_talker(
+            provider.SessionTalker(
                 repo_name="owner/repo",
                 thread_id=999_999,
                 kind="worker",
                 description="squatter",
                 claude_pid=0,
-                started_at=claude_mod._talker_now(),
+                started_at=provider.talker_now(),
             )
         )
         try:
-            with pytest.raises(claude_mod.ClaudeLeakError):
+            with pytest.raises(provider.SessionLeakError):
                 session.__enter__()
             # Lock must have been released on the leak path so a later
             # legitimate enter (after the squatter clears) still works.
             assert session._lock.acquire(blocking=False) is True
             session._lock.release()
         finally:
-            claude_mod.unregister_talker("owner/repo", 999_999)
+            provider.unregister_talker("owner/repo", 999_999)
 
     def test_worker_contender_does_not_cancel(self, tmp_path: Path) -> None:
         """Worker contender (e.g. its own retry) waits on the lock rather
         than cancelling whichever webhook currently holds it."""
-        from kennel import claude as claude_mod
 
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
@@ -1069,17 +1065,17 @@ class TestCopilotCLISession:
         acquired = threading.Event()
         release = threading.Event()
 
-        claude_mod.set_thread_kind("webhook")
+        provider.set_thread_kind("webhook")
         session.__enter__()
 
         def contender() -> None:
-            claude_mod.set_thread_kind("worker")
+            provider.set_thread_kind("worker")
             try:
                 with session:
                     acquired.set()
                     release.wait()
             finally:
-                claude_mod.set_thread_kind(None)
+                provider.set_thread_kind(None)
 
         thread = threading.Thread(target=contender, daemon=True)
         thread.start()
@@ -1092,7 +1088,7 @@ class TestCopilotCLISession:
             thread.join(timeout=1.0)
             assert runtime.cancel_calls == []
         finally:
-            claude_mod.set_thread_kind(None)
+            provider.set_thread_kind(None)
 
     def test_missing_system_file_and_runtime_factory_branch(
         self, tmp_path: Path
@@ -1167,14 +1163,14 @@ class TestCopilotCLIClient:
     def test_default_session_resolver_uses_current_repo(self) -> None:
         session = MagicMock()
         session.prompt.return_value = "ok"
-        claude.set_session_resolver(lambda repo: session)
-        claude.set_thread_repo("owner/repo")
+        provider.set_session_resolver(lambda repo: session)
+        provider.set_thread_repo("owner/repo")
         try:
             client = CopilotCLIClient()
             assert client.run_turn("hi", model=client.voice_model) == "ok"
         finally:
-            claude.set_thread_repo(None)
-            claude.set_session_resolver(None)
+            provider.set_thread_repo(None)
+            provider.set_session_resolver(None)
 
     def test_session_attachment_and_properties(self) -> None:
         attached = MagicMock(owner="worker-home")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3280,7 +3280,7 @@ class TestReorderTasksBackground:
 
     def test_sets_thread_local_repo_name_during_reorder(self, tmp_path: Path) -> None:
         """Thread-local repo_name is set to repo_cfg.name when reorder runs."""
-        from kennel.claude import current_repo
+        from kennel.provider import current_repo
 
         started: list = []
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -3304,7 +3304,7 @@ class TestReorderTasksBackground:
 
     def test_clears_thread_local_repo_name_after_reorder(self, tmp_path: Path) -> None:
         """Thread-local repo_name is cleared in the finally block after reorder."""
-        from kennel.claude import current_repo, set_thread_repo
+        from kennel.provider import current_repo, set_thread_repo
 
         started: list = []
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -3328,7 +3328,7 @@ class TestReorderTasksBackground:
         self, tmp_path: Path
     ) -> None:
         """Thread-local repo_name is cleared even when reorder raises."""
-        from kennel.claude import current_repo
+        from kennel.provider import current_repo
 
         started: list = []
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
@@ -3352,7 +3352,7 @@ class TestReorderTasksBackground:
 
     def test_no_thread_local_set_when_no_repo_cfg(self, tmp_path: Path) -> None:
         """When repo_cfg is None, set_thread_repo is not called (no crash)."""
-        from kennel.claude import current_repo
+        from kennel.provider import current_repo
 
         started: list = []
         seen: list = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from kennel import provider
 from kennel.config import Config
 from kennel.config import RepoConfig as _RepoConfig
 from kennel.events import Action, recover_reply_promises
@@ -561,11 +562,11 @@ class TestStatusXml:
     def test_status_xml_includes_claude_talker(self, server: tuple) -> None:
         from datetime import datetime, timezone
 
-        from kennel.claude import ClaudeTalker
+        from kennel.provider import SessionTalker
         from kennel.registry import WorkerActivity
 
         url, _ = server
-        talker = ClaudeTalker(
+        talker = SessionTalker(
             repo_name="owner/repo",
             thread_id=42,
             kind="worker",
@@ -589,7 +590,7 @@ class TestStatusXml:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        with patch("kennel.claude.get_talker", return_value=talker):
+        with patch("kennel.provider.get_talker", return_value=talker):
             resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert "<kind>worker</kind>" in body
@@ -1573,14 +1574,14 @@ class TestProcessAction:
             assert "handling webhook action" not in args
 
     def test_status_endpoint_includes_claude_talker(self, server: tuple) -> None:
-        """Active ClaudeTalker appears in /status as a structured object."""
+        """Active SessionTalker appears in /status as a structured object."""
         from datetime import datetime, timezone
 
-        from kennel.claude import ClaudeTalker
+        from kennel.provider import SessionTalker
         from kennel.registry import WorkerActivity
 
         url, _ = server
-        talker = ClaudeTalker(
+        talker = SessionTalker(
             repo_name="owner/repo",
             thread_id=12321,
             kind="worker",
@@ -1604,7 +1605,7 @@ class TestProcessAction:
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-        with patch("kennel.claude.get_talker", return_value=talker):
+        with patch("kennel.provider.get_talker", return_value=talker):
             resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         talker_data = data[0]["claude_talker"]
@@ -1618,8 +1619,7 @@ class TestProcessAction:
         server: tuple,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """ClaudeLeakError from a webhook handler calls os._exit(3)."""
-        from kennel import claude
+        """SessionLeakError from a webhook handler calls os._exit(3)."""
         from kennel import server as server_module
 
         url, cfg = server
@@ -1630,7 +1630,7 @@ class TestProcessAction:
         }
         WebhookHandler.gh = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock(
-            side_effect=claude.ClaudeLeakError("leaked")
+            side_effect=provider.SessionLeakError("leaked")
         )
         exits: list[int] = []
         monkeypatch.setattr(server_module.os, "_exit", exits.append)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1192,7 +1192,7 @@ class TestCollect:
         )
 
     def test_passes_claude_talker_to_repo_status(self, tmp_path: Path) -> None:
-        """An active ClaudeTalker in /status → ClaudeTalkerInfo on RepoStatus."""
+        """An active SessionTalker in /status → ClaudeTalkerInfo on RepoStatus."""
         rc = RepoConfig(name="owner/repo", work_dir=tmp_path)
         activity_info = {
             "what": "running",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,6 +14,7 @@ from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 import pytest
 
 import kennel.worker as worker_module
+from kennel import provider
 from kennel.claude import ClaudeClient
 from kennel.config import RepoConfig, RepoMembership
 from kennel.prompts import Prompts
@@ -10416,8 +10417,7 @@ class TestWorkerThread:
     def test_run_halts_on_claude_leak_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ClaudeLeakError in the worker loop calls os._exit(3)."""
-        from kennel import claude
+        """SessionLeakError in the worker loop calls os._exit(3)."""
         from kennel import worker as worker_module
 
         wt = self._make_thread(tmp_path)
@@ -10425,7 +10425,7 @@ class TestWorkerThread:
         monkeypatch.setattr(worker_module.os, "_exit", exits.append)
         # Force the loop to raise a leak error on the first iteration.
         wt._registry = MagicMock()
-        wt._registry.report_activity.side_effect = claude.ClaudeLeakError("leak")
+        wt._registry.report_activity.side_effect = provider.SessionLeakError("leak")
         wt.run()
         assert exits == [3]
 


### PR DESCRIPTION
Closes #658.

## Problem

Between a webhook handler's individual turns (triage → reply → reaction) the old \`session.prompt\` path released the lock, fired the next turn's preempt, then re-acquired.  If the worker was waiting, it could sneak in during that tiny gap, start a long turn, and stall the webhook's reply.  Observed live: a review-comment webhook waited 54s for the worker's next turn to finish before it could post its reply.

## Fix

Webhook handler holds the session lock for its **entire** duration via a new \`OwnedSession.hold_for_handler()\` context manager.  Inner \`session.prompt\` / \`with session:\` calls re-acquire the RLock and skip the first-enter setup via a per-thread reentrance counter.

Applied to **both** providers.  Copilot's \`_lock\` was a plain \`Lock\`; switched to \`RLock\` so nested acquires by the same thread are free.

\`server._process_action\` wraps \`_process_action_inner\` in \`session.hold_for_handler(preempt_worker=True)\` when the action uses the model (\`reply_to\`/\`review_comments\`/\`comment_body\`).  Plain worker-restart webhooks skip the hold.

## Rename + move

\`OwnedSession\` and everything it depends on — talker registry, thread-kind plumbing, preempt decision gate, session resolver — moved from \`kennel.claude\` to \`kennel.provider\` under provider-neutral names.  These had been living in \`kennel.claude\` with \`Claude\`-prefixed names from before the Copilot provider existed; the move eliminates the naming smell and keeps the two providers in sync.

**Renamed (no compat shims):**

- \`ClaudeTalker\`       → \`SessionTalker\`
- \`ClaudeLeakError\`    → \`SessionLeakError\`
- \`_talker_now\`        → \`talker_now\` (public helper)
- \`HandlerHoldableSession\` → \`OwnedSession\`

All callers updated.

## Test plan

- [x] 2256 tests pass, 100% coverage
- [x] \`uv run ruff check\` clean, \`uv run pyright\` clean
- [x] 6 new ClaudeSession hold-for-handler tests (lock + talker lifecycle, nested \`with\`, preempt on/off, cross-thread blocking, leak-on-collision)
- [x] 3 new CopilotCLISession hold-for-handler tests
- [ ] After merge: post a comment on a claude-backed PR while a long worker turn is in flight; reply should land in seconds regardless of worker duration