### PR TITLE
Stabilize Worker: highlight across between-turn gaps

### DIFF
--- a/kennel/status.py
+++ b/kennel/status.py
@@ -773,10 +773,26 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
 
 
 def _format_worker_thread_line(repo: RepoStatus) -> str:
-    """Worker-thread state line, background-highlighted when it has the agent."""
+    """Worker-thread state line, background-highlighted whenever the worker
+    is assigned to a task.
+
+    The previous rule ("highlight iff the worker currently owns the
+    session lock") flickered to off during the Python-only gaps between
+    turns — the worker finishes a ``session.prompt`` (talker
+    unregisters), processes the result (git ops, task bookkeeping), then
+    calls ``session.prompt`` again.  Those gaps are still active work but
+    read as idle in the old semantics.
+
+    Use ``current_task`` as the stable \"worker is on a task\" signal —
+    set whenever the engine is inside ``execute_task``, cleared only when
+    the worker is napping / picking up / paused.  OR it with the classic
+    talker check so webhook-preemption snapshots (where current_task may
+    briefly be None during task rescopes) still read as busy when the
+    worker lock is held.
+    """
     state = _worker_thread_state(repo)
-    is_talker = _worker_is_agent_talker(repo)
-    label = color(GREEN_BG, "Worker:") if is_talker else color(BOLD, "Worker:")
+    is_active = repo.current_task is not None or _worker_is_agent_talker(repo)
+    label = color(GREEN_BG, "Worker:") if is_active else color(BOLD, "Worker:")
     return f"  {label} {state}"
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1975,6 +1975,38 @@ class TestFormatStatusColor:
         worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
         assert f"{_CODES['green_bg']}Worker:" in worker_line
 
+    def test_worker_label_green_bg_when_on_task_even_without_talker(self) -> None:
+        """Highlight stays on during the Python-only gap between
+        ``session.prompt`` calls — the talker is unregistered but the
+        worker is still assigned to a task (``current_task`` set)."""
+        repo = self._repo(
+            issue=1,
+            current_task="Do thing",
+            task_number=1,
+            task_total=3,
+            # No claude_talker, no session_owner — purely between-turn state.
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
+        assert f"{_CODES['green_bg']}Worker:" in worker_line
+
+    def test_worker_label_plain_when_napping_with_no_task(self) -> None:
+        """Highlight turns off when the worker has no task and no talker —
+        genuinely idle (napping / waiting for work)."""
+        repo = self._repo(
+            issue=1,
+            current_task=None,
+            session_alive=False,
+            session_owner=None,
+        )
+        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+        with patch.dict("os.environ", self._color_env(), clear=True):
+            output = format_status(status)
+        worker_line = [ln for ln in output.splitlines() if "Worker:" in ln][0]
+        assert _CODES["green_bg"] not in worker_line
+
     def test_webhook_label_yellow_when_talker(self) -> None:
         repo = self._repo(
             issue=1,


### PR DESCRIPTION
The GREEN_BG highlight on the \`Worker:\` line was flickering off during the Python-only gaps between \`session.prompt\` calls — the worker finishes a turn (talker unregisters), processes the result (git, task bookkeeping), then starts the next turn (talker re-registers).  Those gaps read as \"idle\" in the old rule even though the worker was clearly still on a task.

Widen the condition: highlight when \`current_task\` is set OR the worker holds the session lock.  \`current_task\` stays set for the full life of a task in \`execute_task\`, so the highlight is stable across every between-turn gap.  Talker-based fallback keeps webhook-preemption snapshots reading correctly.

## Test plan

- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2258 tests, 100% coverage, pyright + ruff clean
- [x] New test: highlight stays on when \`current_task\` set with no talker
- [x] New test: highlight turns off when idle (no task, no talker)
- [ ] After merge: \`kennel status\` stays highlighted on the \`Worker:\` line throughout a multi-turn task