### PR TITLE
Harden worker against transient crashes and cancel-leak

### DIFF
--- a/kennel/copilotcli.py
+++ b/kennel/copilotcli.py
@@ -73,6 +73,28 @@ def _is_line_limit_overrun_error(exc: Exception) -> bool:
     return "Separator is found, but chunk is longer than limit" in str(exc)
 
 
+# #666: Copilot CLI emits this exact string as its final assistant content
+# when a turn is cancelled mid-flight.  We translate it to "no result" at
+# the talker boundary so consumers can't accidentally post it as a reply
+# body or a PR description.
+_COPILOT_CANCEL_SENTINEL = "Info: Operation cancelled by user"
+
+
+def _is_cancel_sentinel(text: str) -> bool:
+    """Return True when *text* is Copilot's cancellation sentinel.
+
+    Matches both the bare sentinel and cases where it trails a block of
+    real narration (seen in logs where Copilot streams progress and then
+    appends the cancel notice as its final line).
+    """
+    if not text:
+        return False
+    stripped = text.rstrip()
+    return stripped == _COPILOT_CANCEL_SENTINEL or stripped.endswith(
+        "\n" + _COPILOT_CANCEL_SENTINEL
+    )
+
+
 def _iter_jsonl(output: str) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for line in output.splitlines():
@@ -1099,13 +1121,22 @@ class CopilotCLISession(OwnedSession):
         self._session_id = session_id
         if model is not None:
             self._model = coerce_provider_model(model)
-        self._last_turn_cancelled = stop_reason == "cancelled"
+        cancelled = stop_reason == "cancelled" or _is_cancel_sentinel(result)
+        self._last_turn_cancelled = cancelled
         _log_for_repo(
             logging.INFO,
             self._repo_name,
             "%s",
             _transcript_block("copilot result", result),
         )
+        # #666: Copilot CLI emits "Info: Operation cancelled by user" as its
+        # final assistant content when a turn is cancelled mid-flight.  If a
+        # caller (e.g. events.post reply paths) forwards that string as a
+        # generated body, it ends up posted on a PR as if it were real text.
+        # Normalize to empty at the talker boundary so every consumer's
+        # existing ``if not body`` guard treats it correctly.
+        if cancelled:
+            return ""
         return result
 
 

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -6,7 +6,8 @@ import logging
 import os
 import re
 import subprocess
-from collections.abc import Iterator
+import time
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,13 @@ import requests as _requests
 log = logging.getLogger(__name__)
 
 _HTTP_TIMEOUT: int = 30  # seconds for all outbound GitHub HTTP requests
+
+# Retry schedule for transient GitHub failures on idempotent GETs (#664).
+# Delays in seconds between successive attempts.  Total retry budget is
+# ~14s of wall clock on top of the per-request _HTTP_TIMEOUT.  Only applied
+# to read-only paths (GET); mutations stay fail-fast.
+_GET_RETRY_DELAYS: tuple[float, ...] = (1.0, 3.0, 10.0)
+_RETRYABLE_STATUS: frozenset[int] = frozenset({500, 502, 503, 504})
 
 
 class _TimeoutSession(_requests.Session):
@@ -87,7 +95,10 @@ class GitHub:
     BASE = "https://api.github.com"
 
     def __init__(
-        self, token: str | None = None, session: _requests.Session | None = None
+        self,
+        token: str | None = None,
+        session: _requests.Session | None = None,
+        sleeper: Callable[[float], None] = time.sleep,
     ) -> None:
         self._s = session if session is not None else _TimeoutSession()
         self._s.headers.update(
@@ -97,11 +108,43 @@ class GitHub:
                 "X-GitHub-Api-Version": "2022-11-28",
             }
         )
+        self._sleep = sleeper
+
+    def _retryable_get(self, url: str) -> _requests.Response:
+        """GET *url* with retry on transient upstream failures (#664).
+
+        Retries idempotent GETs on 5xx status codes and on
+        ``ConnectionError`` / ``Timeout`` from ``requests``.  Mutation paths
+        (POST/PATCH/PUT) never call this — they stay fail-fast.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(len(_GET_RETRY_DELAYS) + 1):
+            try:
+                resp = self._s.get(url)
+                if resp.status_code in _RETRYABLE_STATUS:
+                    last_exc = _requests.HTTPError(
+                        f"{resp.status_code} {resp.reason} for url: {url}",
+                        response=resp,
+                    )
+                else:
+                    resp.raise_for_status()
+                    return resp
+            except (_requests.ConnectionError, _requests.Timeout) as exc:
+                last_exc = exc
+            if attempt < len(_GET_RETRY_DELAYS):
+                delay = _GET_RETRY_DELAYS[attempt]
+                log.warning(
+                    "GitHub GET %s failed (%s) — retrying in %.1fs",
+                    url,
+                    last_exc,
+                    delay,
+                )
+                self._sleep(delay)
+        assert last_exc is not None
+        raise last_exc
 
     def _get(self, path: str) -> Any:
-        resp = self._s.get(f"{self.BASE}{path}")
-        resp.raise_for_status()
-        return resp.json()
+        return self._retryable_get(f"{self.BASE}{path}").json()
 
     def _post(self, path: str, **payload: Any) -> None:
         resp = self._s.post(f"{self.BASE}{path}", json=payload)
@@ -275,11 +318,15 @@ class GitHub:
         return [(c["id"], c.get("body", "")) for c in self._paginate(url)]
 
     def _paginate(self, url: str) -> Iterator[Any]:
-        """Yield each item from all pages of a paginated GitHub API endpoint."""
+        """Yield each item from all pages of a paginated GitHub API endpoint.
+
+        Each page request is retried on transient 5xx / network failures
+        (see ``_retryable_get``).  Pagination is a read-only operation so
+        retry is always safe.
+        """
         current: str | None = url
         while current:
-            resp = self._s.get(current)
-            resp.raise_for_status()
+            resp = self._retryable_get(current)
             yield from resp.json()
             link = resp.headers.get("Link", "")
             current = next(

--- a/kennel/reply_promises.py
+++ b/kennel/reply_promises.py
@@ -53,9 +53,14 @@ def add_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> Pat
 
 
 def remove_reply_promise(fido_dir: Path, comment_type: str, comment_id: int) -> None:
-    """Delete the durable promise file."""
+    """Delete the durable promise file if present.
+
+    The worker's recovery path and the webhook reply path can both race to
+    remove the same promise (see #665).  The caller's intent is "make sure
+    this promise is gone", so a missing file is success, not an error.
+    """
     _validate_comment_type(comment_type)
-    _promise_path(fido_dir, comment_type, comment_id).unlink()
+    _promise_path(fido_dir, comment_type, comment_id).unlink(missing_ok=True)
 
 
 def list_reply_promises(fido_dir: Path) -> list[ReplyPromise]:

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -19,6 +19,7 @@ from acp.exceptions import RequestError
 from kennel import provider
 from kennel.copilotcli import (
     _ACP_STREAM_LIMIT,
+    _COPILOT_CANCEL_SENTINEL,
     CopilotACPRuntime,
     CopilotCLI,
     CopilotCLIAPI,
@@ -26,6 +27,7 @@ from kennel.copilotcli import (
     CopilotCLISession,
     _combine_prompt,
     _CopilotACPClient,
+    _is_cancel_sentinel,
     _is_line_limit_overrun_error,
     _normalize_model,
     _preview_log_value,
@@ -295,6 +297,26 @@ class TestHelpers:
             ValueError("Separator is found, but chunk is longer than limit")
         )
         assert not _is_line_limit_overrun_error(ValueError("boom"))
+
+    def test_is_cancel_sentinel_matches_bare_string(self) -> None:
+        # #666: bare sentinel that leaked onto
+        # rhencke/orly#52 comment 4269109566.
+        assert _is_cancel_sentinel(_COPILOT_CANCEL_SENTINEL)
+
+    def test_is_cancel_sentinel_matches_trailing_sentinel(self) -> None:
+        # #666: some cancelled turns stream narration then append the
+        # sentinel as the final line.  Both shapes must be recognised.
+        narration = (
+            "Sniffing the panel layout and current branch state first...\n"
+            "I found the clean seam...\n"
+            "Info: Operation cancelled by user"
+        )
+        assert _is_cancel_sentinel(narration)
+
+    def test_is_cancel_sentinel_rejects_real_reply(self) -> None:
+        assert not _is_cancel_sentinel("")
+        assert not _is_cancel_sentinel("Info: Operation completed successfully")
+        assert not _is_cancel_sentinel("Info: Operation cancelled by user internally")
 
     def test_combine_prompt_joins_sections(self) -> None:
         assert (
@@ -891,11 +913,14 @@ class TestCopilotCLISession:
         )
 
         assert session.session_id == "sess-created"
+        # #666: a cancelled turn now returns "" so consumers' ``if not body``
+        # guards fire consistently — the raw runtime result string is only
+        # returned when the turn completed normally.
         assert (
             session.prompt(
                 "task", model=CopilotCLIClient.voice_model, system_prompt="system"
             )
-            == "result"
+            == ""
         )
         assert runtime.prompt_calls == [
             (
@@ -918,6 +943,28 @@ class TestCopilotCLISession:
         assert session.is_alive() is True
         session.stop()
         assert runtime.stop_called is True
+
+    def test_prompt_blanks_cancel_sentinel_even_without_cancelled_stop_reason(
+        self, tmp_path: Path
+    ) -> None:
+        # #666: the runtime sometimes returns Copilot's cancellation
+        # sentinel as the assistant-message content while reporting a
+        # non-"cancelled" stop_reason (e.g. "end_turn" after the cancel
+        # propagated late).  The talker boundary must still treat this as
+        # a cancelled turn so consumer ``if not body`` guards fire and
+        # the retry-on-preempt loop retries.
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        runtime.next_prompt = (_COPILOT_CANCEL_SENTINEL, "end_turn", "sess-x")
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+        )
+        assert session.prompt("task") == ""
+        assert session.last_turn_cancelled is True
 
     def test_webhook_preempts_worker_cancels_runtime(self, tmp_path: Path) -> None:
         """Worker holds the session; webhook contender fires the runtime

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -522,6 +522,100 @@ class TestGitHubClass:
         assert mock_s.get.call_count == 2
         assert mock_s.get.call_args_list[1].args[0] == next_url
 
+    def _transient_resp(self, status: int) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status
+        resp.reason = "Server Error"
+        return resp
+
+    def _ok_resp(self, body: list[dict], link: str = "") -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = body
+        resp.headers = {"Link": link} if link else {}
+        return resp
+
+    def test_retryable_get_retries_on_5xx_then_succeeds(self) -> None:
+        # Regression for #664: transient 5xx on a read-only GET must be
+        # retried, not propagated as an uncaught worker-thread crash.
+        import requests as _requests
+
+        sleeper = MagicMock()
+        mock_s = MagicMock()
+        mock_s.get.side_effect = [
+            self._transient_resp(500),
+            self._transient_resp(503),
+            self._ok_resp([{"id": 7}]),
+        ]
+        gh = GitHub("tok", session=mock_s, sleeper=sleeper)
+        assert gh._get("/anything") == [{"id": 7}]
+        assert mock_s.get.call_count == 3
+        # Two failures → two sleeps from the retry schedule.
+        assert sleeper.call_count == 2
+        assert sleeper.call_args_list[0].args[0] == 1.0
+        assert sleeper.call_args_list[1].args[0] == 3.0
+        # Sanity: no real network-error import drift.
+        assert issubclass(_requests.ConnectionError, Exception)
+
+    def test_retryable_get_gives_up_after_budget(self) -> None:
+        import requests as _requests
+
+        sleeper = MagicMock()
+        mock_s = MagicMock()
+        mock_s.get.return_value = self._transient_resp(502)
+        gh = GitHub("tok", session=mock_s, sleeper=sleeper)
+        with pytest.raises(_requests.HTTPError, match="502"):
+            gh._get("/always-bad")
+        # Initial attempt + len(_GET_RETRY_DELAYS) retries.
+        assert mock_s.get.call_count == 4
+        assert sleeper.call_count == 3
+
+    def test_retryable_get_retries_on_connection_error(self) -> None:
+        import requests as _requests
+
+        sleeper = MagicMock()
+        mock_s = MagicMock()
+        mock_s.get.side_effect = [
+            _requests.ConnectionError("boom"),
+            self._ok_resp([{"ok": True}]),
+        ]
+        gh = GitHub("tok", session=mock_s, sleeper=sleeper)
+        assert gh._get("/flaky") == [{"ok": True}]
+        assert mock_s.get.call_count == 2
+        assert sleeper.call_count == 1
+
+    def test_retryable_get_non_retryable_4xx_propagates_immediately(self) -> None:
+        import requests as _requests
+
+        sleeper = MagicMock()
+        mock_s = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.raise_for_status.side_effect = _requests.HTTPError("404")
+        mock_s.get.return_value = resp
+        gh = GitHub("tok", session=mock_s, sleeper=sleeper)
+        with pytest.raises(_requests.HTTPError, match="404"):
+            gh._get("/nope")
+        # No retry on 4xx — single GET, no sleep.
+        assert mock_s.get.call_count == 1
+        sleeper.assert_not_called()
+
+    def test_paginate_retries_on_5xx_mid_stream(self) -> None:
+        # Multi-page pagination: a 5xx on page 2 must not abort the
+        # whole walk — it retries just that page.
+        sleeper = MagicMock()
+        mock_s = MagicMock()
+        next_url = "https://api.github.com/repos/o/r/items?page=2"
+        page1 = self._ok_resp([{"id": 1}], link=f'<{next_url}>; rel="next"')
+        bad = self._transient_resp(502)
+        page2 = self._ok_resp([{"id": 2}])
+        mock_s.get.side_effect = [page1, bad, page2]
+        gh = GitHub("tok", session=mock_s, sleeper=sleeper)
+        result = list(gh._paginate("https://api.github.com/repos/o/r/items"))
+        assert result == [{"id": 1}, {"id": 2}]
+        assert mock_s.get.call_count == 3
+        assert sleeper.call_count == 1
+
     def _gql_pr(
         self, number: int, ref: str, state: str, user: str, body: str = ""
     ) -> dict:

--- a/tests/test_reply_promises.py
+++ b/tests/test_reply_promises.py
@@ -39,9 +39,11 @@ def test_remove_reply_promise_deletes_file(tmp_path: Path) -> None:
     assert not path.exists()
 
 
-def test_remove_reply_promise_missing_file_raises(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
-        remove_reply_promise(tmp_path / "fido", "pulls", 999)
+def test_remove_reply_promise_missing_file_is_noop(tmp_path: Path) -> None:
+    # Regression for #665: the worker recovery path and the webhook reply
+    # path can both try to remove the same promise.  Missing file means the
+    # intent ("make sure it's gone") is already satisfied.
+    remove_reply_promise(tmp_path / "fido", "pulls", 999)
 
 
 def test_list_reply_promises_returns_empty_when_dir_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Three crash/correctness fixes I found during watch:

- **#665** — `remove_reply_promise` now uses `unlink(missing_ok=True)` so the webhook-reply and worker-recovery paths can race without crashing.
- **#664** — transient GitHub 5xx / connection errors in read-only pagination no longer take down the worker thread (retry with backoff, GETs only — mutations remain fail-fast).
- **#666** — Copilot CLI's `"Info: Operation cancelled by user"` sentinel is now treated as a cancelled turn at the talker boundary, so it cannot leak into a PR comment body.

More commits incoming as I finish the other two fixes. Draft until 100% coverage and lint pass.

## Test plan

- [ ] `uv run pytest --cov --cov-fail-under=100` passes
- [ ] `uv run ruff check . && uv run ruff format --check .` passes
- [ ] Regression tests for each bug cover both the existed-then-gone (#665) case, the retryable 5xx case (#664), and the cancel-sentinel case (#666)