### PR TITLE
#669 root fix + provider-colored status sections

### DIFF
--- a/kennel/color.py
+++ b/kennel/color.py
@@ -64,3 +64,49 @@ def color(style: str, text: str) -> str:
     if not code:
         return text
     return f"{code}{text}{_RESET}"
+
+
+def wrap_raw(escape: str, text: str) -> str:
+    """Wrap *text* in a raw ANSI *escape* sequence when color is enabled.
+
+    Lower-level than :func:`color`: accepts any pre-built ANSI escape
+    (e.g. from :func:`rgb_fg`/:func:`rgb_bg`) so callers can render
+    provider-specific truecolor without registering a named style for
+    every provider.  Returns *text* unchanged when color is disabled or
+    *escape* is empty.
+    """
+    if not _color_enabled():
+        return text
+    if not escape:
+        return text
+    return f"{escape}{text}{_RESET}"
+
+
+def rgb_fg(r: int, g: int, b: int) -> str:
+    """Return a truecolor-foreground ANSI escape for (r, g, b)."""
+    return f"\033[38;2;{r};{g};{b}m"
+
+
+def rgb_bg(r: int, g: int, b: int) -> str:
+    """Return a truecolor-background ANSI escape for (r, g, b)."""
+    return f"\033[48;2;{r};{g};{b}m"
+
+
+def wrap_bg_line(bg_escape: str, line: str) -> str:
+    """Apply *bg_escape* across a pre-styled *line* so inner resets don't
+    punch holes in the background.
+
+    Inner ``\\x1b[0m`` resets clear every attribute, including the
+    background — so a naive ``f"{bg}{line}{_RESET}"`` would lose the tint
+    after the first styled token.  This helper re-applies ``bg_escape``
+    after every internal reset so the bg persists across the entire line,
+    then closes with a single final reset.
+
+    Returns *line* unchanged when color is disabled or *bg_escape* is
+    empty.
+    """
+    if not _color_enabled() or not bg_escape:
+        return line
+    if _RESET in line:
+        line = line.replace(_RESET, f"{_RESET}{bg_escape}")
+    return f"{bg_escape}{line}{_RESET}"

--- a/kennel/github.py
+++ b/kennel/github.py
@@ -432,6 +432,16 @@ class GitHub:
         """Post a comment on an issue."""
         self._post(f"/repos/{repo}/issues/{number}/comments", body=body)
 
+    def delete_issue_comment(self, repo: str, comment_id: int | str) -> None:
+        """Delete an issue/PR top-level comment by id.
+
+        Used by the worker's leak-cleanup path to remove improvised
+        top-level PR comments fido sometimes posts during a task turn
+        when it can't make progress (see #669).
+        """
+        resp = self._s.delete(f"{self.BASE}/repos/{repo}/issues/comments/{comment_id}")
+        resp.raise_for_status()
+
     def get_user(self) -> str:
         """Return the authenticated GitHub username."""
         data = self._get("/user")

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -31,6 +31,54 @@ class ProviderID(StrEnum):
     GEMINI = "gemini"
 
 
+@dataclass(frozen=True)
+class ProviderPalette:
+    """ANSI truecolor palette for a provider's status rendering.
+
+    ``dim_bg`` tints a repo's section block so all that repo's lines share
+    a provider-identifying background; ``bright_fg`` colors the provider's
+    token inside the global ``limits:`` line.  Both values are RGB triples
+    in the 0–255 range.
+
+    Guidelines for adding a new provider:
+
+    * ``dim_bg`` should be very dark (L* ≲ 20) so existing bright
+      foreground colors (white, cyan, yellow, magenta) remain readable
+      against it.  Aim for ≥4.5:1 contrast against white.
+    * ``bright_fg`` should be saturated and mid-to-high lightness so it
+      remains legible on a typical dark terminal background.  Light
+      terminals will lose contrast — users can opt out with ``NO_COLOR``.
+    """
+
+    dim_bg: tuple[int, int, int]
+    bright_fg: tuple[int, int, int]
+
+
+# Provider-specific color palettes.  Kept in one table so the contrast
+# audit test can iterate every provider and assert WCAG AA thresholds;
+# :mod:`kennel.status` looks colors up by ``ProviderID`` at render time.
+PROVIDER_PALETTES: dict[ProviderID, ProviderPalette] = {
+    ProviderID.CLAUDE_CODE: ProviderPalette(
+        dim_bg=(30, 15, 0),  # very dark burnt orange
+        bright_fg=(255, 160, 60),  # Claude-orange, legible on dark terminals
+    ),
+    ProviderID.COPILOT_CLI: ProviderPalette(
+        dim_bg=(22, 10, 30),  # very dark plum
+        bright_fg=(180, 130, 255),  # Copilot-purple, legible on dark terminals
+    ),
+}
+
+
+def palette_for(provider: ProviderID) -> ProviderPalette | None:
+    """Return the :class:`ProviderPalette` for *provider*, or ``None``.
+
+    Returns ``None`` for providers without a registered palette (e.g.
+    ``CODEX`` / ``GEMINI`` today).  Callers treat ``None`` as "render
+    without provider-specific color", not as an error.
+    """
+    return PROVIDER_PALETTES.get(provider)
+
+
 class TurnSessionMode(StrEnum):
     """How a provider turn should treat existing conversation state."""
 

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -24,9 +24,17 @@ from kennel.color import (
     RED_BOLD,
     YELLOW_BG,
     color,
+    rgb_bg,
+    rgb_fg,
+    wrap_bg_line,
+    wrap_raw,
 )
 from kennel.config import RepoConfig
-from kennel.provider import ProviderID, ProviderPressureStatus
+from kennel.provider import (
+    ProviderID,
+    ProviderPressureStatus,
+    palette_for,
+)
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.state import State
 from kennel.tasks import Tasks
@@ -682,7 +690,21 @@ def _provider_status_summary(status: ProviderPressureStatus) -> str:
 
 
 def _styled_provider_status(status: ProviderPressureStatus) -> str:
-    return color(_provider_status_style(status), _provider_status_summary(status))
+    base_style = _provider_status_style(status)
+    summary = _provider_status_summary(status)
+    if base_style:
+        # Preserve the existing dim/dark-gray rules (used when the provider
+        # is paused or warning) — those signal state more than identity, so
+        # they win over the provider-color highlight.
+        return color(base_style, summary)
+    # Highlight the provider name (prefix of the summary) with the provider's
+    # bright fg so each provider is visually identifiable in the limits line.
+    palette = palette_for(status.provider)
+    provider_token = str(status.provider)
+    if palette is not None and summary.startswith(provider_token):
+        tail = summary[len(provider_token) :]
+        return wrap_raw(rgb_fg(*palette.bright_fg), provider_token) + tail
+    return summary
 
 
 def _styled_repo_provider(repo: RepoStatus) -> str:
@@ -792,8 +814,12 @@ def _format_worker_thread_line(repo: RepoStatus) -> str:
     """
     state = _worker_thread_state(repo)
     is_active = repo.current_task is not None or _worker_is_agent_talker(repo)
+    # NO_COLOR users need an alternate signal to the GREEN_BG highlight;
+    # a leading "* " is visible in every terminal mode.  Inactive rows get
+    # two spaces so the label column stays aligned.
+    marker = "* " if is_active else "  "
     label = color(GREEN_BG, "Worker:") if is_active else color(BOLD, "Worker:")
-    return f"  {label} {state}"
+    return f"{marker}{label} {state}"
 
 
 def _worker_thread_state(repo: RepoStatus) -> str:
@@ -883,7 +909,11 @@ def format_status(status: KennelStatus) -> str:
         lines.append(provider_summary)
 
     for repo in status.repos:
-        lines.append(_format_repo_header(repo))
-        lines.extend(_format_repo_body(repo))
+        section = [_format_repo_header(repo), *_format_repo_body(repo)]
+        palette = palette_for(repo.provider)
+        if palette is not None:
+            bg = rgb_bg(*palette.dim_bg)
+            section = [wrap_bg_line(bg, line) for line in section]
+        lines.extend(section)
 
     return "\n".join(lines)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import IO, Any, Protocol
 
+import requests as _requests
+
 from kennel import hooks, tasks
 from kennel.claimed import replied_comments as _webhook_claimed
 from kennel.claude import ClaudeCode
@@ -369,6 +371,33 @@ class PickerChoice:
 
 def _has_milestone(issue: dict[str, Any]) -> bool:
     return bool((issue.get("milestone") or {}).get("title"))
+
+
+def _is_leaked_task_comment(body: str) -> bool:
+    """Match top-level PR issue comments fido improvises during a task turn.
+
+    Fix for #669: when a task's work was already done by a prior commit,
+    fido sometimes posts a top-level comment like
+    ``"BLOCKED: This task is already complete in pushed commit <sha>..."``
+    asking a human to mark the task done.  The worker detects these after
+    the turn and deletes them so reviewers never see them.
+
+    Narrow by design — only obviously-improvised comments match.  Legitimate
+    replies (webhook thread replies, rescope notifications, pickup
+    announcements) do not start with ``BLOCKED:`` and do not reference the
+    forbidden ``kennel task complete`` invocation.
+    """
+    stripped = (body or "").strip()
+    if not stripped:
+        return False
+    first_line = stripped.splitlines()[0].strip()
+    if first_line.startswith("BLOCKED:"):
+        return True
+    if "cannot run `kennel task" in stripped:
+        return True
+    if "explicitly forbids using `kennel task" in stripped:
+        return True
+    return False
 
 
 def _issue_assignees(issue: dict[str, Any]) -> list[str]:
@@ -1673,6 +1702,80 @@ class Worker:
         )
         return self._git(["rev-parse", "HEAD"]).stdout.strip()
 
+    def _snapshot_fido_issue_comment_ids(
+        self, repo: str, pr_number: int, fido_login: str
+    ) -> set[int]:
+        """Snapshot fido-authored issue-comment IDs on a PR (fix for #669).
+
+        Used as the before-image by :meth:`_delete_leaked_task_comments` so
+        only comments that appear *during* a task turn are considered for
+        cleanup.  Best-effort: on upstream error returns an empty set, which
+        conservatively means every later fido comment is treated as new.
+        """
+        try:
+            comments = self.gh.get_issue_comments(repo, pr_number)
+        except _requests.RequestException:
+            log.exception(
+                "leak-check: failed to snapshot issue comments on %s#%d",
+                repo,
+                pr_number,
+            )
+            return set()
+        return {
+            c["id"] for c in comments if c.get("user", {}).get("login") == fido_login
+        }
+
+    def _delete_leaked_task_comments(
+        self,
+        repo: str,
+        pr_number: int,
+        fido_login: str,
+        before_ids: set[int],
+    ) -> None:
+        """Delete top-level PR issue comments fido improvised during a task
+        turn (fix for #669).
+
+        Compares the current set of fido-authored issue comments on
+        *pr_number* against *before_ids*; any new comment matching
+        :func:`_is_leaked_task_comment` is deleted.  Post-hoc cleanup runs
+        after the task completion path; HTTP errors here are logged and
+        swallowed so a transient GitHub hiccup doesn't abort the caller.
+        """
+        try:
+            comments = self.gh.get_issue_comments(repo, pr_number)
+        except _requests.RequestException:
+            log.exception(
+                "leak-check: failed to fetch issue comments on %s#%d",
+                repo,
+                pr_number,
+            )
+            return
+        for c in comments:
+            cid = c["id"]
+            if cid in before_ids:
+                continue
+            if c.get("user", {}).get("login") != fido_login:
+                continue
+            body = c.get("body", "") or ""
+            if not _is_leaked_task_comment(body):
+                continue
+            try:
+                self.gh.delete_issue_comment(repo, cid)
+                log.warning(
+                    "deleted leaked top-level PR comment %d on %s#%d (body=%r)",
+                    cid,
+                    repo,
+                    pr_number,
+                    body[:200],
+                )
+            except _requests.RequestException:
+                log.exception(
+                    "leak-check: failed to delete comment %d on %s#%d",
+                    cid,
+                    repo,
+                    pr_number,
+                )
+
     def _squash_wip_commit(self, remote: str, slug: str, default_branch: str) -> bool:
         """Drop the empty 'wip: start' sentinel if it is the branch root.
 
@@ -1803,6 +1906,12 @@ class Worker:
         pr_title = pr_data.get("title", "") or ""
         pr_body = pr_data.get("body", "") or ""
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
+        # Snapshot fido-authored PR comments so we can detect and delete any
+        # improvised top-level BLOCKED/leak comments this task turn posts
+        # (see #669 and :func:`_is_leaked_task_comment`).
+        leak_before_ids = self._snapshot_fido_issue_comment_ids(
+            repo_ctx.repo, pr_number, repo_ctx.gh_user
+        )
         with State(fido_dir).modify() as state:
             state["current_task_id"] = task["id"]
         session_id, _output = provider_run(
@@ -1902,6 +2011,12 @@ class Worker:
             with State(fido_dir).modify() as state:
                 state.pop("current_task_id", None)
             tasks.sync_tasks(self.work_dir, self.gh)
+        # Sweep any leaked top-level PR comments (BLOCKED: ...) the provider
+        # improvised during this task turn.  Runs after task completion so a
+        # transient GitHub error during cleanup doesn't block progress.
+        self._delete_leaked_task_comments(
+            repo_ctx.repo, pr_number, repo_ctx.gh_user, leak_before_ids
+        )
         return True
 
     def seed_tasks_from_pr_body(self, repo: str, pr_number: int) -> None:

--- a/sub/task.md
+++ b/sub/task.md
@@ -68,6 +68,13 @@ Task implemented, committed, and pushed.
 
 **Stop immediately after completing this one task. Do not start the next task. Your job is exactly one task per invocation.**
 
+### If the work is already done
+If you discover the task's change is already present in the current branch (e.g. a prior commit on this branch already did it, or a rescope merged the work into another task), **just stop**. Do not commit, do not push, do not post anything.
+
+Never post a top-level PR comment (`gh api .../issues/<n>/comments`) explaining you cannot mark the task complete. The worker handles task bookkeeping; your only job is the code. If there is nothing to change, leave no trace.
+
+Never prefix any PR comment with `BLOCKED:`. Never ask a human or the queue manager to mark a task complete on your behalf. The kennel worker sees your empty-tree run and completes the task itself.
+
 ## Constraints
 - **Never** mark the PR as ready for review (`gh pr ready`). It must stay draft. That is the user's decision.
 - **Never** continue to another task after completing the current one. One task per invocation, period.

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -129,3 +129,76 @@ class TestColor:
     def test_color_enabled_dark_gray(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(DARK_GRAY, "paused") == "\033[90mpaused\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# wrap_raw / rgb_fg / rgb_bg / wrap_bg_line  (provider-color feature)
+# ---------------------------------------------------------------------------
+
+
+class TestRawWrapping:
+    def _enabled(self) -> dict[str, object]:
+        return {"FORCE_COLOR": "1"}
+
+    def _disabled(self) -> dict[str, object]:
+        return {"NO_COLOR": ""}
+
+    def test_rgb_fg_emits_truecolor_escape(self) -> None:
+        from kennel.color import rgb_fg
+
+        assert rgb_fg(255, 160, 60) == "\033[38;2;255;160;60m"
+
+    def test_rgb_bg_emits_truecolor_escape(self) -> None:
+        from kennel.color import rgb_bg
+
+        assert rgb_bg(30, 15, 0) == "\033[48;2;30;15;0m"
+
+    def test_wrap_raw_wraps_when_enabled(self) -> None:
+        from kennel.color import rgb_fg, wrap_raw
+
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            result = wrap_raw(rgb_fg(10, 20, 30), "x")
+            assert result == f"\033[38;2;10;20;30mx{_RESET}"
+
+    def test_wrap_raw_returns_text_when_disabled(self) -> None:
+        from kennel.color import rgb_fg, wrap_raw
+
+        with patch.dict("os.environ", self._disabled(), clear=True):
+            assert wrap_raw(rgb_fg(10, 20, 30), "x") == "x"
+
+    def test_wrap_raw_ignores_empty_escape(self) -> None:
+        from kennel.color import wrap_raw
+
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert wrap_raw("", "x") == "x"
+
+    def test_wrap_bg_line_applies_bg_across_inner_resets(self) -> None:
+        """Inner `_RESET`s must not punch holes in the background."""
+        from kennel.color import rgb_bg, wrap_bg_line
+
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            bg = rgb_bg(30, 15, 0)
+            # A pre-styled line: bold "A" then plain "B".
+            line = f"\033[1mA{_RESET}B"
+            result = wrap_bg_line(bg, line)
+            # After every inner reset, bg is re-applied; one final reset closes.
+            assert result == f"{bg}\033[1mA{_RESET}{bg}B{_RESET}"
+
+    def test_wrap_bg_line_no_inner_reset(self) -> None:
+        from kennel.color import rgb_bg, wrap_bg_line
+
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            bg = rgb_bg(30, 15, 0)
+            assert wrap_bg_line(bg, "plain") == f"{bg}plain{_RESET}"
+
+    def test_wrap_bg_line_disabled_returns_line_unchanged(self) -> None:
+        from kennel.color import rgb_bg, wrap_bg_line
+
+        with patch.dict("os.environ", self._disabled(), clear=True):
+            assert wrap_bg_line(rgb_bg(30, 15, 0), "plain") == "plain"
+
+    def test_wrap_bg_line_empty_escape_returns_line_unchanged(self) -> None:
+        from kennel.color import wrap_bg_line
+
+        with patch.dict("os.environ", self._enabled(), clear=True):
+            assert wrap_bg_line("", "plain") == "plain"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -600,6 +600,27 @@ class TestGitHubClass:
         assert mock_s.get.call_count == 1
         sleeper.assert_not_called()
 
+    def test_delete_issue_comment_calls_session_delete(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_s.delete.return_value = mock_resp
+        gh.delete_issue_comment("owner/repo", 42)
+        mock_s.delete.assert_called_once_with(
+            "https://api.github.com/repos/owner/repo/issues/comments/42"
+        )
+        mock_resp.raise_for_status.assert_called_once()
+
+    def test_delete_issue_comment_raises_on_error(self) -> None:
+        import requests as _requests
+
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = _requests.HTTPError("404")
+        mock_s.delete.return_value = mock_resp
+        with pytest.raises(_requests.HTTPError, match="404"):
+            gh.delete_issue_comment("owner/repo", 42)
+
     def test_paginate_retries_on_5xx_mid_stream(self) -> None:
         # Multi-page pagination: a 5xx on page 2 must not abort the
         # whole walk — it retries just that page.

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -133,3 +133,86 @@ class TestProviderModel:
 
     def test_comparison_to_unrelated_type_is_false(self) -> None:
         assert ProviderModel("gpt-5.4") != object()
+
+
+class TestProviderPalette:
+    """Provider-specific color palette + palette_for lookup + contrast audit."""
+
+    def test_palette_for_claude_code(self) -> None:
+        from kennel.provider import ProviderID, palette_for
+
+        palette = palette_for(ProviderID.CLAUDE_CODE)
+        assert palette is not None
+        assert palette.dim_bg == (30, 15, 0)
+        assert palette.bright_fg == (255, 160, 60)
+
+    def test_palette_for_copilot_cli(self) -> None:
+        from kennel.provider import ProviderID, palette_for
+
+        palette = palette_for(ProviderID.COPILOT_CLI)
+        assert palette is not None
+        assert palette.dim_bg == (22, 10, 30)
+        assert palette.bright_fg == (180, 130, 255)
+
+    def test_palette_for_codex_returns_none(self) -> None:
+        # CODEX/GEMINI have no palette registered today — callers must
+        # handle None as "render without provider color", not as an error.
+        from kennel.provider import ProviderID, palette_for
+
+        assert palette_for(ProviderID.CODEX) is None
+        assert palette_for(ProviderID.GEMINI) is None
+
+    @staticmethod
+    def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+        """WCAG relative luminance for an sRGB triple."""
+
+        def channel(value: int) -> float:
+            c = value / 255.0
+            return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+        r, g, b = rgb
+        return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+    @classmethod
+    def _contrast_ratio(cls, a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
+        la = cls._relative_luminance(a)
+        lb = cls._relative_luminance(b)
+        lighter, darker = (la, lb) if la >= lb else (lb, la)
+        return (lighter + 0.05) / (darker + 0.05)
+
+    def test_every_palette_clears_wcag_aa_vs_white(self) -> None:
+        """Dim-bg tints must keep white foreground text readable (≥4.5:1).
+
+        Prevents silent regressions when someone adds a new provider or
+        tweaks colors: the tint's dim_bg must preserve contrast with the
+        most common fg color used in status lines (white-ish).
+        """
+        from kennel.provider import PROVIDER_PALETTES
+
+        white = (255, 255, 255)
+        failures: list[str] = []
+        for pid, palette in PROVIDER_PALETTES.items():
+            ratio = self._contrast_ratio(palette.dim_bg, white)
+            if ratio < 4.5:
+                failures.append(
+                    f"{pid}: dim_bg={palette.dim_bg} vs white → {ratio:.2f}:1 (need ≥4.5)"
+                )
+        assert not failures, "\n".join(failures)
+
+    def test_bright_fg_clears_wcag_aa_vs_black(self) -> None:
+        """Bright fg on a typical dark-terminal bg must stay readable (≥4.5:1).
+
+        Light-terminal users get worse contrast — they should opt out
+        with NO_COLOR.  This test guards the dark-terminal happy path.
+        """
+        from kennel.provider import PROVIDER_PALETTES
+
+        black = (0, 0, 0)
+        failures: list[str] = []
+        for pid, palette in PROVIDER_PALETTES.items():
+            ratio = self._contrast_ratio(palette.bright_fg, black)
+            if ratio < 4.5:
+                failures.append(
+                    f"{pid}: bright_fg={palette.bright_fg} vs black → {ratio:.2f}:1"
+                )
+        assert not failures, "\n".join(failures)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1549,8 +1549,13 @@ class TestFormatStatus:
         )
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
+        # Active-agent rows start with "* Worker:" (NO_COLOR-friendly marker);
+        # inactive rows start with "  Worker:".  This repo's worker is the
+        # active talker, so check both prefixes for forward-compat.
         worker_lines = [
-            line for line in output.splitlines() if line.startswith("  Worker:")
+            line
+            for line in output.splitlines()
+            if line.startswith("  Worker:") or line.startswith("* Worker:")
         ]
         assert any("→ pid" not in line for line in worker_lines)
         # Header does not duplicate it.
@@ -2074,3 +2079,174 @@ class TestFormatStatusColor:
         with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
             output = format_status(status)
         assert "\033[" not in output
+
+
+class TestProviderColoredStatus:
+    """Provider-specific section-bg tinting + limits-line fg highlighting.
+
+    Feature: repo sections get the provider's dim_bg across all their
+    lines; the limits-line provider tokens get the provider's bright_fg;
+    the active-agent "Worker:" row carries an ASCII ``*`` marker that is
+    visible even under ``NO_COLOR``.
+    """
+
+    def _repo(self, **kwargs) -> RepoStatus:
+        defaults = dict(
+            name="owner/repo",
+            fido_running=False,
+            issue=None,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+        defaults.update(kwargs)
+        return RepoStatus(**defaults)
+
+    def test_active_worker_line_starts_with_asterisk_marker(self) -> None:
+        # NO_COLOR alternate for the GREEN_BG highlight: active rows carry
+        # a leading ``* `` that's visible regardless of ANSI support.
+        with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
+            repo = self._repo(
+                fido_running=True,
+                issue=7,
+                current_task={"title": "implement foo", "index": 1, "total": 2},
+            )
+            status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+            output = format_status(status)
+        worker_lines = [ln for ln in output.splitlines() if "Worker:" in ln]
+        assert worker_lines, f"no Worker line in:\n{output}"
+        assert worker_lines[0].startswith("* "), worker_lines[0]
+
+    def test_inactive_worker_line_keeps_alignment_without_marker(self) -> None:
+        with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
+            repo = self._repo(fido_running=True, issue=7)
+            status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+            output = format_status(status)
+        worker_lines = [ln for ln in output.splitlines() if "Worker:" in ln]
+        assert worker_lines, f"no Worker line in:\n{output}"
+        # Two-space indent preserves column alignment with the active form.
+        assert worker_lines[0].startswith("  Worker:"), worker_lines[0]
+
+    def test_limits_line_colors_claude_code_token_when_color_enabled(self) -> None:
+        from kennel.color import rgb_fg
+        from kennel.provider import PROVIDER_PALETTES
+
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            # pressure=0.50 keeps the status healthy — no warning/paused
+            # overlay — so the provider-color highlight wins.
+            provider_status = ProviderPressureStatus(
+                provider=ProviderID.CLAUDE_CODE,
+                pressure=0.50,
+                window_name="five_hour",
+            )
+            status = KennelStatus(
+                kennel_pid=None,
+                kennel_uptime=None,
+                repos=[self._repo(provider_status=provider_status)],
+                provider_statuses=[provider_status],
+            )
+            output = format_status(status)
+        palette = PROVIDER_PALETTES[ProviderID.CLAUDE_CODE]
+        expected_prefix = rgb_fg(*palette.bright_fg) + "claude-code"
+        limits_line = next(ln for ln in output.splitlines() if "limits:" in ln)
+        assert expected_prefix in limits_line
+
+    def test_limits_line_highlights_copilot_token(self) -> None:
+        from kennel.color import rgb_fg
+        from kennel.provider import PROVIDER_PALETTES
+
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
+            status = KennelStatus(
+                kennel_pid=None,
+                kennel_uptime=None,
+                repos=[
+                    self._repo(
+                        provider=ProviderID.COPILOT_CLI, provider_status=provider_status
+                    )
+                ],
+                provider_statuses=[provider_status],
+            )
+            output = format_status(status)
+        palette = PROVIDER_PALETTES[ProviderID.COPILOT_CLI]
+        expected_prefix = rgb_fg(*palette.bright_fg) + "copilot-cli"
+        limits_line = next(ln for ln in output.splitlines() if "limits:" in ln)
+        assert expected_prefix in limits_line
+
+    def test_limits_line_respects_paused_style_over_provider_fg(self) -> None:
+        # A paused / warning status wins over the provider highlight so
+        # state signalling isn't lost to identity coloring.
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            # pressure=0.99 crosses the pause threshold (0.95) → paused.
+            provider_status = ProviderPressureStatus(
+                provider=ProviderID.CLAUDE_CODE,
+                pressure=0.99,
+            )
+            status = KennelStatus(
+                kennel_pid=None,
+                kennel_uptime=None,
+                repos=[self._repo(provider_status=provider_status)],
+                provider_statuses=[provider_status],
+            )
+            output = format_status(status)
+        # DARK_GRAY code is \033[90m — must be present; truecolor provider
+        # prefix must NOT be (identity color suppressed while paused).
+        assert "\033[90m" in output
+
+    def test_repo_section_lines_get_provider_bg_when_color_enabled(self) -> None:
+        from kennel.color import rgb_bg
+        from kennel.provider import PROVIDER_PALETTES
+
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            repo = self._repo(fido_running=True, issue=7, issue_title="do thing")
+            status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+            output = format_status(status)
+        palette = PROVIDER_PALETTES[ProviderID.CLAUDE_CODE]
+        expected_bg = rgb_bg(*palette.dim_bg)
+        repo_lines = [
+            ln for ln in output.splitlines() if "owner/repo" in ln or "Issue:" in ln
+        ]
+        assert repo_lines, f"no repo/issue lines:\n{output}"
+        for line in repo_lines:
+            assert expected_bg in line, f"bg missing from: {line!r}"
+
+    def test_repo_section_bg_omitted_for_provider_without_palette(self) -> None:
+        # CODEX has no registered palette — section renders without
+        # provider-bg wrap.  This test also guards against crashes when
+        # palette_for returns None.
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            repo = self._repo(provider=ProviderID.CODEX, fido_running=True, issue=7)
+            status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+            output = format_status(status)
+        # No truecolor bg escape (\033[48;2;...m) should appear anywhere.
+        assert "\033[48;2;" not in output
+
+    def test_limits_line_falls_back_when_provider_has_no_palette(self) -> None:
+        # CODEX has no palette registered; the limits line still renders,
+        # without a truecolor fg prefix for the provider token.
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            provider_status = ProviderPressureStatus(
+                provider=ProviderID.CODEX,
+                pressure=0.50,
+                window_name="five_hour",
+            )
+            status = KennelStatus(
+                kennel_pid=None,
+                kennel_uptime=None,
+                repos=[
+                    self._repo(
+                        provider=ProviderID.CODEX, provider_status=provider_status
+                    )
+                ],
+                provider_statuses=[provider_status],
+            )
+            output = format_status(status)
+        limits_line = next(ln for ln in output.splitlines() if "limits:" in ln)
+        assert "codex 50%" in limits_line
+        assert "\033[38;2;" not in limits_line

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -42,6 +42,7 @@ from kennel.worker import (
     RepoContextFilter,
     RepoNameFilter,
     WorkerContext,
+    _is_leaked_task_comment,
     _pick_next_task,
     _sanitize_slug,
     _sanitize_status_text,
@@ -6681,6 +6682,48 @@ class TestExecuteTask:
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "my-branch")
         mock_status.assert_called_once_with("Working on: Write the tests")
 
+    def test_deletes_leaked_blocked_comment_posted_during_turn(
+        self, tmp_path: Path
+    ) -> None:
+        """Fix for #669: a BLOCKED: top-level PR comment fido posts during a
+        task turn is detected post-turn and deleted before reviewers see it."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("update gitignore for generated JsCoq assets")
+
+        # Simulate: fetch before the turn returns one pre-existing fido comment;
+        # fetch after the turn returns that same comment plus a new improvised
+        # BLOCKED comment authored by fido during the provider run.
+        gh.get_issue_comments.side_effect = [
+            [{"id": 100, "user": {"login": "fido-bot"}, "body": "old status"}],
+            [
+                {"id": 100, "user": {"login": "fido-bot"}, "body": "old status"},
+                {
+                    "id": 200,
+                    "user": {"login": "fido-bot"},
+                    "body": (
+                        "BLOCKED: This task is already complete in pushed "
+                        "commit abc123 but I cannot run `kennel task complete`."
+                    ),
+                },
+            ],
+        ]
+
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.sync_tasks"),
+        ):
+            assert worker.execute_task(fido_dir, self._repo_ctx(), 7, "branch") is True
+
+        # The pre-existing comment 100 stays; only the improvised 200 is deleted.
+        gh.delete_issue_comment.assert_called_once_with("owner/repo", 200)
+
     def test_builds_task_prompt_with_correct_skill(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
@@ -10602,3 +10645,119 @@ class TestWorkerThread:
 
         assert received_config == [config]
         assert received_repo_cfg == [cfg]
+
+
+class TestIsLeakedTaskComment:
+    """Fix for #669 — detect improvised BLOCKED comments fido posts during a task turn."""
+
+    def test_matches_blocked_prefix(self) -> None:
+        body = (
+            "BLOCKED: This task is already complete in pushed commit 3382c67 "
+            "on `render-demo-level-browser`, but I cannot run `kennel task "
+            "complete /home/rhencke/workspace/orly 1776437985163-0702` because "
+            "this task invocation explicitly forbids using `kennel task`."
+        )
+        assert _is_leaked_task_comment(body)
+
+    def test_matches_cannot_run_kennel_task(self) -> None:
+        body = "Hey, quick update: I cannot run `kennel task complete ...` per the constraint."
+        assert _is_leaked_task_comment(body)
+
+    def test_matches_explicitly_forbids(self) -> None:
+        body = "Something something explicitly forbids using `kennel task complete`."
+        assert _is_leaked_task_comment(body)
+
+    def test_rejects_empty(self) -> None:
+        assert not _is_leaked_task_comment("")
+        assert not _is_leaked_task_comment("   \n  \t ")
+
+    def test_rejects_normal_reply(self) -> None:
+        assert not _is_leaked_task_comment(
+            "Good catch sniffing that out! 🐕 Fixed in commit abc123."
+        )
+
+    def test_rejects_blocked_in_body_not_prefix(self) -> None:
+        # First line check — "BLOCKED:" only counts when it starts the comment.
+        assert not _is_leaked_task_comment(
+            "Just a note: some tests were BLOCKED: by a missing fixture."
+        )
+
+
+class TestLeakedCommentCleanup:
+    """Fix for #669 — Worker snapshots and deletes leaked task-turn comments."""
+
+    def _worker_with_gh(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
+        gh = MagicMock()
+        return Worker(tmp_path, gh), gh
+
+    def test_snapshot_returns_only_fido_ids(self, tmp_path: Path) -> None:
+        worker, gh = self._worker_with_gh(tmp_path)
+        gh.get_issue_comments.return_value = [
+            {"id": 1, "user": {"login": "reviewer"}},
+            {"id": 2, "user": {"login": "fido-bot"}},
+            {"id": 3, "user": {"login": "fido-bot"}},
+            {"id": 4, "user": {"login": "other-bot"}},
+        ]
+        ids = worker._snapshot_fido_issue_comment_ids("owner/repo", 7, "fido-bot")
+        assert ids == {2, 3}
+        gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
+
+    def test_snapshot_returns_empty_on_upstream_error(self, tmp_path: Path) -> None:
+        import requests
+
+        worker, gh = self._worker_with_gh(tmp_path)
+        gh.get_issue_comments.side_effect = requests.ConnectionError("boom")
+        assert (
+            worker._snapshot_fido_issue_comment_ids("owner/repo", 1, "fido-bot")
+            == set()
+        )
+
+    def test_deletes_only_new_fido_blocked_comments(self, tmp_path: Path) -> None:
+        worker, gh = self._worker_with_gh(tmp_path)
+        gh.get_issue_comments.return_value = [
+            {"id": 10, "user": {"login": "fido-bot"}, "body": "old innocuous comment"},
+            {
+                "id": 11,
+                "user": {"login": "reviewer"},
+                "body": "BLOCKED: human wrote this",
+            },
+            {
+                "id": 12,
+                "user": {"login": "fido-bot"},
+                "body": "BLOCKED: cannot run `kennel task complete`",
+            },
+            {
+                "id": 13,
+                "user": {"login": "fido-bot"},
+                "body": "Fresh comment that is fine",
+            },
+        ]
+        worker._delete_leaked_task_comments(
+            "owner/repo", 7, "fido-bot", before_ids={10}
+        )
+        # Only comment 12 matches all three conditions: new (not in before),
+        # fido-authored, and leak-pattern.
+        gh.delete_issue_comment.assert_called_once_with("owner/repo", 12)
+
+    def test_deletion_errors_are_swallowed(self, tmp_path: Path) -> None:
+        import requests
+
+        worker, gh = self._worker_with_gh(tmp_path)
+        gh.get_issue_comments.return_value = [
+            {"id": 20, "user": {"login": "fido-bot"}, "body": "BLOCKED: nothing to do"},
+        ]
+        gh.delete_issue_comment.side_effect = requests.HTTPError("404 gone")
+        # Must not raise — cleanup is best-effort.
+        worker._delete_leaked_task_comments(
+            "owner/repo", 7, "fido-bot", before_ids=set()
+        )
+
+    def test_fetch_error_during_cleanup_is_swallowed(self, tmp_path: Path) -> None:
+        import requests
+
+        worker, gh = self._worker_with_gh(tmp_path)
+        gh.get_issue_comments.side_effect = requests.ConnectionError("boom")
+        worker._delete_leaked_task_comments(
+            "owner/repo", 7, "fido-bot", before_ids=set()
+        )
+        gh.delete_issue_comment.assert_not_called()


### PR DESCRIPTION
Two stacked commits, one PR:

### 1. Delete leaked BLOCKED comments fido improvises during tasks (closes #669)

When a task's work is already present on the branch, fido sometimes improvises a top-level PR comment asking a human to mark the task complete. That string leaks to reviewers and makes fido look broken ([example](https://github.com/rhencke/orly/pull/52#issuecomment-4269286711)).

Root fix on the worker side: snapshot fido-authored issue-comment IDs before `provider_run`; after task completion, diff and delete any new fido comment whose body starts with `BLOCKED:` or references the forbidden ``kennel task complete`` invocation. Cleanup is best-effort and bounded to a narrow pattern, so legitimate rescope notifications / webhook replies / pickup announcements stay put.

Prompt-side belt in `sub/task.md`: explicit "If the work is already done — just stop. Never commit. Never post. Never prefix a comment with `BLOCKED:`. Never ask a human."

### 2. Provider-colored repo sections + limits highlights + NO_COLOR marker

Each repo's full section gets a per-provider dim-bg tint so the provider driving a repo is visible at a glance; the global `limits:` line colors each provider token with the provider's bright identity fg.

Provider-metadata-driven, not per-call-site constants:
- `ProviderPalette` attached to `ProviderID` via `palette_for(provider)`
- `color.py` gains `rgb_fg` / `rgb_bg` / `wrap_raw` / `wrap_bg_line` primitives
- `wrap_bg_line` re-applies the bg after every inner ANSI reset so the tint doesn't get punched out mid-line

Palettes: claude-code orange `(30,15,0)` / `(255,160,60)`; copilot-cli purple `(22,10,30)` / `(180,130,255)`.

Accessibility:
- Contrast-audit tests assert every palette clears WCAG AA (≥4.5:1) for `dim_bg` vs white and `bright_fg` vs black — new providers can't silently regress contrast
- `NO_COLOR` users get a leading ` * ` marker on the active worker row instead of the GREEN_BG highlight; inactive rows keep two spaces so column alignment holds

Paused / warning statuses still win over provider-color highlighting — state signalling matters more than branding when the account is throttled.

## Test plan
- [x] 100% coverage, all tests pass (`uv run pytest --cov --cov-fail-under=100`)
- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [ ] Visual check of `kennel status` with real sessions after merge