### PR TITLE
sync_tasks logs success but PR body work-queue stays stale after task completion (closes #674)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1204,6 +1204,7 @@ def _rewrite_pr_description(
 
         body = gh.get_pr_body(repo, pr_number)
         _write_pr_description(
+            work_dir,
             gh,
             repo,
             pr_number,

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -286,10 +286,21 @@ def sync_tasks(
 
         body = gh.get_pr_body(repo, pr_number)
 
-        if "WORK_QUEUE_START" not in body:
+        has_start = "WORK_QUEUE_START" in body
+        has_end = "WORK_QUEUE_END" in body
+        if not has_start and not has_end:
             log.info(
                 "sync_tasks: PR #%s has no work queue markers — skipping",
                 pr_number,
+            )
+            return
+        if not has_start or not has_end:
+            log.warning(
+                "sync_tasks: PR #%s has incomplete work queue markers "
+                "(start=%s end=%s) — skipping",
+                pr_number,
+                has_start,
+                has_end,
             )
             return
 

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -10,7 +10,8 @@ import re
 import subprocess
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
 
@@ -226,6 +227,27 @@ def _auto_complete_ask_tasks(
                 "sync_tasks: ASK task thread resolved — completing: %s", task["title"]
             )
             tasks.complete_by_id(task["id"])
+
+
+@contextmanager
+def pr_body_lock(work_dir: Path) -> Iterator[None]:
+    """Blocking exclusive lock on the PR-body sync.lock file.
+
+    Acquires LOCK_EX (blocking, not LOCK_NB) so callers wait rather than
+    skip.  Use to serialize any full-body PR edit against sync_tasks, which
+    also acquires this same lock (with LOCK_NB).  Prevents a description
+    rewrite from overwriting a concurrent work-queue sync.
+    """
+    git_dir = _resolve_git_dir(work_dir)
+    fido_dir = git_dir / "fido"
+    fido_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = fido_dir / "sync.lock"
+    fd = open(lock_path, "w")  # noqa: SIM115
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fd.close()
 
 
 def sync_tasks(

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -305,6 +305,12 @@ def sync_tasks(
             return
 
         new_body = _apply_queue_to_body(body, queue)
+        if new_body == body:
+            log.info(
+                "sync_tasks: PR #%s work queue already up to date — no change",
+                pr_number,
+            )
+            return
         gh.edit_pr_body(repo, pr_number, new_body)
         log.info("sync_tasks: PR #%s work queue synced", pr_number)
     finally:

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -716,6 +716,7 @@ def _extract_body(raw: str | None) -> str:
 
 
 def _write_pr_description(
+    work_dir: Path,
     gh: Any,
     repo: str,
     pr_number: int,
@@ -733,9 +734,13 @@ def _write_pr_description(
     divider).
 
     Generates the description via the provider agent and writes it back via
-    ``gh.edit_pr_body``.  Raises ``ValueError`` when the existing body has no
-    ``---`` divider (rewrite precondition) or when the agent returns no
-    ``<body>``-tagged content.
+    ``gh.edit_pr_body``.  The final PATCH is serialized through the same
+    ``sync.lock`` that :func:`kennel.tasks.sync_tasks` holds, preventing a
+    description rewrite from overwriting a concurrent work-queue update.
+
+    Raises ``ValueError`` when the existing body has no ``---`` divider
+    (rewrite precondition) or when the agent returns no ``<body>``-tagged
+    content.
     """
     if agent is None:
         raise ValueError("_write_pr_description requires agent")
@@ -781,7 +786,10 @@ def _write_pr_description(
         new_desc = f"{new_desc.rstrip()}\n\nFixes #{issue}."
 
     new_body = f"{new_desc.strip()}{divider}{rest}"
-    gh.edit_pr_body(repo, pr_number, new_body)
+    # Hold sync.lock during the PATCH so concurrent sync_tasks calls (which
+    # also acquire this lock) cannot interleave and overwrite each other.
+    with tasks.pr_body_lock(work_dir):
+        gh.edit_pr_body(repo, pr_number, new_body)
     log.info("_write_pr_description: PR #%s description written", pr_number)
 
 
@@ -1308,6 +1316,7 @@ class Worker:
             state["pr_number"] = pr_number
             state["pr_title"] = request
         _write_pr_description(
+            self.work_dir,
             self.gh,
             repo_ctx.repo,
             pr_number,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3987,6 +3987,13 @@ class TestReplyToCommentTerseEnrichment:
 
 
 class TestRewritePrDescription:
+    @pytest.fixture(autouse=True)
+    def _mock_pr_body_lock(self):
+        from contextlib import nullcontext
+
+        with patch("kennel.tasks.pr_body_lock", return_value=nullcontext()):
+            yield
+
     def _pr_body(self, desc: str = "Does something useful.\n\nFixes #42.") -> str:
         return (
             f"{desc}\n\n---\n\n## Work queue\n\n"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -33,6 +33,7 @@ from kennel.tasks import (
     _apply_queue_to_body,
     _auto_complete_ask_tasks,
     _format_work_queue,
+    pr_body_lock,
     sync_tasks,
     sync_tasks_background,
 )
@@ -3344,10 +3345,14 @@ class TestWritePrDescription:
         print_return="<body>Desc.\n\nFixes #1.</body>",
         issue=1,
         pr_number=42,
+        work_dir: Path | None = None,
     ):
+        from contextlib import nullcontext
+
         mock_cc = _client(print_return)
-        return (
-            _write_pr_description(
+        with patch("kennel.tasks.pr_body_lock", return_value=nullcontext()):
+            result = _write_pr_description(
+                work_dir or Path("/tmp"),
                 gh,
                 "owner/repo",
                 pr_number,
@@ -3355,14 +3360,31 @@ class TestWritePrDescription:
                 task_list or [],
                 existing_body,
                 agent=mock_cc,
-            ),
-            mock_cc,
-        )
+            )
+        return result, mock_cc
 
     def test_writes_to_github(self) -> None:
         gh = MagicMock()
         self._call(gh)
         gh.edit_pr_body.assert_called_once()
+
+    def test_acquires_pr_body_lock_when_writing(self) -> None:
+        from contextlib import nullcontext
+
+        gh = MagicMock()
+        with patch(
+            "kennel.tasks.pr_body_lock", return_value=nullcontext()
+        ) as mock_lock:
+            _write_pr_description(
+                Path("/tmp"),
+                gh,
+                "owner/repo",
+                42,
+                1,
+                [],
+                agent=_client("<body>Desc.\n\nFixes #1.</body>"),
+            )
+        mock_lock.assert_called_once_with(Path("/tmp"))
 
     def test_raises_when_opus_returns_empty(self) -> None:
         gh = MagicMock()
@@ -3514,7 +3536,7 @@ class TestWritePrDescription:
     def test_requires_agent(self) -> None:
         gh = MagicMock()
         with pytest.raises(ValueError, match="_write_pr_description requires agent"):
-            _write_pr_description(gh, "owner/repo", 99, 42, [])
+            _write_pr_description(Path("/tmp"), gh, "owner/repo", 99, 42, [])
 
 
 class TestFindOrCreatePr:
@@ -9558,6 +9580,32 @@ class TestFormatWorkQueue:
         result = _format_work_queue(tasks)
         assert "<!-- type:ci -->" in result
         assert "<!-- type:thread -->" in result
+
+
+class TestPrBodyLock:
+    def test_acquires_and_releases_lock(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True, exist_ok=True)
+        with patch("kennel.tasks._resolve_git_dir", return_value=tmp_path / ".git"):
+            with pr_body_lock(tmp_path):
+                assert (fido_dir / "sync.lock").exists()
+
+    def test_lock_blocks_sync_tasks(self, tmp_path: Path) -> None:
+        """sync_tasks (LOCK_NB) must skip while pr_body_lock holds the lock."""
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True, exist_ok=True)
+        (fido_dir / "state.json").write_text('{"issue": 1}')
+        gh = MagicMock()
+        with patch("kennel.tasks._resolve_git_dir", return_value=tmp_path / ".git"):
+            with pr_body_lock(tmp_path):
+                sync_tasks(
+                    tmp_path,
+                    gh,
+                    _resolve_git_dir_fn=MagicMock(return_value=tmp_path / ".git"),
+                    _auto_complete_ask_tasks_fn=MagicMock(),
+                )
+        # sync_tasks should have skipped (couldn't acquire LOCK_NB)
+        gh.find_pr.assert_not_called()
 
 
 class TestApplyQueueToBody:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9819,6 +9819,48 @@ class TestSyncTasks:
             sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_not_called()
 
+    def test_warns_and_skips_when_only_start_marker_present(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        import logging
+
+        gh = MagicMock()
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
+        gh.get_pr_body.return_value = "<!-- WORK_QUEUE_START -->\nno end marker"
+        task = {"title": "Do it", "status": "pending"}
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            caplog.at_level(logging.WARNING, logger="kennel"),
+        ):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
+        gh.edit_pr_body.assert_not_called()
+        assert "incomplete work queue markers" in caplog.text
+
+    def test_warns_and_skips_when_only_end_marker_present(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        import logging
+
+        gh = MagicMock()
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
+        gh.get_pr_body.return_value = "no start marker\n<!-- WORK_QUEUE_END -->"
+        task = {"title": "Do it", "status": "pending"}
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[task]),
+            caplog.at_level(logging.WARNING, logger="kennel"),
+        ):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
+        gh.edit_pr_body.assert_not_called()
+        assert "incomplete work queue markers" in caplog.text
+
     def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9861,6 +9861,24 @@ class TestSyncTasks:
         gh.edit_pr_body.assert_not_called()
         assert "incomplete work queue markers" in caplog.text
 
+    def test_skips_patch_and_logs_when_body_unchanged(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 5, "state": "OPEN"}
+        # Build a body whose queue already matches the single pending task
+        task = {"title": "Do it", "status": "pending", "type": "spec"}
+        from kennel.tasks import _format_work_queue
+
+        queue = _format_work_queue([task])
+        body = f"desc\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
+        gh.get_pr_body.return_value = body
+        with patch("kennel.tasks.Tasks.list", return_value=[task]):
+            sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
+        gh.edit_pr_body.assert_not_called()
+
     def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9927,6 +9927,41 @@ class TestSyncTasks:
             sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.edit_pr_body.assert_not_called()
 
+    def test_completed_task_appears_in_pr_body_after_sync(self, tmp_path: Path) -> None:
+        """End-to-end: add a task, complete it, sync — PR body must show it done."""
+        from kennel.tasks import Tasks
+        from kennel.types import TaskType
+
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+
+        # Use real Tasks operations — no task-list mock
+        task = Tasks(tmp_path).add("Replace the marker", TaskType.SPEC)
+        Tasks(tmp_path).complete_by_id(task["id"])
+
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 42, "state": "OPEN"}
+        gh.get_pr_body.return_value = (
+            "desc\n\n---\n\n## Work queue\n\n"
+            "<!-- WORK_QUEUE_START -->\n"
+            "- [ ] Replace the marker **→ next** <!-- type:spec -->\n"
+            "<!-- WORK_QUEUE_END -->"
+        )
+
+        sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
+
+        gh.edit_pr_body.assert_called_once()
+        new_body = gh.edit_pr_body.call_args[0][2]
+        # Completed task must appear inside the <details> block, not as a pending item
+        assert "Replace the marker" in new_body
+        assert "- [x]" in new_body
+        assert "<details>" in new_body
+        assert "Completed (1)" in new_body
+        # Must not remain as a pending checkbox
+        assert "- [ ] Replace the marker" not in new_body
+
     def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)


### PR DESCRIPTION
Fixes #674.

Fixes sync_tasks silently logging success when the PR body work-queue is actually stale — adds missing END marker validation, skips the PATCH when nothing changed, and serializes all PR body writes through the same lock to prevent concurrent overwrites.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Serialize PR body writes through sync.lock in _write_pr_description <!-- type:spec -->
- [x] Add end-to-end test: task completion then sync_tasks updates PR body <!-- type:spec -->
- [x] Skip PATCH and log no-change when new_body equals current body <!-- type:spec -->
- [x] Check both WORK_QUEUE markers in sync_tasks, warn on missing END <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->