### PR TITLE
Status rendering: provider bg invisible, '<- provider' suffix mistake, '*' leaks into color mode (closes #676)

### DIFF
--- a/kennel/color.py
+++ b/kennel/color.py
@@ -44,7 +44,7 @@ _CODES: dict[str, str] = {
 }
 
 
-def _color_enabled() -> bool:
+def color_enabled() -> bool:
     """Return True if ANSI color output should be used."""
     if os.environ.get("FORCE_COLOR") == "1":
         return True
@@ -58,7 +58,7 @@ def color(style: str, text: str) -> str:
 
     Returns *text* unchanged when color is disabled or *style* is unknown.
     """
-    if not _color_enabled():
+    if not color_enabled():
         return text
     code = _CODES.get(style, "")
     if not code:
@@ -75,7 +75,7 @@ def wrap_raw(escape: str, text: str) -> str:
     every provider.  Returns *text* unchanged when color is disabled or
     *escape* is empty.
     """
-    if not _color_enabled():
+    if not color_enabled():
         return text
     if not escape:
         return text
@@ -105,7 +105,7 @@ def wrap_bg_line(bg_escape: str, line: str) -> str:
     Returns *line* unchanged when color is disabled or *bg_escape* is
     empty.
     """
-    if not _color_enabled() or not bg_escape:
+    if not color_enabled() or not bg_escape:
         return line
     if _RESET in line:
         line = line.replace(_RESET, f"{_RESET}{bg_escape}")

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -42,7 +42,7 @@ class ProviderPalette:
 
     Guidelines for adding a new provider:
 
-    * ``dim_bg`` should be very dark (L* ≲ 20) so existing bright
+    * ``dim_bg`` should be noticeably tinted but dark enough that bright
       foreground colors (white, cyan, yellow, magenta) remain readable
       against it.  Aim for ≥4.5:1 contrast against white.
     * ``bright_fg`` should be saturated and mid-to-high lightness so it
@@ -59,11 +59,11 @@ class ProviderPalette:
 # :mod:`kennel.status` looks colors up by ``ProviderID`` at render time.
 PROVIDER_PALETTES: dict[ProviderID, ProviderPalette] = {
     ProviderID.CLAUDE_CODE: ProviderPalette(
-        dim_bg=(30, 15, 0),  # very dark burnt orange
+        dim_bg=(60, 30, 5),  # noticeable burnt orange tint, still dark
         bright_fg=(255, 160, 60),  # Claude-orange, legible on dark terminals
     ),
     ProviderID.COPILOT_CLI: ProviderPalette(
-        dim_bg=(22, 10, 30),  # very dark plum
+        dim_bg=(40, 20, 60),  # obvious plum tint, still dark
         bright_fg=(180, 130, 255),  # Copilot-purple, legible on dark terminals
     ),
 }

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -24,6 +24,7 @@ from kennel.color import (
     RED_BOLD,
     YELLOW_BG,
     color,
+    color_enabled,
     rgb_bg,
     rgb_fg,
     wrap_bg_line,
@@ -831,9 +832,10 @@ def _format_worker_thread_line(repo: RepoStatus) -> str:
     state = _worker_thread_state(repo)
     is_active = repo.current_task is not None or _worker_is_agent_talker(repo)
     # NO_COLOR users need an alternate signal to the GREEN_BG highlight;
-    # a leading "* " is visible in every terminal mode.  Inactive rows get
-    # two spaces so the label column stays aligned.
-    marker = "* " if is_active else "  "
+    # a leading "* " is visible when color is disabled.  Under color mode
+    # GREEN_BG already provides the highlight, so the asterisk is omitted.
+    # Inactive rows always get two spaces so the label column stays aligned.
+    marker = "* " if (is_active and not color_enabled()) else "  "
     label = color(GREEN_BG, "Worker:") if is_active else color(BOLD, "Worker:")
     line = f"{marker}{label} {state}"
     return line

--- a/kennel/status.py
+++ b/kennel/status.py
@@ -836,8 +836,6 @@ def _format_worker_thread_line(repo: RepoStatus) -> str:
     marker = "* " if is_active else "  "
     label = color(GREEN_BG, "Worker:") if is_active else color(BOLD, "Worker:")
     line = f"{marker}{label} {state}"
-    if _worker_is_agent_talker(repo):
-        line += f" {color(DIM, f'<- {repo.provider}')}"
     return line
 
 
@@ -898,8 +896,6 @@ def _format_webhook_lines(repo: RepoStatus) -> list[str]:
         )
         elapsed = color(DIM, f"({_format_uptime(w.elapsed_seconds)})")
         line = f"  {branch} {wh_label} {w.description} {elapsed}"
-        if is_talker:
-            line += f" {color(DIM, f'<- {repo.provider}')}"
         lines.append(line)
     if overflow > 0:
         lines.append(

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -18,49 +18,49 @@ from kennel.color import (
     RED,
     RED_BOLD,
     YELLOW,
-    _color_enabled,
     color,
+    color_enabled,
 )
 
 # ---------------------------------------------------------------------------
-# _color_enabled
+# color_enabled
 # ---------------------------------------------------------------------------
 
 
 class TestColorEnabled:
     def test_force_color_enables(self) -> None:
         with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
-            assert _color_enabled() is True
+            assert color_enabled() is True
 
     def test_force_color_overrides_no_color(self) -> None:
         with patch.dict("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": ""}, clear=True):
-            assert _color_enabled() is True
+            assert color_enabled() is True
 
     def test_no_color_disables(self) -> None:
         with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):
-            assert _color_enabled() is False
+            assert color_enabled() is False
 
     def test_no_color_any_value_disables(self) -> None:
         with patch.dict("os.environ", {"NO_COLOR": "1"}, clear=True):
-            assert _color_enabled() is False
+            assert color_enabled() is False
 
     def test_tty_enables(self) -> None:
         with patch.dict("os.environ", {}, clear=True):
             with patch("sys.stdout") as mock_stdout:
                 mock_stdout.isatty.return_value = True
-                assert _color_enabled() is True
+                assert color_enabled() is True
 
     def test_non_tty_disables(self) -> None:
         with patch.dict("os.environ", {}, clear=True):
             with patch("sys.stdout") as mock_stdout:
                 mock_stdout.isatty.return_value = False
-                assert _color_enabled() is False
+                assert color_enabled() is False
 
     def test_force_color_wrong_value_falls_through_to_tty(self) -> None:
         with patch.dict("os.environ", {"FORCE_COLOR": "0"}, clear=True):
             with patch("sys.stdout") as mock_stdout:
                 mock_stdout.isatty.return_value = False
-                assert _color_enabled() is False
+                assert color_enabled() is False
 
 
 # ---------------------------------------------------------------------------
@@ -94,39 +94,39 @@ class TestColor:
             result = color(style, "text")
             assert result == f"{_CODES[style]}text{_RESET}"
 
-    def test_color_enabled_bold(self) -> None:
+    def testcolor_enabled_bold(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(BOLD, "hi") == "\033[1mhi\033[0m"
 
-    def test_color_enabled_dim(self) -> None:
+    def testcolor_enabled_dim(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(DIM, "quiet") == "\033[2mquiet\033[0m"
 
-    def test_color_enabled_red(self) -> None:
+    def testcolor_enabled_red(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(RED, "danger") == "\033[31mdanger\033[0m"
 
-    def test_color_enabled_red_bold(self) -> None:
+    def testcolor_enabled_red_bold(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(RED_BOLD, "alarm") == "\033[1;31malarm\033[0m"
 
-    def test_color_enabled_cyan(self) -> None:
+    def testcolor_enabled_cyan(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(CYAN, "#42") == "\033[36m#42\033[0m"
 
-    def test_color_enabled_magenta(self) -> None:
+    def testcolor_enabled_magenta(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(MAGENTA, "#99") == "\033[35m#99\033[0m"
 
-    def test_color_enabled_green(self) -> None:
+    def testcolor_enabled_green(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(GREEN, "worker") == "\033[32mworker\033[0m"
 
-    def test_color_enabled_yellow(self) -> None:
+    def testcolor_enabled_yellow(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(YELLOW, "webhook") == "\033[33mwebhook\033[0m"
 
-    def test_color_enabled_dark_gray(self) -> None:
+    def testcolor_enabled_dark_gray(self) -> None:
         with patch.dict("os.environ", self._enabled(), clear=True):
             assert color(DARK_GRAY, "paused") == "\033[90mpaused\033[0m"
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -143,7 +143,7 @@ class TestProviderPalette:
 
         palette = palette_for(ProviderID.CLAUDE_CODE)
         assert palette is not None
-        assert palette.dim_bg == (30, 15, 0)
+        assert palette.dim_bg == (60, 30, 5)
         assert palette.bright_fg == (255, 160, 60)
 
     def test_palette_for_copilot_cli(self) -> None:
@@ -151,7 +151,7 @@ class TestProviderPalette:
 
         palette = palette_for(ProviderID.COPILOT_CLI)
         assert palette is not None
-        assert palette.dim_bg == (22, 10, 30)
+        assert palette.dim_bg == (40, 20, 60)
         assert palette.bright_fg == (180, 130, 255)
 
     def test_palette_for_codex_returns_none(self) -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -2247,8 +2247,9 @@ class TestProviderColoredStatus:
 
     Feature: repo sections get the provider's dim_bg across all their
     lines; the limits-line provider tokens get the provider's bright_fg;
-    the active-agent "Worker:" row carries an ASCII ``*`` marker that is
-    visible even under ``NO_COLOR``.
+    the active-agent "Worker:" row carries an ASCII ``*`` marker under
+    ``NO_COLOR`` (GREEN_BG is the signal when color is enabled, so no
+    asterisk is needed in color mode).
     """
 
     def _repo(self, **kwargs) -> RepoStatus:
@@ -2283,6 +2284,28 @@ class TestProviderColoredStatus:
         worker_lines = [ln for ln in output.splitlines() if "Worker:" in ln]
         assert worker_lines, f"no Worker line in:\n{output}"
         assert worker_lines[0].startswith("* "), worker_lines[0]
+
+    def test_active_worker_line_has_no_asterisk_when_color_enabled(self) -> None:
+        # When color is on, GREEN_BG provides the active-worker signal;
+        # the ``*`` marker must NOT appear (it would be redundant clutter).
+        with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
+            repo = self._repo(
+                fido_running=True,
+                issue=7,
+                current_task={"title": "implement foo", "index": 1, "total": 2},
+            )
+            status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
+            output = format_status(status)
+        worker_lines = [ln for ln in output.splitlines() if "Worker:" in ln]
+        assert worker_lines, f"no Worker line in:\n{output}"
+        # Strip ANSI codes to check prefix cleanly.
+        import re
+
+        plain = re.sub(r"\033\[[^m]*m", "", worker_lines[0])
+        assert not plain.startswith("* "), (
+            f"unexpected asterisk in color mode: {plain!r}"
+        )
+        assert plain.startswith("  "), f"expected two-space indent: {plain!r}"
 
     def test_inactive_worker_line_keeps_alignment_without_marker(self) -> None:
         with patch.dict("os.environ", {"NO_COLOR": ""}, clear=True):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1824,8 +1824,8 @@ class TestFormatStatus:
         assert "triaging comment" in webhook_lines[1]
         assert "→ pid" not in webhook_lines[1]
 
-    def test_worker_line_shows_provider_marker_when_worker_is_talker(self) -> None:
-        """Worker line gets a <- {provider} marker when the worker owns the session."""
+    def test_worker_line_has_no_provider_suffix_when_worker_is_talker(self) -> None:
+        """Worker line has no '<- provider' suffix even when the worker owns the session."""
         repo = self._repo(
             issue=1,
             current_task="Do thing",
@@ -1841,7 +1841,7 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         worker_line = next(ln for ln in output.splitlines() if "Worker:" in ln)
-        assert "<- claude-code" in worker_line
+        assert "<-" not in worker_line
 
     def test_worker_line_no_marker_when_not_talker(self) -> None:
         """Worker line has no provider marker when the worker is on a task but not talking."""
@@ -1856,8 +1856,8 @@ class TestFormatStatus:
         worker_line = next(ln for ln in output.splitlines() if "Worker:" in ln)
         assert "<-" not in worker_line
 
-    def test_webhook_line_shows_provider_marker_when_talker(self) -> None:
-        """Active webhook talker line gets a <- {provider} marker."""
+    def test_webhook_talker_sorts_first_and_has_no_provider_suffix(self) -> None:
+        """Active webhook talker sorts to top; neither line has a '<- provider' suffix."""
         repo = self._repo(
             issue=1,
             webhook_activities=[
@@ -1878,49 +1878,12 @@ class TestFormatStatus:
         status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
         output = format_status(status)
         webhook_lines = [ln for ln in output.splitlines() if "webhook:" in ln]
-        # Active talker (replying to review, tid=2) sorts to top and gets marker.
+        # Active talker (replying to review, tid=2) sorts to top.
         assert "replying to review" in webhook_lines[0]
-        assert "<- claude-code" in webhook_lines[0]
-        # Non-talker has no marker.
+        assert "<-" not in webhook_lines[0]
+        # Non-talker also has no suffix.
         assert "triaging comment" in webhook_lines[1]
         assert "<-" not in webhook_lines[1]
-
-    def test_webhook_marker_uses_provider_name(self) -> None:
-        """Marker uses the configured provider name, not a hardcoded string."""
-        repo = self._repo(
-            issue=1,
-            provider=ProviderID.COPILOT_CLI,
-            webhook_activities=[
-                WebhookActivityInfo(
-                    description="triaging", elapsed_seconds=3, thread_id=5
-                ),
-            ],
-            claude_talker=ClaudeTalkerInfo(
-                thread_id=5,
-                kind="webhook",
-                description="copilot session",
-                claude_pid=77,
-            ),
-        )
-        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
-        output = format_status(status)
-        webhook_line = next(ln for ln in output.splitlines() if "webhook:" in ln)
-        assert "<- copilot-cli" in webhook_line
-
-    def test_worker_marker_uses_provider_name(self) -> None:
-        """Worker marker uses the configured provider name, not a hardcoded string."""
-        repo = self._repo(
-            issue=1,
-            provider=ProviderID.COPILOT_CLI,
-            current_task="Do thing",
-            task_number=1,
-            task_total=1,
-            session_owner="worker-orly",
-        )
-        status = KennelStatus(kennel_pid=None, kennel_uptime=None, repos=[repo])
-        output = format_status(status)
-        worker_line = next(ln for ln in output.splitlines() if "Worker:" in ln)
-        assert "<- copilot-cli" in worker_line
 
     def test_webhook_overflow_summary_when_more_than_five(self) -> None:
         """More than 5 webhook activities → first 5 shown + '+N more' line."""


### PR DESCRIPTION
Fixes #676.

Fixes three status rendering regressions from PR #670: bumps provider background tint values so they're actually visible in dark terminals, removes the redundant `<- provider` suffix from worker and webhook lines, and scopes the `*` active-marker to NO_COLOR mode only.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Remove '<- provider' suffix from worker and webhook lines <!-- type:spec -->
- [x] Scope asterisk active-marker to NO_COLOR mode only <!-- type:spec -->
- [x] Bump provider dim_bg palette values so tint is visible <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->