### PR TITLE
Worker bypasses thread-resolve on task complete — review threads stay unresolved after fix (closes #673)

### DIFF
--- a/kennel/cli.py
+++ b/kennel/cli.py
@@ -21,47 +21,6 @@ class Cmd:
     def __init__(self, *, github: GitHub) -> None:
         self._github = github
 
-    def _resolve_thread_if_ours(self, thread: dict[str, Any]) -> None:
-        """Resolve the review thread if the last reply came from us."""
-        repo = thread.get("repo", "")
-        pr = thread.get("pr")
-        comment_id = thread.get("comment_id")
-        if not (repo and pr and comment_id):
-            return
-
-        github = self._github
-        try:
-            us = github.get_user()
-            comments = github.get_pull_comments(repo, pr)
-            thread_comments = sorted(
-                [
-                    c
-                    for c in comments
-                    if c.get("id") == comment_id
-                    or c.get("in_reply_to_id") == comment_id
-                ],
-                key=lambda c: c.get("created_at", ""),
-            )
-            if not thread_comments:
-                return
-            last_author = thread_comments[-1].get("user", {}).get("login", "")
-            if last_author != us:
-                log.info("thread has new replies from %s — not resolving", last_author)
-                return
-
-            owner, repo_name = repo.split("/", 1)
-            threads = github.get_review_threads(owner, repo_name, pr)
-            for t in threads:
-                if t["isResolved"]:
-                    continue
-                nodes = t["comments"]["nodes"]
-                if nodes and nodes[0].get("databaseId") == comment_id:
-                    github.resolve_thread(t["id"])
-                    log.info("thread resolved: %s", t["id"])
-                    return
-        except Exception as exc:  # noqa: BLE001
-            log.warning("thread resolution skipped: %s", exc)
-
     def add(
         self,
         work_dir: Path,
@@ -89,9 +48,7 @@ class Cmd:
         return task
 
     def complete(self, work_dir: Path, task_id: str) -> None:
-        thread = Tasks(work_dir).complete_by_id(task_id)
-        if thread:
-            self._resolve_thread_if_ours(thread)
+        Tasks(work_dir).complete_with_resolve(task_id, self._github)
 
     def list(self, work_dir: Path) -> None:
         result = Tasks(work_dir).list()

--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -681,6 +681,53 @@ class Tasks(JsonFileStore):
                     return t.get("thread")
         return None
 
+    def complete_with_resolve(self, task_id: str, gh: GitHub) -> None:
+        """Mark a task completed and resolve its review thread if we posted last.
+
+        Combines :meth:`complete_by_id` with the per-task thread-resolve logic
+        so both the worker and CLI share one path.  If the task has no thread
+        metadata, or we are not the last commenter, the resolve step is skipped
+        silently.
+        """
+        thread = self.complete_by_id(task_id)
+        if not thread:
+            return
+        repo = thread.get("repo", "")
+        pr = thread.get("pr")
+        comment_id = thread.get("comment_id")
+        if not (repo and pr and comment_id):
+            return
+        try:
+            us = gh.get_user()
+            comments = gh.get_pull_comments(repo, pr)
+            thread_comments = sorted(
+                [
+                    c
+                    for c in comments
+                    if c.get("id") == comment_id
+                    or c.get("in_reply_to_id") == comment_id
+                ],
+                key=lambda c: c.get("created_at", ""),
+            )
+            if not thread_comments:
+                return
+            last_author = thread_comments[-1].get("user", {}).get("login", "")
+            if last_author != us:
+                log.info("thread has new replies from %s — not resolving", last_author)
+                return
+            owner, repo_name = repo.split("/", 1)
+            threads = gh.get_review_threads(owner, repo_name, pr)
+            for t in threads:
+                if t["isResolved"]:
+                    continue
+                nodes = t["comments"]["nodes"]
+                if nodes and nodes[0].get("databaseId") == comment_id:
+                    gh.resolve_thread(t["id"])
+                    log.info("thread resolved: %s", t["id"])
+                    return
+        except Exception as exc:  # noqa: BLE001
+            log.warning("thread resolution skipped: %s", exc)
+
     def has_pending_for_comment(self, comment_id: int | str) -> bool:
         """Return True if any pending task references *comment_id*."""
         cid = int(comment_id)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2016,7 +2016,7 @@ class Worker:
         self._squash_wip_commit("origin", slug, repo_ctx.default_branch)
         pushed = self.ensure_pushed("origin", slug)
         if pushed is not False:
-            self._tasks.complete_by_id(task["id"])
+            self._tasks.complete_with_resolve(task["id"], self.gh)
             with State(fido_dir).modify() as state:
                 state.pop("current_task_id", None)
             tasks.sync_tasks(self.work_dir, self.gh)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1047,3 +1047,161 @@ class TestTasks:
         with pytest.raises(ValueError, match="missing required type field"):
             with Tasks(work_dir).modify() as _:
                 pass
+
+
+class TestTasksCompleteWithResolve:
+    """Tests for Tasks.complete_with_resolve — the unified complete+thread-resolve path."""
+
+    def _work_dir(self, tmp_path: Path) -> Path:
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        return work_dir
+
+    def test_marks_task_completed(self, tmp_path: Path) -> None:
+        work_dir = self._work_dir(tmp_path)
+        task = add_task(work_dir, "task", TaskType.SPEC)
+        Tasks(work_dir).complete_with_resolve(task["id"], MagicMock())
+        assert list_tasks(work_dir)[0]["status"] == "completed"
+
+    def test_no_thread_does_not_call_github(self, tmp_path: Path) -> None:
+        work_dir = self._work_dir(tmp_path)
+        task = add_task(work_dir, "task", TaskType.SPEC)
+        gh = MagicMock()
+        Tasks(work_dir).complete_with_resolve(task["id"], gh)
+        gh.get_user.assert_not_called()
+        gh.resolve_thread.assert_not_called()
+
+    def test_thread_missing_fields_skips_resolve(self, tmp_path: Path) -> None:
+        """Thread dict with missing pr/comment_id skips resolution."""
+        work_dir = self._work_dir(tmp_path)
+        task = add_task(work_dir, "task", TaskType.THREAD, thread={"repo": "a/b"})
+        gh = MagicMock()
+        Tasks(work_dir).complete_with_resolve(task["id"], gh)
+        gh.resolve_thread.assert_not_called()
+
+    def test_nonexistent_id_does_not_raise(self, tmp_path: Path) -> None:
+        work_dir = self._work_dir(tmp_path)
+        Tasks(work_dir).complete_with_resolve("nonexistent-id", MagicMock())
+
+    def test_resolves_thread_when_we_are_last(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        work_dir = self._work_dir(tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+
+        gh = MagicMock()
+        gh.get_user.return_value = "fido-bot"
+        gh.get_pull_comments.return_value = [
+            {
+                "id": 42,
+                "in_reply_to_id": None,
+                "user": {"login": "reviewer"},
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "id": 99,
+                "in_reply_to_id": 42,
+                "user": {"login": "fido-bot"},
+                "created_at": "2024-01-02T00:00:00Z",
+            },
+        ]
+        gh.get_review_threads.return_value = [
+            {
+                "id": "thread_node_abc",
+                "isResolved": False,
+                "comments": {"nodes": [{"databaseId": 42}]},
+            }
+        ]
+
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            Tasks(work_dir).complete_with_resolve(task["id"], gh)
+
+        gh.resolve_thread.assert_called_once_with("thread_node_abc")
+        assert "thread resolved: thread_node_abc" in caplog.text
+
+    def test_skips_resolve_when_not_last_commenter(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        import logging
+
+        work_dir = self._work_dir(tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+
+        gh = MagicMock()
+        gh.get_user.return_value = "fido-bot"
+        gh.get_pull_comments.return_value = [
+            {
+                "id": 42,
+                "in_reply_to_id": None,
+                "user": {"login": "fido-bot"},
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "id": 99,
+                "in_reply_to_id": 42,
+                "user": {"login": "reviewer"},
+                "created_at": "2024-01-02T00:00:00Z",
+            },
+        ]
+
+        with caplog.at_level(logging.INFO, logger="kennel"):
+            Tasks(work_dir).complete_with_resolve(task["id"], gh)
+
+        gh.resolve_thread.assert_not_called()
+        assert "not resolving" in caplog.text
+
+    def test_skips_resolve_when_no_matching_comments(self, tmp_path: Path) -> None:
+        work_dir = self._work_dir(tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+
+        gh = MagicMock()
+        gh.get_user.return_value = "fido-bot"
+        gh.get_pull_comments.return_value = []
+
+        Tasks(work_dir).complete_with_resolve(task["id"], gh)
+
+        gh.resolve_thread.assert_not_called()
+
+    def test_skips_resolve_when_thread_already_resolved(self, tmp_path: Path) -> None:
+        work_dir = self._work_dir(tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+
+        gh = MagicMock()
+        gh.get_user.return_value = "fido-bot"
+        gh.get_pull_comments.return_value = [
+            {
+                "id": 42,
+                "in_reply_to_id": None,
+                "user": {"login": "fido-bot"},
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+        ]
+        gh.get_review_threads.return_value = [
+            {
+                "id": "thread_node_abc",
+                "isResolved": True,
+                "comments": {"nodes": [{"databaseId": 42}]},
+            }
+        ]
+
+        Tasks(work_dir).complete_with_resolve(task["id"], gh)
+
+        gh.resolve_thread.assert_not_called()
+
+    def test_exception_silenced_and_logged(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        work_dir = self._work_dir(tmp_path)
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+
+        gh = MagicMock()
+        gh.get_user.side_effect = RuntimeError("network error")
+
+        with caplog.at_level(logging.WARNING, logger="kennel"):
+            Tasks(work_dir).complete_with_resolve(task["id"], gh)
+        assert "thread resolution skipped" in caplog.text

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4855,7 +4855,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("sid", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4873,7 +4873,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("sid", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4891,7 +4891,7 @@ class TestHandleCi:
             patch.object(worker, "set_status") as mock_status,
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 7, "branch")
@@ -4913,7 +4913,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4930,7 +4930,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4953,7 +4953,7 @@ class TestHandleCi:
                 side_effect=lambda fd, sk, ctx: captured_context.update({"ctx": ctx}),
             ),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -4973,7 +4973,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 42, "branch")
@@ -4991,7 +4991,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt") as mock_bp,
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 5, "fix-branch")
@@ -5014,7 +5014,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("sess-1", "")) as mock_cr,
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -5040,7 +5040,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -5058,7 +5058,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -5078,7 +5078,7 @@ class TestHandleCi:
             patch.object(worker, "set_status") as mock_status,
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -5099,7 +5099,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -5135,7 +5135,7 @@ class TestHandleCi:
             patch.object(worker, "set_status"),
             patch("kennel.worker.build_prompt"),
             patch("kennel.worker.provider_run", return_value=("sid", "")),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
@@ -6681,7 +6681,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
@@ -6698,7 +6698,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "my-branch")
@@ -6738,7 +6738,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             assert worker.execute_task(fido_dir, self._repo_ctx(), 7, "branch") is True
@@ -6757,7 +6757,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "fix-branch")
@@ -6775,7 +6775,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "my-slug")
@@ -6796,7 +6796,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6824,7 +6824,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "br")
@@ -6844,7 +6844,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6863,7 +6863,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("sess", "")) as mock_run,
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6887,14 +6887,14 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True) as mock_push,
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "my-slug")
         mock_push.assert_called_once_with("origin", "my-slug")
 
     def test_completes_task_by_id(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
+        worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("My task title")
         with (
@@ -6904,11 +6904,11 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_complete.assert_called_once_with(task["id"])
+        mock_complete.assert_called_once_with(task["id"], gh)
 
     def test_skips_complete_when_push_fails(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -6921,7 +6921,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6938,7 +6938,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -6955,14 +6955,14 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         mock_sync.assert_not_called()
 
     def test_completes_when_already_in_sync(self, tmp_path: Path) -> None:
-        worker, _ = self._make_worker(tmp_path)
+        worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         task = self._pending_task("A task")
         with (
@@ -6972,11 +6972,11 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_complete.assert_called_once_with(task["id"])
+        mock_complete.assert_called_once_with(task["id"], gh)
 
     def test_returns_true_when_already_in_sync(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
@@ -6989,7 +6989,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7006,7 +7006,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7023,7 +7023,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7042,7 +7042,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -7062,7 +7062,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("my-session", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
             caplog.at_level(logging.INFO, logger="kennel"),
         ):
@@ -7092,7 +7092,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7122,7 +7122,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7161,7 +7161,7 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7199,14 +7199,14 @@ class TestExecuteTask:
             ) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         # provider_run called exactly once (initial dispatch), not again after break
         mock_run.assert_called_once()
-        # complete_by_id still called (idempotent — task already completed externally)
-        mock_complete.assert_called_once_with(task["id"])
+        # complete_with_resolve still called (idempotent — task already completed externally)
+        mock_complete.assert_called_once_with(task["id"], worker.gh)
 
     def test_uses_fresh_session_mode_once_after_repeated_no_commit_nudges(
         self, tmp_path: Path
@@ -7240,7 +7240,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", side_effect=fake_run) as mock_run,
             patch.object(worker, "_git", git_mock),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 42, "br-42")
@@ -7280,7 +7280,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", side_effect=capture),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7298,7 +7298,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("sess", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7324,7 +7324,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", side_effect=capture),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 5, "br")
@@ -7343,7 +7343,7 @@ class TestExecuteTask:
             patch("kennel.worker.provider_run", return_value=("sess", "")),
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "ensure_pushed", return_value=False),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7424,7 +7424,7 @@ class TestExecuteTask:
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
 
-    def test_abort_does_not_call_complete_by_id(self, tmp_path: Path) -> None:
+    def test_abort_does_not_call_complete_with_resolve(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1})
@@ -7438,7 +7438,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean"),
             patch("kennel.tasks.Tasks.remove"),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7458,7 +7458,7 @@ class TestExecuteTask:
                 worker, "_squash_wip_commit", return_value=False
             ) as mock_squash,
             patch.object(worker, "ensure_pushed", return_value=True),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 7, "feat-branch")
@@ -7487,7 +7487,7 @@ class TestExecuteTask:
                 "ensure_pushed",
                 side_effect=lambda *a: call_order.append("push") or True,
             ),
-            patch("kennel.tasks.Tasks.complete_by_id"),
+            patch("kennel.tasks.Tasks.complete_with_resolve"),
             patch("kennel.tasks.sync_tasks"),
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
@@ -7505,7 +7505,7 @@ class TestExecuteTask:
             patch.object(worker, "_git", self._git_with_new_commits()),
             patch.object(worker, "_squash_wip_commit", return_value=True),
             patch.object(worker, "ensure_pushed", return_value=None),
-            patch("kennel.tasks.Tasks.complete_by_id") as mock_complete,
+            patch("kennel.tasks.Tasks.complete_with_resolve") as mock_complete,
             patch("kennel.tasks.sync_tasks"),
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7512,6 +7512,62 @@ class TestExecuteTask:
         assert result is True
         mock_complete.assert_called_once()
 
+    def test_thread_task_resolves_review_thread_on_completion(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #673: execute_task must resolve the review thread when
+        a thread task completes, not just mark the task done.
+
+        complete_with_resolve is NOT mocked here — the full resolution path runs
+        end-to-end so gh.resolve_thread is what we assert on.
+        """
+        from kennel.tasks import Tasks
+        from kennel.types import TaskType
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+
+        # Add a real thread task to the task file so both Tasks.list() and
+        # complete_with_resolve() operate against the actual filesystem.
+        thread = {"repo": "owner/repo", "pr": 5, "comment_id": 42}
+        Tasks(tmp_path).add("Fix the review comment", TaskType.THREAD, thread=thread)
+
+        # Set up gh to confirm fido posted the last reply on the thread.
+        gh.get_user.return_value = "fido-bot"
+        gh.get_pull_comments.return_value = [
+            {
+                "id": 42,
+                "in_reply_to_id": None,
+                "user": {"login": "reviewer"},
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+            {
+                "id": 99,
+                "in_reply_to_id": 42,
+                "user": {"login": "fido-bot"},
+                "created_at": "2024-01-02T00:00:00Z",
+            },
+        ]
+        gh.get_review_threads.return_value = [
+            {
+                "id": "thread-node-xyz",
+                "isResolved": False,
+                "comments": {"nodes": [{"databaseId": 42}]},
+            }
+        ]
+
+        with (
+            patch.object(worker, "set_status"),
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("kennel.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 5, "branch")
+
+        gh.resolve_thread.assert_called_once_with("thread-node-xyz")
+
 
 class TestRunExecuteTaskIntegration:
     """Tests that Worker.run() calls execute_task after handle_threads."""


### PR DESCRIPTION
Fixes #673.

Unifies thread-resolve logic so both the worker and CLI share one code path on Tasks, ensuring review threads actually get resolved when the worker completes a thread task instead of only on the CLI path. Adds a regression test to verify thread resolution fires after worker task completion.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Unify thread-resolve onto Tasks so worker and CLI share one path <!-- type:spec -->
- [x] Add regression test for thread resolution after worker task completion <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->