### PR TITLE
Duplicate review-thread reply to same comment: webhook + worker both post (claim system missed) (closes #672)

### DIFF
--- a/kennel/claimed.py
+++ b/kennel/claimed.py
@@ -1,17 +1,25 @@
-"""Process-wide set of webhook-claimed review comment IDs.
+"""Process-wide set of claimed review comment IDs.
 
 The :class:`RepliedComments` class is a thread-safe owner of a set of
-comment database IDs that the webhook handler has already claimed (or is
-currently processing a reply for).  A single instance lives here so that
-both the webhook handler (``server.py``) and the worker (``worker.py``)
-can consult it without a circular import.
+comment database IDs that have been claimed by either the webhook handler or
+the worker's ``handle_threads`` path.  A single instance lives here so that
+both sides can coordinate without a circular import.
 
-``server.py`` claims IDs before calling ``reply_to_comment()`` (atomic
-check-and-add via :meth:`RepliedComments.claim`).  ``worker.py`` uses the
-same set in :meth:`~kennel.worker.Worker._filter_threads` to skip threads
-whose first comment was already claimed, preventing the comments sub-agent
-from posting a duplicate reply even when the webhook reply is still in
-flight and not yet visible in the GitHub API.
+**Bidirectional claim protocol**:
+
+- ``server.py`` claims IDs before calling ``reply_to_comment()`` (atomic
+  check-and-add via :meth:`RepliedComments.claim`).  ``worker.py`` uses the
+  same set in :meth:`~kennel.worker.Worker._filter_threads` to skip threads
+  whose first comment was already claimed.
+
+- ``worker.py`` also claims each thread's ``first_db_id`` in
+  :meth:`~kennel.worker.Worker.handle_threads` before launching the comments
+  sub-agent.  A concurrent webhook handler that arrives after the worker has
+  claimed a thread will see the claim and skip its own reply.
+
+Whichever path claims first wins.  The other path sees the claim and skips,
+preventing the comments sub-agent and the webhook handler from each posting
+a duplicate reply to the same thread (fixes #672).
 """
 
 from __future__ import annotations

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1628,7 +1628,28 @@ class Worker:
         )
         if not threads:
             return False
-        log.info("unresolved threads: %d", len(threads))
+
+        # Claim each thread's first_db_id before launching the comments
+        # sub-agent.  This makes the claim bidirectional: if the webhook
+        # handler claims a thread between _filter_threads and here we skip it;
+        # conversely, if we claim a thread here, a concurrent webhook handler
+        # will see the claim and skip its own reply.  Either way, exactly one
+        # path handles each thread.
+        claimable: list[dict[str, Any]] = []
+        claimed_ids: list[int] = []
+        for t in threads:
+            first_db_id = t.get("first_db_id")
+            if first_db_id is not None and not _webhook_claimed.claim(first_db_id):
+                log.info("skipping thread %s — claimed by webhook", first_db_id)
+            else:
+                if first_db_id is not None:
+                    claimed_ids.append(first_db_id)
+                claimable.append(t)
+
+        if not claimable:
+            return False
+
+        log.info("unresolved threads: %d", len(claimable))
         context = (
             f"PR: {pr_number}\n"
             f"Repo: {repo_ctx.repo}\n"
@@ -1638,17 +1659,24 @@ class Worker:
             f"Upstream: origin/{repo_ctx.default_branch}\n"
             f"Work dir: {self.work_dir}\n"
             f"GitHub user: {repo_ctx.gh_user}\n"
-            f"\nUnresolved threads (JSON):\n{json.dumps({'threads': threads})}"
+            f"\nUnresolved threads (JSON):\n{json.dumps({'threads': claimable})}"
         )
         build_prompt(fido_dir, "comments", context)
-        session_id, _ = provider_run(
-            fido_dir,
-            agent=self._provider_agent,
-            model=self._provider_agent.work_model,
-            cwd=self.work_dir,
-            session=None,
-            session_mode=self._consume_turn_session_mode(),
-        )
+        try:
+            session_id, _ = provider_run(
+                fido_dir,
+                agent=self._provider_agent,
+                model=self._provider_agent.work_model,
+                cwd=self.work_dir,
+                session=None,
+                session_mode=self._consume_turn_session_mode(),
+            )
+        except Exception:
+            # Release claims so a webhook redelivery (or the next worker
+            # iteration) can retry.
+            for cid in claimed_ids:
+                _webhook_claimed.release(cid)
+            raise
         log.info("threads done (session=%s)", session_id)
         tasks.sync_tasks_background(self.work_dir, self.gh)
         return True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5701,6 +5701,16 @@ class TestResolveAddressedThreads:
 class TestHandleThreads:
     """Tests for Worker.handle_threads."""
 
+    @pytest.fixture(autouse=True)
+    def _clean_claimed(self):  # type: ignore[override]
+        """Discard the databaseId=1 that _open_thread_node puts in claimed after each test."""
+        import kennel.claimed as kc
+
+        yield
+        # _open_thread_node() uses databaseId=1 for its first comment; handle_threads now
+        # claims that ID.  Discard it so subsequent tests start with a clean slate.
+        kc.replied_comments.discard(1)
+
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         return Worker(tmp_path, gh), gh
@@ -5835,6 +5845,222 @@ class TestHandleThreads:
         ):
             worker.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
         assert "unresolved threads" in caplog.text
+
+    def test_claims_thread_first_db_id_before_sub_agent(self, tmp_path: Path) -> None:
+        """handle_threads claims each thread's first_db_id in _webhook_claimed before the sub-agent runs."""
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        node = self._open_thread_node()  # first comment databaseId=1
+        gh.get_review_threads.return_value = [node]
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.provider_run", return_value=("sid", "")),
+            patch("kennel.tasks.sync_tasks_background"),
+        ):
+            result = w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+        assert result is True
+        # The first_db_id must now be in the claim set so a concurrent webhook
+        # handler will see it and skip its own reply.
+        assert 1 in kc.replied_comments
+        # autouse fixture discards 1 after the test
+
+    def test_skips_thread_if_claimed_in_race_window(self, tmp_path: Path) -> None:
+        """Race simulation: webhook claims a thread ID after _filter_threads but before handle_threads claims it.
+
+        _filter_threads already checks the claim set, so we patch it to inject a thread
+        with a pre-claimed first_db_id — simulating the narrow race window between
+        _filter_threads returning and handle_threads reaching the claim step.
+        """
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        gh.get_review_threads.return_value = []  # not used; _filter_threads is patched
+        fido_dir = self._fido_dir(tmp_path)
+        race_thread = {
+            "id": "thread-race",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 901,
+            "first_body": "feedback",
+            "last_author": "owner",
+            "last_body": "feedback",
+            "url": "https://example.com",
+            "total": 1,
+        }
+        kc.replied_comments.add(901)
+        try:
+            with (
+                patch.object(w, "_filter_threads", return_value=[race_thread]),
+                patch("kennel.worker.build_prompt") as mock_bp,
+                patch(
+                    "kennel.worker.provider_run", return_value=("sid", "")
+                ) as mock_pr,
+                patch("kennel.tasks.sync_tasks_background"),
+            ):
+                result = w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+            assert result is False
+            mock_bp.assert_not_called()
+            mock_pr.assert_not_called()
+        finally:
+            kc.replied_comments.discard(901)
+
+    def test_returns_false_when_all_threads_claimed_in_race_window(
+        self, tmp_path: Path
+    ) -> None:
+        """Returns False when every filtered thread is claimed before handle_threads claims them."""
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        gh.get_review_threads.return_value = []
+        fido_dir = self._fido_dir(tmp_path)
+        race_thread_a = {
+            "id": "thread-a",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 902,
+            "first_body": "feedback a",
+            "last_author": "owner",
+            "last_body": "feedback a",
+            "url": "https://example.com/a",
+            "total": 1,
+        }
+        race_thread_b = {
+            "id": "thread-b",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 903,
+            "first_body": "feedback b",
+            "last_author": "owner",
+            "last_body": "feedback b",
+            "url": "https://example.com/b",
+            "total": 1,
+        }
+        kc.replied_comments.add(902)
+        kc.replied_comments.add(903)
+        try:
+            with (
+                patch.object(
+                    w, "_filter_threads", return_value=[race_thread_a, race_thread_b]
+                ),
+                patch(
+                    "kennel.worker.provider_run", return_value=("sid", "")
+                ) as mock_pr,
+            ):
+                result = w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+            assert result is False
+            mock_pr.assert_not_called()
+        finally:
+            kc.replied_comments.discard(902)
+            kc.replied_comments.discard(903)
+
+    def test_releases_claims_on_provider_run_failure(self, tmp_path: Path) -> None:
+        """If provider_run raises, claimed thread IDs are released so the next attempt can retry."""
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        node = self._open_thread_node()  # first comment databaseId=1
+        gh.get_review_threads.return_value = [node]
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch("kennel.worker.build_prompt"),
+            patch("kennel.worker.provider_run", side_effect=RuntimeError("boom")),
+            patch("kennel.tasks.sync_tasks_background"),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+        # Claim must be released so the webhook or next iteration can retry.
+        assert 1 not in kc.replied_comments
+        # autouse fixture also discards 1, redundant but harmless
+
+    def test_logs_skip_when_thread_claimed_in_race_window(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Threads dropped in the race window produce an info-level log with the claimed ID."""
+        import logging
+
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        gh.get_review_threads.return_value = []
+        fido_dir = self._fido_dir(tmp_path)
+        race_thread = {
+            "id": "thread-race",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 904,
+            "first_body": "feedback",
+            "last_author": "owner",
+            "last_body": "feedback",
+            "url": "https://example.com",
+            "total": 1,
+        }
+        kc.replied_comments.add(904)
+        try:
+            with (
+                patch.object(w, "_filter_threads", return_value=[race_thread]),
+                patch("kennel.worker.build_prompt"),
+                patch("kennel.worker.provider_run", return_value=("sid", "")),
+                patch("kennel.tasks.sync_tasks_background"),
+                caplog.at_level(logging.INFO, logger="kennel"),
+            ):
+                w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+            assert "claimed by webhook" in caplog.text
+        finally:
+            kc.replied_comments.discard(904)
+
+    def test_passes_only_claimable_threads_to_sub_agent_context(
+        self, tmp_path: Path
+    ) -> None:
+        """Only unclaimed threads are included in the context JSON passed to the sub-agent."""
+        import kennel.claimed as kc
+
+        w, gh = self._make_worker(tmp_path)
+        gh.get_review_threads.return_value = []
+        fido_dir = self._fido_dir(tmp_path)
+        # Inject two threads via _filter_threads: one pre-claimed (race window),
+        # one still free.
+        claimed_thread = {
+            "id": "thread-c",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 905,
+            "first_body": "claimed comment body",
+            "last_author": "owner",
+            "last_body": "claimed comment body",
+            "url": "https://example.com/c",
+            "total": 1,
+        }
+        free_thread = {
+            "id": "thread-f",
+            "is_bot": False,
+            "first_author": "owner",
+            "first_db_id": 906,
+            "first_body": "free comment body",
+            "last_author": "owner",
+            "last_body": "free comment body",
+            "url": "https://example.com/f",
+            "total": 1,
+        }
+        kc.replied_comments.add(905)
+        kc.replied_comments.discard(906)
+        try:
+            with (
+                patch.object(
+                    w, "_filter_threads", return_value=[claimed_thread, free_thread]
+                ),
+                patch("kennel.worker.build_prompt") as mock_bp,
+                patch("kennel.worker.provider_run", return_value=("sid", "")),
+                patch("kennel.tasks.sync_tasks_background"),
+            ):
+                w.handle_threads(fido_dir, self._repo_ctx(), 1, "branch")
+            _, _, context = mock_bp.call_args[0]
+            assert "free comment body" in context
+            assert "claimed comment body" not in context
+        finally:
+            kc.replied_comments.discard(905)
+            kc.replied_comments.discard(906)
 
 
 class TestRunThreadsIntegration:


### PR DESCRIPTION
Fixes #672.

Makes the thread claim system bidirectional so both the webhook handler and the worker's `handle_threads()` claim thread IDs before posting replies, preventing the race where the worker passes `_filter_threads()` before the webhook claims. Whichever path claims first wins; the other skips the reply.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Claim thread IDs in handle_threads before sub-agent to prevent duplicate replies <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->