### PR TITLE
Duplicate replies to PR issue-comments: webhook + worker both post (closes #671)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1066,20 +1066,14 @@ def _notify_thread_change(
     """Post a brief comment notifying a commenter that their task was rescoped.
 
     Called for each thread task that was dropped or modified during dependency
-    analysis.  Uses Opus (in Fido's voice) to generate the message; falls back
-    to a plain factual note if Opus returns nothing.
+    analysis.  Uses Opus (in Fido's voice) to generate the message.
 
-    For review comments (comment_type='pulls') replies in-thread via the pull
-    review comment API; for issue comments (comment_type='issues') posts via
-    the issue comments API.
+    Only fires for review comments (comment_type='pulls'), where it replies
+    in-thread via the pull review comment API.  Issue comments
+    (comment_type='issues') are skipped: the webhook handler already posted a
+    triage reply to the original comment, and a second notification here would
+    be a duplicate top-level issue comment.
     """
-    if agent is None:
-        agent = _configured_agent(
-            config, config.repos[change["task"]["thread"]["repo"]]
-        )
-    if prompts is None:
-        prompts = Prompts(_load_persona(config))
-
     task = change["task"]
     thread = task.get("thread") or {}
     comment_id = thread.get("comment_id")
@@ -1090,6 +1084,23 @@ def _notify_thread_change(
     comment_type = thread.get("comment_type", "issues")
     if not (comment_id and repo and pr):
         return
+
+    # Issue comments already received a triage reply from the webhook handler.
+    # Posting again here would produce a duplicate top-level PR comment.
+    if comment_type != "pulls":
+        log.info(
+            "skipping rescope notification for issue comment %s"
+            " (webhook already replied)",
+            comment_id,
+        )
+        return
+
+    if agent is None:
+        agent = _configured_agent(
+            config, config.repos[change["task"]["thread"]["repo"]]
+        )
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
 
     kind = change["kind"]
     original_title = task.get("title", "")
@@ -1128,10 +1139,7 @@ def _notify_thread_change(
         )
 
     try:
-        if comment_type == "pulls":
-            gh.reply_to_review_comment(repo, pr, body, comment_id)
-        else:
-            gh.comment_issue(repo, pr, body)
+        gh.reply_to_review_comment(repo, pr, body, comment_id)
         log.info("notified thread %s (%s)", comment_id, kind)
     except Exception:
         log.exception("failed to notify thread %s", comment_id)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3460,14 +3460,18 @@ class TestNotifyThreadChange:
         t.update(overrides)
         return t
 
-    def test_completed_posts_comment(self, tmp_path: Path) -> None:
+    def test_completed_issue_comment_skips(self, tmp_path: Path) -> None:
+        """Issue comments are silently skipped — webhook already replied."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         change = {"task": self._task(), "kind": "completed"}
-        _notify_thread_change(change, cfg, mock_gh, agent=_client("Noted!"))
-        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Noted!")
+        agent = _client("Should not be called")
+        _notify_thread_change(change, cfg, mock_gh, agent=agent)
+        mock_gh.comment_issue.assert_not_called()
+        mock_gh.reply_to_review_comment.assert_not_called()
 
-    def test_modified_posts_comment(self, tmp_path: Path) -> None:
+    def test_modified_issue_comment_skips(self, tmp_path: Path) -> None:
+        """Issue comments are silently skipped — webhook already replied."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         change = {
@@ -3476,8 +3480,10 @@ class TestNotifyThreadChange:
             "new_title": "Updated title",
             "new_description": "",
         }
-        _notify_thread_change(change, cfg, mock_gh, agent=_client("Updated!"))
-        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Updated!")
+        agent = _client("Should not be called")
+        _notify_thread_change(change, cfg, mock_gh, agent=agent)
+        mock_gh.comment_issue.assert_not_called()
+        mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_missing_thread_skips_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -3488,18 +3494,26 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, mock_gh, agent=_client())
         mock_gh.comment_issue.assert_not_called()
 
-    def test_empty_opus_raises_for_completed(self, tmp_path: Path) -> None:
+    def test_review_comment_empty_opus_raises_for_completed(
+        self, tmp_path: Path
+    ) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "completed"}
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
+        change = {"task": task, "kind": "completed"}
         with pytest.raises(ValueError, match="_notify_thread_change"):
             _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
 
-    def test_empty_opus_raises_for_modified(self, tmp_path: Path) -> None:
+    def test_review_comment_empty_opus_raises_for_modified(
+        self, tmp_path: Path
+    ) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
         change = {
-            "task": self._task(),
+            "task": task,
             "kind": "modified",
             "new_title": "New title",
             "new_description": "",
@@ -3534,14 +3548,15 @@ class TestNotifyThreadChange:
         # Should not raise
         _notify_thread_change(change, cfg, mock_gh, agent=_client("ok"))
 
-    def test_no_comment_type_defaults_to_issue_comment(self, tmp_path: Path) -> None:
+    def test_no_comment_type_defaults_to_skip(self, tmp_path: Path) -> None:
+        """Missing comment_type defaults to the 'issues' skip path."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
         del task["thread"]["comment_type"]
         change = {"task": task, "kind": "completed"}
         _notify_thread_change(change, cfg, mock_gh, agent=_client("Fallback"))
-        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Fallback")
+        mock_gh.comment_issue.assert_not_called()
         mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_author_in_opus_instruction(self, tmp_path: Path) -> None:
@@ -3552,24 +3567,38 @@ class TestNotifyThreadChange:
             captured_prompt.append(prompt)
             return "ok"
 
-        change = {"task": self._task(), "kind": "completed"}
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
+        change = {"task": task, "kind": "completed"}
         _notify_thread_change(
             change, cfg, MagicMock(), agent=_client(side_effect=fake_pp)
         )
         assert "alice" in captured_prompt[0]
 
-    def test_comment_issue_exception_does_not_raise(self, tmp_path: Path) -> None:
+    def test_issue_comment_skips_before_opus_call(self, tmp_path: Path) -> None:
+        """Issue comments must not invoke the LLM — return before the expensive call."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        mock_gh.comment_issue.side_effect = RuntimeError("api error")
+        invoked: list[bool] = []
+
+        def should_not_be_called(prompt, model, **kwargs):
+            invoked.append(True)
+            return "oops"
+
         change = {"task": self._task(), "kind": "completed"}
-        # Should not raise
-        _notify_thread_change(change, cfg, mock_gh, agent=_client("ok"))
+        _notify_thread_change(
+            change, cfg, mock_gh, agent=_client(side_effect=should_not_be_called)
+        )
+        assert not invoked
+        mock_gh.comment_issue.assert_not_called()
+        mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_default_repo_configured_agent_used(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "completed"}
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
+        change = {"task": task, "kind": "completed"}
         with patch("kennel.events.DefaultProviderFactory") as factory_cls:
             factory_cls.return_value.create_agent.return_value = _client("Auto reply")
             _notify_thread_change(change, cfg, mock_gh)
@@ -3578,7 +3607,10 @@ class TestNotifyThreadChange:
             work_dir=tmp_path,
             repo_name="owner/repo",
         )
-        mock_gh.comment_issue.assert_called_once_with("owner/repo", 42, "Auto reply")
+        mock_gh.reply_to_review_comment.assert_called_once_with(
+            "owner/repo", 42, "Auto reply", 999
+        )
+        mock_gh.comment_issue.assert_not_called()
 
 
 class TestLaunchSync:


### PR DESCRIPTION
Fixes #671.

Suppresses the rescope notification (`_notify_thread_change`) for issue comments, where the webhook's triage reply already acknowledged the commenter. The duplicate arose because the notification path bypassed the `_replied_comments` claim system entirely.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Skip _notify_thread_change for issue comments to prevent duplicate replies <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->