### PR TITLE
Fido posts duplicate replies to the same review comment (closes #438)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -579,6 +579,16 @@ def reply_to_comment(
                 "fetched %d comment(s) in thread for context", len(thread_comments)
             )
 
+    # Fido login set — used for initial snapshot and post-re-fetch comparison.
+    _fido_logins = {"fidocancode", "fido-can-code"}
+
+    # Capture Fido reply IDs from the initial snapshot so we can detect new
+    # replies posted by concurrent handlers during the triage + generation
+    # window (compared against the re-fetched thread below).
+    initial_fido_ids: set[int] = {
+        c["id"] for c in thread_comments if c.get("author", "").lower() in _fido_logins
+    }
+
     # Root comment body — used for task title generation.
     # When the webhook fires on a reply (e.g. "Yes" or "Woof, you're right!"),
     # the task title should describe the reviewer's original feedback, not the reply.
@@ -658,10 +668,26 @@ def reply_to_comment(
                 len(thread_comments),
             )
 
+    # Skip posting if a concurrent handler already replied during triage.
+    # A Fido reply ID in the re-fetched thread that was not in the initial
+    # snapshot means another handler handled this comment — adding a second
+    # reply would be a duplicate.  Return early with the triage result so
+    # the caller can still queue tasks based on the category.
+    current_fido_ids: set[int] = {
+        c["id"] for c in thread_comments if c.get("author", "").lower() in _fido_logins
+    }
+    if current_fido_ids - initial_fido_ids:
+        log.info(
+            "concurrent handler already replied — skipping post for comment %s",
+            info.get("comment_id"),
+        )
+        if lock_fd:
+            lock_fd.close()
+        return (category, titles)
+
     # Edit the last Fido reply only if it is the most recent comment in the thread
     # (i.e. no human has spoken since). If a human posted a new comment after
     # Fido's last reply, post a fresh reply so the conversation stays coherent.
-    _fido_logins = {"fidocancode", "fido-can-code"}
     last_thread_author = (
         thread_comments[-1].get("author", "").lower() if thread_comments else ""
     )

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -643,6 +643,21 @@ def reply_to_comment(
             f"review-comment reply: run_turn returned empty for PR #{info['pr']}"
         )
 
+    # Re-fetch the thread right before posting so the edit-vs-post decision
+    # uses current GitHub state rather than the snapshot taken before triage.
+    # Concurrent handlers may have posted replies during the triage + generation
+    # window; without a re-fetch the stale snapshot leads to duplicate posts.
+    if info.get("repo") and info.get("pr") and info.get("comment_id"):
+        refreshed = gh.fetch_comment_thread(
+            info["repo"], info["pr"], info["comment_id"]
+        )
+        if refreshed:
+            thread_comments = list(refreshed)
+            log.info(
+                "re-fetched %d comment(s) in thread before posting",
+                len(thread_comments),
+            )
+
     # Edit the last Fido reply only if it is the most recent comment in the thread
     # (i.e. no human has spoken since). If a human posted a new comment after
     # Fido's last reply, post a fresh reply so the conversation stays coherent.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4074,9 +4074,12 @@ class TestReplyToCommentThreadRefetch:
         mock_gh.fetch_comment_thread.assert_called_with("owner/repo", 1, 500)
 
     def test_refetch_result_used_for_edit_vs_post(self, tmp_path: Path) -> None:
-        """If the re-fetch reveals a Fido reply that wasn't in the initial
-        snapshot (posted by a concurrent handler during triage), the decision
-        to edit vs. post uses the fresh data."""
+        """The edit-vs-post decision uses re-fetched thread state, not the
+        stale initial snapshot.  When the initial fetch shows Fido as last
+        speaker (→ would edit) but the re-fetch reveals a human replied since
+        (→ should post fresh), the re-fetch data wins: a new reply is posted.
+        Note: the Fido reply ID is in both fetches, so the concurrent-skip
+        guard is not triggered."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -4089,9 +4092,7 @@ class TestReplyToCommentThreadRefetch:
             if model == "claude-haiku-4-5":
                 return "NO"
             if "Triage" in prompt:
-                return "ACT: add type hints"
-            if "Convert this PR review comment" in prompt:
-                return "Add type hints"
+                return "ANSWER: acknowledged"
             return "Will do!"
 
         mock_gh = MagicMock()
@@ -4101,13 +4102,17 @@ class TestReplyToCommentThreadRefetch:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # Initial fetch: no Fido reply yet
-                return [{"id": 501, "author": "reviewer", "body": "add type hints"}]
-            else:
-                # Re-fetch: concurrent handler posted a Fido reply during triage
+                # Initial fetch: Fido was last speaker (stale snapshot)
                 return [
                     {"id": 501, "author": "reviewer", "body": "add type hints"},
                     {"id": 502, "author": "fidocancode", "body": "Got it!"},
+                ]
+            else:
+                # Re-fetch: human commented after the initial fetch
+                return [
+                    {"id": 501, "author": "reviewer", "body": "add type hints"},
+                    {"id": 502, "author": "fidocancode", "body": "Got it!"},
+                    {"id": 503, "author": "reviewer", "body": "also type the return"},
                 ]
 
         mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
@@ -4120,11 +4125,10 @@ class TestReplyToCommentThreadRefetch:
             agent=_client(side_effect=fake_pp),
         )
 
-        # Re-fetch shows Fido reply is last → edit it rather than posting new
-        mock_gh.edit_review_comment.assert_called_once_with(
-            "owner/repo", 502, "Will do!"
-        )
-        mock_gh.reply_to_review_comment.assert_not_called()
+        # Re-fetch shows human is last → post new reply, not edit
+        # (Fido ID 502 existed in initial, so concurrent-skip is NOT triggered)
+        mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
 
     def test_refetch_human_comment_added_during_triage_triggers_new_post(
         self, tmp_path: Path
@@ -4230,6 +4234,156 @@ class TestReplyToCommentThreadRefetch:
 
         # Falls back to initial snapshot (no Fido reply) → posts new reply
         mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
+
+    def test_skips_post_when_concurrent_fido_reply_detected(
+        self, tmp_path: Path
+    ) -> None:
+        """If a new Fido reply appears in the re-fetch that wasn't in the
+        initial snapshot, a concurrent handler already replied — skip to
+        avoid duplicates.  Closes #438."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 507},
+            comment_body="please add docstrings",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add docstrings"
+            if "Convert this PR review comment" in prompt:
+                return "Add docstrings"
+            return "Woof, on it!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Initial fetch: no Fido reply yet
+                return [
+                    {"id": 507, "author": "reviewer", "body": "please add docstrings"}
+                ]
+            else:
+                # Re-fetch: concurrent handler posted a Fido reply during triage
+                return [
+                    {"id": 507, "author": "reviewer", "body": "please add docstrings"},
+                    {"id": 508, "author": "fidocancode", "body": "On it!"},
+                ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        cat, titles = reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Concurrent handler already replied — neither post nor edit is called
+        mock_gh.reply_to_review_comment.assert_not_called()
+        mock_gh.edit_review_comment.assert_not_called()
+        # Triage result is still returned so the caller can queue tasks
+        assert cat == "ACT"
+        assert titles == ["Add docstrings"]
+
+    def test_no_skip_when_fido_reply_was_already_in_initial_fetch(
+        self, tmp_path: Path
+    ) -> None:
+        """A Fido reply that existed in the initial fetch is not treated as
+        a concurrent duplicate — the edit-vs-post flow proceeds normally."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 509},
+            comment_body="looks good to me",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ANSWER: acknowledged"
+            return "Thanks for the feedback!"
+
+        mock_gh = MagicMock()
+
+        def fetch_side_effect(repo, pr, cid):
+            # Both fetches return the same Fido reply — it was already there
+            return [
+                {"id": 509, "author": "reviewer", "body": "looks good"},
+                {"id": 510, "author": "fidocancode", "body": "On it!"},
+            ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Fido was already last speaker — edits in place (not skipped)
+        mock_gh.edit_review_comment.assert_called_once()
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_skips_post_fido_can_code_login_also_detected(self, tmp_path: Path) -> None:
+        """The 'fido-can-code' login is also recognised as a Fido reply
+        when checking for concurrent duplicates."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 511},
+            comment_body="fix the typo",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: fix typo"
+            if "Convert this PR review comment" in prompt:
+                return "Fix the typo"
+            return "Fixed the typo!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"id": 511, "author": "reviewer", "body": "fix the typo"}]
+            else:
+                # Concurrent reply from the fido-can-code login variant
+                return [
+                    {"id": 511, "author": "reviewer", "body": "fix the typo"},
+                    {"id": 512, "author": "fido-can-code", "body": "Fixed!"},
+                ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Concurrent Fido reply detected (via fido-can-code) — skip
+        mock_gh.reply_to_review_comment.assert_not_called()
         mock_gh.edit_review_comment.assert_not_called()
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4015,6 +4015,224 @@ class TestReplyToCommentTerseEnrichment:
         assert "sibling_threads" not in captured_context
 
 
+# ── reply_to_comment: thread re-fetch before posting ─────────────────────────
+
+
+class TestReplyToCommentThreadRefetch:
+    """The thread is re-fetched from GitHub right before posting so the
+    edit-vs-post decision uses current state, not the stale snapshot from
+    before triage.  Closes #438."""
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _repo_cfg(self, tmp_path: Path) -> RepoConfig:
+        return RepoConfig(name="owner/repo", work_dir=tmp_path)
+
+    def test_fetch_comment_thread_called_twice(self, tmp_path: Path) -> None:
+        """fetch_comment_thread is called once for context (before triage) and
+        once right before posting (after reply generation)."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 500},
+            comment_body="please refactor this",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: refactor"
+            if "Convert this PR review comment" in prompt:
+                return "Refactor this module"
+            return "On it!"
+
+        mock_gh = MagicMock()
+        mock_gh.fetch_comment_thread.return_value = [
+            {"id": 500, "author": "reviewer", "body": "please refactor this"}
+        ]
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Must be called exactly twice: initial context fetch + pre-post re-fetch
+        assert mock_gh.fetch_comment_thread.call_count == 2
+        mock_gh.fetch_comment_thread.assert_called_with("owner/repo", 1, 500)
+
+    def test_refetch_result_used_for_edit_vs_post(self, tmp_path: Path) -> None:
+        """If the re-fetch reveals a Fido reply that wasn't in the initial
+        snapshot (posted by a concurrent handler during triage), the decision
+        to edit vs. post uses the fresh data."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 501},
+            comment_body="add type hints",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add type hints"
+            if "Convert this PR review comment" in prompt:
+                return "Add type hints"
+            return "Will do!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Initial fetch: no Fido reply yet
+                return [{"id": 501, "author": "reviewer", "body": "add type hints"}]
+            else:
+                # Re-fetch: concurrent handler posted a Fido reply during triage
+                return [
+                    {"id": 501, "author": "reviewer", "body": "add type hints"},
+                    {"id": 502, "author": "fidocancode", "body": "Got it!"},
+                ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Re-fetch shows Fido reply is last → edit it rather than posting new
+        mock_gh.edit_review_comment.assert_called_once_with(
+            "owner/repo", 502, "Will do!"
+        )
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_refetch_human_comment_added_during_triage_triggers_new_post(
+        self, tmp_path: Path
+    ) -> None:
+        """If a human comments AFTER the initial fetch but BEFORE the re-fetch,
+        the fresh data shows them as last speaker, so a new reply is posted
+        rather than editing the old Fido reply."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 503},
+            comment_body="please add tests",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add tests"
+            if "Convert this PR review comment" in prompt:
+                return "Add tests"
+            return "Adding tests now!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Initial fetch: Fido is last speaker
+                return [
+                    {"id": 503, "author": "reviewer", "body": "please add tests"},
+                    {"id": 504, "author": "fidocancode", "body": "On it!"},
+                ]
+            else:
+                # Re-fetch: human replied after the initial fetch
+                return [
+                    {"id": 503, "author": "reviewer", "body": "please add tests"},
+                    {"id": 504, "author": "fidocancode", "body": "On it!"},
+                    {
+                        "id": 505,
+                        "author": "reviewer",
+                        "body": "also add integration tests",
+                    },
+                ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Fresh data shows human is last speaker → post new reply, never edit
+        mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
+
+    def test_refetch_returns_empty_falls_back_to_initial(self, tmp_path: Path) -> None:
+        """If the re-fetch returns empty/None (e.g. race with deletion), the
+        stale initial snapshot is kept and posting proceeds normally."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 506},
+            comment_body="fix the import",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: fix import"
+            if "Convert this PR review comment" in prompt:
+                return "Fix the import"
+            return "Fixed!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"id": 506, "author": "reviewer", "body": "fix the import"}]
+            else:
+                return None  # re-fetch returned nothing
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Falls back to initial snapshot (no Fido reply) → posts new reply
+        mock_gh.reply_to_review_comment.assert_called_once()
+        mock_gh.edit_review_comment.assert_not_called()
+
+
 # ── _rewrite_pr_description ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Fixes #438.

Closes the race window where concurrent webhook handlers both post replies to the same review comment by re-fetching the thread from GitHub right before posting — making the actual thread state the source of truth instead of a stale initial fetch. If a Fido reply appeared during triage, the second handler skips instead of duplicating.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Re-fetch comment thread before posting to detect concurrent Fido replies <!-- type:spec -->
- [x] Skip reply when Fido already replied in the thread since initial fetch <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->