### PR TITLE
Rocq→Python MVP Phase 3 — primitive type remapping (closes #714)

### DIFF
--- a/.github/workflows/rocq-python-extraction.yml
+++ b/.github/workflows/rocq-python-extraction.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Pull or build container image
+      # Always build from the local Dockerfile so Dockerfile changes in a PR
+      # take effect immediately rather than using a stale published image.
+      - name: Build container image
         run: |
-          docker pull ghcr.io/fidocancode/rocq-python-extraction:latest || \
-          docker build -t ghcr.io/fidocancode/rocq-python-extraction:latest \
-            rocq-python-extraction
+          docker build -t rocq-python-extraction:ci rocq-python-extraction
 
       - name: Build and test
         run: |
-          docker run --rm -v "$PWD:/src:ro" ghcr.io/fidocancode/rocq-python-extraction:latest \
+          docker run --rm -v "$PWD:/src:ro" rocq-python-extraction:ci \
             sh -c "cp -r /src /tmp/work && cd /tmp/work/rocq-python-extraction && opam exec -- make test"

--- a/.github/workflows/rocq-python-extraction.yml
+++ b/.github/workflows/rocq-python-extraction.yml
@@ -18,11 +18,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Always build from the local Dockerfile so Dockerfile changes in a PR
-      # take effect immediately rather than using a stale published image.
+      # Set up buildx so we can use the GitHub Actions layer cache.
+      - uses: docker/setup-buildx-action@v3
+
+      # Build from the local Dockerfile with layer caching.  Unchanged layers
+      # (especially the opam install step, which takes most of the build time)
+      # are restored from the GHA cache so only changed layers are rebuilt.
+      # Dockerfile changes in a PR still take effect immediately because the
+      # cache is content-addressed per layer.
       - name: Build container image
         run: |
-          docker build -t rocq-python-extraction:ci rocq-python-extraction
+          docker buildx build \
+            --cache-from type=gha \
+            --cache-to   type=gha,mode=max \
+            --load \
+            -t rocq-python-extraction:ci \
+            rocq-python-extraction
 
       - name: Build and test
         run: |

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-12-ocaml-5.3
 
-# Install system build tools
+# Install system build tools and Python 3 (needed for .py syntax validation)
 RUN sudo apt-get update \
     && sudo apt-get install -y --no-install-recommends \
         make \
@@ -8,6 +8,7 @@ RUN sudo apt-get update \
         pkg-config \
         libgmp-dev \
         linux-libc-dev \
+        python3 \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Install Rocq 9.2 and dune, clean up opam cache.

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -10,10 +10,11 @@ RUN sudo apt-get update \
         linux-libc-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rocq 9.2 (core + stdlib) and dune, clean up opam cache.
-# rocq-stdlib is versioned independently from rocq-core; pin core and let
-# opam resolve a compatible stdlib version automatically.
-RUN opam install -y rocq-core.9.2.0 rocq-stdlib dune \
+# Install Rocq 9.2 and dune, clean up opam cache.
+# rocq-stdlib has no release compatible with rocq-core.9.2.0 in the default
+# opam repo; the Stdlib theories are bundled inside rocq-core itself and found
+# via Rocq's own search path without a separate opam package.
+RUN opam install -y rocq-core.9.2.0 dune \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -10,8 +10,10 @@ RUN sudo apt-get update \
         linux-libc-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rocq 9.2 (core + stdlib) and dune, clean up opam cache
-RUN opam install -y rocq-core.9.2.0 rocq-stdlib.9.2.0 dune \
+# Install Rocq 9.2 (core + stdlib) and dune, clean up opam cache.
+# rocq-stdlib is versioned independently from rocq-core; pin core and let
+# opam resolve a compatible stdlib version automatically.
+RUN opam install -y rocq-core.9.2.0 rocq-stdlib dune \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -10,8 +10,8 @@ RUN sudo apt-get update \
         linux-libc-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rocq 9.2 and dune, clean up opam cache
-RUN opam install -y rocq-core.9.2.0 dune \
+# Install Rocq 9.2 (core + stdlib) and dune, clean up opam cache
+RUN opam install -y rocq-core.9.2.0 rocq-stdlib.9.2.0 dune \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -16,8 +16,17 @@ RUN sudo apt-get update \
 # 9.1.0, and dune, and clean up the opam cache.  rocq-stdlib.9.1.0 provides
 # PrimInt63, PrimFloat, and PrimString (needed for MLuint/MLfloat/MLstring
 # test coverage).
+#
+# The install is wrapped in a retry loop because the rocq-prover release
+# server occasionally returns 504 Gateway Timeout on the stdlib tarball.
+# Three attempts with 20-second back-off is enough to ride out transient
+# upstream hiccups without failing the whole image build.
 RUN opam repo add rocq-released https://rocq-prover.org/opam/released \
-    && opam install -y rocq-core.9.1.0 rocq-stdlib.9.1.0 dune \
+    && for attempt in 1 2 3; do \
+         opam install -y rocq-core.9.1.0 rocq-stdlib.9.1.0 dune && break; \
+         echo "opam install attempt $attempt failed — retrying in 20 s..."; \
+         sleep 20; \
+       done \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -11,11 +11,11 @@ RUN sudo apt-get update \
         python3 \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rocq 9.2 and dune, clean up opam cache.
-# rocq-stdlib has no release compatible with rocq-core.9.2.0 in the default
-# opam repo; the Stdlib theories are bundled inside rocq-core itself and found
-# via Rocq's own search path without a separate opam package.
-RUN opam install -y rocq-core.9.2.0 dune \
+# Install Rocq 9.1, rocq-stdlib 9.1.0, and dune, then clean up opam cache.
+# rocq-stdlib.9.1.0 is the latest release with an opam package that matches
+# rocq-core.9.1.0; it provides PrimInt63, PrimFloat, and PrimString (needed for
+# MLuint/MLfloat/MLstring test coverage).
+RUN opam install -y rocq-core.9.1.0 rocq-stdlib.9.1.0 dune \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Dockerfile
+++ b/rocq-python-extraction/Dockerfile
@@ -11,11 +11,13 @@ RUN sudo apt-get update \
         python3 \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rocq 9.1, rocq-stdlib 9.1.0, and dune, then clean up opam cache.
-# rocq-stdlib.9.1.0 is the latest release with an opam package that matches
-# rocq-core.9.1.0; it provides PrimInt63, PrimFloat, and PrimString (needed for
-# MLuint/MLfloat/MLstring test coverage).
-RUN opam install -y rocq-core.9.1.0 rocq-stdlib.9.1.0 dune \
+# Add the rocq-prover opam repository, which carries rocq-stdlib.9.1.0 (not
+# yet in the default opam repository).  Then install Rocq 9.1, rocq-stdlib
+# 9.1.0, and dune, and clean up the opam cache.  rocq-stdlib.9.1.0 provides
+# PrimInt63, PrimFloat, and PrimString (needed for MLuint/MLfloat/MLstring
+# test coverage).
+RUN opam repo add rocq-released https://rocq-prover.org/opam/released \
+    && opam install -y rocq-core.9.1.0 rocq-stdlib.9.1.0 dune \
     && opam clean --all
 
 WORKDIR /workspace

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -12,7 +12,8 @@ PY_ARTIFACTS := \
 	_build/default/uint_val.py \
 	_build/default/float_val.py \
 	_build/default/str_val.py \
-	_build/default/todo_val.py
+	_build/default/todo_val.py \
+	_build/default/bool_not.py
 
 test: build
 	@for f in $(PY_ARTIFACTS); do \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -13,7 +13,8 @@ PY_ARTIFACTS := \
 	_build/default/float_val.py \
 	_build/default/str_val.py \
 	_build/default/todo_val.py \
-	_build/default/bool_not.py
+	_build/default/bool_not.py \
+	_build/default/nat_double.py
 
 test: build
 	@for f in $(PY_ARTIFACTS); do \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -16,7 +16,8 @@ PY_ARTIFACTS := \
 	_build/default/bool_not.py \
 	_build/default/nat_double.py \
 	_build/default/option_inc.py \
-	_build/default/pair_swap.py
+	_build/default/pair_swap.py \
+	_build/default/list_add_one.py
 
 test: build
 	@for f in $(PY_ARTIFACTS); do \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -14,7 +14,8 @@ PY_ARTIFACTS := \
 	_build/default/str_val.py \
 	_build/default/todo_val.py \
 	_build/default/bool_not.py \
-	_build/default/nat_double.py
+	_build/default/nat_double.py \
+	_build/default/option_inc.py
 
 test: build
 	@for f in $(PY_ARTIFACTS); do \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -9,6 +9,9 @@ PY_ARTIFACTS := \
 	_build/default/nat_add.py \
 	_build/default/mk_pair_r.py \
 	_build/default/zeros.py \
+	_build/default/uint_val.py \
+	_build/default/float_val.py \
+	_build/default/str_val.py \
 	_build/default/todo_val.py \
 	_build/default/bool_not.py \
 	_build/default/nat_double.py \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -15,7 +15,8 @@ PY_ARTIFACTS := \
 	_build/default/todo_val.py \
 	_build/default/bool_not.py \
 	_build/default/nat_double.py \
-	_build/default/option_inc.py
+	_build/default/option_inc.py \
+	_build/default/pair_swap.py
 
 test: build
 	@for f in $(PY_ARTIFACTS); do \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -9,9 +9,6 @@ PY_ARTIFACTS := \
 	_build/default/nat_add.py \
 	_build/default/mk_pair_r.py \
 	_build/default/zeros.py \
-	_build/default/uint_val.py \
-	_build/default/float_val.py \
-	_build/default/str_val.py \
 	_build/default/todo_val.py \
 	_build/default/bool_not.py \
 	_build/default/nat_double.py \

--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean
+.PHONY: build test clean docker-build docker-test
 
 build:
 	dune build
@@ -28,3 +28,26 @@ test: build
 
 clean:
 	dune clean
+
+# ---------------------------------------------------------------------------
+# Local Docker targets — mirrors the CI build so your dev environment matches
+# exactly what GitHub Actions runs.
+#
+#   make docker-build   — build the image from the local Dockerfile (uses
+#                          Docker's own layer cache; no GHA credentials needed)
+#   make docker-test    — build the image then run the full test suite inside
+#                          the container, mounting the repo root read-only
+# ---------------------------------------------------------------------------
+
+# Build the image from the Dockerfile in this directory.  The build context is
+# '.' (this directory), the same files CI sends when it does:
+#   docker buildx build ... rocq-python-extraction/
+docker-build:
+	docker buildx build --load -t rocq-python-extraction:ci .
+
+# Run tests inside the container.  The repo root (one level up) is mounted
+# read-only at /src; the container copies it to a writable /tmp/work so dune
+# can write build artifacts without touching the source tree.
+docker-test: docker-build
+	docker run --rm -v "$(CURDIR)/..:/src:ro" rocq-python-extraction:ci \
+	  sh -c "cp -r /src /tmp/work && cd /tmp/work/rocq-python-extraction && opam exec -- make test"

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -59,3 +59,18 @@ assert nat_double(5) == 10, 'nat_double(5): got ' + repr(nat_double(5)); \
 print('Phase 3 nat round-trip: OK')\
 \""
   )))
+
+; option → Python Optional: option_inc propagates None and increments Some values.
+(rule
+ (alias runtest)
+ (deps test/phase3.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('option_inc.py').read()); \
+assert option_inc(None) is None, 'option_inc(None): got ' + repr(option_inc(None)); \
+assert option_inc(0) == 1, 'option_inc(0): got ' + repr(option_inc(0)); \
+assert option_inc(5) == 6, 'option_inc(5): got ' + repr(option_inc(5)); \
+print('Phase 3 option round-trip: OK')\
+\""
+  )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -44,3 +44,18 @@ assert bool_not(False) is True, 'bool_not(False): got ' + repr(bool_not(False));
 print('Phase 3 bool round-trip: OK')\
 \""
   )))
+
+; nat → Python int: nat_double(k) == 2*k for k in {0, 3, 5}.
+(rule
+ (alias runtest)
+ (deps test/phase3.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('nat_double.py').read()); \
+assert nat_double(0) == 0, 'nat_double(0): got ' + repr(nat_double(0)); \
+assert nat_double(3) == 6, 'nat_double(3): got ' + repr(nat_double(3)); \
+assert nat_double(5) == 10, 'nat_double(5): got ' + repr(nat_double(5)); \
+print('Phase 3 nat round-trip: OK')\
+\""
+  )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -89,3 +89,18 @@ assert pair_swap((5, 5)) == (5, 5), 'pair_swap((5, 5)): got ' + repr(pair_swap((
 print('Phase 3 prod round-trip: OK')\
 \""
   )))
+
+; list → Python list: list_add_one increments every element by one.
+(rule
+ (alias runtest)
+ (deps test/phase3.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('list_add_one.py').read()); \
+assert list_add_one([]) == [], 'list_add_one([]): got ' + repr(list_add_one([])); \
+assert list_add_one([0, 1, 2]) == [1, 2, 3], 'list_add_one([0,1,2]): got ' + repr(list_add_one([0, 1, 2])); \
+assert list_add_one([5]) == [6], 'list_add_one([5]): got ' + repr(list_add_one([5])); \
+print('Phase 3 list round-trip: OK')\
+\""
+  )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -27,3 +27,20 @@ for f in nat_add.py mk_pair_r.py zeros.py uint_val.py float_val.py str_val.py to
   python3 -m py_compile \"$f\" || exit 1; \
 done && echo 'All extracted .py files are syntactically valid Python.'"
   )))
+
+; Phase 3 round-trip tests: extracted(f(x)) == expected(x) for each primitive.
+; Each rule depends on the phase3.vo build which produces the .py side-effects.
+
+; bool → Python bool: bool_not(True) is False and bool_not(False) is True.
+(rule
+ (alias runtest)
+ (deps test/phase3.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('bool_not.py').read()); \
+assert bool_not(True) is False, 'bool_not(True): got ' + repr(bool_not(True)); \
+assert bool_not(False) is True, 'bool_not(False): got ' + repr(bool_not(False)); \
+print('Phase 3 bool round-trip: OK')\
+\""
+  )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -23,7 +23,7 @@
  (deps test/phase2.vo)
  (action
   (bash "\
-for f in nat_add.py mk_pair_r.py zeros.py todo_val.py; do \
+for f in nat_add.py mk_pair_r.py zeros.py uint_val.py float_val.py str_val.py todo_val.py; do \
   python3 -m py_compile \"$f\" || exit 1; \
 done && echo 'All extracted .py files are syntactically valid Python.'"
   )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -74,3 +74,18 @@ assert option_inc(5) == 6, 'option_inc(5): got ' + repr(option_inc(5)); \
 print('Phase 3 option round-trip: OK')\
 \""
   )))
+
+; prod → Python tuple: pair_swap swaps the two components of an int 2-tuple.
+(rule
+ (alias runtest)
+ (deps test/phase3.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('pair_swap.py').read()); \
+assert pair_swap((0, 1)) == (1, 0), 'pair_swap((0, 1)): got ' + repr(pair_swap((0, 1))); \
+assert pair_swap((3, 7)) == (7, 3), 'pair_swap((3, 7)): got ' + repr(pair_swap((3, 7))); \
+assert pair_swap((5, 5)) == (5, 5), 'pair_swap((5, 5)): got ' + repr(pair_swap((5, 5))); \
+print('Phase 3 prod round-trip: OK')\
+\""
+  )))

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -23,7 +23,7 @@
  (deps test/phase2.vo)
  (action
   (bash "\
-for f in nat_add.py mk_pair_r.py zeros.py uint_val.py float_val.py str_val.py todo_val.py; do \
+for f in nat_add.py mk_pair_r.py zeros.py todo_val.py; do \
   python3 -m py_compile \"$f\" || exit 1; \
 done && echo 'All extracted .py files are syntactically valid Python.'"
   )))

--- a/rocq-python-extraction/g_python_extraction.mlg
+++ b/rocq-python-extraction/g_python_extraction.mlg
@@ -30,7 +30,7 @@ let python_extract ~opaque_access qid =
   let base   = Id.to_string (Nametab.basename_of_global gr) in
   let name   = Id.of_string base in
   let pp     =
-    Python.python_descr.preamble state name None DirPath.Set.empty safe ++
+    Python.python_descr.preamble state name None [] safe ++
     Python.python_descr.pp_struct state struc
   in
   let fname  = base ^ ".py" in

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -290,6 +290,12 @@ let rec pp_expr state env = function
         pp_expr state env body_true  ++ str " if " ++
         pp_expr state env scrutinee  ++ str " else " ++
         pp_expr state env body_false
+      else if is_custom_match branches then
+        (* Custom match function: [Extract Inductive T => "t" [...] "fn"].
+           Emit as [fn(branch_thunk_0, branch_thunk_1, …, scrutinee)] where
+           each branch becomes a Python lambda.  This handles types like
+           [nat → int] whose constructors do not exist as Python patterns. *)
+        pp_custom_match_expr state env (find_custom_match branches) scrutinee branches
       else
         (* General match: emit Python [match]/[case] statement.
            This is a statement in Python, so it only works correctly when the
@@ -342,12 +348,55 @@ let rec pp_expr state env = function
       prlist_with_sep fnl pp_one (List.init n (fun j -> j)) ++ fnl () ++
       pp_pyid name_arr.(i)
 
+(*s Custom-match expression emitter.
+    When [Extract Inductive T => "t" [conA conB] "fn"] supplies a match
+    function, case analysis on [T] cannot use Python [match]/[case] (the
+    constructors don't exist as Python patterns).  Instead we emit a
+    functional application:
+
+      (fn)(lambda: arm0_body, lambda x: arm1_body, …, scrutinee)
+
+    Each branch becomes a [lambda] thunk.  The convention — branch thunks
+    first, scrutinee last — must match what the user wrote in ["fn"].
+    For example, for [nat → int]:
+
+      Extract Inductive nat => "int" ["0" "(lambda x: x+1)"]
+        "(lambda fO, fS, n: fO() if n == 0 else fS(n-1))".
+
+    yields  [(lambda fO, fS, n: fO() if n == 0 else fS(n-1))(lambda: 0,
+              lambda m_: ..., n)].
+
+    [pp_custom_match_expr] is mutually recursive with [pp_expr] because it
+    calls [pp_expr] to emit each branch body. *)
+
+and pp_custom_match_expr state env s scrutinee branches =
+  let pp_arm (ids, _pat, body) =
+    let ids', env' = push_vars (List.rev_map id_of_mlid ids) env in
+    let params = List.rev ids' in
+    match params with
+    | [] ->
+        (* No binders: unit thunk. *)
+        str "lambda: " ++ pp_expr state env' body
+    | _  ->
+        let pp_p id = if Id.equal id dummy_name then str "_" else pp_pyid id in
+        str "lambda " ++
+        prlist_with_sep (fun () -> str ", ") pp_p params ++
+        str ": " ++
+        pp_expr state env' body
+  in
+  str "(" ++ str s ++ str ")(" ++
+  prlist_with_sep (fun () -> str ", ") pp_arm (Array.to_list branches) ++
+  str ", " ++
+  pp_expr state env scrutinee ++
+  str ")"
+
 (*s Statement-level body printer for Python [def] bodies.
     Inside a [def], [return <match-stmt>] is invalid Python because [match] is
     a statement, not an expression.  This printer recurses into [MLcase]
     branches so that each leaf arm gets its own [return], producing valid
     Python.  The boolean ternary (two-arm bool match) is still treated as an
-    expression and wrapped in a single [return].
+    expression and wrapped in a single [return].  Custom-match expressions
+    are pure expressions and likewise wrapped in a single [return].
 
     [indent] is the indentation level (in spaces) at which the [match] keyword
     itself will appear.  [case] arms are emitted at [indent + 4], and their
@@ -365,6 +414,10 @@ let rec pp_return_body state env indent = function
       if is_bool then
         (* Ternary — valid expression; a single [return] suffices. *)
         str "return " ++ pp_expr state env expr
+      else if is_custom_match branches then
+        (* Custom-match — also a pure expression. *)
+        str "return " ++
+        pp_custom_match_expr state env (find_custom_match branches) scrutinee branches
       else
         (* General match: put [return] inside each arm so the branch is
            a valid statement.  [case] must be indented inside the [match]

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -450,6 +450,9 @@ let pp_ind_decl state (ind : ml_ind) =
       let p = ind.ind_packets.(0) in
       if p.ip_logical then
         str "# " ++ Id.print p.ip_typename ++ str ": logical inductive" ++ fnl ()
+      else if is_custom p.ip_typename_ref then
+        str "# " ++ Id.print p.ip_typename ++
+        str ": remapped to Python primitive via Extract Inductive" ++ fnl ()
       else
         str "# " ++ Id.print p.ip_typename ++
         str ": singleton inductive, constructor was " ++
@@ -458,12 +461,18 @@ let pp_ind_decl state (ind : ml_ind) =
       let p = ind.ind_packets.(0) in
       if p.ip_logical then
         str "# " ++ Id.print p.ip_typename ++ str ": logical record" ++ fnl ()
+      else if is_custom p.ip_typename_ref then
+        str "# " ++ Id.print p.ip_typename ++
+        str ": remapped to Python primitive via Extract Inductive" ++ fnl ()
       else
         pp_one_cons state p (Some fields) 0
   | Standard | Coinductive ->
       let pp_packet p =
         if p.ip_logical then
           str "# " ++ Id.print p.ip_typename ++ str ": logical inductive" ++ fnl ()
+        else if is_custom p.ip_typename_ref then
+          str "# " ++ Id.print p.ip_typename ++
+          str ": remapped to Python primitive via Extract Inductive" ++ fnl ()
         else
           let n = Array.length p.ip_types in
           prlist_with_sep (fun () -> fnl ())

--- a/rocq-python-extraction/rocq-python-extraction.opam
+++ b/rocq-python-extraction/rocq-python-extraction.opam
@@ -7,5 +7,5 @@ authors: ["FidoCanCode"]
 license: "LGPL-2.1-or-later"
 depends: [
   "dune" {>= "3.21"}
-  "rocq-core" {>= "9.2"}
+  "rocq-core" {>= "9.1"}
 ]

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -1,6 +1,6 @@
 (rocq.theory
  (name PyExtractTest)
- (synopsis "Phase 2 acceptance tests — all core term nodes")
+ (synopsis "Phase 2–3 acceptance tests — core term nodes and primitive remapping")
  (plugins rocq-python-extraction)
  (theories Stdlib)
- (modules acceptance phase2))
+ (modules acceptance phase2 phase3))

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -2,5 +2,7 @@
  (name PyExtractTest)
  (synopsis "Phase 2–3 acceptance tests — core term nodes and primitive remapping")
  (plugins rocq-python-extraction)
- (theories Stdlib)
+ ; rocq-stdlib has no release compatible with rocq-core.9.2.0 in the default
+ ; opam repo.  The Stdlib theories are bundled in rocq-core and found via
+ ; Rocq's own search path; dune does not need to resolve a separate package.
  (modules acceptance phase2 phase3))

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -2,7 +2,5 @@
  (name PyExtractTest)
  (synopsis "Phase 2–3 acceptance tests — core term nodes and primitive remapping")
  (plugins rocq-python-extraction)
- ; rocq-stdlib has no release compatible with rocq-core.9.2.0 in the default
- ; opam repo.  The Stdlib theories are bundled in rocq-core and found via
- ; Rocq's own search path; dune does not need to resolve a separate package.
+ (theories Stdlib)
  (modules acceptance phase2 phase3))

--- a/rocq-python-extraction/test/phase2.v
+++ b/rocq-python-extraction/test/phase2.v
@@ -28,19 +28,13 @@
 
 Declare ML Module "rocq-python-extraction".
 
-(* ------------------------------------------------------------------ *)
-(*  Load extraction vernaculars (Extract Inductive, etc.)              *)
-(* ------------------------------------------------------------------ *)
+(* The extraction vernaculars (Extract Inductive, etc.) are registered by
+   the rocq-runtime.plugins.extraction ML plugin, which our plugin depends
+   on.  No Stdlib theory import is required — they are available the moment
+   the plugin is loaded via [Declare ML Module] above.
 
-From Stdlib Require Import extraction.Extraction.
-
-(* ------------------------------------------------------------------ *)
-(*  Stdlib imports for primitive types                                 *)
-(* ------------------------------------------------------------------ *)
-
-From Stdlib Require Import Numbers.Cyclic.Int63.PrimInt63.
-From Stdlib Require Import Floats.PrimFloat.
-From Stdlib Require Import Strings.PrimString.
+   Similarly, [int], [float], and primitive string literals are kernel
+   primitives; no Stdlib import is needed for their basic use. *)
 
 (* ------------------------------------------------------------------ *)
 (*  Extract Inductive bool → Python True/False (enables ternary emit)  *)
@@ -116,8 +110,10 @@ Definition uint_val : int := 42.
 (** MLfloat: IEEE 754 float literal. *)
 Definition float_val : float := 3.14.
 
-(** MLstring: primitive byte-string literal. *)
-Definition str_val : PrimString.string := "hello"%pstring.
+(** MLstring: primitive byte-string literal.  Type inferred from the
+    [%pstring] notation; no [PrimString.string] qualified annotation needed
+    when the Stdlib is not installed. *)
+Definition str_val := "hello"%pstring.
 
 (** MLaxiom: unproved assumption — extracts to [raise NotImplementedError]. *)
 Axiom todo_val : nat.

--- a/rocq-python-extraction/test/phase2.v
+++ b/rocq-python-extraction/test/phase2.v
@@ -31,13 +31,19 @@ Declare ML Module "rocq-python-extraction".
 (* [Extract Inductive] and related vernaculars are registered by the
    rocq-runtime.plugins.extraction ML plugin.  That plugin is part of
    rocq-core (not rocq-stdlib), so it is always available.  We load it
-   directly here rather than going through [From Stdlib Require Import
-   extraction.Extraction], which would require a compatible rocq-stdlib
-   release (none exists for rocq-core.9.2.0 in the default opam repo).
+   directly rather than via [From Stdlib Require Import extraction.Extraction],
+   which has no compatible release for rocq-core.9.2.0 in the default opam repo.
 
-   [int], [float], and primitive string literals are kernel primitives;
-   no Stdlib import is needed for their basic use. *)
+   The primitive-type theories (PrimInt63, PrimFloat, PrimString) are bundled
+   inside rocq-core and accessible via Rocq's search path even though there is
+   no separate rocq-stdlib opam package installed; dune does not need a
+   [(theories Stdlib)] entry to find them at compile time. *)
 Declare ML Module "rocq-runtime.plugins.extraction".
+
+From Stdlib Require Import
+  Numbers.Cyclic.Int63.PrimInt63  (* provides the [int] type *)
+  Floats.PrimFloat                 (* provides the [float] type *)
+  Strings.PrimString.              (* provides the [%pstring] notation *)
 
 (* ------------------------------------------------------------------ *)
 (*  Extract Inductive bool → Python True/False (enables ternary emit)  *)

--- a/rocq-python-extraction/test/phase2.v
+++ b/rocq-python-extraction/test/phase2.v
@@ -14,6 +14,9 @@
       [MLcase]      — bool ternary + general structural match
       [MLfix]       — Dfix mutual-fixpoint declaration
       [Dind]        — Standard, Record, Coinductive inductive declarations
+      [MLuint]      — 63-bit integer literal
+      [MLfloat]     — IEEE 754 float literal
+      [MLstring]    — primitive byte-string literal
       [MLaxiom]     — unproved axiom
       [MLdummy]     — erased (logical) argument
 
@@ -21,12 +24,6 @@
       [MLexn]     — requires empty-match or erasure edge-cases; deferred
       [MLmagic]   — internal extraction coercion; hard to trigger directly
       [MLparray]  — persistent arrays intentionally not supported (MVP stub)
-      [MLuint]    — 63-bit integer literal; requires [PrimInt63] from rocq-stdlib,
-                    which has no opam release compatible with rocq-core.9.2.0
-      [MLfloat]   — IEEE 754 float literal; requires [PrimFloat] from rocq-stdlib,
-                    same constraint as MLuint
-      [MLstring]  — primitive byte-string literal; requires [PrimString] from
-                    rocq-stdlib, same constraint as MLuint
 *)
 
 Declare ML Module "rocq-python-extraction".
@@ -34,10 +31,18 @@ Declare ML Module "rocq-python-extraction".
 (* [Extract Inductive] and related vernaculars are registered by the
    rocq-runtime.plugins.extraction ML plugin.  That plugin is part of
    rocq-core (not rocq-stdlib), so it is always available.  We load it
-   directly rather than via [From Stdlib Require Import extraction.Extraction]:
-   no rocq-stdlib release is compatible with rocq-core.9.2.0 in the default
-   opam repo, so all [From Stdlib Require Import] are unavailable in CI. *)
+   directly rather than via [From Stdlib Require Import extraction.Extraction].
+
+   The primitive-type theories (PrimInt63, PrimFloat, PrimString) come from
+   rocq-stdlib.9.1.0 — the latest stdlib release compatible with our Docker
+   image.  We import them explicitly so that [int], [float], and [%pstring]
+   are in scope for the MLuint/MLfloat/MLstring definitions below. *)
 Declare ML Module "rocq-runtime.plugins.extraction".
+
+From Stdlib Require Import
+  Numbers.Cyclic.Int63.PrimInt63  (* provides the [int] type *)
+  Floats.PrimFloat                 (* provides the [float] type *)
+  Strings.PrimString.              (* provides the [%pstring] notation *)
 
 (* ------------------------------------------------------------------ *)
 (*  Extract Inductive bool → Python True/False (enables ternary emit)  *)
@@ -107,6 +112,15 @@ Fixpoint nat_add (n m : nat) : nat :=
   | S n' => S (nat_add n' m)
   end.
 
+(** MLuint: 63-bit machine integer literal. *)
+Definition uint_val : int := 42.
+
+(** MLfloat: IEEE 754 float literal. *)
+Definition float_val : float := 3.14.
+
+(** MLstring: primitive byte-string literal. *)
+Definition str_val := "hello"%pstring.
+
 (** MLaxiom: unproved assumption — extracts to [raise NotImplementedError]. *)
 Axiom todo_val : nat.
 
@@ -124,6 +138,15 @@ Python Extraction mk_pair_r.
 
 (** [zeros.py]: covers stream (Dind Coinductive), MLcons Coinductive. *)
 Python Extraction zeros.
+
+(** [uint_val.py]: MLuint literal. *)
+Python Extraction uint_val.
+
+(** [float_val.py]: MLfloat literal. *)
+Python Extraction float_val.
+
+(** [str_val.py]: MLstring literal. *)
+Python Extraction str_val.
 
 (** [todo_val.py]: MLaxiom. *)
 Python Extraction todo_val.

--- a/rocq-python-extraction/test/phase2.v
+++ b/rocq-python-extraction/test/phase2.v
@@ -14,9 +14,6 @@
       [MLcase]      — bool ternary + general structural match
       [MLfix]       — Dfix mutual-fixpoint declaration
       [Dind]        — Standard, Record, Coinductive inductive declarations
-      [MLuint]      — 63-bit integer literal
-      [MLfloat]     — IEEE 754 float literal
-      [MLstring]    — primitive byte-string literal
       [MLaxiom]     — unproved axiom
       [MLdummy]     — erased (logical) argument
 
@@ -24,6 +21,12 @@
       [MLexn]     — requires empty-match or erasure edge-cases; deferred
       [MLmagic]   — internal extraction coercion; hard to trigger directly
       [MLparray]  — persistent arrays intentionally not supported (MVP stub)
+      [MLuint]    — 63-bit integer literal; requires [PrimInt63] from rocq-stdlib,
+                    which has no opam release compatible with rocq-core.9.2.0
+      [MLfloat]   — IEEE 754 float literal; requires [PrimFloat] from rocq-stdlib,
+                    same constraint as MLuint
+      [MLstring]  — primitive byte-string literal; requires [PrimString] from
+                    rocq-stdlib, same constraint as MLuint
 *)
 
 Declare ML Module "rocq-python-extraction".
@@ -31,19 +34,10 @@ Declare ML Module "rocq-python-extraction".
 (* [Extract Inductive] and related vernaculars are registered by the
    rocq-runtime.plugins.extraction ML plugin.  That plugin is part of
    rocq-core (not rocq-stdlib), so it is always available.  We load it
-   directly rather than via [From Stdlib Require Import extraction.Extraction],
-   which has no compatible release for rocq-core.9.2.0 in the default opam repo.
-
-   The primitive-type theories (PrimInt63, PrimFloat, PrimString) are bundled
-   inside rocq-core and accessible via Rocq's search path even though there is
-   no separate rocq-stdlib opam package installed; dune does not need a
-   [(theories Stdlib)] entry to find them at compile time. *)
+   directly rather than via [From Stdlib Require Import extraction.Extraction]:
+   no rocq-stdlib release is compatible with rocq-core.9.2.0 in the default
+   opam repo, so all [From Stdlib Require Import] are unavailable in CI. *)
 Declare ML Module "rocq-runtime.plugins.extraction".
-
-From Stdlib Require Import
-  Numbers.Cyclic.Int63.PrimInt63  (* provides the [int] type *)
-  Floats.PrimFloat                 (* provides the [float] type *)
-  Strings.PrimString.              (* provides the [%pstring] notation *)
 
 (* ------------------------------------------------------------------ *)
 (*  Extract Inductive bool → Python True/False (enables ternary emit)  *)
@@ -113,17 +107,6 @@ Fixpoint nat_add (n m : nat) : nat :=
   | S n' => S (nat_add n' m)
   end.
 
-(** MLuint: 63-bit machine integer literal. *)
-Definition uint_val : int := 42.
-
-(** MLfloat: IEEE 754 float literal. *)
-Definition float_val : float := 3.14.
-
-(** MLstring: primitive byte-string literal.  Type inferred from the
-    [%pstring] notation; no [PrimString.string] qualified annotation needed
-    when the Stdlib is not installed. *)
-Definition str_val := "hello"%pstring.
-
 (** MLaxiom: unproved assumption — extracts to [raise NotImplementedError]. *)
 Axiom todo_val : nat.
 
@@ -141,15 +124,6 @@ Python Extraction mk_pair_r.
 
 (** [zeros.py]: covers stream (Dind Coinductive), MLcons Coinductive. *)
 Python Extraction zeros.
-
-(** [uint_val.py]: MLuint literal. *)
-Python Extraction uint_val.
-
-(** [float_val.py]: MLfloat literal. *)
-Python Extraction float_val.
-
-(** [str_val.py]: MLstring literal. *)
-Python Extraction str_val.
 
 (** [todo_val.py]: MLaxiom. *)
 Python Extraction todo_val.

--- a/rocq-python-extraction/test/phase2.v
+++ b/rocq-python-extraction/test/phase2.v
@@ -28,13 +28,16 @@
 
 Declare ML Module "rocq-python-extraction".
 
-(* The extraction vernaculars (Extract Inductive, etc.) are registered by
-   the rocq-runtime.plugins.extraction ML plugin, which our plugin depends
-   on.  No Stdlib theory import is required — they are available the moment
-   the plugin is loaded via [Declare ML Module] above.
+(* [Extract Inductive] and related vernaculars are registered by the
+   rocq-runtime.plugins.extraction ML plugin.  That plugin is part of
+   rocq-core (not rocq-stdlib), so it is always available.  We load it
+   directly here rather than going through [From Stdlib Require Import
+   extraction.Extraction], which would require a compatible rocq-stdlib
+   release (none exists for rocq-core.9.2.0 in the default opam repo).
 
-   Similarly, [int], [float], and primitive string literals are kernel
-   primitives; no Stdlib import is needed for their basic use. *)
+   [int], [float], and primitive string literals are kernel primitives;
+   no Stdlib import is needed for their basic use. *)
+Declare ML Module "rocq-runtime.plugins.extraction".
 
 (* ------------------------------------------------------------------ *)
 (*  Extract Inductive bool → Python True/False (enables ternary emit)  *)

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -6,6 +6,7 @@
 
     Coverage (grows as tasks land):
       bool → Python bool  ([True]/[False] ternary, both directions)
+      nat  → Python int   (constructor inline lambdas + custom match function)
 *)
 
 Declare ML Module "rocq-python-extraction".
@@ -24,3 +25,31 @@ Extract Inductive bool => "bool" [ "True" "False" ].
 Definition bool_not (b : bool) : bool := if b then false else true.
 
 Python Extraction bool_not.
+
+(* ------------------------------------------------------------------ *)
+(*  nat → Python int                                                   *)
+(*                                                                     *)
+(*  Constructor mapping:                                               *)
+(*    O → 0             (zero literal)                                 *)
+(*    S → (lambda x: x + 1)  (inline successor function)              *)
+(*  Custom match function encodes case analysis via Python lambda:     *)
+(*    (lambda fO, fS, n: fO() if n == 0 else fS(n - 1))              *)
+(*  Applied as: fn(O_thunk, S_thunk, scrutinee)                       *)
+(* ------------------------------------------------------------------ *)
+
+Extract Inductive nat => "int"
+  [ "0" "(lambda x: x + 1)" ]
+  "(lambda fO, fS, n: fO() if n == 0 else fS(n - 1))".
+
+(** [nat_double]: 2*n via structural recursion — exercises both the
+    O branch (returns 0) and the S branch (applies successor twice).
+    Extracted form uses the custom match function to dispatch on int
+    and inline lambdas for constructor application.
+    Expected: nat_double(k) == 2 * k for all k ≥ 0. *)
+Fixpoint nat_double (n : nat) : nat :=
+  match n with
+  | O   => O
+  | S m => S (S (nat_double m))
+  end.
+
+Python Extraction nat_double.

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -5,8 +5,9 @@
     [extracted(f(x)) == expected(x)] via a Python driver in the [dune] file.
 
     Coverage (grows as tasks land):
-      bool → Python bool  ([True]/[False] ternary, both directions)
-      nat  → Python int   (constructor inline lambdas + custom match function)
+      bool   → Python bool      ([True]/[False] ternary, both directions)
+      nat    → Python int       (constructor inline lambdas + custom match)
+      option → Python Optional  (Some erased to value; None → Python None)
 *)
 
 Declare ML Module "rocq-python-extraction".
@@ -53,3 +54,31 @@ Fixpoint nat_double (n : nat) : nat :=
   end.
 
 Python Extraction nat_double.
+
+(* ------------------------------------------------------------------ *)
+(*  option → Python Optional                                           *)
+(*                                                                     *)
+(*  Constructor mapping (Rocq ctor order: Some=0, None=1):            *)
+(*    Some → ""     (singleton erasure: emit the wrapped value as-is) *)
+(*    None → "None" (Python's None literal)                           *)
+(*  Custom match function dispatches on Python None-ness:             *)
+(*    (lambda fSome, fNone, x: fNone() if x is None else fSome(x))   *)
+(*  Applied as: fn(Some_thunk, None_thunk, scrutinee)                 *)
+(* ------------------------------------------------------------------ *)
+
+Extract Inductive option => ""
+  [ "" "None" ]
+  "(lambda fSome, fNone, x: fNone() if x is None else fSome(x))".
+
+(** [option_inc]: lift successor over option nat — exercises both the
+    Some branch (applies S to the wrapped nat) and the None branch
+    (propagates None).  With nat→int and option→Optional, the extracted
+    function operates on plain Python ints and Python None.
+    Expected: option_inc None = None; option_inc (Some n) = Some (S n). *)
+Definition option_inc (o : option nat) : option nat :=
+  match o with
+  | None   => None
+  | Some n => Some (S n)
+  end.
+
+Python Extraction option_inc.

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -17,8 +17,13 @@ Declare ML Module "rocq-python-extraction".
 (* [Extract Inductive] and related vernaculars are registered by the
    rocq-runtime.plugins.extraction ML plugin, part of rocq-core.  Load it
    directly — no rocq-stdlib import needed.  [nat], [bool], [option], [prod],
-   and [list] are prelude types; always in scope without explicit imports. *)
+   and [list] are prelude types; always in scope without explicit imports.
+
+   [list_scope] is defined in [Init.Datatypes] (part of the prelude) and
+   provides the [[h :: t]] cons notation.  Open it here so the list section
+   can use infix notation without importing [Lists.List]. *)
 Declare ML Module "rocq-runtime.plugins.extraction".
+Open Scope list_scope.
 
 (* ------------------------------------------------------------------ *)
 (*  bool → Python bool                                                 *)

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -1,0 +1,26 @@
+(** Phase 3 acceptance tests: primitive type remapping round-trips.
+
+    Each section extracts a Rocq function via an [Extract Inductive] pragma
+    that maps a Rocq primitive to the matching Python builtin, then verifies
+    [extracted(f(x)) == expected(x)] via a Python driver in the [dune] file.
+
+    Coverage (grows as tasks land):
+      bool → Python bool  ([True]/[False] ternary, both directions)
+*)
+
+Declare ML Module "rocq-python-extraction".
+
+From Stdlib Require Import extraction.Extraction.
+
+(* ------------------------------------------------------------------ *)
+(*  bool → Python bool                                                 *)
+(* ------------------------------------------------------------------ *)
+
+Extract Inductive bool => "bool" [ "True" "False" ].
+
+(** [bool_not]: logical negation defined inline so the extraction includes
+    only the ternary pattern; no Stdlib dependency, no extra declarations.
+    Extracted form: [False if b else True]. *)
+Definition bool_not (b : bool) : bool := if b then false else true.
+
+Python Extraction bool_not.

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -9,11 +9,13 @@
       nat    → Python int       (constructor inline lambdas + custom match)
       option → Python Optional  (Some erased to value; None → Python None)
       prod   → Python tuple     (erased constructor; tuple patterns in match)
+      list   → Python list      (nil→[], cons→prepend; custom match on emptiness)
 *)
 
 Declare ML Module "rocq-python-extraction".
 
 From Stdlib Require Import extraction.Extraction.
+From Stdlib Require Import Lists.List.
 
 (* ------------------------------------------------------------------ *)
 (*  bool → Python bool                                                 *)
@@ -108,3 +110,32 @@ Definition pair_swap (p : nat * nat) : nat * nat :=
   end.
 
 Python Extraction pair_swap.
+
+(* ------------------------------------------------------------------ *)
+(*  list → Python list                                                 *)
+(*                                                                     *)
+(*  Constructor mapping:                                               *)
+(*    nil  → "[]"                    (empty list literal)              *)
+(*    cons → "(lambda h, t: [h] + t)" (prepend head onto tail)        *)
+(*  Custom match function dispatches on Python list emptiness:         *)
+(*    (lambda fnil, fcons, l: fnil() if l == [] else fcons(l[0], l[1:])) *)
+(*  Applied as: fn(nil_thunk, cons_thunk, scrutinee)                  *)
+(* ------------------------------------------------------------------ *)
+
+Extract Inductive list => "list"
+  [ "[]" "(lambda h, t: [h] + t)" ]
+  "(lambda fnil, fcons, l: fnil() if l == [] else fcons(l[0], l[1:]))".
+
+(** [list_add_one]: increment every element of a [list nat] by one.
+    Exercises both the nil branch (returns []) and the cons branch
+    (prepends the incremented head onto the recursively-processed tail).
+    With [nat → int] and [list → list], the extracted function operates
+    on plain Python lists of ints.
+    Expected: list_add_one [] = []; list_add_one [h; …] = [h+1; …]. *)
+Fixpoint list_add_one (l : list nat) : list nat :=
+  match l with
+  | nil    => nil
+  | h :: t => (S h) :: list_add_one t
+  end.
+
+Python Extraction list_add_one.

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -14,8 +14,8 @@
 
 Declare ML Module "rocq-python-extraction".
 
-From Stdlib Require Import extraction.Extraction.
-From Stdlib Require Import Lists.List.
+(* Extraction vernaculars come from the ML plugin; [nat], [bool], [option],
+   [prod], and [list] are prelude types — no Stdlib imports required. *)
 
 (* ------------------------------------------------------------------ *)
 (*  bool → Python bool                                                 *)

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -8,6 +8,7 @@
       bool   → Python bool      ([True]/[False] ternary, both directions)
       nat    → Python int       (constructor inline lambdas + custom match)
       option → Python Optional  (Some erased to value; None → Python None)
+      prod   → Python tuple     (erased constructor; tuple patterns in match)
 *)
 
 Declare ML Module "rocq-python-extraction".
@@ -82,3 +83,28 @@ Definition option_inc (o : option nat) : option nat :=
   end.
 
 Python Extraction option_inc.
+
+(* ------------------------------------------------------------------ *)
+(*  prod → Python tuple                                                *)
+(*                                                                     *)
+(*  Constructor mapping:                                               *)
+(*    pair → ""   (multi-arg erasure: emit (a, b) directly)           *)
+(*  No custom match function needed: Python tuple patterns work natively *)
+(*  in [match]/[case], so the general structural match path handles it. *)
+(* ------------------------------------------------------------------ *)
+
+Extract Inductive prod => "" [ "" ].
+
+(** [pair_swap]: swap the two components of a [nat * nat] pair.
+    Exercises both tuple construction ([MLcons]/[MLtuple] with erased
+    constructor → [(a, b)] literal) and tuple pattern matching
+    ([Pcons]/[Ptuple] → [(a, b)] pattern).  With [nat → int] and
+    [prod → tuple], the extracted function operates on plain Python tuples
+    of ints.
+    Expected: pair_swap (a, b) = (b, a) for all a, b. *)
+Definition pair_swap (p : nat * nat) : nat * nat :=
+  match p with
+  | (a, b) => (b, a)
+  end.
+
+Python Extraction pair_swap.

--- a/rocq-python-extraction/test/phase3.v
+++ b/rocq-python-extraction/test/phase3.v
@@ -14,8 +14,11 @@
 
 Declare ML Module "rocq-python-extraction".
 
-(* Extraction vernaculars come from the ML plugin; [nat], [bool], [option],
-   [prod], and [list] are prelude types — no Stdlib imports required. *)
+(* [Extract Inductive] and related vernaculars are registered by the
+   rocq-runtime.plugins.extraction ML plugin, part of rocq-core.  Load it
+   directly — no rocq-stdlib import needed.  [nat], [bool], [option], [prod],
+   and [list] are prelude types; always in scope without explicit imports. *)
+Declare ML Module "rocq-runtime.plugins.extraction".
 
 (* ------------------------------------------------------------------ *)
 (*  bool → Python bool                                                 *)


### PR DESCRIPTION
Fixes #714.

Honor `Extract Inductive` pragmas for bool→bool, nat→int, list→list, option→Optional, and prod→tuple in the Python extraction backend. Custom-mapped inductives skip dataclass emission, a custom match function emitter handles types like nat whose constructors aren't valid Python patterns, and each primitive gets a round-trip acceptance test. Also switching to a Rocq version with a compatible rocq-stdlib to restore full MLuint/MLfloat/MLstring test coverage, using docker buildx with GHA layer caching for faster CI builds, and adding Makefile targets so local dev builds reuse the same Docker image as CI.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (11)</summary>

- [x] [Replace python3 apt package with uv-managed Python 3.14t in the Dockerfile](https://github.com/FidoCanCode/home/pull/784#discussion_r3105225527) <!-- type:thread -->
- [x] [Add Makefile targets for local docker buildx build and test that reuse the CI image](https://github.com/FidoCanCode/home/pull/784#issuecomment-4273746563) <!-- type:thread -->
- [x] [Switch to a Rocq version that has a compatible rocq-stdlib release and restore MLuint/MLfloat/MLstring test coverage](https://github.com/FidoCanCode/home/pull/784#issuecomment-4273657526) <!-- type:thread -->
- [x] [Investigate docker buildx caching strategies and implement a build approach that keeps CI images up-to-date without rebuilding from scratch every run](https://github.com/FidoCanCode/home/pull/784#issuecomment-4273655423) <!-- type:thread -->
- [x] [Fix CI build failure caused by Dockerfile changes](https://github.com/FidoCanCode/home/pull/784#discussion_r3104369700) <!-- type:thread -->
- [x] Add prod-to-tuple primitive remapping with round-trip test <!-- type:spec -->
- [x] [Fix CI build failure](https://github.com/FidoCanCode/home/pull/784#issuecomment-4272478337) <!-- type:thread -->
- [x] Add option-to-Optional primitive remapping with round-trip test <!-- type:spec -->
- [x] Add nat-to-int primitive remapping with round-trip test <!-- type:spec -->
- [x] Add bool round-trip extraction test <!-- type:spec -->
- [x] Skip Dind emission for custom-mapped inductives <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->