### PR TITLE
Enforce git identity invariant on every worker iteration (closes #792)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import requests as _requests
 
+from kennel.types import GitIdentity
+
 log = logging.getLogger(__name__)
 
 _HTTP_TIMEOUT: int = 30  # seconds for all outbound GitHub HTTP requests
@@ -446,6 +448,22 @@ class GitHub:
         """Return the authenticated GitHub username."""
         data = self._get("/user")
         return data["login"]
+
+    def get_authenticated_identity(self) -> GitIdentity:
+        """Return the git commit identity derived from the authenticated GitHub user.
+
+        Name: the account's display name, falling back to ``login`` when unset.
+        Email: the GitHub noreply form
+        ``{id}+{login}@users.noreply.github.com`` — never the real email.
+        """
+        data = self._get("/user")
+        login = data["login"]
+        uid = data["id"]
+        name = data.get("name") or login
+        return GitIdentity(
+            name=name,
+            email=f"{uid}+{login}@users.noreply.github.com",
+        )
 
     def get_collaborators(self, repo: str) -> list[str]:
         """Return logins of collaborators with write+ permission on *repo*.

--- a/kennel/types.py
+++ b/kennel/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
 
 
@@ -16,3 +17,20 @@ class TaskStatus(StrEnum):
     COMPLETED = "completed"
     IN_PROGRESS = "in_progress"
     BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class GitIdentity:
+    """GitHub-derived git commit identity.
+
+    Name comes from the authenticated user's display name (falling back to
+    login).  Email is always the GitHub noreply form
+    ``{id}+{login}@users.noreply.github.com`` — the user's real email is
+    never used, even if exposed via the API.
+    """
+
+    name: str
+    email: str
+
+    def __str__(self) -> str:
+        return f"{self.name} <{self.email}>"

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -41,7 +41,15 @@ from kennel.state import (
     _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
 )
 from kennel.tasks import Tasks
-from kennel.types import TaskStatus, TaskType
+from kennel.types import GitIdentity, TaskStatus, TaskType
+
+
+class GitIdentityError(Exception):
+    """Raised when a workspace's git identity doesn't match the authenticated
+    GitHub user — fails closed so we never ship commits under the wrong author
+    (see #792).
+    """
+
 
 _CI_LOG_TAIL = 200  # max lines of failure log to include in the CI prompt
 
@@ -2445,6 +2453,45 @@ class Worker:
         log.info("rescope_before_pick: rescoping task list before next pick")
         reorder_tasks(self.work_dir, commit_summary, **kwargs)
 
+    def assert_git_identity(self, *, phase: str) -> None:
+        """Enforce the git-identity invariant (see #792).
+
+        An invariant, checked at both the start (pre-condition) and end
+        (post-condition) of every worker iteration: the workspace's configured
+        git identity must match the authenticated GitHub user.  If it doesn't,
+        raise — loud failure in the crash log beats silently shipping a commit
+        under the wrong author.
+
+        The expected identity is derived dynamically from the GitHub API —
+        ``name`` from the account's display name (fallback: login), ``email``
+        from the noreply form ``{id}+{login}@users.noreply.github.com`` so a
+        real address is never used.
+
+        A post-condition failure (``phase="post"``) is the scary case: it means
+        something *during the iteration* mutated the config.  Either way the
+        worker aborts and the watchdog restarts.
+        """
+        expected = self.gh.get_authenticated_identity()
+        actual = GitIdentity(
+            name=self._git_config_get("user.name"),
+            email=self._git_config_get("user.email"),
+        )
+        if actual != expected:
+            raise GitIdentityError(
+                f"git identity invariant violated ({phase}) in {self.work_dir}: "
+                f"actual={actual} expected={expected}"
+            )
+
+    def _git_config_get(self, key: str) -> str:
+        """Return ``git config --get <key>`` in the workspace, empty on unset."""
+        result = subprocess.run(
+            ["git", "config", "--get", key],
+            cwd=self.work_dir,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+
     def run(self) -> int:
         """Run one iteration of the worker loop.
 
@@ -2462,116 +2509,122 @@ class Worker:
         with ctx:
             log.info("worker started for %s (git_dir=%s)", self.work_dir, ctx.git_dir)
 
-            repo_ctx = self.discover_repo_context()
-            log.info(
-                "repo=%s user=%s default_branch=%s",
-                repo_ctx.repo,
-                repo_ctx.gh_user,
-                repo_ctx.default_branch,
-            )
-
-            compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
-            session_fresh = self._session is None
-            if session_fresh:
-                self.create_session()
+            self.assert_git_identity(phase="pre")
             try:
-                issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
-                if issue is None:
-                    issue = self.find_next_issue(ctx.fido_dir, repo_ctx)
-                if issue is None:
-                    return 0
-
-                # Guard: if the active issue has acquired open sub-issues
-                # post-pickup (e.g. fido groomed it into sub-issues, or a
-                # human added children), it is no longer a leaf.  Drop the
-                # issue out of state.json so the next iteration's picker
-                # re-descends from the true root and lands on the first
-                # open child.  Assignees are not touched (per-repo policy).
-                # Fix for #780.
-                if self._issue_has_open_sub_issues(repo_ctx.repo, issue):
-                    log.warning(
-                        "issue #%s has acquired open sub-issues — abandoning "
-                        "state so picker re-descends next iteration (see #780)",
-                        issue,
-                    )
-                    with State(ctx.fido_dir).modify() as state:
-                        state.pop("issue", None)
-                        state.pop("issue_title", None)
-                        state.pop("issue_started_at", None)
-                        state.pop("pr_number", None)
-                        state.pop("pr_title", None)
-                        state.pop("current_task_id", None)
-                    return 0
-
-                self._next_turn_session_mode = TurnSessionMode.REUSE
-                if not session_fresh and issue != self._session_issue:
-                    log.info(
-                        "worker: new issue #%s — restarting session at issue boundary",
-                        issue,
-                    )
-                    self._next_turn_session_mode = TurnSessionMode.FRESH
-                self._session_issue = issue
-
-                issue_data = self.gh.view_issue(repo_ctx.repo, issue)
-                issue_title = issue_data["title"]
-                issue_body = issue_data.get("body", "") or ""
-                pr_number, slug, pr_is_fresh = self.find_or_create_pr(
-                    ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
-                )
-                recovery_provider = (
-                    self._ensure_provider().provider_id
-                    if self._repo_cfg is None
-                    else self._repo_cfg.provider
-                )
-                recovery_repo_cfg = RepoConfig(
-                    name=repo_ctx.repo,
-                    work_dir=self.work_dir,
-                    provider=recovery_provider,
-                    membership=repo_ctx.membership,
-                )
-                recovery_config = Config(
-                    port=0,
-                    secret=b"",
-                    repos={repo_ctx.repo: recovery_repo_cfg},
-                    allowed_bots=frozenset(),
-                    log_level="WARNING",
-                    sub_dir=_sub_dir(),
-                )
-                from kennel.events import recover_reply_promises
-
-                recovered_promises = recover_reply_promises(
-                    ctx.fido_dir,
-                    recovery_config,
-                    recovery_repo_cfg,
-                    self.gh,
-                    pr_number,
-                    agent=self._provider_agent,
-                    prompts=self._get_prompts(),
-                )
-                self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
-                if pr_is_fresh:
-                    log.info("fresh PR — skipping CI/thread/rescope checks")
-                else:
-                    self.rescope_before_pick()
-                    if self.handle_merge_conflict(
-                        ctx.fido_dir, repo_ctx, pr_number, slug
-                    ):
-                        return 1
-                    if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
-                        return 1
-                    if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):
-                        return 1
-                if self.execute_task(ctx.fido_dir, repo_ctx, pr_number, slug):
-                    self.resolve_addressed_threads(repo_ctx, pr_number)
-                    return 1
-                promote_result = self.handle_promote_merge(
-                    ctx.fido_dir, repo_ctx, pr_number, slug, issue
-                )
-                return (
-                    1 if recovered_promises and promote_result == 0 else promote_result
-                )
+                return self._run_iteration(ctx)
             finally:
-                self.teardown_hooks(ctx.fido_dir, compact_cmd, sync_cmd)
+                self.assert_git_identity(phase="post")
+
+    def _run_iteration(self, ctx: WorkerContext) -> int:
+        """Body of :meth:`run` — guaranteed to run between the pre- and
+        post-condition identity checks in :meth:`run`.
+        """
+        repo_ctx = self.discover_repo_context()
+        log.info(
+            "repo=%s user=%s default_branch=%s",
+            repo_ctx.repo,
+            repo_ctx.gh_user,
+            repo_ctx.default_branch,
+        )
+
+        compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
+        session_fresh = self._session is None
+        if session_fresh:
+            self.create_session()
+        try:
+            issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
+            if issue is None:
+                issue = self.find_next_issue(ctx.fido_dir, repo_ctx)
+            if issue is None:
+                return 0
+
+            # Guard: if the active issue has acquired open sub-issues
+            # post-pickup (e.g. fido groomed it into sub-issues, or a
+            # human added children), it is no longer a leaf.  Drop the
+            # issue out of state.json so the next iteration's picker
+            # re-descends from the true root and lands on the first
+            # open child.  Assignees are not touched (per-repo policy).
+            # Fix for #780.
+            if self._issue_has_open_sub_issues(repo_ctx.repo, issue):
+                log.warning(
+                    "issue #%s has acquired open sub-issues — abandoning "
+                    "state so picker re-descends next iteration (see #780)",
+                    issue,
+                )
+                with State(ctx.fido_dir).modify() as state:
+                    state.pop("issue", None)
+                    state.pop("issue_title", None)
+                    state.pop("issue_started_at", None)
+                    state.pop("pr_number", None)
+                    state.pop("pr_title", None)
+                    state.pop("current_task_id", None)
+                return 0
+
+            self._next_turn_session_mode = TurnSessionMode.REUSE
+            if not session_fresh and issue != self._session_issue:
+                log.info(
+                    "worker: new issue #%s — restarting session at issue boundary",
+                    issue,
+                )
+                self._next_turn_session_mode = TurnSessionMode.FRESH
+            self._session_issue = issue
+
+            issue_data = self.gh.view_issue(repo_ctx.repo, issue)
+            issue_title = issue_data["title"]
+            issue_body = issue_data.get("body", "") or ""
+            pr_number, slug, pr_is_fresh = self.find_or_create_pr(
+                ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
+            )
+            recovery_provider = (
+                self._ensure_provider().provider_id
+                if self._repo_cfg is None
+                else self._repo_cfg.provider
+            )
+            recovery_repo_cfg = RepoConfig(
+                name=repo_ctx.repo,
+                work_dir=self.work_dir,
+                provider=recovery_provider,
+                membership=repo_ctx.membership,
+            )
+            recovery_config = Config(
+                port=0,
+                secret=b"",
+                repos={repo_ctx.repo: recovery_repo_cfg},
+                allowed_bots=frozenset(),
+                log_level="WARNING",
+                sub_dir=_sub_dir(),
+            )
+            from kennel.events import recover_reply_promises
+
+            recovered_promises = recover_reply_promises(
+                ctx.fido_dir,
+                recovery_config,
+                recovery_repo_cfg,
+                self.gh,
+                pr_number,
+                agent=self._provider_agent,
+                prompts=self._get_prompts(),
+            )
+            self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
+            if pr_is_fresh:
+                log.info("fresh PR — skipping CI/thread/rescope checks")
+            else:
+                self.rescope_before_pick()
+                if self.handle_merge_conflict(ctx.fido_dir, repo_ctx, pr_number, slug):
+                    return 1
+                if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
+                    return 1
+                if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):
+                    return 1
+            if self.execute_task(ctx.fido_dir, repo_ctx, pr_number, slug):
+                self.resolve_addressed_threads(repo_ctx, pr_number)
+                return 1
+            promote_result = self.handle_promote_merge(
+                ctx.fido_dir, repo_ctx, pr_number, slug, issue
+            )
+            return 1 if recovered_promises and promote_result == 0 else promote_result
+        finally:
+            self.teardown_hooks(ctx.fido_dir, compact_cmd, sync_cmd)
 
 
 _IDLE_TIMEOUT = 60.0  # seconds to wait when there was no work to do

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -897,6 +897,52 @@ class TestGitHubClass:
         assert url.endswith("/user")
         assert result == "fido"
 
+    def test_get_authenticated_identity_builds_noreply_email(self) -> None:
+        from kennel.types import GitIdentity
+
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "login": "FidoCanCode",
+            "id": 190991155,
+            "name": "Fido Can Code",
+        }
+        mock_s.get.return_value = mock_resp
+        assert gh.get_authenticated_identity() == GitIdentity(
+            name="Fido Can Code",
+            email="190991155+FidoCanCode@users.noreply.github.com",
+        )
+
+    def test_get_authenticated_identity_falls_back_to_login_when_name_missing(
+        self,
+    ) -> None:
+        from kennel.types import GitIdentity
+
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"login": "fido", "id": 1, "name": None}
+        mock_s.get.return_value = mock_resp
+        assert gh.get_authenticated_identity() == GitIdentity(
+            name="fido", email="1+fido@users.noreply.github.com"
+        )
+
+    def test_get_authenticated_identity_never_leaks_real_email(self) -> None:
+        """Even if the API exposes an email, we build the noreply form — the
+        real address never appears on a commit.
+        """
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "login": "fido",
+            "id": 42,
+            "name": "Fido",
+            "email": "real.person@example.com",
+        }
+        mock_s.get.return_value = mock_resp
+        identity = gh.get_authenticated_identity()
+        assert "real.person@example.com" not in identity.email
+        assert identity.email == "42+fido@users.noreply.github.com"
+
     def test_get_collaborators_filters_by_permission(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -36,7 +36,9 @@ from kennel.tasks import (
     sync_tasks,
     sync_tasks_background,
 )
+from kennel.types import GitIdentity
 from kennel.worker import (
+    GitIdentityError,
     LockHeld,
     RepoContext,
     RepoContextFilter,
@@ -96,6 +98,11 @@ class Worker(_WorkerBase):
                 membership=kwargs.get("membership"),
             )
         super().__init__(work_dir, gh, *args, **kwargs)
+
+    def assert_git_identity(self, *, phase: str) -> None:
+        """No-op by default in tests — the git identity invariant is exercised
+        in ``TestAssertGitIdentity`` directly against the real method."""
+        return None
 
 
 class WorkerThread(_WorkerThreadBase):
@@ -2104,6 +2111,73 @@ class TestIssueHasOpenSubIssues:
         gh.get_sub_issues.return_value = iter([])
         worker._issue_has_open_sub_issues("FidoCanCode/home", 710)
         gh.get_sub_issues.assert_called_once_with("FidoCanCode", "home", 710)
+
+
+class TestAssertGitIdentity:
+    """Pre/post invariant: workspace git identity must match the authenticated
+    GitHub user (fix for #792)."""
+
+    _EXPECTED = GitIdentity(
+        name="Fido Can Code",
+        email="190991155+FidoCanCode@users.noreply.github.com",
+    )
+
+    def _worker(self, tmp_path: Path) -> tuple[_WorkerBase, MagicMock]:
+        """Use the real Worker class (not the module-level test shim) so the
+        guard method is exercised, not the no-op override."""
+        gh = MagicMock()
+        gh.get_authenticated_identity.return_value = self._EXPECTED
+        return _WorkerBase(tmp_path, gh), gh
+
+    def _init_repo(
+        self, tmp_path: Path, *, name: str | None, email: str | None
+    ) -> None:
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        if name is not None:
+            subprocess.run(
+                ["git", "config", "user.name", name], cwd=tmp_path, check=True
+            )
+        if email is not None:
+            subprocess.run(
+                ["git", "config", "user.email", email], cwd=tmp_path, check=True
+            )
+
+    def test_passes_when_config_matches(self, tmp_path: Path) -> None:
+        self._init_repo(
+            tmp_path,
+            name="Fido Can Code",
+            email="190991155+FidoCanCode@users.noreply.github.com",
+        )
+        worker, _ = self._worker(tmp_path)
+        worker.assert_git_identity(phase="pre")  # must not raise
+
+    def test_raises_on_name_mismatch(self, tmp_path: Path) -> None:
+        self._init_repo(
+            tmp_path,
+            name="test",
+            email="190991155+FidoCanCode@users.noreply.github.com",
+        )
+        worker, _ = self._worker(tmp_path)
+        with pytest.raises(GitIdentityError, match="invariant violated \\(pre\\)"):
+            worker.assert_git_identity(phase="pre")
+
+    def test_raises_on_email_mismatch(self, tmp_path: Path) -> None:
+        self._init_repo(tmp_path, name="Fido Can Code", email="test@example.com")
+        worker, _ = self._worker(tmp_path)
+        with pytest.raises(GitIdentityError, match="invariant violated \\(post\\)"):
+            worker.assert_git_identity(phase="post")
+
+    def test_message_uses_git_style_identity_format(self, tmp_path: Path) -> None:
+        self._init_repo(tmp_path, name="test", email="test@example.com")
+        worker, _ = self._worker(tmp_path)
+        with pytest.raises(GitIdentityError) as excinfo:
+            worker.assert_git_identity(phase="pre")
+        msg = str(excinfo.value)
+        assert "test <test@example.com>" in msg
+        assert "Fido Can Code <190991155+FidoCanCode@users.noreply.github.com>" in msg
+
+    def test_git_identity_str_is_git_author_format(self) -> None:
+        assert str(GitIdentity(name="A Dog", email="a@b.c")) == "A Dog <a@b.c>"
 
 
 class TestNoCommitNudge:


### PR DESCRIPTION
Closes #792.

## Summary

- Adds `GitIdentity` frozen dataclass in `kennel/types.py` with git-style `__str__` (`Name <email>`).
- New `GitHub.get_authenticated_identity()` derives the expected identity from `/user`: display name (falling back to login) + GitHub noreply email `{id}+{login}@users.noreply.github.com`. Real email never leaks onto a commit.
- New `Worker.assert_git_identity(phase=...)` raises `GitIdentityError` when the workspace's configured identity doesn't match the authenticated user.
- Invariant checked **pre** (top of every `Worker.run` iteration) and **post** (in `finally` after the body) — post catches anything that mutated config mid-iteration.

## Context

The local git config in `/home/rhencke/workspace/home` had drifted to `user.name=test / user.email=test@example.com`, overriding the global Fido identity. 29 commits on PR #784 shipped with the wrong author before a human noticed. Root cause of the drift is unknown (the only test that sets `user.name=test` scopes via `cwd=tmp_path` and should not leak); this PR is the defensive fix so the next drift crashes loudly instead.

Force-pushed history on #784 to re-author the bad commits; this PR prevents a repeat.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .`
- [x] `uv run pytest --cov --cov-fail-under=100` — 2386 passed, 100% coverage
- [x] `TestAssertGitIdentity` uses the real Worker class (bypasses the no-op shim used elsewhere)
- [x] `TestGitHubClass::test_get_authenticated_identity_never_leaks_real_email` verifies noreply-only behavior