### PR TITLE
Fix make test to survive stale _build (rocq-python-extraction)

### DIFF
--- a/rocq-python-extraction/Makefile
+++ b/rocq-python-extraction/Makefile
@@ -3,28 +3,13 @@
 build:
 	dune build
 
-# After dune builds the test theory, Python Extraction side-effects land in
-# _build/default/.  Validate each one is syntactically valid Python.
-PY_ARTIFACTS := \
-	_build/default/nat_add.py \
-	_build/default/mk_pair_r.py \
-	_build/default/zeros.py \
-	_build/default/uint_val.py \
-	_build/default/float_val.py \
-	_build/default/str_val.py \
-	_build/default/todo_val.py \
-	_build/default/bool_not.py \
-	_build/default/nat_double.py \
-	_build/default/option_inc.py \
-	_build/default/pair_swap.py \
-	_build/default/list_add_one.py
-
-test: build
-	@for f in $(PY_ARTIFACTS); do \
-	  echo "checking $$f ..."; \
-	  python3 -m py_compile $$f || exit 1; \
-	done
-	@echo "All extracted .py files are syntactically valid."
+# Extracted .py files are side-effects of the rocq.theory build and land in
+# _build/default/.  Dune treats them as undeclared outputs and removes them
+# between separate invocations, so we cannot validate them in a second dune
+# call.  Instead we delegate entirely to `dune build @runtest`, which runs the
+# py_compile checks inside the same dune invocation that writes the files.
+test:
+	dune build @runtest
 
 clean:
 	dune clean


### PR DESCRIPTION
## Summary

- The old `make test` ran `dune build` then separately validated extracted `.py` files in `_build/default/`. Dune removes undeclared side-effect outputs between invocations, so a stale `_build` caused the py_compile step to fail with "No such file or directory".
- Switch `test` target to `dune build @runtest` — runs py_compile checks inside the same dune invocation that writes the files, so they're guaranteed present.
- Removes the now-redundant `PY_ARTIFACTS` list (single source of truth stays in `dune`).

## Test plan

- [x] Confirmed `make docker-test` passes end-to-end (all 13 extracted .py files validated, all 5 phase-3 round-trip assertions pass)
- [x] Confirmed `dune build @runtest` works correctly with a fresh build (no `_build`) — simulates CI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)