### PR TITLE
Backfill missed PR comments on worker startup (closes #794)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1508,6 +1508,61 @@ def create_task(
     return new_task
 
 
+def backfill_missed_pr_comments(
+    config: Config,
+    repo_cfg: RepoConfig,
+    gh: GitHub,
+    pr_number: int,
+    *,
+    gh_user: str,
+) -> int:
+    """Replay ``issue_comment`` webhooks we may have missed while kennel was
+    down (fix for #794).  Returns the number of comments inspected.
+
+    Scope is narrow by design: only **top-level PR comments** are replayed.
+    Inline review comments and review threads are already scanned each
+    iteration by ``Worker.handle_threads``, so the worker loop backfills
+    those on its own — only issue-comments are invisible to the loop.
+
+    Idempotent: :func:`create_task` dedups on ``comment_id`` regardless of
+    status, so replaying the same comment after fido already replied is a
+    no-op.  This function is intended to run **once per WorkerThread
+    lifetime** (at startup) — not every iteration.
+    """
+    log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
+    comments = gh.get_issue_comments(repo_cfg.name, pr_number)
+    for c in comments:
+        user = (c.get("user") or {}).get("login", "")
+        if not user:
+            continue
+        if user.lower() == gh_user.lower():
+            continue
+        if user.lower() in ("fidocancode", "fido-can-code"):
+            continue
+        if not _is_allowed(user, repo_cfg, config):
+            continue
+        comment_id = c.get("id")
+        if comment_id is None:
+            continue
+        body = c.get("body", "") or ""
+        is_bot = user.endswith("[bot]")
+        thread = {
+            "repo": repo_cfg.name,
+            "pr": pr_number,
+            "comment_id": comment_id,
+            "url": c.get("html_url", ""),
+            "author": user,
+            "comment_type": "issues",
+        }
+        prompt = (
+            f"PR top-level comment on #{pr_number} by {user} "
+            f"({'bot' if is_bot else 'human/owner'}):\n\n{body}"
+        )
+        create_task(prompt, config, repo_cfg, gh, thread=thread)
+    log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
+    return len(comments)
+
+
 def launch_sync(config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
     """Sync tasks.json → PR body in a background thread."""
     from kennel.tasks import sync_tasks_background

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -827,11 +827,16 @@ class Worker:
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
+        first_iteration: bool = False,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
         self._abort_task = abort_task if abort_task is not None else threading.Event()
         self._repo_name = repo_name
+        # Replay missed issue_comment webhooks exactly once per WorkerThread
+        # lifetime (at startup).  Fix for #794 — without this, top-level PR
+        # comments that land while kennel is down go unanswered on restart.
+        self._first_iteration = first_iteration
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
         self._session_issue: int | None = session_issue
@@ -2606,6 +2611,21 @@ class Worker:
                 prompts=self._get_prompts(),
             )
             self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
+            if self._first_iteration and not pr_is_fresh:
+                # One-shot replay of missed issue_comment webhooks (fix #794).
+                # Runs only on the first iteration per WorkerThread lifetime so
+                # the steady-state loop stays fast; create_task dedups on
+                # comment_id so re-tasking already-handled comments is a no-op.
+                from kennel.events import backfill_missed_pr_comments
+
+                backfill_missed_pr_comments(
+                    recovery_config,
+                    recovery_repo_cfg,
+                    self.gh,
+                    pr_number,
+                    gh_user=repo_ctx.gh_user,
+                )
+                self._first_iteration = False
             if pr_is_fresh:
                 log.info("fresh PR — skipping CI/thread/rescope checks")
             else:
@@ -2710,6 +2730,9 @@ class WorkerThread(threading.Thread):
         self._config = config
         self._repo_cfg = repo_cfg
         self.__dict__["_bootstrap_session"] = session
+        # True until the first ``Worker.run()`` returns — flipped after that so
+        # the one-shot startup backfill (fix #794) only fires once per thread.
+        self._is_first_iteration = True
 
     @property
     def _session(self) -> PromptSession | None:
@@ -2922,6 +2945,7 @@ class WorkerThread(threading.Thread):
                     config=self._config,
                     repo_cfg=self._repo_cfg,
                     provider_factory=self._provider_factory,
+                    first_iteration=self._is_first_iteration,
                 )
                 worker._provider = provider  # pyright: ignore[reportPrivateUsage]
                 worker._provider_agent = provider.agent  # pyright: ignore[reportPrivateUsage]
@@ -2932,6 +2956,7 @@ class WorkerThread(threading.Thread):
                         self._provider = worker._provider  # pyright: ignore[reportPrivateUsage]
                     self._session_issue = worker._session_issue  # pyright: ignore[reportPrivateUsage]
                     self._persist_session_id()
+                    self._is_first_iteration = False
 
                 if result == 1:
                     # Did work — loop immediately without waiting.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from kennel.claude import ClaudeClient
-from kennel.config import Config
+from kennel.config import Config, RepoMembership
 from kennel.config import RepoConfig as _RepoConfig
 from kennel.events import (
     Action,
@@ -3611,6 +3611,215 @@ class TestNotifyThreadChange:
             "owner/repo", 42, "Auto reply", 999
         )
         mock_gh.comment_issue.assert_not_called()
+
+
+class TestBackfillMissedPrComments:
+    """Replay of issue_comment webhooks missed during kennel downtime (fix #794).
+
+    Only top-level PR comments are in scope — inline review comments and review
+    threads are already scanned each iteration by ``Worker.handle_threads``.
+    """
+
+    def _cfg(
+        self, tmp_path: Path, allowed_bots: frozenset[str] = frozenset()
+    ) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=allowed_bots,
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _repo_cfg(
+        self, tmp_path: Path, collaborators: frozenset[str] = frozenset({"rhencke"})
+    ) -> RepoConfig:
+        return RepoConfig(
+            name="owner/repo",
+            work_dir=tmp_path,
+            membership=RepoMembership(collaborators=collaborators),
+        )
+
+    def _comment(
+        self,
+        comment_id: int,
+        user: str = "rhencke",
+        body: str = "hello",
+    ) -> dict:
+        return {
+            "id": comment_id,
+            "user": {"login": user},
+            "body": body,
+            "html_url": f"https://github.com/owner/repo/pull/1#issuecomment-{comment_id}",
+        }
+
+    def test_creates_task_for_allowed_collaborator_comment(
+        self, tmp_path: Path
+    ) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [self._comment(100)]
+        mock_gh.is_thread_resolved_for_comment.return_value = False
+        cfg = self._cfg(tmp_path)
+        repo_cfg = self._repo_cfg(tmp_path)
+        with patch("kennel.events.create_task") as mock_create:
+            count = backfill_missed_pr_comments(
+                cfg, repo_cfg, mock_gh, 1, gh_user="fidocancode"
+            )
+        assert count == 1
+        mock_create.assert_called_once()
+        _, kwargs = mock_create.call_args
+        assert kwargs["thread"]["comment_id"] == 100
+        assert kwargs["thread"]["comment_type"] == "issues"
+        assert kwargs["thread"]["author"] == "rhencke"
+
+    def test_skips_fido_own_comments(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="fidocancode", body="my own reply")
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="FidoCanCode",
+            )
+        mock_create.assert_not_called()
+
+    def test_skips_by_gh_user_case_insensitive(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="Alice", body="mine")
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="alice",
+            )
+        mock_create.assert_not_called()
+
+    def test_skips_fido_literal_name_even_if_gh_user_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        """Defense in depth: even if ``gh_user`` is misconfigured, comments
+        from the literal fido account must never trigger a backfill task."""
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="fido-can-code", body="my reply")
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="mis-configured-bot",
+            )
+        mock_create.assert_not_called()
+
+    def test_skips_non_allowed_users(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="random-stranger")
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path, collaborators=frozenset({"rhencke"})),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+        mock_create.assert_not_called()
+
+    def test_allows_configured_bots(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="dependabot[bot]", body="bump dep")
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path, allowed_bots=frozenset({"dependabot[bot]"})),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+        assert mock_create.call_count == 1
+        _, kwargs = mock_create.call_args
+        assert "bot" in kwargs["thread"]["author"]
+
+    def test_prompt_marks_bot_vs_human(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, user="rhencke", body="human msg"),
+            self._comment(101, user="bot[bot]", body="bot msg"),
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path, allowed_bots=frozenset({"bot[bot]"})),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+        prompts = [c.args[0] for c in mock_create.call_args_list]
+        assert any("human/owner" in p for p in prompts)
+        assert any("(bot)" in p for p in prompts)
+
+    def test_skips_empty_login_and_missing_id(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            {"id": 1, "user": {"login": ""}, "body": "x"},
+            {"id": None, "user": {"login": "rhencke"}, "body": "x"},
+            {"id": 2, "user": None, "body": "x"},
+        ]
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+        mock_create.assert_not_called()
+
+    def test_empty_comment_list_is_noop(self, tmp_path: Path) -> None:
+        from kennel.events import backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = []
+        with patch("kennel.events.create_task") as mock_create:
+            count = backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+        assert count == 0
+        mock_create.assert_not_called()
 
 
 class TestLaunchSync:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4622,6 +4622,71 @@ class TestRunSeedTasksIntegration:
             worker.run()
         mock_seed.assert_called_once_with("owner/repo", 42)
 
+    def test_backfill_runs_on_first_iteration_only(self, tmp_path: Path) -> None:
+        """Worker with ``first_iteration=True`` triggers the missed-comments
+        backfill (fix #794); with False it does not.
+        """
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        repo_ctx = self._make_mock_repo_ctx()
+        calls: list[int] = []
+
+        def _backfill(*_args, **kwargs):
+            calls.append(kwargs.get("gh_user") or _args[-1])
+            return 0
+
+        def _run_once(first: bool) -> None:
+            worker = Worker(tmp_path, gh, first_iteration=first)
+            with (
+                patch.object(
+                    worker, "create_context", return_value=self._make_mock_ctx(tmp_path)
+                ),
+                patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+                patch.object(worker, "setup_hooks", return_value=("c", "s")),
+                patch.object(worker, "teardown_hooks"),
+                patch.object(worker, "get_current_issue", return_value=7),
+                patch.object(worker, "post_pickup_comment"),
+                patch.object(
+                    worker, "find_or_create_pr", return_value=(42, "fix-bug", False)
+                ),
+                patch.object(worker, "seed_tasks_from_pr_body"),
+                patch.object(worker, "handle_ci", return_value=False),
+                patch.object(worker, "handle_threads", return_value=False),
+                patch(
+                    "kennel.events.backfill_missed_pr_comments", side_effect=_backfill
+                ),
+            ):
+                worker.run()
+
+        _run_once(first=True)
+        _run_once(first=False)
+        assert len(calls) == 1  # exactly one backfill, on the first-iteration run
+
+    def test_backfill_skipped_for_fresh_pr(self, tmp_path: Path) -> None:
+        """A freshly-created PR has no comments to backfill — skip the call to
+        avoid one superfluous API round-trip."""
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        worker = Worker(tmp_path, gh, first_iteration=True)
+        repo_ctx = self._make_mock_repo_ctx()
+        with (
+            patch.object(
+                worker, "create_context", return_value=self._make_mock_ctx(tmp_path)
+            ),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=7),
+            patch.object(worker, "post_pickup_comment"),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(42, "fix-bug", True)
+            ),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch("kennel.events.backfill_missed_pr_comments") as mock_backfill,
+        ):
+            worker.run()
+        mock_backfill.assert_not_called()
+
     def test_seed_not_called_when_find_or_create_pr_raises(
         self, tmp_path: Path
     ) -> None:
@@ -10918,8 +10983,9 @@ class TestWorkerThread:
             config=None,
             repo_cfg=None,
             provider_factory=None,
+            first_iteration=False,
         ):
-            del provider_factory
+            del provider_factory, first_iteration
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -11023,8 +11089,9 @@ class TestWorkerThread:
             config=None,
             repo_cfg=None,
             provider_factory=None,
+            first_iteration=False,
         ) -> None:
-            del provider_factory
+            del provider_factory, first_iteration
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -11075,8 +11142,9 @@ class TestWorkerThread:
             config=None,
             repo_cfg=None,
             provider_factory=None,
+            first_iteration=False,
         ) -> None:
-            del provider_factory
+            del provider_factory, first_iteration
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -11216,8 +11284,9 @@ class TestWorkerThread:
             config=None,
             repo_cfg=None,
             provider_factory=None,
+            first_iteration=False,
         ) -> None:
-            del provider_factory
+            del provider_factory, first_iteration
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -11427,8 +11496,9 @@ class TestWorkerThread:
             config=None,
             repo_cfg=None,
             provider_factory=None,
+            first_iteration=False,
         ) -> None:
-            del provider_factory
+            del provider_factory, first_iteration
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task


### PR DESCRIPTION
Closes #794.

## Summary

When kennel is down (vet-mode stop, crash, deploy), GitHub eventually stops retrying webhook delivery for the missed events. Top-level PR comments from that window are then invisible to the worker loop on restart — fido never sees them, never replies.

This PR adds a one-shot backfill pass that runs on the **first iteration of each \`WorkerThread\` lifetime**:

- For the active PR, fetch \`gh.get_issue_comments(repo, pr)\` and enqueue thread tasks for any not already tasked.
- \`create_task\` dedups on \`comment_id\` regardless of task status, so replays are idempotent.
- Zero steady-state cost: runs exactly once per thread, then the flag flips.

## Scope

**Top-level PR comments only.** Inline review comments and review threads are already scanned every iteration by \`Worker.handle_threads\` — only issue-comments (\`issue_comment\` webhooks) are invisible to the loop.

Fresh PRs skip the scan (no history to backfill).

## Test plan

- [x] \`uv run ruff format . && uv run ruff check .\`
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2397 passed, 100% coverage
- [x] \`TestBackfillMissedPrComments\` (9 cases): allowed collaborators, fido self-skip, case-insensitive gh_user, non-allowed users, allowed bots, bot/human prompt markers, missing fields, empty list, fido literal-name defense
- [x] Worker integration: backfill fires once per WorkerThread; skipped for fresh PRs