### PR TITLE
Salvage interrupted PR setup instead of rebuilding (closes #795)

### DIFF
--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1208,6 +1208,91 @@ class Worker:
         else:
             log.info("git clean: nothing to remove")
 
+    def _salvage_interrupted_pr(
+        self,
+        fido_dir: Path,
+        repo_ctx: RepoContext,
+        issue: int,
+        request: str,
+        remote: str,
+    ) -> tuple[int, str, bool] | None:
+        """Recover from a prior ``find_or_create_pr`` that crashed after setup
+        ran but before :meth:`GitHub.create_pr`.  Fix for #795.
+
+        Symptoms of the limbo state:
+        - ``find_pr`` returned ``None`` (no PR exists on GitHub);
+        - the current local branch is not the default branch;
+        - that branch has at least one commit ahead of the upstream default;
+        - ``tasks.json`` is populated (setup completed).
+
+        When all four hold, the prior iteration got as far as "push branch +
+        run setup" but never opened the PR.  Rather than delete the branch
+        and re-run setup from scratch (the old behavior — confusio's #206
+        loop), open the draft PR against the existing branch and continue as
+        if setup had just finished.
+
+        Returns the ``(pr_number, slug, is_fresh=True)`` tuple to hand back
+        to the caller, or ``None`` when no salvage is possible.
+        """
+        # Cheap check first: no tasks → nothing to salvage, no git calls.
+        if not self._tasks.list():
+            return None
+        try:
+            current_stdout = self._git(["branch", "--show-current"]).stdout
+        except subprocess.CalledProcessError:
+            return None
+        if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            current_stdout, str
+        ):
+            return None
+        current = current_stdout.strip()
+        if not current or current == repo_ctx.default_branch:
+            return None
+        try:
+            ahead_stdout = self._git(
+                [
+                    "rev-list",
+                    "--count",
+                    f"{remote}/{repo_ctx.default_branch}..HEAD",
+                ]
+            ).stdout
+        except subprocess.CalledProcessError:
+            return None
+        if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            ahead_stdout, str
+        ):
+            return None
+        ahead = ahead_stdout.strip()
+        if not ahead.isdigit() or int(ahead) < 1:
+            return None
+        log.info(
+            "salvage: interrupted attempt on branch %s — opening PR against "
+            "existing branch instead of rebuilding (see #795)",
+            current,
+        )
+        url = self.gh.create_pr(
+            repo_ctx.repo,
+            request,
+            f"Fixes #{issue}.",
+            repo_ctx.default_branch,
+            current,
+        )
+        pr_number = int(url.rstrip("/").split("/")[-1])
+        with State(fido_dir).modify() as state:
+            state["pr_number"] = pr_number
+            state["pr_title"] = request
+        _write_pr_description(
+            self.work_dir,
+            self.gh,
+            repo_ctx.repo,
+            pr_number,
+            issue,
+            self._tasks.list(),
+            agent=self._provider_agent,
+        )
+        log.info("salvage: PR #%s opened on branch %s  %s", pr_number, current, url)
+        return pr_number, current, True
+
     def find_or_create_pr(
         self,
         fido_dir: Path,
@@ -1284,6 +1369,18 @@ class Worker:
                 pr_number,
             )
             return pr_number, slug, False
+
+        # Recovery path for #795: if a previous iteration got as far as
+        # running setup (tasks.json populated) and pushing a branch, but
+        # crashed before ``create_pr``, then the current branch is the slug
+        # from that attempt and there is no PR on GitHub.  Before starting
+        # over from scratch, try to salvage that work: open the PR against
+        # the existing branch and treat it like a fresh PR from here on.
+        salvaged = self._salvage_interrupted_pr(
+            fido_dir, repo_ctx, issue, request, remote
+        )
+        if salvaged is not None:
+            return salvaged
 
         # Generate branch slug via the provider brief model
         raw_slug = self._provider_agent.generate_branch_name(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4332,6 +4332,290 @@ class TestFindOrCreatePr:
         assert "42" in caplog.text
 
 
+class TestSalvageInterruptedPr:
+    """Recovery path for #795: prior iteration ran setup + pushed branch but
+    crashed before ``create_pr``.  Salvage opens the PR on the existing branch
+    instead of rebuilding."""
+
+    def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido"
+        gh.get_default_branch.return_value = "main"
+        gh.create_pr.return_value = "https://github.com/owner/repo/pull/88"
+        return Worker(tmp_path, gh, provider_agent=_client()), gh
+
+    def _fido_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".git" / "fido"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _repo_ctx(self) -> RepoContext:
+        return RepoContext(
+            repo="owner/repo",
+            owner="owner",
+            repo_name="repo",
+            gh_user="fido",
+            default_branch="main",
+        )
+
+    def _git_side_effect(self, branch: str, ahead: str):
+        def _side(args, *_, **__):
+            if args == ["branch", "--show-current"]:
+                return subprocess.CompletedProcess(args, 0, stdout=branch, stderr="")
+            if args[0] == "rev-list":
+                return subprocess.CompletedProcess(args, 0, stdout=ahead, stderr="")
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        return _side
+
+    def test_salvages_when_branch_has_commits_and_tasks_exist(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("rescue-me", "3\n"),
+            ),
+            patch("kennel.worker._write_pr_description") as mock_write,
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                fido_dir, self._repo_ctx(), 42, "title (closes #42)", "origin"
+            )
+        assert result == (88, "rescue-me", True)
+        gh.create_pr.assert_called_once_with(
+            "owner/repo", "title (closes #42)", "Fixes #42.", "main", "rescue-me"
+        )
+        mock_write.assert_called_once()
+        state = State(fido_dir).load()
+        assert state["pr_number"] == 88
+        assert state["pr_title"] == "title (closes #42)"
+
+    def test_skips_when_on_default_branch(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("main", "0\n"),
+            ),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_branch_has_no_commits_ahead(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("work", "0\n"),
+            ),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_tasks_empty(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("work", "2\n"),
+            ),
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_branch_query_fails(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+
+        def _raise(*_, **__):
+            raise subprocess.CalledProcessError(1, ["git"])
+
+        with (
+            patch.object(worker, "_git", side_effect=_raise),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_rev_list_fails(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        calls: list[list[str]] = []
+
+        def _side(args, *_, **__):
+            calls.append(args)
+            if args == ["branch", "--show-current"]:
+                return subprocess.CompletedProcess(args, 0, stdout="work", stderr="")
+            raise subprocess.CalledProcessError(1, ["git", *args])
+
+        with (
+            patch.object(worker, "_git", side_effect=_side),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_ahead_is_not_numeric(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("work", "garbage\n"),
+            ),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_branch_query_returns_non_string(self, tmp_path: Path) -> None:
+        """Defensive: if ``_git`` ever hands back a non-str stdout (mocks,
+        future refactors), salvage bails rather than exploding downstream."""
+        worker, gh = self._make_worker(tmp_path)
+        fake = MagicMock()
+        fake.stdout = None
+        with (
+            patch.object(worker, "_git", return_value=fake),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_skips_when_ahead_stdout_is_non_string(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+
+        def _side(args, *_, **__):
+            if args == ["branch", "--show-current"]:
+                return subprocess.CompletedProcess(args, 0, stdout="work", stderr="")
+            fake = MagicMock()
+            fake.stdout = None
+            return fake
+
+        with (
+            patch.object(worker, "_git", side_effect=_side),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+        ):
+            result = worker._salvage_interrupted_pr(
+                self._fido_dir(tmp_path),
+                self._repo_ctx(),
+                1,
+                "t",
+                "origin",
+            )
+        assert result is None
+        gh.create_pr.assert_not_called()
+
+    def test_find_or_create_pr_uses_salvage_before_rebuild(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: when no PR exists but the workspace has an interrupted
+        attempt, ``find_or_create_pr`` returns via the salvage path without
+        running the setup sub-agent again."""
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = None
+        fido_dir = self._fido_dir(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=self._git_side_effect("rescue-me", "2\n"),
+            ),
+            patch("kennel.worker._write_pr_description"),
+            patch(
+                "kennel.tasks.Tasks.list",
+                return_value=[{"id": "t1", "title": "x", "status": "pending"}],
+            ),
+            patch("kennel.worker.provider_start") as mock_setup,
+        ):
+            result = worker.find_or_create_pr(
+                fido_dir, self._repo_ctx(), 7, "fix thing"
+            )
+        assert result == (88, "rescue-me", True)
+        mock_setup.assert_not_called()
+
+
 class TestSeedTasksFromPrBody:
     """Tests for Worker.seed_tasks_from_pr_body."""
 


### PR DESCRIPTION
Closes #795.  Follow-up backlog: #799.

## Summary

Confusio was trapped in a loop on issue #206: setup would plan 14 tasks and push a branch, kennel would stop mid-setup, and on restart \`find_pr\` returned None → fresh-start path → branch rebuilt → setup re-run → repeat forever.  No PR ever opened.

This PR adds \`_salvage_interrupted_pr\`, which fires in \`find_or_create_pr\` right before the "delete-and-rebuild" branch.  When:

1. \`tasks.json\` has entries (setup completed on a prior attempt);
2. the current git branch isn't the default branch;
3. the branch has ≥1 commit ahead of \`origin/default\`;
4. no PR exists (already the precondition — \`find_pr\` returned None).

...then we open the draft PR on the **existing** branch, persist \`pr_number\` to state.json, write the full PR description from the already-planned tasks, and return as a fresh PR.  The normal iteration picks up from there.

**No dummy PRs ever open** — the PR that shows up in GitHub already has a populated work queue in its body.  (Full deferral-until-first-commit tracked in #799.)

## Test plan

- [x] \`uv run ruff format . && uv run ruff check .\` + pyright clean
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2407 passed, 100% coverage
- [x] \`TestSalvageInterruptedPr\` (10 cases): happy path, skip on default branch, no commits ahead, empty tasks, git errors, non-numeric ahead, non-string stdout (both positions), end-to-end via \`find_or_create_pr\`