### PR TITLE
Stop iter_events from clobbering a live preempt cancel (closes #786)

### DIFF
--- a/kennel/claude.py
+++ b/kennel/claude.py
@@ -862,12 +862,21 @@ class ClaudeSession(OwnedSession):
         ``control_request`` so claude aborts the running tool on its
         side rather than completing it first.
 
+        Also sets :attr:`_preempt_pending` so :meth:`iter_events` does
+        not clobber the cancel signal at the start of the very next
+        turn (fix for #786 — worker could run a full turn to completion
+        when the webhook fired cancel during the worker's
+        ``__enter__`` → ``send`` window, because ``_in_turn`` was still
+        False at fire time and ``iter_events`` then cleared the signal
+        before the poll loop could respect it).
+
         Gated on :attr:`_in_turn` because ``control_request`` sent to an
         idle subprocess never elicits a ``type=result`` back and would
         hang the next :meth:`consume_until_result` indefinitely (hazard
         called out in the original :meth:`prompt` docstring).
         """
         self._cancel.set()
+        self._preempt_pending.set()
         self._wake()
         if self._in_turn:
             try:
@@ -1110,7 +1119,12 @@ class ClaudeSession(OwnedSession):
         should not be silently swallowed.
         """
         assert self._proc.stdout is not None
-        self._cancel.clear()
+        # Clear the cancel event only when no preempter is actively waiting
+        # (fix for #786).  Otherwise the signal fired by the preempter is
+        # meant for the current holder — clobbering it here lets the turn
+        # run to completion before the preempter ever gets the lock.
+        if not self._preempt_pending.is_set():
+            self._cancel.clear()
         self._last_turn_cancelled = False
         last_activity = time.monotonic()
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1252,6 +1252,57 @@ class TestClaudeSessionIterEvents:
         assert not session._cancel.is_set()
         session.stop()
 
+    def test_cancel_preserved_when_preempt_pending(self, tmp_path: Path) -> None:
+        """Fix for #786: when a preempter is actively waiting, the cancel
+        signal targeting the current holder must survive iter_events' start
+        so the first poll cycle respects it — otherwise the turn runs to
+        full completion before the preempter ever gets the lock.
+        """
+        import json as _json
+
+        lines = [
+            _json.dumps({"type": "assistant", "text": "thinking"}) + "\n",
+            _json.dumps({"type": "result", "result": "done"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        session = _make_session(tmp_path, proc)
+        # Simulate the exact webhook preempt race: _fire_worker_cancel has
+        # set both events on the target thread's side.
+        session._cancel.set()
+        session._preempt_pending.set()
+        events = list(session.iter_events())
+        # Loop must bail immediately — no events consumed — because the
+        # pending-preempter branch kept the cancel signal intact.
+        assert events == []
+        assert session._cancel.is_set()
+        assert session._last_turn_cancelled is True
+        session.stop()
+
+    def test_cancel_still_cleared_when_no_preempt_pending(self, tmp_path: Path) -> None:
+        """Symmetry check: with no preempter waiting, a stale cancel from a
+        previous turn is still cleared at iter_events' start (preserves the
+        existing ``test_cancel_cleared_at_iter_events_start`` semantics)."""
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._cancel.set()
+        # _preempt_pending intentionally NOT set — cancel is stale.
+        list(session.iter_events())
+        assert not session._cancel.is_set()
+        session.stop()
+
+    def test_fire_worker_cancel_sets_preempt_pending(self, tmp_path: Path) -> None:
+        """Regression guard for #786: the cancel fire path must mark a
+        preempter as pending, not just set the cancel event, so the race
+        with iter_events' clear is defused."""
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        assert not session._cancel.is_set()
+        assert not session._preempt_pending.is_set()
+        session._fire_worker_cancel()
+        assert session._cancel.is_set()
+        assert session._preempt_pending.is_set()
+        session.stop()
+
     def test_stops_when_cancel_set_during_turn(self, tmp_path: Path) -> None:
         # A cancel set AFTER iter_events() starts (i.e., during polling) must
         # abort the loop on the next cycle.


### PR DESCRIPTION
Closes #786.

## Summary

On home, webhook preempt could take **147s** to actually cede — the full length of the worker's in-flight sonnet turn — instead of the intended mid-flight abort.

Root cause: a race between \`_fire_worker_cancel\` and \`iter_events\`'s start-of-turn cancel clear:

1. Worker's \`prompt()\` acquires the session lock and registers as talker.
2. Webhook's \`hold_for_handler(preempt_worker=True)\` fires \`_fire_worker_cancel\` → sets \`_cancel\`, tries \`control_request\`.  But \`_in_turn\` was still False at fire time (worker hadn't yet called \`send\`), so \`control_request\` was skipped — only the soft signal was set.
3. Worker's \`send()\` flips \`_in_turn\` to True *after* the fire has already happened.
4. Worker's \`consume_until_result → iter_events\` clears \`_cancel\` at the top (intended to wipe stale signals from its *own* prior turn).  **The webhook's signal is now lost.**
5. Worker runs the whole sonnet turn to completion; webhook finally gets the lock minutes later.

## Fix

\`_fire_worker_cancel\` now sets \`_preempt_pending\` alongside \`_cancel\`.  \`iter_events\` only clears \`_cancel\` when \`_preempt_pending\` is *unset*.  When a preempter is actively waiting, the cancel targets the current holder and must be respected — clearing it defeats the whole preempt contract.  With no preempter pending, stale-signal clearing still happens exactly as before.

## Test plan

- [x] \`uv run ruff format . && uv run ruff check .\`
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2410 passed, 100% coverage
- [x] New tests: \`test_cancel_preserved_when_preempt_pending\`, \`test_cancel_still_cleared_when_no_preempt_pending\`, \`test_fire_worker_cancel_sets_preempt_pending\`
- [x] Existing \`test_cancel_cleared_at_iter_events_start\` unchanged — stale-signal semantics intact