### PR TITLE
Enable auto-merge when marking PR ready (closes #787)

### DIFF
--- a/kennel/github.py
+++ b/kennel/github.py
@@ -797,6 +797,24 @@ class GitHub:
                     return
             raise
 
+    def try_enable_auto_merge(
+        self, repo: str, pr: int | str, squash: bool = True
+    ) -> bool:
+        """Enable GitHub's native auto-merge on *pr* without falling back to
+        an immediate REST merge (fix for #787).
+
+        Returns ``True`` if auto-merge was enabled, ``False`` when the repo
+        has auto-merge disabled (GraphQL ``UNPROCESSABLE``).  Unlike
+        :meth:`pr_merge` with ``auto=True``, this does not attempt the REST
+        merge on failure — callers using this in the "mark ready, not yet
+        approved" path must not trigger the REST path, which would 405 on
+        the pending review requirement.
+        """
+        pr_data = self._get(f"/repos/{repo}/pulls/{pr}")
+        if pr_data.get("merged"):
+            return False
+        return self._try_enable_auto_merge(repo, pr, pr_data, squash)
+
     def _try_enable_auto_merge(
         self,
         repo: str,

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -2480,6 +2480,7 @@ class Worker:
                     ", ".join(missing),
                 )
                 self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
+            self._enable_auto_merge_on_approval(repo_ctx, pr_number)
             return 1
 
         missing = sorted(repo_ctx.collaborators - set(requested_reviewers))
@@ -2495,6 +2496,7 @@ class Worker:
                     ", ".join(missing),
                 )
                 self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, missing)
+                self._enable_auto_merge_on_approval(repo_ctx, pr_number)
             else:
                 log.info(
                     "PR #%s: CI not yet passing — waiting before requesting review",
@@ -2505,6 +2507,41 @@ class Worker:
         log.info("PR #%s: no work", pr_number)
         self.set_status("Napping — waiting for work", busy=False)
         return 0
+
+    def _enable_auto_merge_on_approval(
+        self, repo_ctx: RepoContext, pr_number: int
+    ) -> None:
+        """Try to enable GitHub's native auto-merge on a just-ready / review-
+        requested PR so the merge lands the instant approval arrives — rather
+        than relying on the worker's 60s polling cadence to notice the state
+        flip (fix for #787).
+
+        Silently no-ops when the repo has auto-merge disabled (common on
+        repos without branch protection).  The worker's approval-polling
+        path remains as a fallback so this change is strictly additive.
+        """
+        try:
+            enabled = self.gh.try_enable_auto_merge(
+                repo_ctx.repo, pr_number, squash=True
+            )
+        except Exception as exc:
+            log.warning(
+                "PR #%s: failed to enable auto-merge (%s) — will rely on polling",
+                pr_number,
+                exc,
+            )
+            return
+        if enabled:
+            log.info(
+                "PR #%s: auto-merge enabled — will merge on approval",
+                pr_number,
+            )
+        else:
+            log.info(
+                "PR #%s: auto-merge not available on this repo — "
+                "will rely on polling to merge after approval",
+                pr_number,
+            )
 
     def rescope_before_pick(self) -> None:
         """Run a synchronous provider-agent rescope before picking the next task.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1577,6 +1577,57 @@ class TestGitHubClass:
         assert body["variables"]["mergeMethod"] == "SQUASH"
         assert body["variables"]["prId"] == "PR_abc"
 
+    def test_try_enable_auto_merge_returns_true_when_enabled(self) -> None:
+        """Fix #787: try_enable_auto_merge enables auto-merge without
+        falling back to an immediate REST merge on unapproved PRs."""
+        gh, mock_s = self._gh()
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {
+            "data": {
+                "enablePullRequestAutoMerge": {
+                    "pullRequest": {"autoMergeRequest": {"mergeMethod": "SQUASH"}}
+                }
+            }
+        }
+        mock_s.get.return_value = pr_resp
+        mock_s.post.return_value = graphql_resp
+        assert gh.try_enable_auto_merge("o/r", 10, squash=True) is True
+        body = mock_s.post.call_args.kwargs["json"]
+        assert "enablePullRequestAutoMerge" in body["query"]
+        assert body["variables"]["mergeMethod"] == "SQUASH"
+        mock_s.put.assert_not_called()
+
+    def test_try_enable_auto_merge_returns_false_when_unavailable(self) -> None:
+        """When the repo has auto-merge disabled, return False — caller
+        must not fall back to an immediate REST merge (would 405 on
+        unapproved PRs, unlike pr_merge(auto=True))."""
+        gh, mock_s = self._gh()
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"merged": False, "node_id": "PR_abc"}
+        graphql_resp = MagicMock()
+        graphql_resp.json.return_value = {
+            "errors": [
+                {
+                    "type": "UNPROCESSABLE",
+                    "message": "Pull request Auto merge is not allowed for this repository",
+                }
+            ]
+        }
+        mock_s.get.return_value = pr_resp
+        mock_s.post.return_value = graphql_resp
+        assert gh.try_enable_auto_merge("o/r", 10) is False
+        mock_s.put.assert_not_called()
+
+    def test_try_enable_auto_merge_returns_false_on_already_merged(self) -> None:
+        gh, mock_s = self._gh()
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"merged": True, "node_id": "PR_abc"}
+        mock_s.get.return_value = pr_resp
+        assert gh.try_enable_auto_merge("o/r", 10) is False
+        mock_s.post.assert_not_called()
+
     def test_pr_merge_already_merged_returns_early(self) -> None:
         """If the PR is already merged, skip the merge call silently."""
         gh, mock_s = self._gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10348,6 +10348,129 @@ class TestHandlePromoteMerge:
         assert result == 1
         gh.pr_ready.assert_called_once()
 
+    # --- auto-merge on approval (fix #787) ---
+
+    def test_draft_promote_enables_auto_merge(self, tmp_path: Path) -> None:
+        """After marking a draft PR ready, auto-merge is enabled so the PR
+        squash-merges the instant approval lands — no 60s polling lag."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(is_draft=True, state="NONE")
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        gh.try_enable_auto_merge.return_value = True
+        completed = {"id": "t1", "title": "x", "status": "completed", "type": "spec"}
+        with patch("kennel.tasks.Tasks.list", return_value=[completed]):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "b", 1)
+        gh.try_enable_auto_merge.assert_called_once_with(
+            "rhencke/myrepo", 9, squash=True
+        )
+
+    def test_non_draft_review_request_enables_auto_merge(self, tmp_path: Path) -> None:
+        """Non-draft PR in NONE review state, CI green, reviewer requested —
+        auto-merge should be enabled here too."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [],
+            "commits": [],
+            "isDraft": False,
+            "requestedReviewers": [],
+        }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.try_enable_auto_merge.return_value = True
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch.object(worker, "set_status"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 11, "b", 1)
+        gh.try_enable_auto_merge.assert_called_once_with(
+            "rhencke/myrepo", 11, squash=True
+        )
+
+    def test_auto_merge_skipped_when_repo_has_it_disabled(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        import logging
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(is_draft=True, state="NONE")
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        gh.try_enable_auto_merge.return_value = False
+        completed = {"id": "t1", "title": "x", "status": "completed", "type": "spec"}
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[completed]),
+            caplog.at_level(logging.INFO, logger="kennel"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "b", 1)
+        assert "auto-merge not available" in caplog.text
+
+    def test_auto_merge_enabled_logs_confirmation(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(is_draft=True, state="NONE")
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        gh.try_enable_auto_merge.return_value = True
+        completed = {"id": "t1", "title": "x", "status": "completed", "type": "spec"}
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[completed]),
+            caplog.at_level(logging.INFO, logger="kennel"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "b", 1)
+        assert "auto-merge enabled" in caplog.text
+
+    def test_auto_merge_failure_logs_and_continues(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Auto-merge enable raising doesn't break the mark-ready flow —
+        polling fallback still works, but we log the failure."""
+        import logging
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = self._reviews(is_draft=True, state="NONE")
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        gh.try_enable_auto_merge.side_effect = RuntimeError("boom")
+        completed = {"id": "t1", "title": "x", "status": "completed", "type": "spec"}
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[completed]),
+            caplog.at_level(logging.WARNING, logger="kennel"),
+        ):
+            result = worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "b", 1)
+        assert result == 1  # mark-ready still happened
+        assert "failed to enable auto-merge" in caplog.text
+
+    def test_auto_merge_not_attempted_on_ci_not_passing(self, tmp_path: Path) -> None:
+        """When CI isn't green yet, we don't request review and don't try to
+        enable auto-merge — nothing to auto-merge against."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [],
+            "commits": [],
+            "isDraft": False,
+            "requestedReviewers": [],
+        }
+        gh.pr_checks.return_value = [{"name": "ci", "state": "FAILURE"}]
+        gh.get_required_checks.return_value = ["ci"]
+        with (
+            patch("kennel.tasks.Tasks.list", return_value=[]),
+            patch.object(worker, "set_status"),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 11, "b", 1)
+        gh.try_enable_auto_merge.assert_not_called()
+
 
 class TestRunPromoteMergeIntegration:
     """Tests that Worker.run() calls handle_promote_merge after execute_task."""


### PR DESCRIPTION
Closes #787.

## Summary

Enable GitHub's native auto-merge at mark-ready / review-request time so the PR squash-merges the instant all branch-protection gates clear — independent of the worker's 60s polling cadence.

Confusio PR #213 got stuck in this trap: \`mergeStateStatus\` flipped from BLOCKED to CLEAN after rhencke approved, but the worker never looped back to try merging (the next polling tick apparently didn't see the state change).  With auto-merge enabled upfront, GitHub handles the transition itself.

## Implementation

- **\`GitHub.try_enable_auto_merge(repo, pr, squash=True) -> bool\`** — new thin wrapper that *only* enables auto-merge via GraphQL.  Returns \`False\` when the repo has auto-merge disabled; returns \`False\` if the PR is already merged.  **Does not** fall back to an immediate REST merge the way \`pr_merge(auto=True)\` does — that fallback is wrong for the mark-ready path (unapproved PRs 405).
- **\`Worker._enable_auto_merge_on_approval\`** wraps the call with a warn-and-continue on any exception.  Strictly additive — polling path remains as fallback.
- Called from both mark-ready paths in \`handle_promote_merge\`: draft promotion, and non-draft-in-NONE-review-state review request.

Repos with auto-merge disabled see a single log line and the existing polling behaviour, unchanged.  Repos that allow it (confusio, home, orly) get GitHub-native merge the moment approval lands.

## Test plan

- [x] \`uv run ruff format . && uv run ruff check .\`
- [x] \`uv run pytest --cov --cov-fail-under=100\` — 2419 passed, 100% coverage
- [x] Client: \`try_enable_auto_merge\` enabled, unavailable (UNPROCESSABLE), already merged
- [x] Worker: auto-merge enabled on draft promote, on non-draft review request; skipped when CI not passing; logs confirmation / unavailable / failure paths