### PR TITLE
Handle sub_issues webhook event in cache (closes #817)

### DIFF
--- a/kennel/cache_webhooks.py
+++ b/kennel/cache_webhooks.py
@@ -1,5 +1,5 @@
 """Translate raw GitHub webhook payloads into :class:`IssueTreeCache`
-event tuples (closes #812).
+event tuples (closes #812, sub-issue half closes #817).
 
 Pure value-only helper — no I/O, no cache mutation.  Caller passes the
 result to ``cache.apply_event(*translation)`` if non-None.
@@ -7,8 +7,10 @@ result to ``cache.apply_event(*translation)`` if non-None.
 Required webhook subscriptions (verify per repo at startup):
 
 - ``issues`` — opened, closed, reopened, assigned, unassigned, edited,
-  milestoned, demilestoned, transferred, deleted, sub_issue_added,
-  sub_issue_removed
+  milestoned, demilestoned, transferred, deleted
+- ``sub_issues`` — sub_issue_added, sub_issue_removed, parent_issue_added,
+  parent_issue_removed.  Without this subscription the cache misses every
+  sub-issue link change and the picker descends a stale tree (#817).
 - ``pull_request`` — closed, reopened (used by other code paths; the
   cache itself does not currently track PRs)
 """
@@ -53,11 +55,17 @@ def translate(
     Webhook source-of-truth shape per GitHub docs:
 
     - ``issues``: payload has ``action``, ``issue`` (full issue
-      snapshot), and ``assignee`` / ``milestone`` / ``sub_issue`` /
-      ``parent_issue`` keys depending on action.
+      snapshot), and ``assignee`` / ``milestone`` keys depending on action.
+    - ``sub_issues``: payload has ``action`` plus ``parent_issue`` and
+      ``sub_issue`` (full issue snapshots for both ends of the link).
+      Both ``sub_issue_added`` / ``parent_issue_added`` and the
+      corresponding ``_removed`` actions describe the same logical
+      mutation from opposite ends — both map to the same cache event.
     - ``pull_request``: not currently translated (PRs aren't in the
       tree cache).
     """
+    if event_type == "sub_issues":
+        return _translate_sub_issues(payload)
     if event_type != "issues":
         return None
     action = payload.get("action", "")
@@ -122,6 +130,47 @@ def translate(
             if child is None:
                 return None
             return ("sub_issue_removed", {**base, "child": child})
+        case _:
+            return None
+
+
+def _translate_sub_issues(
+    payload: dict[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    """Translate a ``sub_issues`` webhook payload (closes #817).
+
+    GitHub fires this event from both sides of the link:
+
+    - ``sub_issue_added`` / ``sub_issue_removed`` — fired on the parent
+    - ``parent_issue_added`` / ``parent_issue_removed`` — fired on the child
+
+    Both shapes carry the same ``parent_issue`` + ``sub_issue`` snapshots,
+    so we map all four actions to the existing
+    ``sub_issue_added`` / ``sub_issue_removed`` cache events keyed by the
+    parent's number.  ``IssueTreeCache._handle_sub_issue_added`` already
+    updates *both* nodes (parent.sub_issues and child.parent), so handling
+    either side once is enough — and idempotent if both sides arrive.
+    """
+    action = payload.get("action", "")
+    parent = payload.get("parent_issue") or {}
+    sub = payload.get("sub_issue") or {}
+    parent_number = parent.get("number")
+    child_number = sub.get("number")
+    if parent_number is None or child_number is None:
+        return None
+    timestamp = _parse_ts(
+        parent.get("updated_at") or sub.get("updated_at") or parent.get("created_at")
+    )
+    base = {
+        "issue_number": parent_number,
+        "child": child_number,
+        "timestamp": timestamp,
+    }
+    match action:
+        case "sub_issue_added" | "parent_issue_added":
+            return ("sub_issue_added", base)
+        case "sub_issue_removed" | "parent_issue_removed":
+            return ("sub_issue_removed", base)
         case _:
             return None
 

--- a/tests/test_cache_webhooks.py
+++ b/tests/test_cache_webhooks.py
@@ -1,10 +1,38 @@
-"""Tests for kennel.cache_webhooks.translate (closes #812)."""
+"""Tests for kennel.cache_webhooks.translate (closes #812, #817)."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 
 from kennel.cache_webhooks import translate
+
+
+def _sub_issues_payload(
+    action: str,
+    *,
+    parent_number: int = 195,
+    sub_number: int = 222,
+    parent_updated_at: str = "2026-04-19T01:00:00Z",
+    sub_updated_at: str = "2026-04-19T01:00:00Z",
+    parent_created_at: str = "2026-04-15T00:00:00Z",
+    sub_created_at: str = "2026-04-15T00:00:00Z",
+    parent_present: bool = True,
+    sub_present: bool = True,
+) -> dict[str, object]:
+    payload: dict[str, object] = {"action": action}
+    if parent_present:
+        payload["parent_issue"] = {
+            "number": parent_number,
+            "updated_at": parent_updated_at,
+            "created_at": parent_created_at,
+        }
+    if sub_present:
+        payload["sub_issue"] = {
+            "number": sub_number,
+            "updated_at": sub_updated_at,
+            "created_at": sub_created_at,
+        }
+    return payload
 
 
 def _issue(
@@ -270,3 +298,103 @@ class TestEdgeCases:
         )
         assert result is not None
         assert result[1]["milestone"] is None
+
+
+# ── sub_issues event family (closes #817) ────────────────────────────────────
+
+
+class TestSubIssuesEvent:
+    """Translate the dedicated ``sub_issues`` webhook event."""
+
+    def test_sub_issue_added_maps_to_cache_event(self) -> None:
+        result = translate(
+            "sub_issues",
+            _sub_issues_payload("sub_issue_added", parent_number=195, sub_number=222),
+        )
+        assert result is not None
+        cache_event, payload = result
+        assert cache_event == "sub_issue_added"
+        assert payload["issue_number"] == 195
+        assert payload["child"] == 222
+
+    def test_sub_issue_removed_maps_to_cache_event(self) -> None:
+        result = translate(
+            "sub_issues",
+            _sub_issues_payload("sub_issue_removed", parent_number=195, sub_number=222),
+        )
+        assert result is not None
+        assert result[0] == "sub_issue_removed"
+        assert result[1]["issue_number"] == 195
+        assert result[1]["child"] == 222
+
+    def test_parent_issue_added_maps_to_sub_issue_added_keyed_by_parent(self) -> None:
+        """Child-side notification maps to the same parent-keyed cache event."""
+        result = translate(
+            "sub_issues",
+            _sub_issues_payload(
+                "parent_issue_added", parent_number=195, sub_number=222
+            ),
+        )
+        assert result is not None
+        assert result[0] == "sub_issue_added"
+        assert result[1]["issue_number"] == 195
+        assert result[1]["child"] == 222
+
+    def test_parent_issue_removed_maps_to_sub_issue_removed(self) -> None:
+        result = translate(
+            "sub_issues",
+            _sub_issues_payload(
+                "parent_issue_removed", parent_number=195, sub_number=222
+            ),
+        )
+        assert result is not None
+        assert result[0] == "sub_issue_removed"
+        assert result[1]["issue_number"] == 195
+        assert result[1]["child"] == 222
+
+    def test_returns_none_when_parent_missing(self) -> None:
+        assert (
+            translate(
+                "sub_issues",
+                _sub_issues_payload("sub_issue_added", parent_present=False),
+            )
+            is None
+        )
+
+    def test_returns_none_when_sub_missing(self) -> None:
+        assert (
+            translate(
+                "sub_issues",
+                _sub_issues_payload("sub_issue_added", sub_present=False),
+            )
+            is None
+        )
+
+    def test_returns_none_for_unknown_action(self) -> None:
+        assert translate("sub_issues", _sub_issues_payload("nonsense")) is None
+
+    def test_falls_back_through_timestamp_sources(self) -> None:
+        """When parent.updated_at is absent the translator falls back to
+        sub.updated_at, then parent.created_at."""
+        payload: dict[str, object] = {
+            "action": "sub_issue_added",
+            "parent_issue": {"number": 1, "created_at": "2026-04-15T00:00:00Z"},
+            "sub_issue": {"number": 2, "updated_at": "2026-04-19T01:00:00Z"},
+        }
+        result = translate("sub_issues", payload)
+        assert result is not None
+        assert result[1]["timestamp"] == datetime(
+            2026, 4, 19, 1, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_falls_back_to_parent_created_at_when_no_updated_at(self) -> None:
+        payload: dict[str, object] = {
+            "action": "sub_issue_added",
+            "parent_issue": {"number": 1, "created_at": "2026-04-15T00:00:00Z"},
+            "sub_issue": {"number": 2, "created_at": "2026-04-15T00:00:00Z"},
+        }
+        result = translate("sub_issues", payload)
+        assert result is not None
+        assert result[1]["timestamp"] == datetime(
+            2026, 4, 15, 0, 0, 0, tzinfo=timezone.utc
+        )


### PR DESCRIPTION
## Summary

`cache_webhooks.translate` checked `event_type != "issues"` first thing and dropped every `sub_issues` webhook on the floor. Effect: every sub-issue link change vanished from the cache, so when manually attaching 51 sub-issues to confusio#195 just now, the picker descended a snapshot from 14 minutes earlier (no children) and treated #195 as a leaf instead of descending into the first child (#222 Design doc).

## What changed

- `cache_webhooks._translate_sub_issues` handles the dedicated `sub_issues` event type with all four actions (`sub_issue_added`, `sub_issue_removed`, `parent_issue_added`, `parent_issue_removed`).
- All four map to the existing `sub_issue_added` / `sub_issue_removed` cache mutations keyed by the parent's number — `IssueTreeCache._handle_sub_issue_added` already updates both nodes (parent.sub_issues + child.parent), so handling either side once is enough, idempotent on duplicates.
- Module docstring now lists `sub_issues` in the required webhook subscriptions.
- 9 new tests (TestSubIssuesEvent), 100% coverage maintained across 2605 tests.

## Webhook subscription

After this lands, **each managed repo's webhook needs `sub_issues` added to its event list**:

- `FidoCanCode/home`: I added it before pushing this PR (token has admin).
- `rhencke/confusio`, `rhencke/orly`: token returns 404 on the webhook list — needs manual update via repo settings → Webhooks → edit → check `Sub-issues`.

## Test plan

- [x] `uv run pytest --cov --cov-fail-under=100` — 2605 pass, 100% coverage
- [x] `uv run ruff format --check && uv run ruff check`
- [ ] Post-merge: restart kennel, re-attach a sub-issue on a test repo, observe `issue-cache: applied sub_issue_added` in `~/log/kennel.log`