### PR TITLE
Use now() for sub_issues event timestamp (closes #819)

### DIFF
--- a/kennel/cache_webhooks.py
+++ b/kennel/cache_webhooks.py
@@ -158,9 +158,14 @@ def _translate_sub_issues(
     child_number = sub.get("number")
     if parent_number is None or child_number is None:
         return None
-    timestamp = _parse_ts(
-        parent.get("updated_at") or sub.get("updated_at") or parent.get("created_at")
-    )
+    # Sub-issue link mutations don't bump either end's ``updated_at`` —
+    # that field tracks issue-body edits, which are unrelated to
+    # relationship changes.  Using it as the event timestamp caused the
+    # cache to drop legit mutations as stale whenever the parent or
+    # child hadn't been edited recently (#819).  The mutation is
+    # happening now from our perspective, so use now() — correct for
+    # the cache's last_applied_at monotonicity check.
+    timestamp = datetime.now(tz=timezone.utc)
     base = {
         "issue_number": parent_number,
         "child": child_number,

--- a/tests/test_cache_webhooks.py
+++ b/tests/test_cache_webhooks.py
@@ -373,28 +373,41 @@ class TestSubIssuesEvent:
     def test_returns_none_for_unknown_action(self) -> None:
         assert translate("sub_issues", _sub_issues_payload("nonsense")) is None
 
-    def test_falls_back_through_timestamp_sources(self) -> None:
-        """When parent.updated_at is absent the translator falls back to
-        sub.updated_at, then parent.created_at."""
+    def test_timestamp_is_now_not_payload_updated_at(self) -> None:
+        """Sub-issue relationship mutations don't bump either end's
+        ``updated_at``; using that field caused the cache to drop legit
+        mutations as stale (#819).  Translator must use ``now()`` so the
+        cache's last_applied_at monotonicity check accepts them."""
         payload: dict[str, object] = {
             "action": "sub_issue_added",
-            "parent_issue": {"number": 1, "created_at": "2026-04-15T00:00:00Z"},
-            "sub_issue": {"number": 2, "updated_at": "2026-04-19T01:00:00Z"},
+            "parent_issue": {
+                "number": 1,
+                "updated_at": "2020-01-01T00:00:00Z",
+                "created_at": "2020-01-01T00:00:00Z",
+            },
+            "sub_issue": {
+                "number": 2,
+                "updated_at": "2020-01-01T00:00:00Z",
+                "created_at": "2020-01-01T00:00:00Z",
+            },
         }
+        before = datetime.now(tz=timezone.utc)
         result = translate("sub_issues", payload)
+        after = datetime.now(tz=timezone.utc)
         assert result is not None
-        assert result[1]["timestamp"] == datetime(
-            2026, 4, 19, 1, 0, 0, tzinfo=timezone.utc
-        )
+        ts = result[1]["timestamp"]
+        assert isinstance(ts, datetime)
+        assert before <= ts <= after
 
-    def test_falls_back_to_parent_created_at_when_no_updated_at(self) -> None:
+    def test_timestamp_works_without_any_issue_timestamps(self) -> None:
+        """Payload with no updated_at / created_at on either end must
+        still produce a usable timestamp (closes #819)."""
         payload: dict[str, object] = {
-            "action": "sub_issue_added",
-            "parent_issue": {"number": 1, "created_at": "2026-04-15T00:00:00Z"},
-            "sub_issue": {"number": 2, "created_at": "2026-04-15T00:00:00Z"},
+            "action": "sub_issue_removed",
+            "parent_issue": {"number": 1},
+            "sub_issue": {"number": 2},
         }
         result = translate("sub_issues", payload)
         assert result is not None
-        assert result[1]["timestamp"] == datetime(
-            2026, 4, 15, 0, 0, 0, tzinfo=timezone.utc
-        )
+        assert isinstance(result[1]["timestamp"], datetime)
+        assert result[1]["timestamp"].tzinfo is not None


### PR DESCRIPTION
## Summary

Sub-issue mutations (add/remove links) don't bump the \`updated_at\` field on either end's issue body. The translator was using \`parent.updated_at\` as the cache event's timestamp, so every sub-issue change got tagged with whatever date the parent issue was last text-edited. When the cache had been bootstrapped more recently than that date — almost always — the monotonicity guard dropped the mutation as stale.

See #819 for the full trace: live removal of \`#533\` from \`#298\` on FidoCanCode/home → two webhooks delivered → both dropped because \`#298.updated_at\` was 2 days old vs cache bootstrap 3 min old → picker kept seeing \`#533\` in \`#298\`'s children → \`#396\` never picked.

## Change

\`kennel/cache_webhooks._translate_sub_issues\` now uses \`datetime.now(tz=timezone.utc)\` for the event timestamp. The issues event family is untouched — there \`updated_at\` IS the right signal.

## Test plan

- [x] 2605 tests pass, 100% coverage
- [x] Two new tests: payload with stale \`updated_at\` still gets current timestamp; payload with no timestamps at all still produces a valid event
- [ ] Post-merge: restart kennel, verify \`#396\` gets picked (first open child of \`#41\` / \`#298\` with fido assigned)