### PR TITLE
Capitalize base class names in Rocq→Python extraction plugin output (closes #823)

### DIFF
--- a/kennel/models_generated/transition.py
+++ b/kennel/models_generated/transition.py
@@ -8,58 +8,58 @@ _A = TypeVar("_A")
 # option: remapped to Python primitive via Extract Inductive
 
 
-class state:
+class State:
     pass
 
 
 @dataclass(frozen=True)
-class Free(state):
+class Free(State):
     pass
 
 
 @dataclass(frozen=True)
-class OwnedByWorker(state):
+class OwnedByWorker(State):
     pass
 
 
 @dataclass(frozen=True)
-class OwnedByHandler(state):
+class OwnedByHandler(State):
     pass
 
 
-stateT = Free | OwnedByWorker | OwnedByHandler
+StateT = Free | OwnedByWorker | OwnedByHandler
 
 
-class event:
-    pass
-
-
-@dataclass(frozen=True)
-class WorkerAcquire(event):
+class Event:
     pass
 
 
 @dataclass(frozen=True)
-class HandlerAcquire(event):
+class WorkerAcquire(Event):
     pass
 
 
 @dataclass(frozen=True)
-class WorkerRelease(event):
+class HandlerAcquire(Event):
     pass
 
 
 @dataclass(frozen=True)
-class HandlerRelease(event):
+class WorkerRelease(Event):
     pass
 
 
 @dataclass(frozen=True)
-class Preempt(event):
+class HandlerRelease(Event):
     pass
 
 
-eventT = WorkerAcquire | HandlerAcquire | WorkerRelease | HandlerRelease | Preempt
+@dataclass(frozen=True)
+class Preempt(Event):
+    pass
+
+
+EventT = WorkerAcquire | HandlerAcquire | WorkerRelease | HandlerRelease | Preempt
 
 
 def transition(current, event0):

--- a/kennel/provider.py
+++ b/kennel/provider.py
@@ -25,9 +25,9 @@ from kennel.models_generated.transition import Free as _FsmFree
 from kennel.models_generated.transition import HandlerAcquire as _FsmHandlerAcquire
 from kennel.models_generated.transition import HandlerRelease as _FsmHandlerRelease
 from kennel.models_generated.transition import OwnedByWorker as _FsmOwnedByWorker
+from kennel.models_generated.transition import State as _FsmState
 from kennel.models_generated.transition import WorkerAcquire as _FsmWorkerAcquire
 from kennel.models_generated.transition import WorkerRelease as _FsmWorkerRelease
-from kennel.models_generated.transition import state as _FsmState
 from kennel.models_generated.transition import transition as _fsm_transition
 
 

--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -186,3 +186,22 @@ assert isinstance(r3, MySome) and r3.arg0 == 42, 'myopt_flatten(MySome(MySome(42
 print('Phase 4 MyOpt round-trip: OK')\
 \""
   )))
+
+; color: lowercase Rocq inductive → capitalized Python base class.
+; Verifies that the extraction plugin capitalizes the base class name
+; (color → Color) per PEP 8.  The isinstance check confirms the name
+; is correct in the emitted class hierarchy, not just in a comment.
+(rule
+ (alias runtest)
+ (deps test/phase4.vo)
+ (action
+  (bash "\
+python3 -c \"\
+exec(open('color_is_red.py').read()); \
+assert color_is_red(Red()) is True,    'color_is_red(Red()): got '   + repr(color_is_red(Red())); \
+assert color_is_red(Green()) is False, 'color_is_red(Green()): got ' + repr(color_is_red(Green())); \
+assert color_is_red(Blue()) is False,  'color_is_red(Blue()): got '  + repr(color_is_red(Blue())); \
+assert isinstance(Red(), Color), 'Red() must be instance of Color (capitalized base class)'; \
+print('Phase 4 color capitalization: OK')\
+\""
+  )))

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -91,6 +91,16 @@ let pp_float_lit f =
 let pp_pyid id =
   str (String.map (function '\'' -> '_' | c -> c) (Id.to_string id))
 
+(** Capitalize the first character of [s] for Python class names.
+    Rocq type names are lowercased by the extraction framework (OCaml
+    convention); Python expects PascalCase for class names (PEP 8). *)
+let capitalize_first s =
+  if String.length s = 0 then s
+  else
+    let b = Bytes.of_string s in
+    Bytes.set b 0 (Char.uppercase_ascii (Bytes.get b 0));
+    Bytes.to_string b
+
 (*s Global reference printer.  Honours [Extract Constant ... => "..."]
     inline-custom declarations. *)
 
@@ -517,10 +527,17 @@ let rec pp_type state = function
       (* Look up the Python name: prefer the custom string if present
          (e.g. [nat → "int"]), otherwise use the mangled global name.
          An empty custom string signals singleton/transparent erasure
-         (e.g. [option → ""]); fall back to [object] in that case. *)
+         (e.g. [option → ""]); fall back to [object] in that case.
+         Inductive type names are capitalized to match the class names
+         emitted by [pp_ind_decl] (PEP 8 PascalCase convention). *)
       let name =
         if is_inline_custom r then find_custom r
-        else pp_global state Term r
+        else
+          let n = pp_global state Term r in
+          let open GlobRef in
+          match r.glob with
+          | IndRef _ -> capitalize_first n
+          | _        -> n
       in
       if String.equal "" name then str "object"
       else if List.is_empty args then str name
@@ -648,7 +665,7 @@ let pp_ind_decl state (ind : ml_ind) =
           str "# " ++ Id.print p.ip_typename ++
           str ": remapped to Python primitive via Extract Inductive" ++ fnl ()
         else
-          let tname = pp_global state Term p.ip_typename_ref in
+          let tname = capitalize_first (pp_global state Term p.ip_typename_ref) in
           let n = Array.length p.ip_types in
           (* Shared base class.  For parameterised inductives it inherits
              [Generic[_A, …]] so that type-checkers can track type arguments. *)

--- a/rocq-python-extraction/test/phase4.v
+++ b/rocq-python-extraction/test/phase4.v
@@ -147,3 +147,31 @@ Definition myopt_flatten {A : Set} (o : MyOpt (MyOpt A)) : MyOpt A :=
   end.
 
 Python Extraction myopt_flatten.
+
+(* ------------------------------------------------------------------ *)
+(*  6. Lowercase-first inductive — capitalization smoke test           *)
+(*                                                                      *)
+(*  Rocq convention uses lowercase for type names (e.g. [color]);      *)
+(*  the extraction framework follows OCaml and also lowercases them.   *)
+(*  This section verifies that [python.ml] re-capitalizes the base     *)
+(*  class to [Color] in the emitted Python (PEP 8 PascalCase).         *)
+(* ------------------------------------------------------------------ *)
+
+Inductive color :=
+  | Red   : color
+  | Green : color
+  | Blue  : color.
+
+(** [color_is_red]: [True] iff the color is [Red].
+    The generated file must contain [class Color:] (capitalized) as the
+    shared base class; constructors [Red], [Green], [Blue] inherit from
+    it.  The dune rule asserts [isinstance(Red(), Color)] to confirm the
+    capitalized name is present and correct. *)
+Definition color_is_red (c : color) : bool :=
+  match c with
+  | Red   => true
+  | Green => false
+  | Blue  => false
+  end.
+
+Python Extraction color_is_red.

--- a/tests/test_session_lock_hypothesis.py
+++ b/tests/test_session_lock_hypothesis.py
@@ -32,7 +32,7 @@ from kennel.models_generated.transition import (
     transition,
 )
 from kennel.models_generated.transition import (
-    state as FsmState,
+    State as FsmState,
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #823.

Capitalizes base class names in the Rocq→Python extraction plugin so that inductive type names like `state` and `event` emit as `State` and `Event` in generated Python, matching PEP 8 class naming conventions. Updates the generated model files and their downstream imports to match, and adds an extraction test with a lowercase-first Rocq inductive to verify the capitalization logic.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Update transition.py and Python imports for capitalized base class names <!-- type:spec -->
- [x] Add phase4 test with lowercase-first Rocq inductive to verify capitalization <!-- type:spec -->
- [x] Add capitalize_first helper and apply to inductive type names in python.ml <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->