### PR TITLE
Three git-resilience fixes: stale lock, exit-128 discrimination, orphan-claude on self-restart (closes #827, #828, #829)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -496,6 +496,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_spawn_bg = staticmethod(_spawn_bg)
     _fn_after_do_post = staticmethod(_noop_after_post)
     _fn_runner_dir = staticmethod(_runner_dir)
+    _fn_kill_active_children = staticmethod(kill_active_children)
 
     def do_POST(self) -> None:
         try:
@@ -895,7 +896,17 @@ class WebhookHandler(BaseHTTPRequestHandler):
         log.info(
             "self-restart: runner synced — stopping workers and re-execing (%s)", reason
         )
+        # Stop the merged repo's worker cleanly.
         self.registry.stop_and_join(repo_name)
+        # Tear down every remaining worker and SIGTERM all tracked claude
+        # subprocesses before execvp (closes #829).  execvp replaces the
+        # process image immediately; any subprocess not explicitly killed
+        # here gets reparented to init and keeps running after restart —
+        # accepting its still-open stdin, still writing to the workspace.
+        # We've seen this orphan a session that then committed + reset
+        # over an in-progress human edit hours after kennel was "stopped".
+        self.registry.stop_all()
+        type(self)._fn_kill_active_children()
         self.infra.os_proc.chdir(runner_dir)
         self.infra.os_proc.execvp("uv", ["uv", "run", "kennel", *sys.argv[1:]])
 

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -69,6 +69,51 @@ log = logging.getLogger(__name__)
 _thread_repo: threading.local = threading.local()
 
 
+_STALE_INDEX_LOCK_SECONDS: float = 30.0
+"""How old ``.git/index.lock`` must be before :func:`_remove_stale_index_lock`
+treats it as abandoned.  Larger than any normal kennel-initiated git
+operation, so a concurrent legit writer won't have its lock yanked."""
+
+
+def _stderr_is_index_lock_error(stderr: str) -> bool:
+    """Match git's specific lock-contention error message.
+
+    Git emits ``fatal: Unable to create '<path>/.git/index.lock': File
+    exists.`` on any index-touching operation when the lock file is
+    already present.  Matching on the stable substring avoids false
+    positives from other exit-128 failure modes (closes #827).
+    """
+    return "Unable to create" in stderr and "index.lock" in stderr
+
+
+def _remove_stale_index_lock(
+    work_dir: Path,
+    *,
+    stale_after_seconds: float = _STALE_INDEX_LOCK_SECONDS,
+    _now: Callable[..., datetime] = datetime.now,
+) -> bool:
+    """Remove ``<work_dir>/.git/index.lock`` iff it is older than
+    *stale_after_seconds*.  Returns ``True`` when a stale lock was
+    removed, ``False`` otherwise (lock missing, or too fresh to be
+    safely considered abandoned).
+
+    The age gate is deliberately larger than any realistic concurrent
+    git write so we never race a legit writer.  Kennel is
+    single-worker-per-repo, so contention in practice comes from
+    provider tool calls that finished seconds ago; 30 s is a safe floor.
+    """
+    lock = work_dir / ".git" / "index.lock"
+    try:
+        stat = lock.stat()
+    except FileNotFoundError:
+        return False
+    age = _now(tz=timezone.utc).timestamp() - stat.st_mtime
+    if age < stale_after_seconds:
+        return False
+    lock.unlink()
+    return True
+
+
 class RepoContextFilter(logging.Filter):
     """Inject the current worker thread's repo name into every log record.
 
@@ -1303,21 +1348,66 @@ class Worker:
             return False
         return data.get("state") == "OPEN"
 
+    def _local_branch_exists(self, slug: str) -> bool:
+        """Return ``True`` when ``refs/heads/<slug>`` exists locally.
+
+        Discriminates git's exit codes (closes #828):
+
+        - exit 0 → branch exists.
+        - exit 1 → branch missing (expected; rev-parse's "no match" code).
+        - anything else (128 = stale lock, corrupt repo, bad cwd, …) →
+          propagate as :class:`subprocess.CalledProcessError` so callers
+          don't silently fall through to the create-branch path on a
+          real failure.
+        """
+        try:
+            self._git(["rev-parse", "--verify", "--quiet", f"refs/heads/{slug}"])
+            return True
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode == 1:
+                return False
+            raise
+
     def _git(
         self,
         args: list[str],
         check: bool = True,
         *,
         _run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        _now: Callable[..., datetime] = datetime.now,
     ) -> subprocess.CompletedProcess[str]:
-        """Run a git command in self.work_dir."""
-        return _run(
-            ["git", *args],
-            cwd=self.work_dir,
-            capture_output=True,
-            text=True,
-            check=check,
-        )
+        """Run a git command in self.work_dir.
+
+        Self-heals from stale ``.git/index.lock`` (closes #827): if the
+        command fails with git's "Unable to create '.git/index.lock':
+        File exists" error AND the lock file is older than
+        :data:`_STALE_INDEX_LOCK_SECONDS` seconds, the lock is removed
+        and the command is retried exactly once.  The staleness window
+        protects against yanking a lock from under a concurrent writer.
+        """
+
+        def _call() -> subprocess.CompletedProcess[str]:
+            return _run(
+                ["git", *args],
+                cwd=self.work_dir,
+                capture_output=True,
+                text=True,
+                check=check,
+            )
+
+        try:
+            return _call()
+        except subprocess.CalledProcessError as exc:
+            if not _stderr_is_index_lock_error(exc.stderr or ""):
+                raise
+            if not _remove_stale_index_lock(self.work_dir, _now=_now):
+                raise
+            log.warning(
+                "git: removed stale .git/index.lock in %s and retrying %s",
+                self.work_dir,
+                args[0] if args else "(no args)",
+            )
+            return _call()
 
     def git_clean(self) -> None:
         """Discard uncommitted changes and untracked files in the work tree.
@@ -1489,9 +1579,9 @@ class Worker:
             # Open PR — resume
             log.info("resuming PR #%s on branch %s", pr_number, slug)
             self._git(["fetch", remote])
-            try:
+            if self._local_branch_exists(slug):
                 self._git(["checkout", slug])
-            except subprocess.CalledProcessError:
+            else:
                 self._git(["checkout", "-b", slug, "--track", f"{remote}/{slug}"])
             task_list = self._tasks.list()
             if not task_list:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3702,6 +3702,65 @@ class TestSelfRestart:
         finally:
             srv.shutdown()
 
+    def test_kills_active_children_before_exec(self, tmp_path: Path) -> None:
+        """execvp replaces the process image; any claude subprocess not
+        killed first gets reparented to init and keeps writing to the
+        workspace (closes #829).  Self-restart must stop every worker
+        and SIGTERM every tracked child BEFORE the exec."""
+        srv, url, cfg, mock_registry = self._make_server(tmp_path)
+        try:
+            WebhookHandler._fn_runner_dir = lambda: tmp_path  # type: ignore[assignment]
+            call_log: list[str] = []
+
+            def _kill():
+                call_log.append("kill_active_children")
+
+            real_stop_all = mock_registry.stop_all
+            real_stop_and_join = mock_registry.stop_and_join
+            real_stop_all.side_effect = lambda: call_log.append("stop_all")
+            real_stop_and_join.side_effect = lambda repo: call_log.append(
+                f"stop_and_join:{repo}"
+            )
+            WebhookHandler._fn_kill_active_children = staticmethod(_kill)  # type: ignore[assignment]
+
+            os_proc = _FakeOsProcess()
+            # Wrap execvp so we can observe ordering.
+            original_execvp = os_proc.execvp
+            orig_execvp_calls = os_proc.execvp_calls
+
+            def _tracking_execvp(cmd, args):  # type: ignore[no-untyped-def]
+                call_log.append("execvp")
+                orig_execvp_calls.append((cmd, args))
+
+            os_proc.execvp = _tracking_execvp  # type: ignore[method-assign]
+            WebhookHandler.infra = Infra(
+                proc=_FakeProcessRunner(
+                    [
+                        MagicMock(stdout="git@github.com:owner/kennel.git\n"),
+                        MagicMock(),  # fetch
+                        MagicMock(),  # reset
+                    ]
+                ),
+                clock=_FakeClock(times=[0.0, 0.0]),
+                fs=_FakeFilesystem(),
+                os_proc=os_proc,
+            )
+            status = _post_webhook(url, cfg, "pull_request", _MERGE_PAYLOAD)
+            assert status == 200
+            # stop_and_join + stop_all + kill_active_children MUST all run
+            # before execvp.
+            execvp_idx = call_log.index("execvp")
+            assert "stop_and_join:owner/kennel" in call_log[:execvp_idx]
+            assert "stop_all" in call_log[:execvp_idx]
+            assert "kill_active_children" in call_log[:execvp_idx]
+            # Defensive: kill_active_children should be the last thing
+            # before execvp so it's the most recent TERM.
+            assert call_log[execvp_idx - 1] == "kill_active_children"
+            # Silence the cleanup-path noise.
+            del original_execvp
+        finally:
+            srv.shutdown()
+
     def test_skips_when_self_repo_mismatch(self, tmp_path: Path) -> None:
         srv, url, cfg, mock_registry = self._make_server(tmp_path)
         try:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3753,6 +3753,174 @@ class TestGit:
         assert mock_run.call_args[1]["capture_output"] is True
         assert mock_run.call_args[1]["text"] is True
 
+    def test_stale_index_lock_removed_and_retried(self, tmp_path: Path) -> None:
+        """First call fails with git's index.lock error; when the lock
+        is stale, the second call succeeds (closes #827)."""
+        import os as _os
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        lock = git_dir / "index.lock"
+        lock.write_bytes(b"stale")
+        old = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
+        _os.utime(lock, (old, old))
+
+        calls: list[int] = []
+        success = MagicMock(returncode=0)
+
+        def _run(*args, **kwargs):  # noqa: ARG001
+            calls.append(1)
+            if len(calls) == 1:
+                raise subprocess.CalledProcessError(
+                    128,
+                    args[0],
+                    stderr="fatal: Unable to create '.git/index.lock': File exists.",
+                )
+            return success
+
+        result = Worker(tmp_path, MagicMock())._git(["add", "-A"], _run=_run)
+        assert result is success
+        assert len(calls) == 2
+        assert not lock.exists()
+
+    def test_fresh_index_lock_not_removed(self, tmp_path: Path) -> None:
+        """Lock younger than the staleness window: original error
+        propagates without retry, lock is not touched."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        lock = git_dir / "index.lock"
+        lock.write_bytes(b"fresh")
+
+        mock_run = MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                128,
+                "git",
+                stderr="fatal: Unable to create '.git/index.lock': File exists.",
+            )
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            Worker(tmp_path, MagicMock())._git(["add", "-A"], _run=mock_run)
+        assert lock.exists()
+        assert mock_run.call_count == 1
+
+    def test_non_lock_error_propagates_without_retry(self, tmp_path: Path) -> None:
+        """Other git failures must not trigger the lock self-heal."""
+        mock_run = MagicMock(
+            side_effect=subprocess.CalledProcessError(
+                128, "git", stderr="fatal: not a git repository"
+            )
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            Worker(tmp_path, MagicMock())._git(["status"], _run=mock_run)
+        assert mock_run.call_count == 1
+
+
+class TestStaleIndexLockHelpers:
+    """Module-level helpers for #827 self-heal."""
+
+    def test_stderr_matches_standard_message(self) -> None:
+        from kennel.worker import _stderr_is_index_lock_error
+
+        assert _stderr_is_index_lock_error(
+            "fatal: Unable to create '/repo/.git/index.lock': File exists."
+        )
+
+    def test_stderr_matches_on_both_tokens(self) -> None:
+        from kennel.worker import _stderr_is_index_lock_error
+
+        assert _stderr_is_index_lock_error("Unable to create 'x/index.lock'")
+
+    def test_stderr_rejects_unrelated(self) -> None:
+        from kennel.worker import _stderr_is_index_lock_error
+
+        assert not _stderr_is_index_lock_error("fatal: not a git repository")
+        assert not _stderr_is_index_lock_error("")
+
+    def test_stderr_rejects_partial(self) -> None:
+        from kennel.worker import _stderr_is_index_lock_error
+
+        assert not _stderr_is_index_lock_error("Unable to create 'foo'")
+        assert not _stderr_is_index_lock_error("index.lock missing")
+
+    def test_remove_returns_false_when_missing(self, tmp_path: Path) -> None:
+        from kennel.worker import _remove_stale_index_lock
+
+        (tmp_path / ".git").mkdir()
+        assert _remove_stale_index_lock(tmp_path) is False
+
+    def test_remove_returns_false_when_fresh(self, tmp_path: Path) -> None:
+        from kennel.worker import _remove_stale_index_lock
+
+        (tmp_path / ".git").mkdir()
+        lock = tmp_path / ".git" / "index.lock"
+        lock.write_bytes(b"")
+        assert _remove_stale_index_lock(tmp_path) is False
+        assert lock.exists()
+
+    def test_remove_returns_true_when_stale(self, tmp_path: Path) -> None:
+        import os as _os
+
+        from kennel.worker import _remove_stale_index_lock
+
+        (tmp_path / ".git").mkdir()
+        lock = tmp_path / ".git" / "index.lock"
+        lock.write_bytes(b"")
+        old = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
+        _os.utime(lock, (old, old))
+        assert _remove_stale_index_lock(tmp_path) is True
+        assert not lock.exists()
+
+    def test_respects_custom_staleness_window(self, tmp_path: Path) -> None:
+        from kennel.worker import _remove_stale_index_lock
+
+        (tmp_path / ".git").mkdir()
+        lock = tmp_path / ".git" / "index.lock"
+        lock.write_bytes(b"")
+        assert _remove_stale_index_lock(tmp_path, stale_after_seconds=0.0) is True
+        assert not lock.exists()
+
+
+class TestLocalBranchExists:
+    """Tests for Worker._local_branch_exists (closes #828)."""
+
+    def _worker(self, tmp_path: Path) -> Worker:
+        return Worker(tmp_path, MagicMock())
+
+    def test_returns_true_on_exit_zero(self, tmp_path: Path) -> None:
+        worker = self._worker(tmp_path)
+        with patch.object(worker, "_git", return_value=MagicMock(returncode=0)):
+            assert worker._local_branch_exists("my-branch") is True
+
+    def test_returns_false_on_exit_one(self, tmp_path: Path) -> None:
+        worker = self._worker(tmp_path)
+        with patch.object(
+            worker, "_git", side_effect=subprocess.CalledProcessError(1, "git")
+        ):
+            assert worker._local_branch_exists("ghost") is False
+
+    def test_propagates_other_exit_codes(self, tmp_path: Path) -> None:
+        worker = self._worker(tmp_path)
+        with (
+            patch.object(
+                worker,
+                "_git",
+                side_effect=subprocess.CalledProcessError(128, "git"),
+            ),
+            pytest.raises(subprocess.CalledProcessError) as excinfo,
+        ):
+            worker._local_branch_exists("any")
+        assert excinfo.value.returncode == 128
+
+    def test_queries_refs_heads_with_quiet_verify(self, tmp_path: Path) -> None:
+        worker = self._worker(tmp_path)
+        with patch.object(
+            worker, "_git", return_value=MagicMock(returncode=0)
+        ) as mock_git:
+            worker._local_branch_exists("feature/foo")
+        mock_git.assert_called_once_with(
+            ["rev-parse", "--verify", "--quiet", "refs/heads/feature/foo"]
+        )
+
 
 class TestGitClean:
     """Tests for Worker.git_clean."""
@@ -4307,7 +4475,9 @@ class TestFindOrCreatePr:
         mock_build.assert_not_called()
 
     def test_open_pr_checkout_fallback_on_error(self, tmp_path: Path) -> None:
-        """If git checkout slug fails, try checkout -b --track."""
+        """When rev-parse reports branch-missing (exit 1), fall back to
+        checkout -b --track.  The discrimination (exit 1 vs 128 = real
+        error) is covered by TestLocalBranchExists (closes #828)."""
         worker, gh = self._make_worker(tmp_path)
         gh.find_pr.return_value = self._open_pr(slug="br")
         fido_dir = self._fido_dir(tmp_path)
@@ -4315,7 +4485,7 @@ class TestFindOrCreatePr:
 
         def side_effect(args, check=True):  # noqa: ARG001
             git_calls.append(args)
-            if args == ["checkout", "br"]:
+            if args == ["rev-parse", "--verify", "--quiet", "refs/heads/br"]:
                 raise subprocess.CalledProcessError(1, "git")
             return MagicMock()
 
@@ -4325,6 +4495,31 @@ class TestFindOrCreatePr:
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert ["checkout", "-b", "br", "--track", "origin/br"] in git_calls
+        assert ["checkout", "br"] not in git_calls
+
+    def test_open_pr_propagates_exit_128_from_rev_parse(self, tmp_path: Path) -> None:
+        """A git error (stale index.lock → exit 128) on the
+        branch-existence check must propagate, NOT silently fall into
+        the create-branch recovery path (closes #828)."""
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = self._open_pr(slug="br")
+        fido_dir = self._fido_dir(tmp_path)
+        git_calls = []
+
+        def side_effect(args, check=True):  # noqa: ARG001
+            git_calls.append(args)
+            if args == ["rev-parse", "--verify", "--quiet", "refs/heads/br"]:
+                raise subprocess.CalledProcessError(128, "git", stderr="fatal: bad cwd")
+            return MagicMock()
+
+        with (
+            patch.object(worker, "_git", side_effect=side_effect),
+            patch("kennel.tasks.Tasks.list", return_value=["t"]),
+            pytest.raises(subprocess.CalledProcessError) as excinfo,
+        ):
+            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
+        assert excinfo.value.returncode == 128
+        assert ["checkout", "-b", "br", "--track", "origin/br"] not in git_calls
 
     def test_open_pr_fetches_before_checkout(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)


### PR DESCRIPTION
## Summary

Three fixes on the same fault line, discovered while orly crash-looped for ~1 minute on a stale `.git/index.lock`:

1. **`#827` — Stale lock self-heal.** `Worker._git` catches git's specific lock-contention stderr, removes the lock if it's older than 30 s, retries once. Without this, any stuck lock turned a single git hiccup into a worker-restart crash loop.
2. **`#828` — Exit-128 discrimination.** `find_or_create_pr` used to `try: git checkout slug; except CalledProcessError: git checkout -b --track`, treating every non-zero exit as "branch missing". New `Worker._local_branch_exists` uses `git rev-parse --verify --quiet` and discriminates exit 0 / 1 / real-error.
3. **`#829` — Orphan claude on self-restart.** `_self_restart` was stopping only the merged repo's worker, then `execvp`. All other workers and their claude subprocesses got reparented to init and kept writing to the workspace after kennel was "stopped". In the field: an orphan ran for ~1 h 30 m after kennel died, committing + `git reset --hard`'ing a feature branch out from under an unrelated edit. Fix: `stop_all()` + `kill_active_children()` (the existing ClaudeSession registry) before `execvp`.

## Test plan

- [x] `uv run pytest --cov --cov-fail-under=100` — 2 637 pass, 100 % coverage
- [x] `uv run ruff format --check && uv run ruff check`
- [x] Manual: stale-lock test — `touch /path/to/.git/index.lock && set mtime to 2020 && _git(['status'])` returns success, lock is gone
- [ ] Post-merge: observe next self-restart, `ps aux | grep claude` is empty after kennel dies

## Notes

- `WebhookHandler._fn_kill_active_children` is a new callable-slot for test injection (one more `_fn_*` smell; tracked in `#404`).
- The lock self-heal's 30-second window is deliberately larger than any realistic concurrent write so we never yank from a legit writer.