### PR TITLE
Fido re-picks up PR comments it already replied to — claim-set write skipped for some replies (closes #834)

### DIFF
--- a/kennel/events.py
+++ b/kennel/events.py
@@ -996,8 +996,15 @@ def reply_to_issue_comment(
     gh.comment_issue(repo_full, number, body)
     log.info("reply posted on PR #%s", number)
 
-    # Get comment_id from the dispatch payload (stored in context)
+    # Write durable claim file so a kennel restart doesn't re-pick this comment.
+    # Without this, backfill_missed_pr_comments re-queues comments triaged as
+    # ANSWER/DUMP/ASK because those paths create no tasks.json entry for the
+    # Tasks.add dedup to match against.  This mirrors the claim-file pattern used
+    # by reply_to_comment for review comments (closes #834).
     _cid = (action.context or {}).get("comment_id")
+    if _cid is not None:
+        _comment_lock(repo_cfg.work_dir, _cid).touch(exist_ok=True)
+        log.info("wrote durable claim for issue comment %s", _cid)
     if _cid:
         log.info(
             "reply_to_issue_comment: adding reaction on PR #%s comment %s", number, _cid

--- a/kennel/events.py
+++ b/kennel/events.py
@@ -1531,10 +1531,12 @@ def backfill_missed_pr_comments(
     iteration by ``Worker.handle_threads``, so the worker loop backfills
     those on its own — only issue-comments are invisible to the loop.
 
-    Idempotent: :func:`create_task` dedups on ``comment_id`` regardless of
-    status, so replaying the same comment after fido already replied is a
-    no-op.  This function is intended to run **once per WorkerThread
-    lifetime** (at startup) — not every iteration.
+    Idempotent: comments with a durable claim file
+    (``.git/fido/comments/<id>.lock``) are skipped — fido already replied
+    to them.  Comments handled with a task (ACT/DO) are additionally
+    deduped by :func:`create_task` via ``comment_id`` in ``tasks.json``.
+    This function is intended to run **once per WorkerThread lifetime** (at
+    startup) — not every iteration.
     """
     log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
     comments = gh.get_issue_comments(repo_cfg.name, pr_number)
@@ -1550,6 +1552,13 @@ def backfill_missed_pr_comments(
             continue
         comment_id = c.get("id")
         if comment_id is None:
+            continue
+        # Skip comments fido already replied to (claim file written by
+        # reply_to_issue_comment after posting).  Without this check,
+        # ANSWER/DUMP/ASK replies — which create no tasks.json entry —
+        # would be re-queued on every kennel restart (closes #834).
+        if _comment_lock(repo_cfg.work_dir, comment_id).exists():
+            log.info("backfill: comment %s already claimed — skipping", comment_id)
             continue
         body = c.get("body", "") or ""
         is_bot = user.endswith("[bot]")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3869,6 +3869,38 @@ class TestBackfillMissedPrComments:
         assert count == 0
         mock_create.assert_not_called()
 
+    def test_skips_already_claimed_comments(self, tmp_path: Path) -> None:
+        """Comments with a durable claim file are not re-queued on restart.
+
+        reply_to_issue_comment writes .git/fido/comments/<id>.lock after
+        posting; backfill must honour that file and skip re-queueing —
+        closes #834.
+        """
+        from kennel.events import _comment_lock, backfill_missed_pr_comments
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [
+            self._comment(100, body="already answered"),
+            self._comment(200, body="not yet handled"),
+        ]
+        mock_gh.is_thread_resolved_for_comment.return_value = False
+        # Pre-create the claim file for comment 100 (simulates a prior reply).
+        _comment_lock(tmp_path, 100).touch(exist_ok=True)
+
+        with patch("kennel.events.create_task") as mock_create:
+            backfill_missed_pr_comments(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                1,
+                gh_user="fidocancode",
+            )
+
+        # Only comment 200 (unclaimed) should be queued.
+        assert mock_create.call_count == 1
+        _, kwargs = mock_create.call_args
+        assert kwargs["thread"]["comment_id"] == 200
+
 
 class TestLaunchSync:
     def _cfg(self, tmp_path: Path) -> Config:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2102,6 +2102,54 @@ class TestReplyToIssueComment:
         # the reply generation call, which must survive session preemption.
         assert any(kw.get("retry_on_preempt") is True for kw in all_run_turn_kwargs)
 
+    def test_writes_durable_claim_file_after_reply(self, tmp_path: Path) -> None:
+        """After posting a reply, a .lock file is written at
+        .git/fido/comments/<comment_id>.lock so a kennel restart doesn't
+        re-pick the comment via backfill (closes #834)."""
+        cfg = self._cfg(tmp_path)
+
+        def fake_pp(prompt, model, **kwargs):
+            if "Triage" in prompt:
+                return "ANSWER: it works this way"
+            return "Yes, here is why..."
+
+        reply_to_issue_comment(
+            self._action(cid=4275080243),
+            cfg,
+            self._repo_cfg(tmp_path),
+            MagicMock(),
+            agent=_client(side_effect=fake_pp),
+        )
+        claim_file = tmp_path / ".git" / "fido" / "comments" / "4275080243.lock"
+        assert claim_file.exists(), "durable claim file must be written after reply"
+
+    def test_no_comment_id_skips_claim_write(self, tmp_path: Path) -> None:
+        """When comment_id is absent, no claim file is created (no-op)."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="PR top-level comment on #7 by owner:\n\nhi",
+            comment_body="hi",
+            is_bot=False,
+            context={"pr_title": "My PR"},  # no comment_id
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if "Triage" in prompt:
+                return "ACT: do it"
+            return "ok"
+
+        reply_to_issue_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            MagicMock(),
+            agent=_client(side_effect=fake_pp),
+        )
+        claim_dir = tmp_path / ".git" / "fido" / "comments"
+        assert not claim_dir.exists() or not list(claim_dir.iterdir()), (
+            "no claim files should be written when comment_id is absent"
+        )
+
 
 class TestCreateTask:
     def _cfg(self, tmp_path: Path) -> Config:


### PR DESCRIPTION
Fixes #834.

Fido re-picks up PR comments it already replied to because `reply_to_issue_comment` never writes a durable claim file (unlike the review-comment path), and `backfill_missed_pr_comments` doesn't check the claim set before queueing. This adds durable `.lock` file writes after posting issue-comment replies and filters the backfill path against existing claims.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Write durable claim file in reply_to_issue_comment after posting <!-- type:spec -->
- [x] Filter backfill_missed_pr_comments by durable claim set before queueing <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->