### PR TITLE
IssueTreeCache should bootstrap at kennel start, not lazily on first find_next_issue (closes #837)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -1053,6 +1053,40 @@ def populate_memberships(config: Config, gh: GitHub) -> None:
         )
 
 
+def bootstrap_issue_caches(
+    repos: dict[str, RepoConfig],
+    gh: GitHub,
+    registry: WorkerRegistry,
+) -> None:
+    """Bootstrap every per-repo :class:`~kennel.issue_cache.IssueTreeCache` at startup (#837).
+
+    Called once in :func:`run` after the registry is created but before the
+    watchdog threads start.  Each repo gets a fresh ``find_all_open_issues``
+    snapshot so the cache is warm from the first moment — even for repos
+    whose worker resumes on an existing issue and never calls
+    ``find_next_issue`` during the current kennel run.
+
+    Per-repo failures are swallowed (logged, not raised): a single GitHub
+    API hiccup must not prevent kennel from starting.  The hourly
+    :class:`~kennel.watchdog.ReconcileWatchdog` will heal any cold repo
+    within the hour.
+    """
+    for name in repos:
+        owner, repo_name = name.split("/", 1)
+        cache = registry.get_issue_cache(name)
+        try:
+            snapshot_started_at = datetime.now(tz=timezone.utc)
+            log.info("startup: bootstrapping issue cache for %s", name)
+            inventory = gh.find_all_open_issues(owner, repo_name)
+            cache.load_inventory(inventory, snapshot_started_at=snapshot_started_at)
+        except Exception:
+            log.exception(
+                "startup: failed to bootstrap issue cache for %s — "
+                "ReconcileWatchdog will heal within the hour",
+                name,
+            )
+
+
 def _startup_pull(proc: ProcessRunner, clock: Clock, os_proc: OsProcess) -> None:
     """Sync the runner clone on startup and re-exec if HEAD changed."""
     runner_dir = _runner_dir()
@@ -1094,6 +1128,7 @@ def run(
     _preflight_sub_dir: Callable[..., None] = preflight_sub_dir,
     _preflight_gh_auth: Callable[..., None] = preflight_gh_auth,
     _GitHub: type[GitHub] = GitHub,
+    _bootstrap_issue_caches: Callable[..., None] = bootstrap_issue_caches,
 ) -> None:
     config = _from_args()
 
@@ -1167,6 +1202,10 @@ def run(
     )
     registry = _make_registry(config.repos, gh, config)
     WebhookHandler.registry = registry
+    # Bootstrap issue caches eagerly so the picker has warm data immediately —
+    # even for repos whose worker resumes on an existing issue and never calls
+    # find_next_issue during this run (closes #837).
+    _bootstrap_issue_caches(config.repos, gh, registry)
     # Route webhook-handler prompt calls through the per-repo persistent
     # ClaudeSession (closes #479 — "one claude per repo" invariant).
     provider.set_session_resolver(registry.get_session)

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1259,11 +1259,13 @@ class Worker:
     def _pick_from_cache(self, repo_ctx: RepoContext) -> PickerChoice | None:
         """Cache-driven picker (closes #812).
 
-        Bootstraps the cache from a single ``find_all_open_issues`` call
-        when not yet loaded, then runs the same priority-rank +
-        strict-first-priority descent as the GraphQL path — but reading
-        cached :class:`~kennel.issue_cache.IssueNode` data instead of
-        re-querying every iteration.
+        Reads candidates + the full issue tree from the per-repo
+        :class:`~kennel.issue_cache.IssueTreeCache` — zero GraphQL on the
+        steady-state pick — and runs the same priority-rank +
+        strict-first-priority descent as the old GraphQL path.
+
+        The cache is bootstrapped eagerly at kennel startup (closes #837)
+        so it is always loaded by the time this method runs.
 
         Before returning a non-None choice, makes one cheap REST call
         (``GET /repos/{repo}/issues/{n}``) to confirm the issue is still
@@ -1271,21 +1273,6 @@ class Worker:
         the cache read and the ``add_assignee`` write.
         """
         cache = self._issue_cache
-        if not cache.is_loaded:
-            snapshot_started_at = datetime.now(tz=timezone.utc)
-            log.info(
-                "picker[cache]: cache empty for %s — bootstrapping inventory "
-                "via find_all_open_issues",
-                repo_ctx.repo,
-            )
-            inventory = self.gh.find_all_open_issues(repo_ctx.owner, repo_ctx.repo_name)
-            cache.load_inventory(inventory, snapshot_started_at=snapshot_started_at)
-            log.info(
-                "picker[cache]: bootstrap loaded %d open issues for %s",
-                len(inventory),
-                repo_ctx.repo,
-            )
-
         cache_index = cache.all_open()
         issue_index = {
             n: _node_to_dict(node, cache_index) for n, node in cache_index.items()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2470,6 +2470,87 @@ class TestPopulateMemberships:
         assert cfg.repos["o/r2"].membership.collaborators == frozenset({"bob", "carol"})
 
 
+class TestBootstrapIssueCaches:
+    """Tests for bootstrap_issue_caches() (#837)."""
+
+    def _make_repos(self, tmp_path: Path) -> dict[str, RepoConfig]:
+        return {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+
+    def test_calls_find_all_open_issues_with_owner_and_repo_name(
+        self, tmp_path: Path
+    ) -> None:
+        from kennel.server import bootstrap_issue_caches
+
+        repos = self._make_repos(tmp_path)
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.return_value = []
+        mock_registry = MagicMock()
+        mock_registry.get_issue_cache.return_value = MagicMock()
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        mock_gh.find_all_open_issues.assert_called_once_with("owner", "repo")
+
+    def test_calls_load_inventory_on_cache_with_returned_issues(
+        self, tmp_path: Path
+    ) -> None:
+        from kennel.server import bootstrap_issue_caches
+
+        repos = self._make_repos(tmp_path)
+        mock_gh = MagicMock()
+        fake_inventory = [{"number": 1}]
+        mock_gh.find_all_open_issues.return_value = fake_inventory
+        mock_cache = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.get_issue_cache.return_value = mock_cache
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        mock_registry.get_issue_cache.assert_called_once_with("owner/repo")
+        mock_cache.load_inventory.assert_called_once_with(
+            fake_inventory, snapshot_started_at=ANY
+        )
+
+    def test_bootstraps_all_repos(self, tmp_path: Path) -> None:
+        from kennel.server import bootstrap_issue_caches
+
+        repos = {
+            "a/r1": RepoConfig(name="a/r1", work_dir=tmp_path),
+            "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
+        }
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.return_value = []
+        mock_registry = MagicMock()
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        assert mock_gh.find_all_open_issues.call_count == 2
+        mock_gh.find_all_open_issues.assert_any_call("a", "r1")
+        mock_gh.find_all_open_issues.assert_any_call("b", "r2")
+
+    def test_per_repo_failure_is_swallowed(self, tmp_path: Path) -> None:
+        """A single GitHub API error must not prevent kennel from starting."""
+        from kennel.server import bootstrap_issue_caches
+
+        repos = {
+            "a/r1": RepoConfig(name="a/r1", work_dir=tmp_path),
+            "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
+        }
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.side_effect = [RuntimeError("API down"), []]
+        mock_cache_r2 = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.get_issue_cache.side_effect = lambda name: (
+            MagicMock() if name == "a/r1" else mock_cache_r2
+        )
+
+        # Must not raise despite the first repo failing.
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        # Second repo should still be bootstrapped.
+        mock_cache_r2.load_inventory.assert_called_once()
+
+
 class TestRun:
     """Tests for the run() entry point."""
 
@@ -2960,6 +3041,41 @@ class TestRun:
         finally:
             _sys.excepthook = saved_sys
             _threading.excepthook = saved_thr
+
+    def test_run_calls_bootstrap_issue_caches_with_repos_gh_and_registry(
+        self, tmp_path: Path
+    ) -> None:
+        from kennel.server import run
+
+        fake_cfg = self._fake_cfg(tmp_path)
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_registry = MagicMock()
+        mock_make_registry = MagicMock(return_value=mock_registry)
+        mock_bootstrap = MagicMock()
+        mock_gh_instance = MagicMock()
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=mock_make_registry,
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _startup_pull=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
+            _GitHub=lambda: mock_gh_instance,
+            _Watchdog=MagicMock(),
+            _ReconcileWatchdog=MagicMock(),
+            _bootstrap_issue_caches=mock_bootstrap,
+        )
+
+        mock_bootstrap.assert_called_once_with(
+            fake_cfg.repos, mock_gh_instance, mock_registry
+        )
 
 
 def _self_restart_cfg(tmp_path: Path) -> Config:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1573,9 +1573,22 @@ class TestWorkerFindNextIssue:
         d.mkdir()
         return d
 
+    def _load_issues(self, worker: "Worker", issues: list) -> None:
+        """Pre-populate the worker's issue cache (replaces the old lazy bootstrap).
+
+        The cache is now seeded eagerly at kennel startup (#837); tests must
+        do the same rather than relying on _pick_from_cache to fetch.
+        """
+        from datetime import datetime, timezone
+
+        worker._issue_cache.load_inventory(  # pyright: ignore[reportPrivateUsage]
+            issues,
+            snapshot_started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
     def test_returns_none_when_no_issues(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
+        # Empty cache (no load_inventory call needed) → no candidates → None.
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
             result = worker.find_next_issue(fido_dir, self._make_repo_ctx())
@@ -1672,7 +1685,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1692,7 +1705,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": [{"state": "CLOSED"}, {"state": "CLOSED"}]},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1720,7 +1733,7 @@ class TestWorkerFindNextIssue:
             "title": "Blocked",
             "subIssues": {"nodes": [child]},
         }
-        gh.find_all_open_issues.return_value = [parent_issue, child]
+        self._load_issues(worker, [parent_issue, child])
         gh.find_issues.return_value = [parent_issue]
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
@@ -1745,7 +1758,7 @@ class TestWorkerFindNextIssue:
                 "subIssues": {"nodes": []},
             },
         ]
-        gh.find_all_open_issues.return_value = issues
+        self._load_issues(worker, issues)
         gh.find_issues.return_value = issues
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1763,7 +1776,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1778,7 +1791,7 @@ class TestWorkerFindNextIssue:
 
     def test_does_not_save_state_when_no_issue(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
+        # Empty cache → no candidates → no state saved.
         gh.find_issues.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
@@ -1793,7 +1806,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         mock_status = MagicMock()
@@ -1812,7 +1825,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         mock_pickup = MagicMock()
@@ -1825,29 +1838,24 @@ class TestWorkerFindNextIssue:
 
     def test_calls_set_status_done_when_no_issue(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
-        gh.find_issues.return_value = []
+        # Empty cache → no candidates → "All done" status.
         fido_dir = self._fido_dir(tmp_path)
         mock_status = MagicMock()
         with patch.object(worker, "set_status", mock_status):
             worker.find_next_issue(fido_dir, self._make_repo_ctx())
         mock_status.assert_called_once_with("All done — no issues to fetch", busy=False)
 
-    def test_bootstraps_inventory_with_correct_args(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
-        fido_dir = self._fido_dir(tmp_path)
-        repo_ctx = self._make_repo_ctx(owner="org", repo_name="myrepo", gh_user="bot")
-        with patch.object(worker, "set_status"):
-            worker.find_next_issue(fido_dir, repo_ctx)
-        gh.find_all_open_issues.assert_called_once_with("org", "myrepo")
-
     def test_logs_info_when_starting_issue(self, tmp_path: Path, caplog) -> None:
         import logging
 
         worker, gh = self._make_worker(tmp_path)
-        issue = {"number": 9, "title": "Chase squirrel", "subIssues": {"nodes": []}}
-        gh.find_all_open_issues.return_value = [issue]
+        issue = {
+            "number": 9,
+            "title": "Chase squirrel",
+            "assignees": {"nodes": [{"login": "fido-bot"}]},
+            "subIssues": {"nodes": []},
+        }
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1862,8 +1870,7 @@ class TestWorkerFindNextIssue:
         import logging
 
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
-        gh.find_issues.return_value = []
+        # Empty cache → no candidates → "no eligible" log line.
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "set_status"),
@@ -1873,8 +1880,8 @@ class TestWorkerFindNextIssue:
         assert "no eligible" in caplog.text
 
     def test_walks_up_via_issue_index(self, tmp_path: Path) -> None:
-        """Assigned issue has a parent — worker uses the issue index built from
-        find_all_open_issues to walk up to the root before descending."""
+        """Assigned issue has a parent — walker uses the issue index from the
+        pre-loaded cache to walk up to the root before descending."""
         worker, gh = self._make_worker(tmp_path)
         child = {
             "number": 200,
@@ -1902,7 +1909,7 @@ class TestWorkerFindNextIssue:
                 ]
             },
         }
-        gh.find_all_open_issues.return_value = [root, child]
+        self._load_issues(worker, [root, child])
         gh.find_issues.return_value = [child]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1911,7 +1918,7 @@ class TestWorkerFindNextIssue:
         ):
             result = worker.find_next_issue(fido_dir, self._make_repo_ctx())
         assert result == 200
-        gh.find_all_open_issues.assert_called_once_with("alice", "proj")
+        gh.find_all_open_issues.assert_not_called()
 
     def test_picks_first_open_sub_issue_under_owned_parent(
         self, tmp_path: Path
@@ -1948,7 +1955,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": [closed_child, open_child]},
         }
-        gh.find_all_open_issues.return_value = [parent_issue, open_child]
+        self._load_issues(worker, [parent_issue, open_child])
         gh.find_issues.return_value = [parent_issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -1963,8 +1970,7 @@ class TestWorkerFindNextIssue:
     def test_does_not_claim_when_no_eligible_issue(self, tmp_path: Path) -> None:
         """When the picker returns None, no leaf-claim fires."""
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
-        gh.find_issues.return_value = []
+        # Empty cache → no candidates → no leaf-claim.
         fido_dir = self._fido_dir(tmp_path)
         with patch.object(worker, "set_status"):
             worker.find_next_issue(fido_dir, self._make_repo_ctx())
@@ -1982,7 +1988,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         with (
@@ -2004,7 +2010,7 @@ class TestWorkerFindNextIssue:
             "assignees": {"nodes": [{"login": "fido-bot"}]},
             "subIssues": {"nodes": []},
         }
-        gh.find_all_open_issues.return_value = [issue]
+        self._load_issues(worker, [issue])
         gh.find_issues.return_value = [issue]
         fido_dir = self._fido_dir(tmp_path)
         mock_pickup = MagicMock()
@@ -2025,8 +2031,7 @@ class TestWorkerFindNextIssue:
         self, tmp_path: Path
     ) -> None:
         worker, gh = self._make_worker(tmp_path)
-        gh.find_all_open_issues.return_value = []
-        gh.find_issues.return_value = []
+        # Empty cache → no candidates → no pickup comment.
         fido_dir = self._fido_dir(tmp_path)
         mock_pickup = MagicMock()
         with (
@@ -2649,23 +2654,25 @@ class TestWorkerPickFromCache:
             membership=RepoMembership(collaborators=frozenset({"owner"})),
         )
 
-    def test_loads_inventory_when_not_yet_loaded(self, tmp_path: Path) -> None:
+    def test_picks_from_preloaded_cache_without_api_call(self, tmp_path: Path) -> None:
         cache = IssueTreeCache("owner/repo")
+        cache.load_inventory(
+            [
+                {
+                    "number": 1,
+                    "title": "Solo",
+                    "createdAt": "2026-04-01T00:00:00Z",
+                    "assignees": {"nodes": [{"login": "fido"}]},
+                    "subIssues": {"nodes": []},
+                }
+            ],
+            snapshot_started_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
         worker, gh = self._worker_with_cache(tmp_path, cache)
-        gh.find_all_open_issues.return_value = [
-            {
-                "number": 1,
-                "title": "Solo",
-                "createdAt": "2026-04-01T00:00:00Z",
-                "assignees": {"nodes": [{"login": "fido"}]},
-                "subIssues": {"nodes": []},
-            }
-        ]
         gh.view_issue.return_value = {"state": "OPEN"}
         choice = worker._pick_from_cache(self._repo_ctx())
         assert choice is not None and choice.number == 1
-        gh.find_all_open_issues.assert_called_once_with("owner", "repo")
-        assert cache.is_loaded
+        gh.find_all_open_issues.assert_not_called()
 
     def test_does_not_reload_inventory_when_cache_already_loaded(
         self, tmp_path: Path


### PR DESCRIPTION
Fixes #837.

Bootstraps the per-repo IssueTreeCache eagerly at kennel startup instead of lazily on first find_next_issue call, so repos with an active PR no longer sit with a cold cache for hours. Removes the now-dead lazy bootstrap fallback from _pick_from_cache.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Bootstrap issue caches eagerly at kennel startup in server.run() <!-- type:spec -->
- [x] Remove lazy bootstrap fallback from _pick_from_cache <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->