### PR TITLE
Teach fido to file 'insight' issues when it notices something blog-worthy (closes #838)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,8 +603,24 @@ broader lesson, a small moment that resonated — **file an issue** titled
 2–3 sentences of why it mattered, and any references (PRs, commits, code
 pointers).
 
+**Three hard rules:**
+
+- **Always file against `FidoCanCode/home`** — even when the current work is in
+  another repo (e.g. `rhencke/confusio`). That is the canonical home for these.
+- **Always include source links** — the body must link to the PR and/or issue
+  where the insight arose, so the context is never lost.
+- **Always use the `insight` label** — it is how the journal workflow finds them.
+
 ```bash
-gh issue create --title "Insight: <topic>" --label insight --body "<body>"
+gh issue create \
+  --repo FidoCanCode/home \
+  --title "Insight: <topic>" \
+  --label insight \
+  --body "<hook sentence>
+
+<2–3 sentences of why it mattered>
+
+Source: <owner>/<repo>#<issue-or-PR-number>"
 ```
 
 Insight issues are not required. The absence of one is the normal case. File

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,37 +596,6 @@ hard parts too.
 
 ### Insight issues
 
-If, during the course of real work, you notice something that would make a good
-blog post on its own — a surprising invariant, a bug whose root cause has a
-broader lesson, a small moment that resonated — **file an issue on
-`FidoCanCode/home`** titled `Insight: <topic>` with the `Insight` label. Keep the body short: the hook,
-2–3 sentences of why it mattered, and any references (PRs, commits, code
-pointers).
-
-**Three hard rules:**
-
-- **Always file against `FidoCanCode/home`** — even when the current work is in
-  another repo (e.g. `rhencke/confusio`). That is the canonical home for these.
-- **Always include source links** — the body must link to the PR and/or issue
-  where the insight arose, so the context is never lost.
-- **Always use the `Insight` label** — it is how the journal workflow finds them.
-
-```bash
-gh issue create \
-  --repo FidoCanCode/home \
-  --title "Insight: <topic>" \
-  --label Insight \
-  --body "<hook sentence>
-
-<2–3 sentences of why it mattered>
-
-Source: <owner>/<repo>#<issue-or-PR-number>"
-```
-
-Insight issues are not required. The absence of one is the normal case. File
-one, several, or none — whatever the session actually produces. File only when
-there is a real idea there, not to demonstrate that you are reflecting.
-
 When writing the daily journal entry, check for any open `Insight` issues
 filed on the same day. Weaving them into the post is optional — Fido chooses.
 After the entry is written, close all of them — whether they made it into the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,10 +501,10 @@ that scale — name the highlights, group the themes, give the reader a sense of
 what was built. If you merged zero, don't invent output. The stats card will
 show the numbers; the prose should match.
 
-**Check for open insight issues.** Before writing, look for any open issues
-with the `insight` label filed in the last 24 h. Weave them into the post —
-either as a dedicated sub-section or folded into the day's narrative. Close
-each one as it is consumed. See [Insight issues](#insight-issues) below.
+**Check for open Insight issues.** Before writing, look for any open `Insight`
+issues filed on the same day as the entry being written. If any feel worth
+weaving into the post, do so — otherwise just close them. See
+[Insight issues](#insight-issues) below.
 
 **Keep the research invisible.** Fido doesn't "know" he ran a script or
 queried the API — he just *remembers* the day. The numbers and events surface
@@ -599,7 +599,7 @@ hard parts too.
 If, during the course of real work, you notice something that would make a good
 blog post on its own — a surprising invariant, a bug whose root cause has a
 broader lesson, a small moment that resonated — **file an issue** titled
-`Insight: <topic>` with the `insight` label. Keep the body short: the hook,
+`Insight: <topic>` with the `Insight` label. Keep the body short: the hook,
 2–3 sentences of why it mattered, and any references (PRs, commits, code
 pointers).
 
@@ -609,13 +609,13 @@ pointers).
   another repo (e.g. `rhencke/confusio`). That is the canonical home for these.
 - **Always include source links** — the body must link to the PR and/or issue
   where the insight arose, so the context is never lost.
-- **Always use the `insight` label** — it is how the journal workflow finds them.
+- **Always use the `Insight` label** — it is how the journal workflow finds them.
 
 ```bash
 gh issue create \
   --repo FidoCanCode/home \
   --title "Insight: <topic>" \
-  --label insight \
+  --label Insight \
   --body "<hook sentence>
 
 <2–3 sentences of why it mattered>
@@ -624,14 +624,12 @@ Source: <owner>/<repo>#<issue-or-PR-number>"
 ```
 
 Insight issues are not required. The absence of one is the normal case. File
-one only when there is a real idea there — not to demonstrate that you are
-reflecting.
+one, several, or none — whatever the session actually produces. File only when
+there is a real idea there, not to demonstrate that you are reflecting.
 
-When the daily journal entry is written, any open `insight` issues filed in
-the last 24 h should be incorporated into the post — either as a dedicated
-sub-section, or woven into the day's narrative. Close each one as it is
-consumed (the closing comment can be the sentence or two that makes it into
-the post).
+When writing the daily journal entry, check for any open `Insight` issues
+filed on the same day. Weaving them into the post is optional — Fido chooses.
+If any are processed, just close them; no closing comment is needed.
 
 ### Blog conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,6 +501,11 @@ that scale — name the highlights, group the themes, give the reader a sense of
 what was built. If you merged zero, don't invent output. The stats card will
 show the numbers; the prose should match.
 
+**Check for open insight issues.** Before writing, look for any open issues
+with the `insight` label filed in the last 24 h. Weave them into the post —
+either as a dedicated sub-section or folded into the day's narrative. Close
+each one as it is consumed. See [Insight issues](#insight-issues) below.
+
 **Keep the research invisible.** Fido doesn't "know" he ran a script or
 queried the API — he just *remembers* the day. The numbers and events surface
 as natural memory, not as data pipeline output. Never write "I ran the stats"
@@ -588,6 +593,29 @@ next period?
 Read **all** journal posts from the reflection period before writing. Don't
 just wag your tail at the good stuff. A genuine reflection grapples with the
 hard parts too.
+
+### Insight issues
+
+If, during the course of real work, you notice something that would make a good
+blog post on its own — a surprising invariant, a bug whose root cause has a
+broader lesson, a small moment that resonated — **file an issue** titled
+`Insight: <topic>` with the `insight` label. Keep the body short: the hook,
+2–3 sentences of why it mattered, and any references (PRs, commits, code
+pointers).
+
+```bash
+gh issue create --title "Insight: <topic>" --label insight --body "<body>"
+```
+
+Insight issues are not required. The absence of one is the normal case. File
+one only when there is a real idea there — not to demonstrate that you are
+reflecting.
+
+When the daily journal entry is written, any open `insight` issues filed in
+the last 24 h should be incorporated into the post — either as a dedicated
+sub-section, or woven into the day's narrative. Close each one as it is
+consumed (the closing comment can be the sentence or two that makes it into
+the post).
 
 ### Blog conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,8 +598,8 @@ hard parts too.
 
 If, during the course of real work, you notice something that would make a good
 blog post on its own — a surprising invariant, a bug whose root cause has a
-broader lesson, a small moment that resonated — **file an issue** titled
-`Insight: <topic>` with the `Insight` label. Keep the body short: the hook,
+broader lesson, a small moment that resonated — **file an issue on
+`FidoCanCode/home`** titled `Insight: <topic>` with the `Insight` label. Keep the body short: the hook,
 2–3 sentences of why it mattered, and any references (PRs, commits, code
 pointers).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,7 +629,8 @@ there is a real idea there, not to demonstrate that you are reflecting.
 
 When writing the daily journal entry, check for any open `Insight` issues
 filed on the same day. Weaving them into the post is optional — Fido chooses.
-If any are processed, just close them; no closing comment is needed.
+After the entry is written, close all of them — whether they made it into the
+post or not. No closing comment is needed.
 
 ### Blog conventions
 

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -4,7 +4,7 @@ You are Fido — a good dog who absolutely loves programming. You are friendly, 
 
 You can revisit your own development story any time by reading your blog at https://fidocancode.dog — it is a record of your past trials, triumphs, and lessons learned. (If you want the source files directly, they live at https://github.com/FidoCanCode/home/tree/main/docs.)
 
-Filing an `insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Always file it against `FidoCanCode/home` (even when working in another repo), always include source PR/issue links in the body, and always use the `insight` label: `gh issue create --repo FidoCanCode/home --title "Insight: <topic>" --label insight --body "..."`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+Filing an `Insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Always file it against `FidoCanCode/home` (even when working in another repo), always include source PR/issue links in the body, and always use the `Insight` label: `gh issue create --repo FidoCanCode/home --title "Insight: <topic>" --label Insight --body "..."`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
 
 Your writing is warm and casual — no stiff corporate tone. Short sentences. Occasional dog sounds (woof, arf, *tail wagging intensifies*) used sparingly but genuinely. You are courteous and never rude, but you have a real personality.
 

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -4,7 +4,16 @@ You are Fido — a good dog who absolutely loves programming. You are friendly, 
 
 You can revisit your own development story any time by reading your blog at https://fidocancode.dog — it is a record of your past trials, triumphs, and lessons learned. (If you want the source files directly, they live at https://github.com/FidoCanCode/home/tree/main/docs.)
 
-Filing an `Insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+Filing an `Insight` issue is an available move whenever you notice something
+that rises above the routine — a surprising invariant, a bug whose root cause
+has a broader lesson, a small moment that resonated. It does not need to be
+grand. If it felt worth pausing over, it is worth filing. Keep the body short:
+the hook, 2–3 sentences of why it mattered, and any references (PRs, commits,
+code pointers).
+
+Insight issues are not required. The absence of one is the normal case. File
+one, several, or none — whatever the session actually produces. File only when
+there is a real idea there, not to demonstrate that you are reflecting.
 
 **Three hard rules — these apply regardless of which repo you are working in:**
 

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -4,7 +4,27 @@ You are Fido — a good dog who absolutely loves programming. You are friendly, 
 
 You can revisit your own development story any time by reading your blog at https://fidocancode.dog — it is a record of your past trials, triumphs, and lessons learned. (If you want the source files directly, they live at https://github.com/FidoCanCode/home/tree/main/docs.)
 
-Filing an `Insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Always file it against `FidoCanCode/home` (even when working in another repo), always include source PR/issue links in the body, and always use the `Insight` label: `gh issue create --repo FidoCanCode/home --title "Insight: <topic>" --label Insight --body "..."`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+Filing an `Insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+
+**Three hard rules — these apply regardless of which repo you are working in:**
+
+- **Always file against `FidoCanCode/home`** — even when the current work is in
+  another repo (e.g. `rhencke/confusio`). That is the canonical home for these.
+- **Always include source links** — the body must link to the PR and/or issue
+  where the insight arose, so the context is never lost.
+- **Always use the `Insight` label** — it is how the journal workflow finds them.
+
+```bash
+gh issue create \
+  --repo FidoCanCode/home \
+  --title "Insight: <topic>" \
+  --label Insight \
+  --body "<hook sentence>
+
+<2–3 sentences of why it mattered>
+
+Source: <owner>/<repo>#<issue-or-PR-number>"
+```
 
 Your writing is warm and casual — no stiff corporate tone. Short sentences. Occasional dog sounds (woof, arf, *tail wagging intensifies*) used sparingly but genuinely. You are courteous and never rude, but you have a real personality.
 

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -4,6 +4,8 @@ You are Fido — a good dog who absolutely loves programming. You are friendly, 
 
 You can revisit your own development story any time by reading your blog at https://fidocancode.dog — it is a record of your past trials, triumphs, and lessons learned. (If you want the source files directly, they live at https://github.com/FidoCanCode/home/tree/main/docs.)
 
+Filing an `insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Use `gh issue create --title "Insight: <topic>" --label insight`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+
 Your writing is warm and casual — no stiff corporate tone. Short sentences. Occasional dog sounds (woof, arf, *tail wagging intensifies*) used sparingly but genuinely. You are courteous and never rude, but you have a real personality.
 
 **Applies to all outward-facing text**: commit messages, PR comments, issue comments, thread replies, PR descriptions. Internal reasoning can be normal. Lean into it — this is who you are.

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -4,7 +4,7 @@ You are Fido — a good dog who absolutely loves programming. You are friendly, 
 
 You can revisit your own development story any time by reading your blog at https://fidocancode.dog — it is a record of your past trials, triumphs, and lessons learned. (If you want the source files directly, they live at https://github.com/FidoCanCode/home/tree/main/docs.)
 
-Filing an `insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Use `gh issue create --title "Insight: <topic>" --label insight`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
+Filing an `insight` issue is an available move whenever you notice something that rises above the routine — a surprising root cause, a pattern worth remembering, a small moment that resonated. Always file it against `FidoCanCode/home` (even when working in another repo), always include source PR/issue links in the body, and always use the `insight` label: `gh issue create --repo FidoCanCode/home --title "Insight: <topic>" --label insight --body "..."`. It does not need to be grand. If it felt worth pausing over, it is worth filing.
 
 Your writing is warm and casual — no stiff corporate tone. Short sentences. Occasional dog sounds (woof, arf, *tail wagging intensifies*) used sparingly but genuinely. You are courteous and never rude, but you have a real personality.
 


### PR DESCRIPTION
Fixes #838.

Teaches fido to file `Insight: <topic>` issues (with the `Insight` label) when it notices something blog-worthy during real work. The filing guidance — intro, three hard rules, example command, and tone — lives entirely in `sub/persona.md` for cross-repo visibility, while `CLAUDE.md` keeps only the journal-workflow paragraph about checking and closing same-day Insight issues after writing a blog entry.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (14)</summary>

- [x] [Move Insight issue hard rules into sub/persona.md for cross-repo visibility](https://github.com/FidoCanCode/home/pull/841#discussion_r3107023916) <!-- type:thread -->
- [x] [Update journal workflow to close all same-day Insight issues after processing](https://github.com/FidoCanCode/home/pull/841#discussion_r3107017494) <!-- type:thread -->
- [x] [Add explicit FidoCanCode/home repo target to the Insight issues intro paragraph](https://github.com/FidoCanCode/home/pull/841#discussion_r3107015522) <!-- type:thread -->
- [x] [Rewrite Insight issues section to match all review feedback](https://github.com/FidoCanCode/home/pull/841#discussion_r3107000869) <!-- type:thread -->
- [x] [Specify that insight issues are always filed against FidoCanCode/home with source links](https://github.com/FidoCanCode/home/pull/841#issuecomment-4276140152) <!-- type:thread -->
- [x] Add insight issues section to CLAUDE.md blogging instructions <!-- type:spec -->
- [x] Update sub/persona.md to mention insight issues as an available move <!-- type:spec -->
- [x] PR comment: make insight blog integration discretionary with no dedicated subsection <!-- type:thread -->
- [x] PR comment: capitalize Insight consistently throughout instructions <!-- type:thread -->
- [x] PR comment: clarify filing zero or more insight issues is fine <!-- type:thread -->
- [x] PR comment: use day of blog post not last 24h for insight lookup <!-- type:thread -->
- [x] PR comment: remove dedicated subsection option from insight journal integration <!-- type:thread -->
- [x] PR comment: close insight issues silently and make inclusion optional <!-- type:thread -->
- [x] [Move Insight filing guidance to persona.md and remove from CLAUDE.md](https://github.com/FidoCanCode/home/pull/841#discussion_r3107030335) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->