### PR TITLE
PR body work-queue skips the most recently completed task — not rendered as [x] even though tasks.json says completed (closes #842)

### DIFF
--- a/kennel/tasks.py
+++ b/kennel/tasks.py
@@ -254,14 +254,17 @@ def sync_tasks(
     work_dir: Path,
     gh: GitHub,
     *,
+    blocking: bool = False,
     _resolve_git_dir_fn: Callable[[Path], Path] = _resolve_git_dir,
     _auto_complete_ask_tasks_fn: Callable[..., None] = _auto_complete_ask_tasks,
 ) -> None:
     """Sync tasks.json → PR body work queue.
 
-    Protected by a flock so concurrent
-    calls silently skip rather than race.  Re-runs if tasks.json changes while
-    the body is being updated.
+    Protected by a flock so concurrent calls don't race.  By default
+    (``blocking=False``) a concurrent sync causes this call to silently skip.
+    Pass ``blocking=True`` at authoritative call sites (e.g. post-completion)
+    to wait for the lock instead — this guarantees the PR body converges even
+    if a background sync holds the lock with stale data.
     """
     try:
         git_dir = _resolve_git_dir_fn(work_dir)
@@ -273,12 +276,15 @@ def sync_tasks(
     fido_dir.mkdir(parents=True, exist_ok=True)
     sync_lock_path = fido_dir / "sync.lock"
     sync_lock_fd = open(sync_lock_path, "w")  # noqa: SIM115
-    try:
-        fcntl.flock(sync_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
-        log.info("sync_tasks: another sync running — skipping")
-        sync_lock_fd.close()
-        return
+    if blocking:
+        fcntl.flock(sync_lock_fd, fcntl.LOCK_EX)
+    else:
+        try:
+            fcntl.flock(sync_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            log.info("sync_tasks: another sync running — skipping")
+            sync_lock_fd.close()
+            return
 
     try:
         state = State(fido_dir).load()

--- a/kennel/worker.py
+++ b/kennel/worker.py
@@ -1877,7 +1877,7 @@ class Worker:
         log.info("CI fix done (session=%s)", session_id)
 
         # CI failures have no task entry — no complete call needed
-        tasks.sync_tasks(self.work_dir, self.gh)
+        tasks.sync_tasks(self.work_dir, self.gh, blocking=True)
         return True
 
     def _filter_threads(
@@ -2248,7 +2248,7 @@ class Worker:
         with State(fido_dir).modify() as state:
             state.pop("current_task_id", None)
         self._abort_task.clear()
-        tasks.sync_tasks(self.work_dir, self.gh)
+        tasks.sync_tasks(self.work_dir, self.gh, blocking=True)
 
     def execute_task(
         self,
@@ -2412,7 +2412,7 @@ class Worker:
             self._tasks.complete_with_resolve(task["id"], self.gh)
             with State(fido_dir).modify() as state:
                 state.pop("current_task_id", None)
-            tasks.sync_tasks(self.work_dir, self.gh)
+            tasks.sync_tasks(self.work_dir, self.gh, blocking=True)
         # Sweep any leaked top-level PR comments (BLOCKED: ...) the provider
         # improvised during this task turn.  Runs after task completion so a
         # transient GitHub error during cleanup doesn't block progress.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11595,6 +11595,72 @@ class TestSyncTasks:
         # Must not remain as a pending checkbox
         assert "- [ ] Replace the marker" not in new_body
 
+    def test_completed_task_renders_as_checked_even_when_background_sync_holds_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: #842 — post-completion sync must not skip when background sync holds lock.
+
+        Scenario: a background sync acquires the lock and starts running with stale data
+        (task still pending).  While it holds the lock, the task is marked completed in
+        tasks.json.  The post-completion sync_tasks(blocking=True) must *wait* for the
+        lock rather than skipping, then read fresh data and render the task as [x].
+        """
+        import fcntl
+        import threading
+
+        from kennel.tasks import Tasks
+        from kennel.types import TaskType
+
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        sync_lock_path = fido_dir / "sync.lock"
+
+        # Add a task to tasks.json so the real Tasks.list() can read it
+        task = Tasks(tmp_path).add("Close the ticket", TaskType.SPEC)
+
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 9, "state": "OPEN"}
+        gh.get_pr_body.return_value = (
+            "desc\n<!-- WORK_QUEUE_START -->\n"
+            "- [ ] Close the ticket **→ next** <!-- type:spec -->\n"
+            "<!-- WORK_QUEUE_END -->"
+        )
+
+        lock_held = threading.Event()
+        complete_done = threading.Event()
+
+        def hold_lock_until_complete() -> None:
+            """Simulate a background sync that holds the lock while task is being completed."""
+            with open(sync_lock_path, "w") as lock_fd:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                lock_held.set()
+                complete_done.wait(timeout=5)
+
+        holder = threading.Thread(target=hold_lock_until_complete, daemon=True)
+        holder.start()
+        lock_held.wait(timeout=5)
+
+        # Simulate the worker completing the task while background sync holds the lock
+        Tasks(tmp_path).complete_by_id(task["id"])
+
+        # Post-completion sync (blocking=True) must wait, not skip
+        # Release the lock shortly after the blocking sync starts waiting
+        release_timer = threading.Timer(0.05, complete_done.set)
+        release_timer.start()
+        sync_tasks(tmp_path, gh, blocking=True, **self._sync_kwargs(fido_dir))
+
+        holder.join(timeout=2)
+
+        # The PR body must reflect the completed state, not the stale pending state
+        gh.edit_pr_body.assert_called_once()
+        new_body = gh.edit_pr_body.call_args[0][2]
+        assert "- [x]" in new_body
+        assert "<details>" in new_body
+        assert "Completed (1)" in new_body
+        assert "- [ ] Close the ticket" not in new_body
+
     def test_get_repo_info_exception_propagates(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11376,6 +11376,48 @@ class TestSyncTasks:
             sync_tasks(tmp_path, gh, **self._sync_kwargs(fido_dir))
         gh.find_pr.assert_not_called()
 
+    def test_blocking_mode_waits_for_lock_and_proceeds(self, tmp_path: Path) -> None:
+        """blocking=True waits rather than skipping — the post-completion sync always fires."""
+        import fcntl
+        import threading
+
+        fido_dir = self._fido_dir(tmp_path)
+        self._state_with_issue(fido_dir)
+        sync_lock_path = fido_dir / "sync.lock"
+
+        gh = MagicMock()
+        gh.get_repo_info.return_value = "owner/repo"
+        gh.get_user.return_value = "fido-bot"
+        gh.find_pr.return_value = {"number": 7, "state": "OPEN"}
+        body = "desc\n<!-- WORK_QUEUE_START -->\nstale\n<!-- WORK_QUEUE_END -->"
+        gh.get_pr_body.return_value = body
+
+        sync_started = threading.Event()
+        lock_released = threading.Event()
+
+        def hold_lock_briefly() -> None:
+            with open(sync_lock_path, "w") as lock_fd:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                sync_started.set()
+                lock_released.wait(timeout=5)
+
+        holder = threading.Thread(target=hold_lock_briefly, daemon=True)
+        holder.start()
+        sync_started.wait(timeout=5)
+
+        task = {"title": "Fresh task", "status": "pending", "type": "spec"}
+        with patch("kennel.tasks.Tasks.list", return_value=[task]):
+            # Release the lock just after blocking sync starts waiting
+            release_timer = threading.Timer(0.1, lock_released.set)
+            release_timer.start()
+            sync_tasks(tmp_path, gh, blocking=True, **self._sync_kwargs(fido_dir))
+
+        holder.join(timeout=2)
+        # blocking=True must have waited and then executed the sync
+        gh.edit_pr_body.assert_called_once()
+        new_body = gh.edit_pr_body.call_args[0][2]
+        assert "Fresh task" in new_body
+
     def test_returns_early_when_no_open_pr(self, tmp_path: Path) -> None:
         gh = MagicMock()
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6248,7 +6248,7 @@ class TestHandleCi:
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.handle_ci(fido_dir, self._repo_ctx(), 1, "branch")
-        mock_sync.assert_called_once_with(tmp_path, gh)
+        mock_sync.assert_called_once_with(tmp_path, gh, blocking=True)
 
     def test_picks_first_failing_check(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -8422,7 +8422,7 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_sync.assert_called_once_with(tmp_path, gh)
+        mock_sync.assert_called_once_with(tmp_path, gh, blocking=True)
 
     def test_syncs_work_queue_after_completion(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -8439,7 +8439,7 @@ class TestExecuteTask:
             patch("kennel.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        mock_sync.assert_called_once_with(tmp_path, gh)
+        mock_sync.assert_called_once_with(tmp_path, gh, blocking=True)
 
     def test_logs_task_name(self, tmp_path: Path, caplog) -> None:
         import logging


### PR DESCRIPTION
Fixes #842.

`sync_tasks` uses `LOCK_NB` on the sync lock, so when a background sync is already running with stale data, the post-completion sync skips entirely and the PR body never converges. This adds a blocking mode to `sync_tasks` and wires it at all post-completion call sites so the authoritative sync always waits for the lock instead of bailing.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Wire blocking sync at all post-completion call sites in Worker <!-- type:spec -->
- [x] Add regression test: completed task renders as [x] even when background sync holds the lock <!-- type:spec -->
- [x] Add blocking mode to sync_tasks so post-completion syncs wait instead of skipping <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->