### PR TITLE
"kennel status" should match status endpoint  (closes #839)

### DIFF
--- a/kennel/server.py
+++ b/kennel/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import fcntl
 import hashlib
 import hmac
 import json
@@ -43,9 +44,10 @@ from kennel.infra import (
 from kennel.provider_factory import DefaultProviderFactory
 from kennel.rate_limit import RateLimitMonitor
 from kennel.registry import WebhookActivityHandle, WorkerRegistry, make_registry
+from kennel.state import State
 from kennel.static_files import StaticFiles
 from kennel.status import provider_statuses_for_repo_configs
-from kennel.tasks import unblock_tasks
+from kennel.tasks import Tasks, unblock_tasks
 from kennel.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
     ReconcileWatchdog,
@@ -267,6 +269,96 @@ def _serialize_issue_cache(cache: Any) -> dict[str, Any] | None:
         if metrics.last_reconcile_at
         else None,
         "last_reconcile_drift": metrics.last_reconcile_drift,
+    }
+
+
+def _collect_fido_state(work_dir: Path, now: datetime) -> dict[str, Any]:
+    """Read fido filesystem state (issue, PR, tasks, lock) for the status endpoint.
+
+    Best-effort: returns safe defaults on any I/O or parse error so that a
+    missing or partially-written state file never breaks the status endpoint.
+    """
+    fido_dir = work_dir / ".git" / "fido"
+
+    # Check whether the fido sub-process lock is held.
+    fido_running = False
+    lock_path = fido_dir / "lock"
+    if lock_path.exists():
+        try:
+            fd = open(lock_path)  # noqa: SIM115
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except BlockingIOError:
+                fido_running = True
+            finally:
+                fd.close()
+        except OSError:
+            pass
+
+    # Load state.json (issue / PR metadata).
+    try:
+        state = State(fido_dir).load()
+    except Exception:  # noqa: BLE001
+        log.warning("_collect_fido_state: failed to load state for %s", work_dir)
+        state = {}
+    issue: int | None = state.get("issue")
+    issue_title: str | None = state.get("issue_title")
+    issue_elapsed_seconds: int | None = None
+    issue_started_at: str | None = state.get("issue_started_at")
+    if issue_started_at:
+        try:
+            started = datetime.fromisoformat(issue_started_at)
+            issue_elapsed_seconds = max(0, int((now - started).total_seconds()))
+        except TypeError, ValueError:
+            pass
+    pr_number: int | None = state.get("pr_number")
+    pr_title: str | None = state.get("pr_title")
+
+    # Load tasks.json.
+    try:
+        task_list = Tasks(work_dir).list()
+    except Exception:  # noqa: BLE001
+        log.warning("_collect_fido_state: failed to load tasks for %s", work_dir)
+        task_list = []
+    pending = sum(1 for t in task_list if t.get("status") == "pending")
+    completed = sum(1 for t in task_list if t.get("status") == "completed")
+
+    current_task: str | None = None
+    for t in task_list:
+        if t.get("status") == "in_progress":
+            current_task = t.get("title")
+            break
+    if current_task is None:
+        for t in task_list:
+            if t.get("status") == "pending":
+                current_task = t.get("title")
+                break
+
+    non_completed = [t for t in task_list if t.get("status") != "completed"]
+    task_number: int | None = None
+    task_total: int | None = None
+    if non_completed:
+        task_total = len(non_completed)
+        for idx, t in enumerate(non_completed, start=1):
+            if t.get("status") == "in_progress":
+                task_number = idx
+                break
+        if task_number is None:
+            task_number = 1
+
+    return {
+        "fido_running": fido_running,
+        "issue": issue,
+        "issue_title": issue_title,
+        "issue_elapsed_seconds": issue_elapsed_seconds,
+        "pr_number": pr_number,
+        "pr_title": pr_title,
+        "pending": pending,
+        "completed": completed,
+        "current_task": current_task,
+        "task_number": task_number,
+        "task_total": task_total,
     }
 
 
@@ -959,6 +1051,23 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 }
                 for w in self.registry.get_webhook_activities(a.repo_name)
             ]
+            fido_state = (
+                _collect_fido_state(repo_cfg.work_dir, now)
+                if repo_cfg is not None
+                else {
+                    "fido_running": False,
+                    "issue": None,
+                    "issue_title": None,
+                    "issue_elapsed_seconds": None,
+                    "pr_number": None,
+                    "pr_title": None,
+                    "pending": 0,
+                    "completed": 0,
+                    "current_task": None,
+                    "task_number": None,
+                    "task_total": None,
+                }
+            )
             activities.append(
                 {
                     "repo_name": a.repo_name,
@@ -986,6 +1095,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "issue_cache": _serialize_issue_cache(
                         self.registry.get_issue_cache(a.repo_name)
                     ),
+                    **fido_state,
                 }
             )
         return activities

--- a/kennel/server.py
+++ b/kennel/server.py
@@ -137,8 +137,8 @@ def _repo_status(act: dict[str, Any]) -> str:
     return act.get("what") or "waiting"
 
 
-def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
-    """Serialize activity dicts to namespaced structural XML with an XSLT PI.
+def _activities_to_xml(payload: dict[str, Any]) -> bytes:
+    """Serialize the full status payload to namespaced structural XML with an XSLT PI.
 
     Pure function — transforms data, no I/O.  The server emits this structural
     XML in the ``https://fidocancode.dog/kennel`` namespace.  The browser
@@ -147,9 +147,33 @@ def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
     is then styled by ``status.css`` via a CSS processing instruction.
 
     Three-layer pipeline: structural XML → XSLT → display XML → CSS.
+
+    The root ``<kennel>`` element carries kennel-level metadata (uptime, rate
+    limits) before the per-repo ``<repo>`` children so XSLT can render a
+    dashboard header without reaching into any individual repo card.
     """
     root = Element(f"{{{_NS_KENNEL}}}kennel")
-    for act in activities:
+
+    # Kennel-level metadata — emitted before per-repo elements.
+    kennel_uptime = payload.get("kennel_uptime_seconds")
+    if kennel_uptime is not None:
+        el = SubElement(root, f"{{{_NS_KENNEL}}}kennel_uptime_seconds")
+        el.text = _xml_text(kennel_uptime)
+
+    rate_limit = payload.get("rate_limit")
+    if rate_limit is not None:
+        rl_el = SubElement(root, f"{{{_NS_KENNEL}}}rate_limit")
+        for rl_key, rl_val in rate_limit.items():
+            if isinstance(rl_val, dict):
+                child_el = SubElement(rl_el, f"{{{_NS_KENNEL}}}{rl_key}")
+                for k, v in rl_val.items():
+                    sub_el = SubElement(child_el, f"{{{_NS_KENNEL}}}{k}")
+                    sub_el.text = _xml_text(v)
+            else:
+                child_el = SubElement(rl_el, f"{{{_NS_KENNEL}}}{rl_key}")
+                child_el.text = _xml_text(rl_val)
+
+    for act in payload.get("activities", []):
         repo = SubElement(root, f"{{{_NS_KENNEL}}}repo")
         repo.set(f"{{{_NS_DOG}}}status", _repo_status(act))
         for key, value in act.items():
@@ -172,6 +196,12 @@ def _activities_to_xml(activities: list[dict[str, Any]]) -> bytes:
                     for pk, pv in value.items():
                         el = SubElement(ps_el, f"{{{_NS_KENNEL}}}{pk}")
                         el.text = _xml_text(pv)
+            elif key == "issue_cache":
+                ic_el = SubElement(repo, f"{{{_NS_KENNEL}}}issue_cache")
+                if value is not None:
+                    for ik, iv in value.items():
+                        el = SubElement(ic_el, f"{{{_NS_KENNEL}}}{ik}")
+                        el.text = _xml_text(iv)
             else:
                 el = SubElement(repo, f"{{{_NS_KENNEL}}}{key}")
                 el.text = _xml_text(value)
@@ -572,6 +602,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
     registry: WorkerRegistry
     provider_factory: DefaultProviderFactory | None = None
     rate_limit_monitor: Any = None
+    # Set by run() to record when the server came up, used for kennel uptime.
+    kennel_started_at: datetime | None = None
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
@@ -1004,7 +1036,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if self.path == "/status":
-            body = _activities_to_xml(self._collect_activities())
+            body = _activities_to_xml(self._collect_status_payload())
             self._respond_body("application/xml; charset=utf-8", body)
         elif self.path == "/status.json":
             body = json.dumps(self._collect_status_payload()).encode()
@@ -1015,16 +1047,19 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self._respond(200, "kennel is running")
 
     def _collect_status_payload(self) -> dict[str, Any]:
-        """Build the JSON payload for ``/status.json``.
+        """Build the status payload shared by ``/status.json`` and ``/status`` XML.
 
-        Wraps the per-repo activity list and a global rate-limit snapshot
-        (closes #812 follow-up) under top-level keys so future global
-        signals can be added without churn — kennel status reads
-        ``activities`` and ``rate_limit`` independently.
+        Wraps the per-repo activity list, a global rate-limit snapshot, and
+        kennel-level metadata (uptime) under top-level keys.  Both endpoints
+        call this method so they always render the same data.
         """
+        now = datetime.now(tz=timezone.utc)
+        started = self.kennel_started_at
+        kennel_uptime = (now - started).total_seconds() if started is not None else None
         return {
             "activities": self._collect_activities(),
             "rate_limit": _serialize_rate_limit(self.rate_limit_monitor),
+            "kennel_uptime_seconds": kennel_uptime,
         }
 
     def _collect_activities(self) -> list[dict[str, Any]]:
@@ -1324,6 +1359,7 @@ def run(
     rate_limit_monitor = _RateLimitMonitor(gh)
     rate_limit_monitor.start_thread()
     WebhookHandler.rate_limit_monitor = rate_limit_monitor
+    WebhookHandler.kennel_started_at = datetime.now(tz=timezone.utc)
 
     server = _HTTPServer(("", config.port), WebhookHandler)
 

--- a/kennel/static/status.css
+++ b/kennel/static/status.css
@@ -6,146 +6,428 @@
  *
  * Display namespace: https://fidocancode.dog/display
  * Attribute namespace: https://fidocancode.dog/woof (dog:status, dog:kind)
+ *
+ * Design: mobile-first, Apple HIG + Material Design inspired.
+ * Spacing rhythm: 8px grid. Touch targets: 44px min.
+ * Breakpoints: 600px (tablet), 900px (desktop).
  */
 
 @namespace url(https://fidocancode.dog/display);
 @namespace dog url(https://fidocancode.dog/woof);
 
-/* === base === */
+/* ─── Reset + box model ───────────────────────────────────────────────────── */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+/* ─── Design tokens ───────────────────────────────────────────────────────── */
+
+dashboard {
+  /* Typography */
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
+    Noto Sans, Helvetica, Arial, sans-serif;
+  --font-mono: "SF Mono", "Cascadia Code", "Fira Code", Menlo, Consolas,
+    "Courier New", monospace;
+
+  /* Neutral surface */
+  --color-bg:          #f6f8fa;
+  --color-surface:     #ffffff;
+  --color-border:      #d0d7de;
+  --color-border-muted:#e8ecf0;
+
+  /* Text */
+  --color-text:        #1f2328;
+  --color-text-muted:  #656d76;
+  --color-text-subtle: #8b949e;
+
+  /* Status: green (busy/active) */
+  --color-green:       #1a7f37;
+  --color-green-mid:   #2da44e;
+  --color-green-light: #dafbe1;
+  --color-green-pulse: rgba(45, 164, 78, 0.25);
+
+  /* Status: red (error/stuck/crash) */
+  --color-red:         #cf222e;
+  --color-red-mid:     #d1242f;
+  --color-red-light:   #ffebe9;
+  --color-red-pulse:   rgba(207, 34, 46, 0.25);
+
+  /* Status: orange (warning/session) */
+  --color-orange:      #bc4c00;
+  --color-orange-light:#fff1e5;
+
+  /* Status: blue (info/rescope) */
+  --color-blue:        #0969da;
+  --color-blue-light:  #ddf4ff;
+
+  /* Status: purple (provider-paused) */
+  --color-purple:      #8250df;
+  --color-purple-light:#fbefff;
+
+  /* Accent bar colors by card state */
+  --color-bar-busy:    var(--color-green-mid);
+  --color-bar-stuck:   var(--color-red-mid);
+  --color-bar-crashed: var(--color-red-mid);
+  --color-bar-waiting: var(--color-border-muted);
+
+  /* Elevation */
+  --shadow-card:       0 1px 3px rgba(31, 35, 40, 0.08),
+                       0 1px 2px rgba(31, 35, 40, 0.04);
+  --shadow-card-hover: 0 3px 8px rgba(31, 35, 40, 0.10),
+                       0 1px 3px rgba(31, 35, 40, 0.06);
+
+  /* Spacing (8px grid) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+
+  /* Radius */
+  --radius-sm:  6px;
+  --radius-md:  10px;
+  --radius-lg:  14px;
+  --radius-pill: 100px;
+
+  /* Card inner indent */
+  --card-indent: 18px;
+}
+
+/* ─── Base layout ─────────────────────────────────────────────────────────── */
 
 dashboard {
   display: block;
   margin: 0;
-  padding: 1rem 0 3rem;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
-    Helvetica, Arial, sans-serif;
-  background: #faf6f0;
-  color: #1f2328;
-  line-height: 1.5;
-  min-height: 100vh;
+  padding: var(--space-4) 0 var(--space-6) * 2;
+  padding-bottom: 48px;
+  font-family: var(--font-sans);
   font-size: 15px;
+  line-height: 1.5;
+  background: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* === title === */
+/* ─── Title ───────────────────────────────────────────────────────────────── */
 
 title {
   display: block;
-  font-size: 1.25rem;
+  font-size: 1.05rem;
   font-weight: 600;
-  color: #656d76;
-  max-width: 52rem;
-  margin: 0 auto;
-  padding: 0.5rem 1.5rem;
+  color: var(--color-text-muted);
   letter-spacing: -0.01em;
+  padding: var(--space-2) var(--space-4);
+  max-width: 52rem;
+  margin: 0 auto var(--space-2);
 }
 
-/* === empty state === */
+/* ─── Dashboard header (uptime + rate limits) ─────────────────────────────── */
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  max-width: 52rem;
+  margin: 0 auto var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  font-size: 0.78rem;
+  color: var(--color-text-subtle);
+}
+
+kennel-uptime {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-subtle);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-pill);
+  padding: 2px var(--space-3);
+}
+
+rate-limits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+rate-window {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-pill);
+  padding: 2px var(--space-3);
+  color: var(--color-text-subtle);
+}
+
+rate-label {
+  display: inline;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+rate-nums {
+  display: inline;
+  color: var(--color-text);
+}
+
+rate-reset {
+  display: inline;
+  color: var(--color-text-subtle);
+}
+
+/* ─── Empty state ─────────────────────────────────────────────────────────── */
 
 empty {
   display: block;
   text-align: center;
-  color: #8b949e;
-  padding: 4rem 1rem;
-  font-size: 1.1rem;
+  color: var(--color-text-subtle);
+  padding: 4rem var(--space-4);
+  font-size: 1.05rem;
 }
 
-/* === repo cards === */
+/* ─── Cards ───────────────────────────────────────────────────────────────── */
 
 card {
   display: block;
-  background: #ffffff;
-  border: 1px solid #d8dee4;
-  border-radius: 10px;
-  padding: 1rem 1.25rem;
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
   max-width: 52rem;
-  margin: 0.75rem auto;
-  box-shadow: 0 1px 3px rgba(31, 35, 40, 0.06);
-  transition: border-color 0.2s ease;
+  margin: 0 var(--space-4) var(--space-3);
+  box-shadow: var(--shadow-card);
+  border-left-width: 3px;
+  border-left-color: var(--color-bar-waiting);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+card[dog|status="busy"] {
+  border-left-color: var(--color-bar-busy);
 }
 
 card[dog|status="stuck"],
 card[dog|status="crashed"] {
-  border-left: 3px solid #cf222e;
-}
-
-card[dog|status="busy"] {
-  border-left: 3px solid #1a7f37;
+  border-left-color: var(--color-bar-stuck);
 }
 
 card[dog|status^="waiting"] {
-  border-left: 3px solid #d8dee4;
+  border-left-color: var(--color-bar-waiting);
 }
 
-/* === status dot via name::before === */
+/* ─── Card: name + status dot ─────────────────────────────────────────────── */
 
 name {
   display: block;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
+  line-height: 1.4;
 }
 
 name::before {
   content: "";
   display: inline-block;
-  width: 9px;
-  height: 9px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  margin-right: 0.5rem;
+  margin-right: 7px;
   vertical-align: middle;
-  background: #8b949e;
+  position: relative;
+  top: -1px;
+  background: var(--color-text-subtle);
+  flex-shrink: 0;
 }
 
 card[dog|status="busy"] > name::before {
-  background: #2da44e;
-  box-shadow: 0 0 0 2px rgba(45, 164, 78, 0.2);
-  animation: pulse 2s ease-in-out infinite;
+  background: var(--color-green-mid);
+  box-shadow: 0 0 0 3px var(--color-green-pulse);
+  animation: pulse-green 2s ease-in-out infinite;
 }
 
 card[dog|status="stuck"] > name::before {
-  background: #cf222e;
-  box-shadow: 0 0 0 2px rgba(207, 34, 46, 0.2);
-  animation: pulse 1s ease-in-out infinite;
+  background: var(--color-red-mid);
+  box-shadow: 0 0 0 3px var(--color-red-pulse);
+  animation: pulse-red 1s ease-in-out infinite;
 }
 
 card[dog|status="crashed"] > name::before {
-  background: #cf222e;
+  background: var(--color-red-mid);
 }
 
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+@keyframes pulse-green {
+  0%, 100% { opacity: 1;   box-shadow: 0 0 0 3px var(--color-green-pulse); }
+  50%       { opacity: 0.6; box-shadow: 0 0 0 5px rgba(45, 164, 78, 0.12); }
 }
 
-/* === uptime === */
+@keyframes pulse-red {
+  0%, 100% { opacity: 1;   box-shadow: 0 0 0 3px var(--color-red-pulse); }
+  50%       { opacity: 0.5; box-shadow: 0 0 0 5px rgba(207, 34, 46, 0.10); }
+}
+
+/* ─── Card: uptime (floated right) ───────────────────────────────────────── */
 
 uptime {
   display: block;
   float: right;
-  font-size: 0.8rem;
-  color: #8b949e;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
   font-variant-numeric: tabular-nums;
+  color: var(--color-text-subtle);
+  margin-top: 2px;
+  margin-left: var(--space-3);
 }
 
-/* === activity === */
+/* ─── Card: activity ─────────────────────────────────────────────────────── */
 
 activity {
   display: block;
-  color: #656d76;
-  font-size: 0.9rem;
-  padding: 0.15rem 0 0.5rem 1.15rem;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  padding: 2px 0 var(--space-3);
+  padding-left: var(--card-indent);
   clear: both;
 }
 
-/* === badges === */
+/* ─── Card: issue row ────────────────────────────────────────────────────── */
+
+issue-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  padding-left: var(--card-indent);
+  margin-bottom: var(--space-1);
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  font-size: 0.825rem;
+}
+
+issue-num {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+issue-title {
+  display: inline;
+  color: var(--color-text);
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+issue-elapsed {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-subtle);
+  flex-shrink: 0;
+}
+
+/* ─── Card: PR row ───────────────────────────────────────────────────────── */
+
+pr-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  padding-left: var(--card-indent);
+  margin-bottom: var(--space-1);
+  background: var(--color-green-light);
+  border-radius: var(--radius-sm);
+  font-size: 0.825rem;
+}
+
+pr-num {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-green);
+  flex-shrink: 0;
+}
+
+pr-title {
+  display: inline;
+  color: var(--color-text);
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Card: task row ─────────────────────────────────────────────────────── */
+
+task-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1) var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  padding-left: var(--card-indent);
+  margin-bottom: var(--space-2);
+  font-size: 0.825rem;
+  border-left: 2px solid var(--color-border-muted);
+  margin-left: calc(var(--card-indent) - 2px);
+  padding-left: var(--space-3);
+}
+
+task-pos {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-subtle);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border-muted);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-2);
+  flex-shrink: 0;
+}
+
+task-title {
+  display: inline;
+  color: var(--color-text-muted);
+  flex: 1;
+}
+
+/* ─── Card: badges ───────────────────────────────────────────────────────── */
 
 badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  padding-left: 1.15rem;
+  gap: var(--space-1);
+  padding-left: var(--card-indent);
+  margin-bottom: var(--space-1);
 }
 
 badges:empty {
@@ -155,83 +437,140 @@ badges:empty {
 badge {
   display: inline-flex;
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 500;
-  padding: 0.15rem 0.55rem;
-  border-radius: 2rem;
+  padding: 2px var(--space-3);
+  border-radius: var(--radius-pill);
+  line-height: 1.6;
+  min-height: 22px;
 }
 
 badge[dog|kind="crash"] {
-  background: #ffebe9;
-  color: #cf222e;
+  background: var(--color-red-light);
+  color: var(--color-red);
 }
 
 badge[dog|kind="rescope"] {
-  background: #ddf4ff;
-  color: #0969da;
+  background: var(--color-blue-light);
+  color: var(--color-blue);
 }
 
 badge[dog|kind="session"] {
-  background: #fdf0d5;
-  color: #c87c0a;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  font-size: 0.7rem;
+  background: var(--color-orange-light);
+  color: var(--color-orange);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
 }
 
-/* === claude talker === */
+badge[dog|kind="session-dropped"] {
+  background: var(--color-red-light);
+  color: var(--color-red);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+badge[dog|kind="provider-paused"] {
+  background: var(--color-purple-light);
+  color: var(--color-purple);
+}
+
+/* ─── Card: provider pressure ────────────────────────────────────────────── */
+
+pressure {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  padding-left: var(--card-indent);
+  margin-top: var(--space-2);
+  font-size: 0.8rem;
+}
+
+pressure-label {
+  display: inline;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+pressure-pct {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+pressure-window {
+  display: inline;
+  font-size: 0.72rem;
+  color: var(--color-text-subtle);
+}
+
+/* ─── Card: claude talker ────────────────────────────────────────────────── */
 
 talker {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  margin-left: 1.15rem;
-  background: #dafbe1;
-  border-radius: 6px;
+  gap: var(--space-1) var(--space-2);
+  margin-top: var(--space-3);
+  margin-left: var(--card-indent);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-green-light);
+  border-radius: var(--radius-sm);
   font-size: 0.8rem;
+  border: 1px solid rgba(26, 127, 55, 0.15);
 }
 
 talker > label {
   display: inline;
-  font-weight: 600;
-  color: #1a7f37;
+  font-weight: 700;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-green);
 }
 
 talker > kind {
   display: inline;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  font-size: 0.75rem;
-  color: #1a7f37;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-green);
   background: rgba(26, 127, 55, 0.1);
-  padding: 0.05rem 0.4rem;
-  border-radius: 3px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
 }
 
 talker > desc {
   display: inline;
-  color: #656d76;
+  color: var(--color-text-muted);
+  flex: 1;
 }
 
 talker > pid {
   display: inline;
-  color: #8b949e;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  font-size: 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-text-subtle);
 }
 
-/* === crash error === */
+/* ─── Card: crash detail ─────────────────────────────────────────────────── */
 
 crash-detail {
   display: block;
-  margin: 0.5rem 0 0 1.15rem;
-  padding: 0.6rem 0.75rem;
-  background: #ffebe9;
-  border-radius: 6px;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  font-size: 0.75rem;
-  color: #cf222e;
+  margin-top: var(--space-3);
+  margin-left: var(--card-indent);
+  padding: var(--space-3);
+  background: var(--color-red-light);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(207, 34, 46, 0.15);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-red);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -239,58 +578,123 @@ crash-detail {
 crash-detail::before {
   content: "last crash";
   display: block;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans,
-    Helvetica, Arial, sans-serif;
-  font-size: 0.8rem;
-  font-weight: 500;
-  margin-bottom: 0.35rem;
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-red);
+  opacity: 0.7;
+  margin-bottom: var(--space-2);
 }
 
-/* === webhook activities === */
+/* ─── Card: issue cache ──────────────────────────────────────────────────── */
+
+issue-cache {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
+  padding-left: var(--card-indent);
+  margin-top: var(--space-2);
+  font-size: 0.75rem;
+  color: var(--color-text-subtle);
+}
+
+cache-issues {
+  display: inline;
+  font-variant-numeric: tabular-nums;
+}
+
+cache-events {
+  display: inline;
+  font-variant-numeric: tabular-nums;
+}
+
+cache-dropped {
+  display: inline;
+  color: var(--color-orange);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Card: webhook hooks ────────────────────────────────────────────────── */
 
 hooks {
   display: block;
-  margin-top: 0.5rem;
-  padding-left: 1.15rem;
+  margin-top: var(--space-3);
+  padding-left: var(--card-indent);
 }
 
 hooks-label {
   display: block;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #656d76;
-  margin-bottom: 0.2rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
 }
 
 hook {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
   font-size: 0.8rem;
-  color: #656d76;
-  padding: 0.15rem 0 0.15rem 0.75rem;
-  border-left: 2px solid #d8dee4;
+  color: var(--color-text-muted);
+  padding: var(--space-1) 0 var(--space-1) var(--space-3);
+  border-left: 2px solid var(--color-border-muted);
+  margin-bottom: var(--space-1);
 }
 
 hook-desc {
   display: inline;
+  flex: 1;
 }
 
 elapsed {
   display: inline;
-  color: #8b949e;
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", Menlo, monospace;
-  font-size: 0.7rem;
-  margin-left: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-subtle);
+  flex-shrink: 0;
 }
 
-/* === responsive === */
+/* ─── Tablet: 600px ──────────────────────────────────────────────────────── */
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
+  dashboard {
+    font-size: 15px;
+  }
+
   title {
-    padding: 0.5rem 1rem;
+    padding: var(--space-3) var(--space-6);
+    font-size: 1.1rem;
+  }
+
+  header {
+    padding: var(--space-2) var(--space-6);
   }
 
   card {
-    margin: 0.5rem 1rem;
-    padding: 0.85rem 1rem;
+    margin: 0 auto var(--space-3);
+    padding: var(--space-5) var(--space-6);
+  }
+
+  issue-title,
+  pr-title {
+    white-space: nowrap;
+  }
+}
+
+/* ─── Desktop: 900px ─────────────────────────────────────────────────────── */
+
+@media (min-width: 900px) {
+  card {
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+  }
+
+  card:hover {
+    box-shadow: var(--shadow-card-hover);
   }
 }

--- a/kennel/static/status.xsl
+++ b/kennel/static/status.xsl
@@ -9,6 +9,18 @@
           styles the result via status.css
 
   Pipeline: server → structural XML → [this XSLT] → display XML → CSS
+
+  Root <kennel> element layout:
+    <kennel_uptime_seconds>  — seconds since kennel started
+    <rate_limit>             — GitHub rate-limit snapshot
+      <rest> <used> <limit> <resets_at>
+      <graphql> ...
+    <repo dog:status="...">  — one per registered repo
+      scalar fields (repo_name, what, busy, ...)
+      <provider_status> nested dict
+      <claude_talker> nested dict
+      <issue_cache> nested dict
+      <webhook_activities> list of <webhook>
 -->
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -19,10 +31,67 @@
 
 <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Root template — dashboard wrapper
+     ═══════════════════════════════════════════════════════════════════════ -->
+
 <xsl:template match="/">
   <xsl:processing-instruction name="xml-stylesheet">type="text/css" href="/static/status.css"</xsl:processing-instruction>
   <dashboard>
     <title>&#x1F43E; kennel</title>
+
+    <!-- Dashboard header: kennel uptime + GitHub rate limits -->
+    <xsl:if test="k:kennel/k:kennel_uptime_seconds != '' or k:kennel/k:rate_limit/k:rest/k:used != ''">
+      <header>
+        <xsl:if test="k:kennel/k:kennel_uptime_seconds != ''">
+          <kennel-uptime>
+            <xsl:text>up </xsl:text>
+            <xsl:call-template name="format-duration">
+              <xsl:with-param name="seconds" select="k:kennel/k:kennel_uptime_seconds"/>
+            </xsl:call-template>
+          </kennel-uptime>
+        </xsl:if>
+        <xsl:if test="k:kennel/k:rate_limit/k:rest/k:used != ''">
+          <rate-limits>
+            <rate-window dog:kind="rest">
+              <rate-label>REST</rate-label>
+              <rate-nums>
+                <xsl:value-of select="k:kennel/k:rate_limit/k:rest/k:used"/>
+                <xsl:text>/</xsl:text>
+                <xsl:value-of select="k:kennel/k:rate_limit/k:rest/k:limit"/>
+              </rate-nums>
+              <xsl:if test="k:kennel/k:rate_limit/k:rest/k:resets_at != ''">
+                <rate-reset>
+                  <xsl:text>resets </xsl:text>
+                  <xsl:call-template name="format-time">
+                    <xsl:with-param name="iso" select="k:kennel/k:rate_limit/k:rest/k:resets_at"/>
+                  </xsl:call-template>
+                </rate-reset>
+              </xsl:if>
+            </rate-window>
+            <xsl:if test="k:kennel/k:rate_limit/k:graphql/k:used != ''">
+              <rate-window dog:kind="graphql">
+                <rate-label>GraphQL</rate-label>
+                <rate-nums>
+                  <xsl:value-of select="k:kennel/k:rate_limit/k:graphql/k:used"/>
+                  <xsl:text>/</xsl:text>
+                  <xsl:value-of select="k:kennel/k:rate_limit/k:graphql/k:limit"/>
+                </rate-nums>
+                <xsl:if test="k:kennel/k:rate_limit/k:graphql/k:resets_at != ''">
+                  <rate-reset>
+                    <xsl:text>resets </xsl:text>
+                    <xsl:call-template name="format-time">
+                      <xsl:with-param name="iso" select="k:kennel/k:rate_limit/k:graphql/k:resets_at"/>
+                    </xsl:call-template>
+                  </rate-reset>
+                </xsl:if>
+              </rate-window>
+            </xsl:if>
+          </rate-limits>
+        </xsl:if>
+      </header>
+    </xsl:if>
+
     <xsl:choose>
       <xsl:when test="k:kennel/k:repo">
         <xsl:apply-templates select="k:kennel/k:repo"/>
@@ -34,14 +103,22 @@
   </dashboard>
 </xsl:template>
 
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Per-repo card
+     ═══════════════════════════════════════════════════════════════════════ -->
+
 <xsl:template match="k:repo">
   <card>
     <xsl:attribute name="dog:status">
       <xsl:value-of select="@dog:status"/>
     </xsl:attribute>
 
-    <name><xsl:value-of select="k:repo_name"/></name>
+    <!-- ── Name + fido state ── -->
+    <name>
+      <xsl:value-of select="k:repo_name"/>
+    </name>
 
+    <!-- Worker uptime floated right -->
     <xsl:if test="k:worker_uptime_seconds != ''">
       <uptime>
         <xsl:text>up </xsl:text>
@@ -51,8 +128,65 @@
       </uptime>
     </xsl:if>
 
-    <activity><xsl:value-of select="k:what"/></activity>
+    <!-- Current worker activity text -->
+    <activity>
+      <xsl:value-of select="k:what"/>
+    </activity>
 
+    <!-- ── Issue assignment ── -->
+    <xsl:if test="k:issue != ''">
+      <issue-row>
+        <issue-num>
+          <xsl:text>#</xsl:text>
+          <xsl:value-of select="k:issue"/>
+        </issue-num>
+        <xsl:if test="k:issue_title != ''">
+          <issue-title>
+            <xsl:value-of select="k:issue_title"/>
+          </issue-title>
+        </xsl:if>
+        <xsl:if test="k:issue_elapsed_seconds != ''">
+          <issue-elapsed>
+            <xsl:call-template name="format-duration">
+              <xsl:with-param name="seconds" select="k:issue_elapsed_seconds"/>
+            </xsl:call-template>
+          </issue-elapsed>
+        </xsl:if>
+      </issue-row>
+    </xsl:if>
+
+    <!-- ── PR assignment ── -->
+    <xsl:if test="k:pr_number != ''">
+      <pr-row>
+        <pr-num>
+          <xsl:text>PR #</xsl:text>
+          <xsl:value-of select="k:pr_number"/>
+        </pr-num>
+        <xsl:if test="k:pr_title != ''">
+          <pr-title>
+            <xsl:value-of select="k:pr_title"/>
+          </pr-title>
+        </xsl:if>
+      </pr-row>
+    </xsl:if>
+
+    <!-- ── Current task progress ── -->
+    <xsl:if test="k:current_task != ''">
+      <task-row>
+        <xsl:if test="k:task_number != '' and k:task_total != ''">
+          <task-pos>
+            <xsl:value-of select="k:task_number"/>
+            <xsl:text>/</xsl:text>
+            <xsl:value-of select="k:task_total"/>
+          </task-pos>
+        </xsl:if>
+        <task-title>
+          <xsl:value-of select="k:current_task"/>
+        </task-title>
+      </task-row>
+    </xsl:if>
+
+    <!-- ── Badges ── -->
     <badges>
       <xsl:if test="k:crash_count &gt; 0">
         <badge dog:kind="crash">
@@ -80,8 +214,49 @@
           </xsl:if>
         </badge>
       </xsl:if>
+
+      <xsl:if test="k:session_dropped_count &gt; 0">
+        <badge dog:kind="session-dropped">
+          <xsl:value-of select="k:session_dropped_count"/>
+          <xsl:text> session</xsl:text>
+          <xsl:if test="k:session_dropped_count &gt; 1">s</xsl:if>
+          <xsl:text> dropped</xsl:text>
+        </badge>
+      </xsl:if>
+
+      <xsl:if test="k:provider_status/k:paused = 'true'">
+        <badge dog:kind="provider-paused">
+          <xsl:value-of select="k:provider"/>
+          <xsl:text> paused</xsl:text>
+          <xsl:if test="k:provider_status/k:resets_at != ''">
+            <xsl:text> until </xsl:text>
+            <xsl:call-template name="format-time">
+              <xsl:with-param name="iso" select="k:provider_status/k:resets_at"/>
+            </xsl:call-template>
+          </xsl:if>
+        </badge>
+      </xsl:if>
     </badges>
 
+    <!-- ── Provider pressure (when not paused) ── -->
+    <xsl:if test="k:provider_status/k:percent_used != '' and k:provider_status/k:paused != 'true'">
+      <pressure>
+        <pressure-label>
+          <xsl:value-of select="k:provider"/>
+        </pressure-label>
+        <pressure-pct>
+          <xsl:value-of select="k:provider_status/k:percent_used"/>
+          <xsl:text>%</xsl:text>
+        </pressure-pct>
+        <xsl:if test="k:provider_status/k:window_name != ''">
+          <pressure-window>
+            <xsl:value-of select="k:provider_status/k:window_name"/>
+          </pressure-window>
+        </xsl:if>
+      </pressure>
+    </xsl:if>
+
+    <!-- ── Active claude talker ── -->
     <xsl:if test="k:claude_talker/k:kind">
       <talker>
         <label>claude</label>
@@ -96,10 +271,38 @@
       </talker>
     </xsl:if>
 
+    <!-- ── Last crash error ── -->
     <xsl:if test="k:last_crash_error != ''">
       <crash-detail><xsl:value-of select="k:last_crash_error"/></crash-detail>
     </xsl:if>
 
+    <!-- ── Issue cache summary ── -->
+    <xsl:if test="k:issue_cache/k:loaded = 'true'">
+      <issue-cache>
+        <xsl:if test="k:issue_cache/k:open_issues != ''">
+          <cache-issues>
+            <xsl:value-of select="k:issue_cache/k:open_issues"/>
+            <xsl:text> open</xsl:text>
+          </cache-issues>
+        </xsl:if>
+        <xsl:if test="k:issue_cache/k:events_applied &gt; 0">
+          <cache-events>
+            <xsl:value-of select="k:issue_cache/k:events_applied"/>
+            <xsl:text> event</xsl:text>
+            <xsl:if test="k:issue_cache/k:events_applied &gt; 1">s</xsl:if>
+            <xsl:text> applied</xsl:text>
+          </cache-events>
+        </xsl:if>
+        <xsl:if test="k:issue_cache/k:events_dropped_stale &gt; 0">
+          <cache-dropped>
+            <xsl:value-of select="k:issue_cache/k:events_dropped_stale"/>
+            <xsl:text> stale</xsl:text>
+          </cache-dropped>
+        </xsl:if>
+      </issue-cache>
+    </xsl:if>
+
+    <!-- ── In-flight webhook handlers ── -->
     <xsl:if test="k:webhook_activities/k:webhook">
       <hooks>
         <hooks-label>webhooks</hooks-label>
@@ -119,7 +322,11 @@
   </card>
 </xsl:template>
 
-<!-- Format seconds into compact human-readable duration -->
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Utility templates
+     ═══════════════════════════════════════════════════════════════════════ -->
+
+<!-- Format seconds into compact human-readable duration: 2h13m, 45m, 8s -->
 <xsl:template name="format-duration">
   <xsl:param name="seconds"/>
   <xsl:variable name="s" select="floor(number($seconds))"/>
@@ -141,6 +348,14 @@
       <xsl:value-of select="$sec"/><xsl:text>s</xsl:text>
     </xsl:otherwise>
   </xsl:choose>
+</xsl:template>
+
+<!-- Extract HH:MM UTC from an ISO-8601 timestamp (e.g. 2026-04-19T13:00:00+00:00) -->
+<xsl:template name="format-time">
+  <xsl:param name="iso"/>
+  <xsl:variable name="time-part" select="substring-after($iso, 'T')"/>
+  <xsl:value-of select="substring($time-part, 1, 5)"/>
+  <xsl:text> UTC</xsl:text>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -663,6 +663,369 @@ class TestGetEndpoint:
         data = json.loads(resp.read())
         assert data["activities"][0]["rescoping"] is False
 
+    def test_status_endpoint_includes_fido_state_defaults_when_no_files(
+        self, server: tuple
+    ) -> None:
+        """With no state.json or tasks.json on disk, fido_state fields default."""
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #1",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.get_session_dropped_count.return_value = 0
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        entry = data["activities"][0]
+        assert entry["fido_running"] is False
+        assert entry["issue"] is None
+        assert entry["issue_title"] is None
+        assert entry["issue_elapsed_seconds"] is None
+        assert entry["pr_number"] is None
+        assert entry["pr_title"] is None
+        assert entry["pending"] == 0
+        assert entry["completed"] == 0
+        assert entry["current_task"] is None
+        assert entry["task_number"] is None
+        assert entry["task_total"] is None
+
+    def test_status_endpoint_includes_fido_state_from_files(
+        self, server: tuple, tmp_path: Path
+    ) -> None:
+        """state.json and tasks.json on disk are surfaced in the activity entry."""
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        # Write state.json
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        state = {
+            "issue": 42,
+            "issue_title": "Fix the thing",
+            "issue_started_at": "2026-04-01T00:00:00+00:00",
+            "pr_number": 99,
+            "pr_title": "Fixes the thing",
+        }
+        (fido_dir / "state.json").write_text(json.dumps(state))
+
+        # Write tasks.json
+        tasks_path = fido_dir / "tasks.json"
+        tasks = [
+            {
+                "id": "1",
+                "title": "first task",
+                "type": "spec",
+                "status": "completed",
+                "description": "",
+            },
+            {
+                "id": "2",
+                "title": "active task",
+                "type": "spec",
+                "status": "in_progress",
+                "description": "",
+            },
+            {
+                "id": "3",
+                "title": "later task",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+        ]
+        tasks_path.write_text(json.dumps(tasks))
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #42",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.get_session_dropped_count.return_value = 0
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        entry = data["activities"][0]
+        assert entry["issue"] == 42
+        assert entry["issue_title"] == "Fix the thing"
+        assert entry["issue_elapsed_seconds"] is not None
+        assert entry["issue_elapsed_seconds"] >= 0
+        assert entry["pr_number"] == 99
+        assert entry["pr_title"] == "Fixes the thing"
+        assert entry["pending"] == 1
+        assert entry["completed"] == 1
+        assert entry["current_task"] == "active task"
+        assert entry["task_number"] == 1
+        assert entry["task_total"] == 2
+
+    def test_status_endpoint_fido_state_defaults_when_repo_cfg_missing(
+        self, server: tuple
+    ) -> None:
+        """When a repo has no config entry, fido_state fields are all defaults."""
+        from datetime import datetime, timezone
+
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        # Report an activity for a repo not in config
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="unknown/repo",
+                what="idle",
+                busy=False,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.get_session_dropped_count.return_value = 0
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        entry = data["activities"][0]
+        assert entry["fido_running"] is False
+        assert entry["issue"] is None
+        assert entry["pending"] == 0
+        assert entry["task_number"] is None
+
+
+class TestCollectFidoState:
+    """Unit tests for _collect_fido_state covering edge-case branches."""
+
+    def _now(self) -> Any:
+        from datetime import datetime, timezone
+
+        return datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_defaults_when_no_files(self, tmp_path: Path) -> None:
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["fido_running"] is False
+        assert result["issue"] is None
+        assert result["issue_title"] is None
+        assert result["issue_elapsed_seconds"] is None
+        assert result["pr_number"] is None
+        assert result["pr_title"] is None
+        assert result["pending"] == 0
+        assert result["completed"] == 0
+        assert result["current_task"] is None
+        assert result["task_number"] is None
+        assert result["task_total"] is None
+
+    def test_lock_file_exists_not_held(self, tmp_path: Path) -> None:
+        """Lock file exists but is not held by another process → fido_running=False."""
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        (fido_dir / "lock").touch()
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["fido_running"] is False
+
+    def test_lock_file_held(self, tmp_path: Path) -> None:
+        """Lock file held by another thread → fido_running=True."""
+        import fcntl
+        import threading
+
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        lock_path = fido_dir / "lock"
+        lock_path.touch()
+
+        ready = threading.Event()
+        release = threading.Event()
+
+        def hold_lock() -> None:
+            with open(lock_path) as fd:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                ready.set()
+                release.wait(timeout=5)
+                fcntl.flock(fd, fcntl.LOCK_UN)
+
+        t = threading.Thread(target=hold_lock, daemon=True)
+        t.start()
+        ready.wait(timeout=5)
+        try:
+            result = _collect_fido_state(tmp_path, self._now())
+            assert result["fido_running"] is True
+        finally:
+            release.set()
+            t.join(timeout=5)
+
+    def test_lock_file_oserror(self, tmp_path: Path) -> None:
+        """If opening the lock file raises OSError, fido_running stays False."""
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        # Create a directory at the lock path to cause OSError on open()
+        (fido_dir / "lock").mkdir()
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["fido_running"] is False
+
+    def test_state_load_exception(self, tmp_path: Path) -> None:
+        """If State.load() raises, state fields default gracefully."""
+        from unittest.mock import patch
+
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        with patch("kennel.server.State") as mock_state_cls:
+            mock_state_cls.return_value.load.side_effect = RuntimeError("disk error")
+            result = _collect_fido_state(tmp_path, self._now())
+        assert result["issue"] is None
+        assert result["issue_title"] is None
+        assert result["pr_number"] is None
+
+    def test_invalid_issue_started_at(self, tmp_path: Path) -> None:
+        """Malformed issue_started_at is silently ignored."""
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        (fido_dir / "state.json").write_text(
+            json.dumps({"issue": 1, "issue_started_at": "not-a-date"})
+        )
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["issue"] == 1
+        assert result["issue_elapsed_seconds"] is None
+
+    def test_tasks_load_exception(self, tmp_path: Path) -> None:
+        """If Tasks.list() raises, task fields default gracefully."""
+        from unittest.mock import patch
+
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        with patch("kennel.server.Tasks") as mock_tasks_cls:
+            mock_tasks_cls.return_value.list.side_effect = RuntimeError("disk error")
+            result = _collect_fido_state(tmp_path, self._now())
+        assert result["pending"] == 0
+        assert result["current_task"] is None
+        assert result["task_number"] is None
+
+    def test_current_task_from_pending_when_no_in_progress(
+        self, tmp_path: Path
+    ) -> None:
+        """current_task comes from the first pending task when none are in_progress."""
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        tasks = [
+            {
+                "id": "1",
+                "title": "do this",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+            {
+                "id": "2",
+                "title": "then that",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+        ]
+        (fido_dir / "tasks.json").write_text(json.dumps(tasks))
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["current_task"] == "do this"
+        assert result["task_number"] == 1
+        assert result["task_total"] == 2
+
+    def test_task_number_from_in_progress(self, tmp_path: Path) -> None:
+        """task_number correctly reflects the in_progress task's position."""
+        from kennel.server import (
+            _collect_fido_state,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        tasks = [
+            {
+                "id": "1",
+                "title": "done",
+                "type": "spec",
+                "status": "completed",
+                "description": "",
+            },
+            {
+                "id": "2",
+                "title": "first pending",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+            {
+                "id": "3",
+                "title": "active",
+                "type": "spec",
+                "status": "in_progress",
+                "description": "",
+            },
+            {
+                "id": "4",
+                "title": "later",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+        ]
+        (fido_dir / "tasks.json").write_text(json.dumps(tasks))
+        result = _collect_fido_state(tmp_path, self._now())
+        assert result["current_task"] == "active"
+        assert result["task_number"] == 2  # position in non-completed list
+        assert result["task_total"] == 3
+
 
 class TestRepoStatus:
     @pytest.mark.parametrize(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -101,6 +101,7 @@ def _restore_handler_fns():
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
         "infra": WebhookHandler.infra,
         "static_files": WebhookHandler.static_files,
+        "kennel_started_at": WebhookHandler.kennel_started_at,
     }
     # Override _fn_after_do_post for all tests so _post_webhook can wait for
     # do_POST to complete without sleeping (see module-level comment above).
@@ -329,7 +330,11 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_all_activities.return_value = []
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
-        assert json.loads(resp.read()) == {"activities": [], "rate_limit": None}
+        assert json.loads(resp.read()) == {
+            "activities": [],
+            "rate_limit": None,
+            "kennel_uptime_seconds": None,
+        }
 
     def test_status_endpoint_content_type_json(self, server: tuple) -> None:
         url, _ = server
@@ -1241,6 +1246,139 @@ class TestStatusXml:
         body = resp.read().decode()
         assert "<description>replying to review</description>" in body
         assert "<thread_id>789</thread_id>" in body
+
+    def test_status_xml_includes_kennel_uptime(self, server: tuple) -> None:
+        """<kennel_uptime_seconds> appears in the root element when kennel_started_at is set."""
+        from datetime import datetime, timezone
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.kennel_started_at = datetime(
+            2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<kennel_uptime_seconds>" in body
+
+    def test_status_xml_no_kennel_uptime_when_not_started(self, server: tuple) -> None:
+        """<kennel_uptime_seconds> is absent when kennel_started_at is None (default)."""
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        assert WebhookHandler.kennel_started_at is None
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<kennel_uptime_seconds>" not in body
+
+    def test_status_xml_includes_rate_limit(self, server: tuple) -> None:
+        """<rate_limit> with nested windows appears in the root element when available."""
+        from datetime import UTC, datetime
+
+        from kennel.rate_limit import (
+            RateLimitMonitor,
+            RateLimitSnapshot,
+            RateLimitWindow,
+        )
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        snap = RateLimitSnapshot(
+            rest=RateLimitWindow(
+                name="rest",
+                used=100,
+                limit=5000,
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=UTC),
+            ),
+            graphql=RateLimitWindow(
+                name="graphql",
+                used=5,
+                limit=5000,
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=UTC),
+            ),
+            fetched_at=datetime(2026, 4, 19, 12, 0, tzinfo=UTC),
+        )
+        monitor = MagicMock(spec=RateLimitMonitor)
+        monitor.latest.return_value = snap
+        WebhookHandler.rate_limit_monitor = monitor
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<rate_limit>" in body
+        assert "<rest>" in body
+        assert "<used>100</used>" in body
+        assert "<graphql>" in body
+        assert "<used>5</used>" in body
+
+    def test_status_json_includes_kennel_uptime(self, server: tuple) -> None:
+        """kennel_uptime_seconds appears in /status.json when kennel_started_at is set."""
+        from datetime import datetime, timezone
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.kennel_started_at = datetime(
+            2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        assert data["kennel_uptime_seconds"] is not None
+        assert data["kennel_uptime_seconds"] >= 0
+
+    def test_status_json_kennel_uptime_null_when_not_started(
+        self, server: tuple
+    ) -> None:
+        """kennel_uptime_seconds is null in /status.json when kennel_started_at is None."""
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = []
+        assert WebhookHandler.kennel_started_at is None
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        assert data["kennel_uptime_seconds"] is None
+
+    def test_status_xml_includes_issue_cache_as_nested_elements(
+        self, server: tuple
+    ) -> None:
+        """issue_cache dict is emitted as nested XML children, not as str(dict)."""
+        from datetime import datetime, timezone
+
+        from kennel.issue_cache import IssueTreeCache
+        from kennel.registry import WorkerActivity
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="working",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+
+        cache = IssueTreeCache("owner/repo")
+        cache.load_inventory(
+            [
+                {
+                    "number": 3,
+                    "title": "demo",
+                    "createdAt": "2026-04-01T00:00:00Z",
+                    "assignees": {"nodes": []},
+                    "subIssues": {"nodes": []},
+                }
+            ],
+            snapshot_started_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
+        )
+        WebhookHandler.registry.get_issue_cache.return_value = cache
+
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        assert "<issue_cache>" in body
+        assert "<open_issues>1</open_issues>" in body
+        assert "<loaded>true</loaded>" in body
 
 
 class TestStaticFileServing:


### PR DESCRIPTION
Fixes #839.

Surfaces all `kennel status` CLI data (issue/PR assignments, task progress, rate limits, provider pressure) on the XML→XSLT→CSS status endpoint, then revamps the styling mobile-first following Apple HIG and Material design guidelines.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Expand XSLT to render all status fields <!-- type:spec -->
- [x] Redesign CSS for mobile-first Apple HIG / Material style <!-- type:spec -->
- [x] Add kennel-level metadata to XML output <!-- type:spec -->
- [x] Add issue/PR/task fields to server activity collection <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->