### PR TITLE
Rocq→Python A3 — records + primitive projections (closes #720)

### DIFF
--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -83,3 +83,19 @@
   (progn
    (run python3 %{dep:test/check_has_left3.py})
    (run python3 %{dep:test/check_expr_is_num_pair.py}))))
+
+; Phase 6 round-trip tests: record projections (issue #720).
+; 2-field record: basic projection (first field, second field) and field-swap
+;   construction — verifies MLcase Record → attribute-access lambda-lift.
+; 5-field record: all 5 named fields accessible by name — the acceptance
+;   criterion that record projections use readable Python identifiers, not
+;   positional _0/_1/… names.
+(rule
+ (alias runtest)
+ (deps test/phase6.vo
+       test/check_proj_pair_r.py
+       test/check_point5.py)
+ (action
+  (progn
+   (run python3 %{dep:test/check_proj_pair_r.py})
+   (run python3 %{dep:test/check_point5.py}))))

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -202,6 +202,47 @@ let rec pp_pattern state env' = function
   | Pwild ->
       str "_"
 
+(*s Record-projection detection helper.
+
+    Returns [Some (r, fds, sub_pats)] when [branches] describes a single-branch
+    match that the optimiser can convert into lambda-lifted attribute accesses:
+
+      (lambda param_0, param_1, …: body)(scrutinee.field_0, scrutinee.field_1, …)
+
+    Three conditions must hold:
+    1. Exactly one branch.
+    2. The branch pattern is [Pusual r] or [Pcons(r,_)] for a constructor [r]
+       whose parent inductive is a record ([get_record_fields] is non-empty).
+    3. Every expanded sub-pattern is [Prel k] (bound) or [Pwild] (discarded),
+       and the sub-pattern count matches the field count.
+
+    Condition 3 rules out nested constructor patterns inside a field position,
+    which require genuine case analysis rather than a plain attribute access.
+
+    Used by both [pp_expr] (expression context) and [pp_return_body] (inside
+    a [def] body), so the optimisation fires in both settings. *)
+let record_proj_info state branches =
+  if Array.length branches <> 1 then None
+  else
+    let (ids, pat, _) = branches.(0) in
+    match pat with
+    | Pusual r | Pcons (r, _) ->
+        let fds = get_record_fields (State.get_table state) r in
+        if List.is_empty fds then None
+        else
+          (* Expand [Pusual r] into [Pcons(r, pats)] for uniform treatment;
+             [Pcons] is returned unchanged by [expand_pusual]. *)
+          ( match expand_pusual (List.length ids) pat with
+            | Pcons (_, sub_pats) ->
+                if List.length sub_pats = List.length fds &&
+                   List.for_all
+                     (function Prel _ | Pwild -> true | _ -> false)
+                     sub_pats
+                then Some (r, fds, sub_pats)
+                else None
+            | _ -> None )
+    | _ -> None
+
 (*s Core expression printer.
     [env] carries de Bruijn binder names (innermost first). *)
 
@@ -354,50 +395,38 @@ let rec pp_expr state env = function
              (lambda f0, f1, …: body)(scrutinee.f0, scrutinee.f1, …)
            This mirrors [MLletin]'s lambda-lift strategy and stays at
            expression level without a [match] statement.
-           Detection: one branch whose pattern is [Pusual r] or [Pcons(r,_)]
-           where [r] is a constructor with non-empty record fields. *)
-        let record_proj_opt =
-          if Array.length branches = 1 then
-            let (_, pat, _) = branches.(0) in
-            ( match pat with
-              | Pusual r | Pcons (r, _) ->
-                  let fds = get_record_fields (State.get_table state) r in
-                  if List.is_empty fds then None else Some (r, fds)
-              | _ -> None )
-          else None
-        in
-        (match record_proj_opt with
-        | Some (r, fds) ->
-            (* [ids] is outermost-first (field-0 first); [push_vars] wants
-               innermost-first, so reverse.  The returned [names] list is in
-               the same order as the (reversed) input — i.e. innermost-first.
-               Reversing again gives field order: [name_0; …; name_{n-1}]. *)
+           [record_proj_info] handles the full detection and edge-case guarding.
+
+           Key subtlety: branch [ids] only contains BOUND binders.  Wildcard
+           sub-patterns in Rocq source compile to real variable binders (with
+           fresh generated names) rather than [Pwild] in MiniML — so in
+           practice every sub-pattern is [Prel k] and every field has a bound
+           name.  The [Pwild] arm is kept as a defence against future changes. *)
+        (match record_proj_info state branches with
+        | Some (r, fds, sub_pats) ->
             let (ids, _, body) = branches.(0) in
-            let names, env' = push_vars (List.rev_map id_of_mlid ids) env in
-            let field_names = List.rev names in
-            let n = List.length field_names in
-            (* For erased binders ([dummy_name]) use a unique synthetic name
-               [_e<i>] so that multiple erased params don't collide in the
-               lambda signature (Python disallows duplicate param names). *)
-            let pp_param i id =
-              if Id.equal id dummy_name
-              then str ("_e" ^ string_of_int i)
-              else pp_pyid id
+            let n_fds = List.length fds in
+            (* Push all binders (innermost-first for push_vars). *)
+            let _, env' = push_vars (List.rev_map id_of_mlid ids) env in
+            (* Derive the lambda parameter name for field position [i]:
+               [Prel k] → look up the name at depth [k] in [env']
+               [Pwild]  → synthetic [_e<i>] (can't repeat [_] in a lambda) *)
+            let pp_param_for_pos i =
+              match List.nth sub_pats i with
+              | Prel k -> pp_pyid (get_db_name k env')
+              | _      -> str ("_e" ^ string_of_int i)
             in
-            (* Scrutinee is evaluated once as a [pp] value; pure extraction
-               terms never have side effects so repeating it is safe, but
-               sharing the printed token avoids spurious string duplication. *)
+            (* Scrutinee is pure; sharing the [pp] value avoids duplication. *)
             let pp_scr = pp_expr state env scrutinee in
             let pp_arg i = pp_scr ++ str "." ++ pp_field_name state r fds i in
             str "(lambda " ++
-            prlist_with_sep (fun () -> str ", ")
-              (fun (i, id) -> pp_param i id)
-              (List.mapi (fun i id -> (i, id)) field_names) ++
+            prlist_with_sep (fun () -> str ", ") pp_param_for_pos
+              (List.init n_fds (fun i -> i)) ++
             str ": " ++
             pp_expr state env' body ++
             str ")(" ++
             prlist_with_sep (fun () -> str ", ") pp_arg
-              (List.init n (fun i -> i)) ++
+              (List.init n_fds (fun i -> i)) ++
             str ")"
         | None ->
         (* General match: emit Python [match]/[case] statement.
@@ -534,29 +563,36 @@ let rec pp_return_body state env indent = function
         str "return " ++
         pp_custom_match_expr state env (find_custom_match branches) scrutinee branches
       else
-        (* General match: put [return] inside each arm so the branch is
-           a valid statement.  [case] must be indented inside the [match]
-           block; [body] must be indented inside the [case] block. *)
-        let case_pfx = String.make (indent + 4) ' ' in
-        let body_pfx = String.make (indent + 8) ' ' in
-        let pp_branch (ids, pat, body) =
-          let _ids', env' = push_vars (List.rev_map id_of_mlid ids) env in
-          let pp_pat  = pp_pattern state env' (expand_pusual (List.length ids) pat) in
-          str case_pfx ++ str "case " ++ pp_pat ++ str ":" ++ fnl () ++
-          str body_pfx ++ pp_return_body state env' (indent + 8) body
-        in
-        (* Same catch-all logic as the expression-context path: append
-           [case _: assert_never(_)] unless the last explicit arm is already
-           a wildcard.  [_] is a valid Python variable even in [case _:],
-           so passing it to [assert_never] satisfies type checkers. *)
-        let catch_all =
-          if has_wildcard_last branches then mt ()
-          else fnl () ++ str case_pfx ++ str "case _:" ++ fnl () ++
-               str body_pfx ++ str "assert_never(_)"
-        in
-        str "match " ++ pp_expr state env scrutinee ++ str ":" ++ fnl () ++
-        prlist_with_sep fnl pp_branch (Array.to_list branches) ++
-        catch_all
+        (* Record projection — [record_proj_info] detects the single-branch
+           record match; [pp_expr] emits the lambda-lift form, which is a
+           valid expression so a single [return] suffices. *)
+        ( match record_proj_info state branches with
+          | Some _ ->
+              str "return " ++ pp_expr state env expr
+          | None ->
+              (* General match: put [return] inside each arm so the branch is
+                 a valid statement.  [case] must be indented inside the [match]
+                 block; [body] must be indented inside the [case] block. *)
+              let case_pfx = String.make (indent + 4) ' ' in
+              let body_pfx = String.make (indent + 8) ' ' in
+              let pp_branch (ids, pat, body) =
+                let _ids', env' = push_vars (List.rev_map id_of_mlid ids) env in
+                let pp_pat  = pp_pattern state env' (expand_pusual (List.length ids) pat) in
+                str case_pfx ++ str "case " ++ pp_pat ++ str ":" ++ fnl () ++
+                str body_pfx ++ pp_return_body state env' (indent + 8) body
+              in
+              (* Same catch-all logic as the expression-context path: append
+                 [case _: assert_never(_)] unless the last explicit arm is already
+                 a wildcard.  [_] is a valid Python variable even in [case _:],
+                 so passing it to [assert_never] satisfies type checkers. *)
+              let catch_all =
+                if has_wildcard_last branches then mt ()
+                else fnl () ++ str case_pfx ++ str "case _:" ++ fnl () ++
+                     str body_pfx ++ str "assert_never(_)"
+              in
+              str "match " ++ pp_expr state env scrutinee ++ str ":" ++ fnl () ++
+              prlist_with_sep fnl pp_branch (Array.to_list branches) ++
+              catch_all )
   | MLaxiom _ | MLexn _ | MLparray _ as expr ->
       (* These emit [raise …], which is a valid Python statement but NOT a
          valid expression.  Emit bare — no [return] prefix. *)

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -348,6 +348,58 @@ let rec pp_expr state env = function
            [nat → int] whose constructors do not exist as Python patterns. *)
         pp_custom_match_expr state env (find_custom_match branches) scrutinee branches
       else
+        (* Record projection: single-branch match over a record inductive.
+           Instead of [match scrutinee: case Ctor(f0,f1): body], emit the
+           lambda-lifted attribute form:
+             (lambda f0, f1, …: body)(scrutinee.f0, scrutinee.f1, …)
+           This mirrors [MLletin]'s lambda-lift strategy and stays at
+           expression level without a [match] statement.
+           Detection: one branch whose pattern is [Pusual r] or [Pcons(r,_)]
+           where [r] is a constructor with non-empty record fields. *)
+        let record_proj_opt =
+          if Array.length branches = 1 then
+            let (_, pat, _) = branches.(0) in
+            ( match pat with
+              | Pusual r | Pcons (r, _) ->
+                  let fds = get_record_fields (State.get_table state) r in
+                  if List.is_empty fds then None else Some (r, fds)
+              | _ -> None )
+          else None
+        in
+        (match record_proj_opt with
+        | Some (r, fds) ->
+            (* [ids] is outermost-first (field-0 first); [push_vars] wants
+               innermost-first, so reverse.  The returned [names] list is in
+               the same order as the (reversed) input — i.e. innermost-first.
+               Reversing again gives field order: [name_0; …; name_{n-1}]. *)
+            let (ids, _, body) = branches.(0) in
+            let names, env' = push_vars (List.rev_map id_of_mlid ids) env in
+            let field_names = List.rev names in
+            let n = List.length field_names in
+            (* For erased binders ([dummy_name]) use a unique synthetic name
+               [_e<i>] so that multiple erased params don't collide in the
+               lambda signature (Python disallows duplicate param names). *)
+            let pp_param i id =
+              if Id.equal id dummy_name
+              then str ("_e" ^ string_of_int i)
+              else pp_pyid id
+            in
+            (* Scrutinee is evaluated once as a [pp] value; pure extraction
+               terms never have side effects so repeating it is safe, but
+               sharing the printed token avoids spurious string duplication. *)
+            let pp_scr = pp_expr state env scrutinee in
+            let pp_arg i = pp_scr ++ str "." ++ pp_field_name state r fds i in
+            str "(lambda " ++
+            prlist_with_sep (fun () -> str ", ")
+              (fun (i, id) -> pp_param i id)
+              (List.mapi (fun i id -> (i, id)) field_names) ++
+            str ": " ++
+            pp_expr state env' body ++
+            str ")(" ++
+            prlist_with_sep (fun () -> str ", ") pp_arg
+              (List.init n (fun i -> i)) ++
+            str ")"
+        | None ->
         (* General match: emit Python [match]/[case] statement.
            This is a statement in Python, so it only works correctly when the
            surrounding [Dterm] or [MLletin] emits it inside a function body.
@@ -377,7 +429,7 @@ let rec pp_expr state env = function
         in
         str "match " ++ pp_expr state env scrutinee ++ str ":" ++ fnl () ++
         prlist_with_sep fnl pp_branch (Array.to_list branches) ++
-        catch_all
+        catch_all)
   | MLfix (i, ids, defs) ->
       (* Mutual fixpoint: push all n names into the env (reversed, per the
          extraction convention so [ids.(0)] becomes the outermost binder),

--- a/rocq-python-extraction/test/check_point5.py
+++ b/rocq-python-extraction/test/check_point5.py
@@ -1,0 +1,49 @@
+# ruff: noqa: E402
+import os
+import sys
+
+# The extracted .py files always land in the dune workspace build root (_build/default/).
+# Walk up from __file__ to find it — works whether or not dune-workspace is present.
+_d = os.path.dirname(os.path.abspath(__file__))
+while not (
+    os.path.basename(_d) == "default"
+    and os.path.basename(os.path.dirname(_d)) == "_build"
+):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+del _d
+
+from get_p5_v import get_p5_v
+from get_p5_w import get_p5_w
+from get_p5_x import MkPoint5, get_p5_x
+from get_p5_y import get_p5_y
+from get_p5_z import get_p5_z
+
+# Build a point5 with 5 distinct field values so each projection is testable.
+p = MkPoint5(p5_x=10, p5_y=20, p5_z=30, p5_w=40, p5_v=50)
+
+# --- individual field projections ---
+assert get_p5_x(p) == 10, "get_p5_x: got " + repr(get_p5_x(p))
+assert get_p5_y(p) == 20, "get_p5_y: got " + repr(get_p5_y(p))
+assert get_p5_z(p) == 30, "get_p5_z: got " + repr(get_p5_z(p))
+assert get_p5_w(p) == 40, "get_p5_w: got " + repr(get_p5_w(p))
+assert get_p5_v(p) == 50, "get_p5_v: got " + repr(get_p5_v(p))
+
+# --- acceptance criterion: field names are readable Python identifiers ---
+# Verify that the generated dataclass exposes each field by its declared name,
+# not as positional _0/_1/… attributes.
+assert p.p5_x == 10, "p.p5_x != 10"
+assert p.p5_y == 20, "p.p5_y != 20"
+assert p.p5_z == 30, "p.p5_z != 30"
+assert p.p5_w == 40, "p.p5_w != 40"
+assert p.p5_v == 50, "p.p5_v != 50"
+
+# Zero-boundary check
+zero = MkPoint5(p5_x=0, p5_y=0, p5_z=0, p5_w=0, p5_v=0)
+assert get_p5_x(zero) == 0, "get_p5_x(zero)"
+assert get_p5_v(zero) == 0, "get_p5_v(zero)"
+
+# Type sanity
+assert isinstance(p, MkPoint5), "p must be instance of MkPoint5"
+
+print("Phase 6 point5 projection round-trip: OK")

--- a/rocq-python-extraction/test/check_proj_pair_r.py
+++ b/rocq-python-extraction/test/check_proj_pair_r.py
@@ -1,0 +1,62 @@
+# ruff: noqa: E402
+import os
+import sys
+
+# The extracted .py files always land in the dune workspace build root (_build/default/).
+# Walk up from __file__ to find it — works whether or not dune-workspace is present.
+_d = os.path.dirname(os.path.abspath(__file__))
+while not (
+    os.path.basename(_d) == "default"
+    and os.path.basename(os.path.dirname(_d)) == "_build"
+):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+del _d
+
+# Each extracted .py file is a self-contained module with its own copy of the
+# MkPairR dataclass.  We import each function from its own module and build
+# test instances from the same module so that isinstance checks stay consistent
+# within each boundary.
+
+from proj_first import MkPairR as MkPairR_pf
+from proj_first import proj_first
+from proj_second import MkPairR as MkPairR_ps
+from proj_second import proj_second
+from swap_pair_r import MkPairR as MkPairR_sw
+from swap_pair_r import swap_pair_r
+
+# --- proj_first ---
+p1 = MkPairR_pf(pfst_r=3, psnd_r=7)
+assert proj_first(p1) == 3, "proj_first(3, 7): got " + repr(proj_first(p1))
+
+p2 = MkPairR_pf(pfst_r=0, psnd_r=99)
+assert proj_first(p2) == 0, "proj_first(0, 99): got " + repr(proj_first(p2))
+
+# --- proj_second ---
+q1 = MkPairR_ps(pfst_r=3, psnd_r=7)
+assert proj_second(q1) == 7, "proj_second(3, 7): got " + repr(proj_second(q1))
+
+q2 = MkPairR_ps(pfst_r=0, psnd_r=99)
+assert proj_second(q2) == 99, "proj_second(0, 99): got " + repr(proj_second(q2))
+
+# Field names are accessible as attributes (acceptance criterion: named fields,
+# not positional _0/_1/…)
+assert p1.pfst_r == 3, "p1.pfst_r != 3"
+assert p1.psnd_r == 7, "p1.psnd_r != 7"
+
+# --- swap_pair_r ---
+s1 = MkPairR_sw(pfst_r=3, psnd_r=7)
+swapped = swap_pair_r(s1)
+assert swapped.pfst_r == 7, "swap(3,7).pfst_r: got " + repr(swapped.pfst_r)
+assert swapped.psnd_r == 3, "swap(3,7).psnd_r: got " + repr(swapped.psnd_r)
+
+# swap is its own inverse
+double_swap = swap_pair_r(swapped)
+assert double_swap.pfst_r == s1.pfst_r, "double-swap pfst_r"
+assert double_swap.psnd_r == s1.psnd_r, "double-swap psnd_r"
+
+# Type sanity (within each module's own class boundary)
+assert isinstance(p1, MkPairR_pf), "p1 must be MkPairR"
+assert isinstance(swapped, MkPairR_sw), "swapped must be MkPairR"
+
+print("Phase 6 pair_r projection round-trip: OK")

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -1,6 +1,6 @@
 (rocq.theory
  (name PyExtractTest)
- (synopsis "Phase 2–5 acceptance tests — core term nodes, primitive remapping, inductive datatype emission, and nested patterns")
+ (synopsis "Phase 2–6 acceptance tests — core term nodes, primitive remapping, inductive datatype emission, nested patterns, and record projections")
  (plugins rocq-python-extraction)
  (theories Stdlib)
- (modules acceptance phase2 phase3 phase4 phase5))
+ (modules acceptance phase2 phase3 phase4 phase5 phase6))

--- a/rocq-python-extraction/test/phase6.v
+++ b/rocq-python-extraction/test/phase6.v
@@ -1,0 +1,87 @@
+(** Phase 6 acceptance tests: record projections (issue #720).
+
+    Exercises [MLcase] on a record inductive, which the new optimisation
+    converts to a lambda-lifted attribute-access form instead of a
+    [match]/[case] statement:
+
+      (lambda f0, f1, …: body)(scrutinee.f0, scrutinee.f1, …)
+
+    Coverage:
+      2-field record [pair_r]: projection of first field, second field, and
+        a swap function that reads both fields and constructs a new record.
+      5-field record [point5]: individual projection of each of the 5 named
+        fields — this is the acceptance criterion from issue #720: "a Rocq
+        record with 5 named fields extracts with readable Python field names
+        and attribute access". *)
+
+Declare ML Module "rocq-python-extraction".
+
+(* [Extract Inductive] and related vernaculars need the extraction plugin. *)
+Declare ML Module "rocq-runtime.plugins.extraction".
+
+(* Remap nat → int so round-trip assertions operate on plain Python ints. *)
+Extract Inductive nat => "int"
+  [ "0" "(lambda x: x + 1)" ]
+  "(lambda fO, fS, n: fO() if n == 0 else fS(n - 1))".
+
+(* ------------------------------------------------------------------ *)
+(*  1. 2-field record — basic projection and swap                      *)
+(* ------------------------------------------------------------------ *)
+
+Record pair_r := MkPairR { pfst_r : nat ; psnd_r : nat }.
+
+(** [proj_first]: project the first field. The single-branch MLcase triggers
+    the record-projection optimisation, yielding attribute access [p.pfst_r]. *)
+Definition proj_first (p : pair_r) : nat :=
+  match p with MkPairR f _ => f end.
+
+(** [proj_second]: project the second field. *)
+Definition proj_second (p : pair_r) : nat :=
+  match p with MkPairR _ s => s end.
+
+(** [swap_pair_r]: swap the two fields.  The match reads both via attribute
+    access and the record-construction notation emits keyword arguments, so
+    the combined output exercises both the projection path and the existing
+    [MLcons Record] keyword-argument path. *)
+Definition swap_pair_r (p : pair_r) : pair_r :=
+  match p with
+  | MkPairR f s => {| pfst_r := s ; psnd_r := f |}
+  end.
+
+Python Extraction proj_first.
+Python Extraction proj_second.
+Python Extraction swap_pair_r.
+
+(* ------------------------------------------------------------------ *)
+(*  2. 5-field record — acceptance criterion for issue #720            *)
+(*                                                                     *)
+(*  A Rocq record with 5 named fields must extract with readable       *)
+(*  Python field names and attribute access (not positional _0/_1/…). *)
+(* ------------------------------------------------------------------ *)
+
+Record point5 := MkPoint5 {
+  p5_x : nat ; p5_y : nat ; p5_z : nat ; p5_w : nat ; p5_v : nat
+}.
+
+(** Individual field projections — each triggers one single-branch
+    MLcase → lambda-lifted attribute-access transformation. *)
+Definition get_p5_x (p : point5) : nat :=
+  match p with MkPoint5 x _ _ _ _ => x end.
+
+Definition get_p5_y (p : point5) : nat :=
+  match p with MkPoint5 _ y _ _ _ => y end.
+
+Definition get_p5_z (p : point5) : nat :=
+  match p with MkPoint5 _ _ z _ _ => z end.
+
+Definition get_p5_w (p : point5) : nat :=
+  match p with MkPoint5 _ _ _ w _ => w end.
+
+Definition get_p5_v (p : point5) : nat :=
+  match p with MkPoint5 _ _ _ _ v => v end.
+
+Python Extraction get_p5_x.
+Python Extraction get_p5_y.
+Python Extraction get_p5_z.
+Python Extraction get_p5_w.
+Python Extraction get_p5_v.


### PR DESCRIPTION
Fixes #720.

Adds record projection support to the Rocq→Python extraction plugin. Single-branch MLcase on record inductives now emits a lambda-lifted attribute-access expression (`(lambda f: f)(scrutinee.field_name)` style) instead of a full `match`/`case` block. Both `pp_expr` and `pp_return_body` share a `record_proj_info` detection helper so the optimisation fires in all contexts.

A new phase6 test suite verifies round-trips for:
- **2-field record** (`pair_r`): `proj_first`, `proj_second`, `swap_pair_r`
- **5-field record** (`point5`): all five named projections — the acceptance criterion from #720 that fields are accessible as readable Python identifiers, not positional `_0/_1/…` names

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Add record-projection optimization to MLcase in python.ml <!-- type:spec -->
- [x] Add phase6 Rocq definitions and round-trip tests for record projections <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->

<details><summary>Completed (2)</summary>

- [x] Add record-projection optimization to MLcase in python.ml <!-- type:spec -->
- [x] Add phase6 Rocq definitions and round-trip tests for record projections <!-- type:spec -->
</details>