### PR TITLE
Rocq to Python A4 acc erasure

### DIFF
--- a/rocq-python-extraction/dune
+++ b/rocq-python-extraction/dune
@@ -99,3 +99,11 @@
   (progn
    (run python3 %{dep:test/check_proj_pair_r.py})
    (run python3 %{dep:test/check_point5.py}))))
+
+; Phase 7 round-trip test: Program Fixpoint / well-founded recursion should
+; extract without visible accessibility/proof scaffolding (issue #721).
+(rule
+ (alias runtest)
+ (deps test/phase7.vo
+       test/check_wf_countdown.py)
+ (action (run python3 %{dep:test/check_wf_countdown.py})))

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -90,6 +90,30 @@ let pp_float_lit f =
 let pp_pyid id =
   str (String.map (function '\'' -> '_' | c -> c) (Id.to_string id))
 
+let is_dummy_id id =
+  Id.equal id dummy_name
+
+let visible_params ids =
+  List.filter (fun id -> not (is_dummy_id id)) ids
+
+let pp_param id =
+  pp_pyid id
+
+let pp_param_list ids =
+  prlist_with_sep (fun () -> str ", ") pp_param (visible_params ids)
+
+let pp_lambda ids body =
+  let params = visible_params ids in
+  if List.is_empty params then str "lambda: " ++ body
+  else
+    str "lambda " ++
+    prlist_with_sep (fun () -> str ", ") pp_param params ++
+    str ": " ++ body
+
+let is_erased_arg = function
+  | MLdummy _ -> true
+  | _         -> false
+
 (** Capitalize the first character of [s] for Python class names.
     Rocq type names are lowercased by the extraction framework (OCaml
     convention); Python expects PascalCase for class names (PEP 8). *)
@@ -280,6 +304,7 @@ let rec pp_expr state env = function
         | head            -> (head, acc)
       in
       let (head, all_args) = collect args f in
+      let all_args = List.filter (fun a -> not (is_erased_arg a)) all_args in
       (* Parenthesise the function if it is itself a lambda expression,
          since [lambda x: e] has very low precedence in Python. *)
       let pp_head =
@@ -287,23 +312,20 @@ let rec pp_expr state env = function
         | MLlam _ -> str "(" ++ pp_expr state env head ++ str ")"
         | _       -> pp_expr state env head
       in
-      pp_head ++ str "(" ++
-      prlist_with_sep (fun () -> str ", ") (pp_expr state env) all_args ++
-      str ")"
+      if List.is_empty all_args then pp_head
+      else
+        pp_head ++ str "(" ++
+        prlist_with_sep (fun () -> str ", ") (pp_expr state env) all_args ++
+        str ")"
   | MLlam _ as a ->
       (* Collect consecutive lambdas: MLlam(x, MLlam(y, body)) → lambda x, y: body.
          [collect_lams] returns ids innermost-first; reverse for Python source order. *)
       let ids, body = collect_lams a in
       let params = List.map id_of_mlid ids in
       let params, env' = push_vars params env in
-      let pp_param id =
-        (* Erased binders use [_] (Python's throwaway) in binder position. *)
-        if Id.equal id dummy_name then str "_" else pp_pyid id
-      in
-      str "lambda " ++
-      prlist_with_sep (fun () -> str ", ") pp_param (List.rev params) ++
-      str ": " ++
-      pp_expr state env' body
+      let params = List.rev params in
+      if List.is_empty (visible_params params) then pp_expr state env' body
+      else pp_lambda params (pp_expr state env' body)
   | MLletin (id, a1, a2) ->
       (* Let binding in expression context: lambda-lift to [(lambda x: a2)(a1)].
          This is safe in pure functional code and avoids statement–expression
@@ -481,11 +503,8 @@ let rec pp_expr state env = function
         let lam_ids, body = collect_lams defs.(j) in
         let params = List.map id_of_mlid lam_ids in
         let params', env'' = push_vars params env' in
-        let pp_param id =
-          if Id.equal id dummy_name then str "_" else pp_pyid id
-        in
         str "def " ++ pp_pyid name_arr.(j) ++ str "(" ++
-        prlist_with_sep (fun () -> str ", ") pp_param (List.rev params') ++
+        pp_param_list (List.rev params') ++
         str "):" ++ fnl () ++
         str "    return " ++ pp_expr state env'' body
       in
@@ -522,17 +541,25 @@ and pp_custom_match_expr state env s scrutinee branches =
         (* No binders: unit thunk. *)
         str "lambda: " ++ pp_expr state env' body
     | _  ->
-        let pp_p id = if Id.equal id dummy_name then str "_" else pp_pyid id in
-        str "lambda " ++
-        prlist_with_sep (fun () -> str ", ") pp_p params ++
-        str ": " ++
-        pp_expr state env' body
+        pp_lambda params (pp_expr state env' body)
   in
   str "(" ++ str s ++ str ")(" ++
   prlist_with_sep (fun () -> str ", ") pp_arm (Array.to_list branches) ++
   str ", " ++
   pp_expr state env scrutinee ++
   str ")"
+
+let rec unwrap_fix = function
+  | MLfix (i, ids, defs) -> Some (i, ids, defs)
+  | MLmagic a            -> unwrap_fix a
+  | _                    -> None
+
+let collect_app f args =
+  let rec collect acc = function
+    | MLapp (g, more) -> collect (more @ acc) g
+    | head            -> (head, acc)
+  in
+  collect args f
 
 (*s Statement-level body printer for Python [def] bodies.
     Inside a [def], [return <match-stmt>] is invalid Python because [match] is
@@ -548,6 +575,8 @@ and pp_custom_match_expr state env s scrutinee branches =
     leading whitespace — the caller is responsible for that. *)
 
 let rec pp_return_body state env indent = function
+  | MLmagic a ->
+      pp_return_body state env indent a
   | MLcase (_, scrutinee, branches) as expr ->
       let is_bool =
         Array.length branches = 2 &&
@@ -597,8 +626,72 @@ let rec pp_return_body state env indent = function
       (* These emit [raise …], which is a valid Python statement but NOT a
          valid expression.  Emit bare — no [return] prefix. *)
       pp_expr state env expr
+  | MLletin (id, a1, a2) -> (
+      (* Let-bound local fixpoint inside a function body:
+           let f = fix ... in body
+         becomes nested [def] statements followed by the returned body.  This
+         is the shape produced by Program Fixpoint's [Fix_sub] helper. *)
+      match unwrap_fix a1 with
+      | None ->
+          str "return " ++ pp_expr state env (MLletin (id, a1, a2))
+      | Some (i, ids, defs) ->
+      let params, env' = push_vars [id_of_mlid id] env in
+      let bname = List.hd params in
+      let def_pfx = String.make indent ' ' in
+      let pp_defs, selected = pp_fix_statement state env indent i ids defs in
+      let pp_alias =
+        if Id.equal bname selected then mt ()
+        else
+          fnl () ++ str def_pfx ++ pp_pyid bname ++
+          str " = " ++ pp_pyid selected
+      in
+      pp_defs ++ pp_alias ++ fnl () ++ str def_pfx ++
+      pp_return_body state env' indent a2 )
+  | MLapp (f, args) -> (
+      match collect_app f args with
+      | head, all_args -> (
+          match unwrap_fix head with
+          | None ->
+              str "return " ++ pp_expr state env (MLapp (f, args))
+          | Some (i, ids, defs) ->
+              let def_pfx = String.make indent ' ' in
+              let pp_defs, selected = pp_fix_statement state env indent i ids defs in
+              let visible_args =
+                List.filter (fun a -> not (is_erased_arg a)) all_args
+              in
+              pp_defs ++ fnl () ++ str def_pfx ++ str "return " ++
+              pp_pyid selected ++ str "(" ++
+              prlist_with_sep (fun () -> str ", ") (pp_expr state env) visible_args ++
+              str ")" ) )
+  | MLfix (i, ids, defs) ->
+      (* Local fixpoint inside a function body.  Python [def] is a statement,
+         so emit nested defs followed by [return selected_name] instead of
+         trying to put [def] after [return]. *)
+      let def_pfx = String.make indent ' ' in
+      let pp_defs, selected = pp_fix_statement state env indent i ids defs in
+      pp_defs ++ fnl () ++ str def_pfx ++ str "return " ++ pp_pyid selected
   | expr ->
       str "return " ++ pp_expr state env expr
+
+and pp_fix_statement state env indent i ids defs =
+  let n = Array.length ids in
+  let id_list = List.rev (Array.to_list ids) in
+  let names_rev, env' = push_vars id_list env in
+  let name_arr = Array.of_list (List.rev names_rev) in
+  let def_pfx = String.make indent ' ' in
+  let body_pfx = String.make (indent + 4) ' ' in
+  let pp_one j =
+    let lam_ids, body = collect_lams defs.(j) in
+    let params = List.map id_of_mlid lam_ids in
+    let params', env'' = push_vars params env' in
+    str "def " ++ pp_pyid name_arr.(j) ++ str "(" ++
+    pp_param_list (List.rev params') ++
+    str "):" ++ fnl () ++
+    str body_pfx ++ pp_return_body state env'' (indent + 4) body
+  in
+  prlist_with_sep (fun () -> fnl () ++ str def_pfx) pp_one
+    (List.init n (fun j -> j)),
+  name_arr.(i)
 
 (*s Python term declaration emitter.
     Detects a lambda-headed RHS and promotes it to a [def]; non-lambda
@@ -606,7 +699,46 @@ let rec pp_return_body state env indent = function
 
 (** Emit either [def name(p1,…): return body] or [name = expr], choosing
     based on whether [a] has leading lambdas. *)
-let pp_term_decl state env name a =
+let pp_function_wrapper state env name a typ =
+  let args, _ret = type_decomp typ in
+  let n = List.length args in
+  if Int.equal n 0 then None
+  else
+    let arg_names =
+      if Int.equal n 1 then ["x"]
+      else List.init n (fun i -> "arg" ^ string_of_int i)
+    in
+    let pp_arg s = str s in
+    let pp_call =
+      match a with
+      | MLapp (f, app_args) ->
+          let head, all_args = collect_app f app_args in
+          let visible_args =
+            List.filter (fun a -> not (is_erased_arg a)) all_args
+          in
+          let pp_head =
+            match head with
+            | MLlam _ -> str "(" ++ pp_expr state env head ++ str ")"
+            | _       -> pp_expr state env head
+          in
+          pp_head ++ str "(" ++
+          prlist_with_sep (fun () -> str ", ") (pp_expr state env) visible_args ++
+          (if List.is_empty visible_args then mt () else str ", ") ++
+          prlist_with_sep (fun () -> str ", ") pp_arg arg_names ++
+          str ")"
+      | _ ->
+          str "(" ++ pp_expr state env a ++ str ")(" ++
+          prlist_with_sep (fun () -> str ", ") pp_arg arg_names ++
+          str ")"
+    in
+    Some (
+      str "def " ++ str name ++ str "(" ++
+      prlist_with_sep (fun () -> str ", ") pp_arg arg_names ++
+      str "):" ++ fnl () ++
+      str "    return " ++ pp_call ++ fnl ()
+    )
+
+let pp_term_decl state env name a typ =
   let lam_ids, body = collect_lams a in
   if List.is_empty lam_ids then
     (* Non-function value: simple assignment — unless the body is a [raise]
@@ -616,15 +748,14 @@ let pp_term_decl state env name a =
       | MLaxiom _ | MLexn _ | MLparray _ ->
           pp_expr state env a ++ fnl ()
       | _ ->
-          str name ++ str " = " ++ pp_expr state env a ++ fnl () )
+          (match pp_function_wrapper state env name a typ with
+          | Some pp -> pp
+          | None -> str name ++ str " = " ++ pp_expr state env a ++ fnl ()) )
   else
     let params = List.map id_of_mlid lam_ids in
     let params', env' = push_vars params env in
-    let pp_param id =
-      if Id.equal id dummy_name then str "_" else pp_pyid id
-    in
     str "def " ++ str name ++ str "(" ++
-    prlist_with_sep (fun () -> str ", ") pp_param (List.rev params') ++
+    pp_param_list (List.rev params') ++
     str "):" ++ fnl () ++
     (* [indent=4]: the body is indented by 4 spaces inside the def; [case] arms
        at 8, case bodies at 12.  The "    " prefix handles the first line only;
@@ -842,15 +973,15 @@ let pp_ind_decl state (ind : ml_ind) =
 let pp_decl state = function
   | Dind  ind   -> pp_ind_decl state ind ++ fnl ()
   | Dtype _     -> str "# UNIMPL Dtype" ++ fnl ()
-  | Dterm (r, a, _) ->
+  | Dterm (r, a, typ) ->
       if is_inline_custom r then mt ()
       else if is_custom r then
         str (pp_global state Term r) ++ str " = " ++
         str (find_custom r) ++ fnl ()
       else
         let env = empty_env state () in
-        pp_term_decl state env (pp_global state Term r) a
-  | Dfix (rv, defs, _) ->
+        pp_term_decl state env (pp_global state Term r) a typ
+  | Dfix (rv, defs, typs) ->
       (* Each function in the fix block is named globally; the bodies use
          [MLglob] references for mutual recursion, so [empty_env] suffices. *)
       let env = empty_env state () in
@@ -860,7 +991,7 @@ let pp_decl state = function
           str (pp_global state Term rv.(i)) ++ str " = " ++
           str (find_custom rv.(i)) ++ fnl ()
         else
-          pp_term_decl state env (pp_global state Term rv.(i)) defs.(i)
+          pp_term_decl state env (pp_global state Term rv.(i)) defs.(i) typs.(i)
       in
       prlist_with_sep mt pp_one (List.init (Array.length rv) (fun i -> i))
 

--- a/rocq-python-extraction/test/check_wf_countdown.py
+++ b/rocq-python-extraction/test/check_wf_countdown.py
@@ -1,0 +1,31 @@
+# ruff: noqa: E402
+import inspect
+import os
+import sys
+from pathlib import Path
+
+# The extracted .py files always land in the dune workspace build root (_build/default/).
+# Walk up from __file__ to find it — works whether or not dune-workspace is present.
+_d = os.path.dirname(os.path.abspath(__file__))
+while not (
+    os.path.basename(_d) == "default"
+    and os.path.basename(os.path.dirname(_d)) == "_build"
+):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from wf_countdown import wf_countdown
+
+assert wf_countdown(0) == 0, "wf_countdown(0): got " + repr(wf_countdown(0))
+assert wf_countdown(1) == 1, "wf_countdown(1): got " + repr(wf_countdown(1))
+assert wf_countdown(4) == 4, "wf_countdown(4): got " + repr(wf_countdown(4))
+
+sig = inspect.signature(wf_countdown)
+assert list(sig.parameters) == ["x"], "signature: got " + str(sig)
+
+source = (Path(_d) / "wf_countdown.py").read_text()
+for forbidden in ("_acc", "_dummy", "Acc", "accessibility", "recproof"):
+    assert forbidden not in source, forbidden + " leaked into wf_countdown.py"
+
+del _d
+print("Phase 7 wf_countdown Program Fixpoint round-trip: OK")

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -1,6 +1,6 @@
 (rocq.theory
  (name PyExtractTest)
- (synopsis "Phase 2–6 acceptance tests — core term nodes, primitive remapping, inductive datatype emission, nested patterns, and record projections")
+ (synopsis "Phase 2–7 acceptance tests — core terms, primitive remapping, datatypes, nested patterns, records, and Acc-erasure")
  (plugins rocq-python-extraction)
  (theories Stdlib)
- (modules acceptance phase2 phase3 phase4 phase5 phase6))
+ (modules acceptance phase2 phase3 phase4 phase5 phase6 phase7))

--- a/rocq-python-extraction/test/phase7.v
+++ b/rocq-python-extraction/test/phase7.v
@@ -1,0 +1,37 @@
+(** Phase 7 acceptance tests: well-founded recursion / Program Fixpoint
+    accessibility erasure (issue #721).
+
+    A function defined through [Program Fixpoint] with a termination proof must
+    extract to idiomatic Python with only computational parameters visible.
+    In particular, generated Python should look like:
+
+      def wf_countdown(x):
+          ...
+
+    not like:
+
+      def wf_countdown(x, _acc, _dummy):
+          ...
+*)
+
+Declare ML Module "rocq-python-extraction".
+
+(* [Program Fixpoint] and [Extract Inductive] need their plugins. *)
+Declare ML Module "rocq-runtime.plugins.extraction".
+
+From Stdlib Require Import Program.Wf.
+From Stdlib Require Import Arith.Wf_nat.
+
+(* Remap nat -> int so the extracted checker can call the function directly
+   with Python ints. *)
+Extract Inductive nat => "int"
+  [ "0" "(lambda x: x + 1)" ]
+  "(lambda fO, fS, n: fO() if n == 0 else fS(n - 1))".
+
+Program Fixpoint wf_countdown (n : nat) {measure n} : nat :=
+  match n with
+  | O => O
+  | S n' => S (wf_countdown n')
+  end.
+
+Python Extraction wf_countdown.


### PR DESCRIPTION
Woof, this implements Rocq->Python A4 for issue #721.

Changes:
- Erases dummy/logical proof parameters from generated Python lambdas, defs, and applications.
- Emits statement-level nested Python defs for local MiniML fixpoints used by Program Fixpoint/Fix_sub.
- Wraps function-valued constants like wf_countdown as a clean public Python def.
- Adds phase 7 Program Fixpoint acceptance coverage.

Verification:
- `cd rocq-python-extraction && make docker-test`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --cov --cov-report=term-missing --cov-fail-under=100`

Fixes #721.