### PR TITLE
implement A9 prop/set discipline

### DIFF
--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -14,6 +14,7 @@ open Mlutil
 open Modutil
 open Table
 open Common
+open CErrors
 
 (*s Keywords that may not be used as Python identifiers. *)
 
@@ -53,10 +54,14 @@ let preamble _state _name comment _used_modules _safe =
   str "# pyright: reportUnusedImport=false, reportUnusedVariable=false, reportUnknownLambdaType=false, reportRedeclaration=false" ++ fnl () ++
   str "from itertools import islice" ++ fnl () ++
   str "from dataclasses import dataclass" ++ fnl () ++
-  str "from typing import Any, Callable, Generic, Iterable, Iterator, Protocol, TypeVar, assert_never, cast" ++ fnl () ++
+  str "from typing import Any, Callable, Generic, Iterable, Iterator, Never, Protocol, TypeVar, assert_never, cast" ++ fnl () ++
   str "_CoForceT = TypeVar(\"_CoForceT\")" ++ fnl () ++
   str "_ModuleArgT = TypeVar(\"_ModuleArgT\")" ++ fnl () ++
   str "_ModuleRetT = TypeVar(\"_ModuleRetT\")" ++ fnl () ++
+  str "class _Impossible(RuntimeError):" ++ fnl () ++
+  str "    pass" ++ fnl () ++
+  str "def _impossible() -> Never:" ++ fnl () ++
+  str "    raise _Impossible()" ++ fnl () ++
   str "def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:" ++ fnl () ++
   str "    return value()" ++ fnl () ++
   str "def coprefix_eq(n: int, left: Iterable[object], right: Iterable[object]) -> bool:" ++ fnl () ++
@@ -178,6 +183,69 @@ let rec type_has_typevars = function
       true
   | Tdummy _ | Tunknown | Taxiom | Tmeta _ ->
       false
+
+type prop_context =
+  | PropIrrelevant
+  | PropValue
+  | PropControl
+
+let is_prop_type = function
+  | Tdummy Kprop -> true
+  | _ -> false
+
+let pp_impossible_expr () =
+  str "_impossible()"
+
+let pp_impossible_stmt () =
+  str "raise _Impossible()"
+
+let prop_extraction_error detail =
+  user_err Pp.(str "Python ExtractionError: " ++ str detail)
+
+let rec validate_prop_discipline_expr context = function
+  | MLdummy Kprop ->
+      (match context with
+       | PropControl ->
+           prop_extraction_error
+             "Prop-typed term used in computational control position"
+       | PropIrrelevant | PropValue -> ())
+  | MLrel _ | MLglob _ | MLdummy _ | MLexn _ | MLaxiom _
+  | MLuint _ | MLfloat _ | MLstring _ | MLparray _ ->
+      ()
+  | MLmagic a ->
+      validate_prop_discipline_expr context a
+  | MLapp (f, args) ->
+      validate_prop_discipline_expr PropControl f;
+      List.iter (validate_prop_discipline_expr PropValue) args
+  | MLlam (_, body) ->
+      validate_prop_discipline_expr PropValue body
+  | MLletin (_, a1, a2) ->
+      validate_prop_discipline_expr PropValue a1;
+      validate_prop_discipline_expr PropValue a2
+  | MLcons (_, _, args) ->
+      List.iter (validate_prop_discipline_expr PropValue) args
+  | MLtuple args ->
+      List.iter (validate_prop_discipline_expr PropValue) args
+  | MLcase (_, scrutinee, branches) ->
+      validate_prop_discipline_expr PropControl scrutinee;
+      Array.iter
+        (fun (_, _, body) -> validate_prop_discipline_expr PropValue body)
+        branches
+  | MLfix (_, _, defs) ->
+      Array.iter (validate_prop_discipline_expr PropValue) defs
+
+let validate_prop_discipline_decl = function
+  | Dterm (_, body, typ) ->
+      if not (is_prop_type typ) then
+        validate_prop_discipline_expr PropValue body
+  | Dfix (_, defs, typs) ->
+      Array.iteri
+        (fun i body ->
+           if not (is_prop_type typs.(i)) then
+             validate_prop_discipline_expr PropValue body)
+        defs
+  | Dind _ | Dtype _ ->
+      ()
 
 let pp_unreachable_fallback ty indent =
   let pfx = String.make indent ' ' in
@@ -394,6 +462,8 @@ let rec pp_expr state env = function
       if Id.equal id dummy_name then str "__" else pp_pyid id
   | MLglob r ->
       pp_glob state r
+  | MLdummy Kprop ->
+      pp_impossible_expr ()
   | MLdummy _ ->
       str "__"
   | MLexn s ->
@@ -701,6 +771,8 @@ let collect_app f args =
     leading whitespace — the caller is responsible for that. *)
 
 let rec pp_return_body state env indent = function
+  | MLdummy Kprop ->
+      pp_impossible_stmt ()
   | MLmagic a ->
       pp_return_body state env indent a
   | MLcase (ty, scrutinee, branches) as expr ->
@@ -1351,11 +1423,13 @@ let pp_decl state = function
   | Dind  ind   -> pp_ind_decl state ind ++ fnl ()
   | Dtype _     -> str "# UNIMPL Dtype" ++ fnl ()
   | Dterm (r, a, typ) ->
-      if is_inline_custom r then mt ()
+      if is_prop_type typ then mt ()
+      else if is_inline_custom r then mt ()
       else if is_custom r then
         str (pp_global state Term r) ++ str " = " ++
         str (find_custom r) ++ fnl ()
       else
+        let () = validate_prop_discipline_decl (Dterm (r, a, typ)) in
         let env = empty_env state () in
         pp_term_decl state env (pp_global state Term r) a typ
   | Dfix (rv, defs, typs) ->
@@ -1363,11 +1437,16 @@ let pp_decl state = function
          [MLglob] references for mutual recursion, so [empty_env] suffices. *)
       let env = empty_env state () in
       let pp_one i =
-        if is_inline_custom rv.(i) then mt ()
+        if is_prop_type typs.(i) then mt ()
+        else if is_inline_custom rv.(i) then mt ()
         else if is_custom rv.(i) then
           str (pp_global state Term rv.(i)) ++ str " = " ++
           str (find_custom rv.(i)) ++ fnl ()
         else
+          let () =
+            validate_prop_discipline_decl
+              (Dterm (rv.(i), defs.(i), typs.(i)))
+          in
           pp_term_decl state env (pp_global state Term rv.(i)) defs.(i) typs.(i)
       in
       prlist_with_sep mt pp_one (List.init (Array.length rv) (fun i -> i))
@@ -1394,13 +1473,15 @@ let rec module_type_annotation state = function
       str "]"
 
 let decl_export_names state = function
-  | Dterm (r, _, _) ->
-      if is_inline_custom r then []
+  | Dterm (r, _, typ) ->
+      if is_prop_type typ || is_inline_custom r then []
       else [pp_global state Term r]
-  | Dfix (rv, _, _) ->
-      Array.to_list rv
-      |> List.filter (fun r -> not (is_inline_custom r))
-      |> List.map (pp_global state Term)
+  | Dfix (rv, _, typs) ->
+      List.init (Array.length rv) Fun.id
+      |> List.filter (fun i ->
+           not (is_prop_type typs.(i)) &&
+           not (is_inline_custom rv.(i)))
+      |> List.map (fun i -> pp_global state Term rv.(i))
   | Dtype (r, _, _) ->
       [pp_global state Type r]
   | Dind ind ->

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -14,5 +14,6 @@
   wf_recursion
   polymorphism
   universe_erasure
+  prop_set_discipline
   coinductives
   modules))

--- a/rocq-python-extraction/test/generated_pytest_targets.txt
+++ b/rocq-python-extraction/test/generated_pytest_targets.txt
@@ -33,6 +33,8 @@ get_p5_v.py
 wf_countdown.py
 list_map.py
 poly_id.py
+eq_dec_bool.py
+proof_pair_zero.py
 zeros_pair.py
 repeat_tree.py
 tree_root_of_repeat.py

--- a/rocq-python-extraction/test/prop_set_discipline.v
+++ b/rocq-python-extraction/test/prop_set_discipline.v
@@ -1,0 +1,16 @@
+Declare ML Module "rocq-python-extraction".
+Declare ML Module "rocq-runtime.plugins.extraction".
+
+Extract Inductive bool => "bool" [ "True" "False" ].
+
+Definition eq_dec_bool (d : {0 = 0} + {0 <> 0}) : bool :=
+  match d with
+  | left _ => true
+  | right _ => false
+  end.
+
+Definition proof_pair_zero (_ : nat) : nat * (0 = 0) :=
+  (0, eq_refl).
+
+Python Extraction eq_dec_bool.
+Python Extraction proof_pair_zero.

--- a/rocq-python-extraction/test/python.v
+++ b/rocq-python-extraction/test/python.v
@@ -13,5 +13,6 @@ From PyExtractTest Require Export
   wf_recursion
   polymorphism
   universe_erasure
+  prop_set_discipline
   coinductives
   modules.

--- a/rocq-python-extraction/test/test_bintree_is_leaf.py
+++ b/rocq-python-extraction/test/test_bintree_is_leaf.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -14,7 +14,3 @@ def test_bintree_is_leaf_round_trip() -> None:
         "bintree_is_leaf(BNode(...)): got "
         + repr(bintree_is_leaf(BNode(BLeaf(), 42, BLeaf())))
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_bintree_is_leaf_round_trip, "BinTree round-trip: OK")

--- a/rocq-python-extraction/test/test_bool_not.py
+++ b/rocq-python-extraction/test/test_bool_not.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -9,7 +9,3 @@ from bool_not import bool_not
 def test_bool_not_round_trip() -> None:
     assert bool_not(True) is False, "bool_not(True): got " + repr(bool_not(True))
     assert bool_not(False) is True, "bool_not(False): got " + repr(bool_not(False))
-
-
-if __name__ == "__main__":
-    run_as_script(test_bool_not_round_trip, "bool round-trip: OK")

--- a/rocq-python-extraction/test/test_coinductives.py
+++ b/rocq-python-extraction/test/test_coinductives.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 from itertools import islice
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -34,10 +34,3 @@ def test_coinductive_round_trip() -> None:
     assert step.arg0 == TreeO()
 
     assert tree_root_of_repeat == RootO()
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_coinductive_round_trip,
-        "Coinductive stream and forcing round-trip: OK",
-    )

--- a/rocq-python-extraction/test/test_color_is_red.py
+++ b/rocq-python-extraction/test/test_color_is_red.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -19,7 +19,3 @@ def test_color_is_red_round_trip() -> None:
     assert isinstance(Red(), Color), (
         "Red() must be instance of Color (capitalized base class)"
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_color_is_red_round_trip, "color capitalization: OK")

--- a/rocq-python-extraction/test/test_core_terms_syntax.py
+++ b/rocq-python-extraction/test/test_core_terms_syntax.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 import py_compile
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -17,10 +17,3 @@ def test_core_terms_syntax() -> None:
         "todo_val.py",
     ]:
         py_compile.compile(str(build_default / filename), doraise=True)
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_core_terms_syntax,
-        "Core-terms extracted .py files are syntactically valid Python.",
-    )

--- a/rocq-python-extraction/test/test_eq_dec_bool.py
+++ b/rocq-python-extraction/test/test_eq_dec_bool.py
@@ -1,0 +1,21 @@
+# ruff: noqa: E402
+from pathlib import Path
+
+from test_support import add_build_default_to_syspath, run_as_script
+
+build_default = add_build_default_to_syspath()
+
+from eq_dec_bool import Left, Right, eq_dec_bool
+
+
+def test_eq_dec_bool_round_trip() -> None:
+    assert eq_dec_bool(Left()) is True
+    assert eq_dec_bool(Right()) is False
+
+    source = (Path(build_default) / "eq_dec_bool.py").read_text()
+    assert "return _impossible()" not in source
+    assert "return __" not in source
+
+
+if __name__ == "__main__":
+    run_as_script(test_eq_dec_bool_round_trip, "prop/set decidable match: OK")

--- a/rocq-python-extraction/test/test_eq_dec_bool.py
+++ b/rocq-python-extraction/test/test_eq_dec_bool.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 from pathlib import Path
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -15,7 +15,3 @@ def test_eq_dec_bool_round_trip() -> None:
     source = (Path(build_default) / "eq_dec_bool.py").read_text()
     assert "return _impossible()" not in source
     assert "return __" not in source
-
-
-if __name__ == "__main__":
-    run_as_script(test_eq_dec_bool_round_trip, "prop/set decidable match: OK")

--- a/rocq-python-extraction/test/test_even_depth.py
+++ b/rocq-python-extraction/test/test_even_depth.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -18,7 +18,3 @@ def test_even_depth_round_trip() -> None:
     )
     assert isinstance(EvenO(), Even), "EvenO() must be instance of Even"
     assert isinstance(OddS(EvenO()), Odd), "OddS() must be instance of Odd"
-
-
-if __name__ == "__main__":
-    run_as_script(test_even_depth_round_trip, "Even/Odd round-trip: OK")

--- a/rocq-python-extraction/test/test_expr_is_num_pair.py
+++ b/rocq-python-extraction/test/test_expr_is_num_pair.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -36,7 +36,3 @@ def test_expr_is_num_pair_round_trip() -> None:
     assert isinstance(ENum(0), Expr), "ENum(0) must be instance of Expr"
     assert isinstance(VNum(0), Val), "VNum(0) must be instance of Val"
     assert isinstance(ELift(VNum(0)), Expr), "ELift(VNum(0)) must be instance of Expr"
-
-
-if __name__ == "__main__":
-    run_as_script(test_expr_is_num_pair_round_trip, "expr_is_num_pair round-trip: OK")

--- a/rocq-python-extraction/test/test_has_left3.py
+++ b/rocq-python-extraction/test/test_has_left3.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -29,7 +29,3 @@ def test_has_left3_round_trip() -> None:
     assert isinstance(Node(0, Leaf(), Leaf()), Tree), (
         "Node(...) must be instance of Tree"
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_has_left3_round_trip, "has_left3 round-trip: OK")

--- a/rocq-python-extraction/test/test_is_even.py
+++ b/rocq-python-extraction/test/test_is_even.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -12,7 +12,3 @@ def test_is_even_round_trip() -> None:
     assert is_even(2) is True, "is_even(2): got " + repr(is_even(2))
     assert is_even(3) is False, "is_even(3): got " + repr(is_even(3))
     assert is_even(4) is True, "is_even(4): got " + repr(is_even(4))
-
-
-if __name__ == "__main__":
-    run_as_script(test_is_even_round_trip, "is_even round-trip: OK")

--- a/rocq-python-extraction/test/test_list_add_one.py
+++ b/rocq-python-extraction/test/test_list_add_one.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -12,7 +12,3 @@ def test_list_add_one_round_trip() -> None:
         list_add_one([0, 1, 2])
     )
     assert list_add_one([5]) == [6], "list_add_one([5]): got " + repr(list_add_one([5]))
-
-
-if __name__ == "__main__":
-    run_as_script(test_list_add_one_round_trip, "list round-trip: OK")

--- a/rocq-python-extraction/test/test_list_map.py
+++ b/rocq-python-extraction/test/test_list_map.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 from pathlib import Path
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -16,7 +16,3 @@ def test_list_map_round_trip() -> None:
     assert "TypeVar" in source, "list_map.py must declare TypeVars"
     assert "def list_map" in source, "list_map.py must define list_map"
     assert "-> list[" in source, "list_map.py must annotate the return type"
-
-
-if __name__ == "__main__":
-    run_as_script(test_list_map_round_trip, "list_map polymorphism round-trip: OK")

--- a/rocq-python-extraction/test/test_mforest_is_empty.py
+++ b/rocq-python-extraction/test/test_mforest_is_empty.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -14,7 +14,3 @@ def test_mforest_is_empty_round_trip() -> None:
         "mforest_is_empty(FCons(...)): got "
         + repr(mforest_is_empty(FCons(MLeaf(1), FNil())))
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_mforest_is_empty_round_trip, "MForest round-trip: OK")

--- a/rocq-python-extraction/test/test_modules.py
+++ b/rocq-python-extraction/test/test_modules.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -15,10 +15,3 @@ def test_module_functor_round_trip() -> None:
     assert phase10.FreshLookupA.run == 0
     assert phase10.FreshLookupB.run == 0
     assert phase10.FreshLookupA is not phase10.FreshLookupB
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_module_functor_round_trip,
-        "Module/functor round-trip: OK",
-    )

--- a/rocq-python-extraction/test/test_mylist_is_empty.py
+++ b/rocq-python-extraction/test/test_mylist_is_empty.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -13,7 +13,3 @@ def test_mylist_is_empty_round_trip() -> None:
     assert mylist_is_empty(MCons(1, MNil())) is False, (
         "mylist_is_empty(MCons(...)): got " + repr(mylist_is_empty(MCons(1, MNil())))
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_mylist_is_empty_round_trip, "MyList round-trip: OK")

--- a/rocq-python-extraction/test/test_myopt_flatten.py
+++ b/rocq-python-extraction/test/test_myopt_flatten.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -15,7 +15,3 @@ def test_myopt_flatten_round_trip() -> None:
     assert isinstance(r3, MySome) and r3.arg0 == 42, (
         "myopt_flatten(MySome(MySome(42))): got " + repr(r3)
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_myopt_flatten_round_trip, "MyOpt round-trip: OK")

--- a/rocq-python-extraction/test/test_nat_double.py
+++ b/rocq-python-extraction/test/test_nat_double.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -10,7 +10,3 @@ def test_nat_double_round_trip() -> None:
     assert nat_double(0) == 0, "nat_double(0): got " + repr(nat_double(0))
     assert nat_double(3) == 6, "nat_double(3): got " + repr(nat_double(3))
     assert nat_double(5) == 10, "nat_double(5): got " + repr(nat_double(5))
-
-
-if __name__ == "__main__":
-    run_as_script(test_nat_double_round_trip, "nat round-trip: OK")

--- a/rocq-python-extraction/test/test_ntree_is_leaf.py
+++ b/rocq-python-extraction/test/test_ntree_is_leaf.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -18,9 +18,3 @@ def test_ntree_is_leaf_round_trip() -> None:
     )
     assert isinstance(NLeaf(), NTree), "NLeaf() must be instance of NTree"
     assert isinstance(NNode([]), NTree), "NNode([]) must be instance of NTree"
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_ntree_is_leaf_round_trip, "NTree nested inductive round-trip: OK"
-    )

--- a/rocq-python-extraction/test/test_option_inc.py
+++ b/rocq-python-extraction/test/test_option_inc.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -10,7 +10,3 @@ def test_option_inc_round_trip() -> None:
     assert option_inc(None) is None, "option_inc(None): got " + repr(option_inc(None))
     assert option_inc(0) == 1, "option_inc(0): got " + repr(option_inc(0))
     assert option_inc(5) == 6, "option_inc(5): got " + repr(option_inc(5))
-
-
-if __name__ == "__main__":
-    run_as_script(test_option_inc_round_trip, "option round-trip: OK")

--- a/rocq-python-extraction/test/test_pair_swap.py
+++ b/rocq-python-extraction/test/test_pair_swap.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -16,7 +16,3 @@ def test_pair_swap_round_trip() -> None:
     assert pair_swap((5, 5)) == (5, 5), "pair_swap((5, 5)): got " + repr(
         pair_swap((5, 5))
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_pair_swap_round_trip, "prod round-trip: OK")

--- a/rocq-python-extraction/test/test_point5.py
+++ b/rocq-python-extraction/test/test_point5.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -30,7 +30,3 @@ def test_point5_round_trip() -> None:
     assert get_p5_v(zero) == 0, "get_p5_v(zero)"
 
     assert isinstance(p, MkPoint5), "p must be instance of MkPoint5"
-
-
-if __name__ == "__main__":
-    run_as_script(test_point5_round_trip, "point5 projection round-trip: OK")

--- a/rocq-python-extraction/test/test_poly_id.py
+++ b/rocq-python-extraction/test/test_poly_id.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 from pathlib import Path
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -16,7 +16,3 @@ def test_poly_id_universe_erasure() -> None:
     assert "Erased universe variables:" in source
     assert "u" in source
     assert "@{" not in source
-
-
-if __name__ == "__main__":
-    run_as_script(test_poly_id_universe_erasure, "universe erasure round-trip: OK")

--- a/rocq-python-extraction/test/test_proj_pair_r.py
+++ b/rocq-python-extraction/test/test_proj_pair_r.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -38,7 +38,3 @@ def test_proj_pair_r_round_trip() -> None:
 
     assert isinstance(p1, MkPairR_pf), "p1 must be MkPairR"
     assert isinstance(swapped, MkPairR_sw), "swapped must be MkPairR"
-
-
-if __name__ == "__main__":
-    run_as_script(test_proj_pair_r_round_trip, "pair_r projection round-trip: OK")

--- a/rocq-python-extraction/test/test_proof_pair_zero.py
+++ b/rocq-python-extraction/test/test_proof_pair_zero.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import pytest
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -15,10 +15,3 @@ def test_proof_pair_zero_uses_impossible_witness() -> None:
 
     source = (Path(build_default) / "proof_pair_zero.py").read_text()
     assert "_impossible()" in source
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_proof_pair_zero_uses_impossible_witness,
-        "prop/set impossible witness: OK",
-    )

--- a/rocq-python-extraction/test/test_proof_pair_zero.py
+++ b/rocq-python-extraction/test/test_proof_pair_zero.py
@@ -1,0 +1,24 @@
+# ruff: noqa: E402
+from pathlib import Path
+
+import pytest
+from test_support import add_build_default_to_syspath, run_as_script
+
+build_default = add_build_default_to_syspath()
+
+from proof_pair_zero import _Impossible, proof_pair_zero
+
+
+def test_proof_pair_zero_uses_impossible_witness() -> None:
+    with pytest.raises(_Impossible):
+        proof_pair_zero(0)
+
+    source = (Path(build_default) / "proof_pair_zero.py").read_text()
+    assert "_impossible()" in source
+
+
+if __name__ == "__main__":
+    run_as_script(
+        test_proof_pair_zero_uses_impossible_witness,
+        "prop/set impossible witness: OK",
+    )

--- a/rocq-python-extraction/test/test_roseforest_is_empty.py
+++ b/rocq-python-extraction/test/test_roseforest_is_empty.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -14,7 +14,3 @@ def test_roseforest_is_empty_round_trip() -> None:
         "roseforest_is_empty(RFCons(...)): got "
         + repr(roseforest_is_empty(RFCons(RNode(1, RFNil()), RFNil())))
     )
-
-
-if __name__ == "__main__":
-    run_as_script(test_roseforest_is_empty_round_trip, "RoseForest round-trip: OK")

--- a/rocq-python-extraction/test/test_stree_size.py
+++ b/rocq-python-extraction/test/test_stree_size.py
@@ -1,5 +1,5 @@
 # ruff: noqa: E402
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 add_build_default_to_syspath()
 
@@ -20,7 +20,3 @@ def test_stree_size_round_trip() -> None:
     )
     assert isinstance(SLit(0), STree), "SLit(0) must be instance of STree"
     assert isinstance(DEnd(), DTree), "DEnd() must be instance of DTree"
-
-
-if __name__ == "__main__":
-    run_as_script(test_stree_size_round_trip, "STree/DTree round-trip: OK")

--- a/rocq-python-extraction/test/test_support.py
+++ b/rocq-python-extraction/test/test_support.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Callable
 
 
 def add_build_default_to_syspath() -> Path:
@@ -34,8 +33,3 @@ def add_build_default_to_syspath() -> Path:
         )
     except ImportError as exc:
         raise RuntimeError("generated extraction artifacts are not present") from exc
-
-
-def run_as_script(test_fn: Callable[[], None], success_message: str) -> None:
-    test_fn()
-    print(success_message)

--- a/rocq-python-extraction/test/test_wf_countdown.py
+++ b/rocq-python-extraction/test/test_wf_countdown.py
@@ -1,7 +1,7 @@
 # ruff: noqa: E402
 import inspect
 
-from test_support import add_build_default_to_syspath, run_as_script
+from test_support import add_build_default_to_syspath
 
 build_default = add_build_default_to_syspath()
 
@@ -19,10 +19,3 @@ def test_wf_countdown_round_trip() -> None:
     source = (build_default / "wf_countdown.py").read_text()
     for forbidden in ("_acc", "_dummy", "Acc", "accessibility", "recproof"):
         assert forbidden not in source, forbidden + " leaked into wf_countdown.py"
-
-
-if __name__ == "__main__":
-    run_as_script(
-        test_wf_countdown_round_trip,
-        "wf_countdown Program Fixpoint round-trip: OK",
-    )


### PR DESCRIPTION
Fixes #726

## Summary
- add Prop-discipline handling in the Python extractor using MiniML `Kprop` metadata
- emit `_Impossible` / `_impossible()` for kept computational Prop slots and reject Prop control-flow positions
- add acceptance coverage for decidable-proposition matching and impossible proof witnesses

## Verification
- `uv run tests -q`
- `./rocq-python-extraction/run_in_docker.sh rocq-python-extraction opam exec -- make test`
- pre-commit hook via `git commit`
