### PR TITLE
Add structured extraction diagnostics

### DIFF
--- a/rocq-python-extraction/DIAGNOSTICS.md
+++ b/rocq-python-extraction/DIAGNOSTICS.md
@@ -1,0 +1,125 @@
+# Rocq -> Python Extraction Diagnostics
+
+Every structured extraction diagnostic has a stable code, a category, and a
+one-line remediation. Human-readable errors include the same fields as the JSON
+line prefixed by `PYTHON_EXTRACTION_DIAGNOSTIC_JSON:`.
+
+## PYEX001 Persistent Arrays Are Unsupported
+Remediation: Avoid Rocq PArray in extracted terms or add an explicit Python remapping.
+
+## PYEX002 Prop Term Used For Computation
+Remediation: Move the proof to Prop-only positions or return data in Set/Type before extraction.
+
+## PYEX003 Type Alias Declaration Is Not Emitted
+Remediation: Use a concrete inductive/record or add an extraction remapping for the type.
+
+## PYEX004 Axiom Has No Computational Realization
+Remediation: Provide an Extract Constant remapping for the axiom before Python extraction.
+
+## PYEX005 Exception Term Cannot Be Emitted As An Expression
+Remediation: Keep extracted exceptions at statement position or rewrite the Rocq term to return data.
+
+## PYEX006 Erased Logical Value Reached Runtime
+Remediation: Keep the logical argument proof-irrelevant or pass a computational witness in Set/Type.
+
+## PYEX007 Unsupported Custom Match Encoding
+Remediation: Give Extract Inductive a Python match function with one thunk per constructor plus the scrutinee.
+
+## PYEX008 Custom Constructor Arity Mismatch
+Remediation: Make every custom constructor expression accept the same arguments as the Rocq constructor.
+
+## PYEX009 Unknown Monad Marker
+Remediation: Use one of the supported __PYMONAD_* markers or extract the operation normally.
+
+## PYEX010 Monad Marker Arity Mismatch
+Remediation: Use the marker with the expected number of computational arguments.
+
+## PYEX011 Record Projection Pattern Is Too Complex
+Remediation: Split the nested match into separate matches or bind the record before matching.
+
+## PYEX012 Nested Wildcard Binder Escaped Erasure
+Remediation: Name the computational field explicitly or keep the wildcard proof-only.
+
+## PYEX013 Coinductive Packet Is Not Stream-Shaped
+Remediation: Expose a one-step destructor or avoid relying on Python iterator synthesis.
+
+## PYEX014 Coinductive Constructor Arity Mismatch
+Remediation: Use native coinductive constructors without custom erasure for this extraction.
+
+## PYEX015 Mutual Cofixpoint Shape Is Unsupported
+Remediation: Extract a wrapper function around one cofixpoint or split the mutual block.
+
+## PYEX016 Higher-Order Module Signature Is Unsupported
+Remediation: Extract the applied module result or simplify the functor signature.
+
+## PYEX017 Module Alias Could Not Be Resolved
+Remediation: Extract the canonical module path or make the alias transparent before extraction.
+
+## PYEX018 Module Type With Constraints Is Unsupported
+Remediation: Extract the constrained module after elaboration or remove the with-constraint.
+
+## PYEX019 Applicative Functor Cache Key Is Unsupported
+Remediation: Pass a first-class module value or extract a non-functorized wrapper.
+
+## PYEX020 Expected An Inductive Or Constructor Reference
+Remediation: Report this backend invariant with the extracted declaration and source map.
+
+## PYEX021 Expected An Inductive Reference
+Remediation: Report this backend invariant with the extracted declaration and source map.
+
+## PYEX022 Pattern Shorthand Was Not Expanded
+Remediation: Report this backend invariant; the printer should expand Pusual before rendering.
+
+## PYEX023 Unexpected Coinductive Constructor Payload
+Remediation: Report this backend invariant with the constructor and generated source map.
+
+## PYEX024 Unsupported Primitive Integer Type Alias
+Remediation: Keep the integer literal in a computational term or remap the type explicitly.
+
+## PYEX025 Unsupported Primitive Float Type Alias
+Remediation: Keep the float literal in a computational term or remap the type explicitly.
+
+## PYEX026 Unsupported Primitive String Type Alias
+Remediation: Keep the string literal in a computational term or remap the type explicitly.
+
+## PYEX027 Unknown Type Annotation Shape
+Remediation: Use an explicit extracted type remapping or simplify the polymorphic type.
+
+## PYEX028 Function Protocol Annotation Is Too Complex
+Remediation: Name the higher-order argument type or specialize the extracted function.
+
+## PYEX029 Generic Constructor Could Not Be Typed
+Remediation: Specialize the inductive parameters or add a primitive remapping.
+
+## PYEX030 Logical Inductive Used Computationally
+Remediation: Move the inductive to Set/Type or erase the use before extraction.
+
+## PYEX031 Logical Record Used Computationally
+Remediation: Separate computational fields into a Set/Type record before extraction.
+
+## PYEX032 Proof-Carrying Pair Leaked Into Python
+Remediation: Project the computational component before extraction.
+
+## PYEX033 Unsupported Well-Founded Recursion Shape
+Remediation: Expose the structurally recursive helper or simplify the Program Fixpoint obligation shape.
+
+## PYEX034 Local Fixpoint Escaped Statement Context
+Remediation: Eta-expand the definition so the local fixpoint appears inside a function body.
+
+## PYEX035 Mutual Recursion Has Erased Selected Function
+Remediation: Extract a computational member of the mutual block or remove the proof-only member.
+
+## PYEX036 Unsupported Bytes Literal Encoding
+Remediation: Restrict extracted strings to byte strings or provide a Python remapping.
+
+## PYEX037 Unsupported Float Literal
+Remediation: Avoid NaN/infinity payloads that cannot round-trip or remap the constant explicitly.
+
+## PYEX038 Generated Python Identifier Is Invalid
+Remediation: Rename the Rocq identifier or add an extraction rename before Python extraction.
+
+## PYEX039 Generated Python Name Collision
+Remediation: Rename one Rocq declaration or extract through a module namespace.
+
+## PYEX040 Unclassified Extraction Failure
+Remediation: Check the detail field, reduce the Rocq input, and add a catalogue entry for this failure.

--- a/rocq-python-extraction/g_python_extraction.mlg
+++ b/rocq-python-extraction/g_python_extraction.mlg
@@ -137,6 +137,35 @@ let write_python_with_source_map ~fname ~span pp =
   close_out oc;
   write_pymap ~python_file:fname ~span ~source:annotated
 
+let string_contains haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then true
+    else if i + needle_len > hay_len then false
+    else if String.equal (String.sub haystack i needle_len) needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let run_with_diagnostics f =
+  try f () with
+  | CErrors.UserError pp
+    when string_contains (Pp.string_of_ppcmds pp) Python.diagnostic_prefix ->
+      raise (CErrors.UserError pp)
+  | CErrors.UserError pp ->
+      Python.extraction_diagnostic_error
+        ~detail:(Pp.string_of_ppcmds pp)
+        "PYEX040"
+  | Assert_failure (file, line, column) ->
+      Python.extraction_diagnostic_error
+        ~detail:(Printf.sprintf "%s:%d:%d" file line column)
+        "PYEX040"
+  | Failure msg ->
+      Python.extraction_diagnostic_error ~detail:msg "PYEX040"
+  | Invalid_argument msg ->
+      Python.extraction_diagnostic_error ~detail:msg "PYEX040"
+
 (** Python-specific file emission copied from Rocq's extraction driver, but
     bound directly to [Python.python_descr] so we do not depend on Rocq's
     closed built-in extraction language enum. *)
@@ -245,11 +274,11 @@ END
 (** [Python Extraction foo.] — extract [foo] to [foo.py]. *)
 VERNAC COMMAND EXTEND PythonExtraction CLASSIFIED AS QUERY STATE opaque_access
 | [ "Python" "Extraction" global(x) ]
-  -> { python_extract x }
+  -> { run_with_diagnostics (fun () -> python_extract x) }
 END
 
 (** [Python Module Extraction M.] — extract module [M] to [M.py]. *)
 VERNAC COMMAND EXTEND PythonModuleExtraction CLASSIFIED AS QUERY STATE opaque_access
 | [ "Python" "Module" "Extraction" identref(m) ]
-  -> { python_extract_module (qualid_of_ident m.CAst.v) }
+  -> { run_with_diagnostics (fun () -> python_extract_module (qualid_of_ident m.CAst.v)) }
 END

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -244,8 +244,129 @@ let pp_impossible_expr () =
 let pp_impossible_stmt () =
   str "raise _Impossible()"
 
+type diagnostic = {
+  code : string;
+  title : string;
+  category : string;
+  remediation : string;
+  docs : string;
+}
+
+let diagnostic_catalogue = [
+  { code = "PYEX001"; title = "Persistent arrays are unsupported"; category = "miniml-expression"; remediation = "Avoid Rocq PArray in extracted terms or add an explicit Python remapping."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex001-persistent-arrays-are-unsupported" };
+  { code = "PYEX002"; title = "Prop term used for computation"; category = "prop-erasure"; remediation = "Move the proof to Prop-only positions or return data in Set/Type before extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex002-prop-term-used-for-computation" };
+  { code = "PYEX003"; title = "Type alias declaration is not emitted"; category = "miniml-declaration"; remediation = "Use a concrete inductive/record or add an extraction remapping for the type."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex003-type-alias-declaration-is-not-emitted" };
+  { code = "PYEX004"; title = "Axiom has no computational realization"; category = "runtime-stub"; remediation = "Provide an Extract Constant remapping for the axiom before Python extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex004-axiom-has-no-computational-realization" };
+  { code = "PYEX005"; title = "Exception term cannot be emitted as an expression"; category = "miniml-expression"; remediation = "Keep extracted exceptions at statement position or rewrite the Rocq term to return data."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex005-exception-term-cannot-be-emitted-as-an-expression" };
+  { code = "PYEX006"; title = "Erased logical value reached runtime"; category = "prop-erasure"; remediation = "Keep the logical argument proof-irrelevant or pass a computational witness in Set/Type."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex006-erased-logical-value-reached-runtime" };
+  { code = "PYEX007"; title = "Unsupported custom match encoding"; category = "custom-remap"; remediation = "Give Extract Inductive a Python match function with one thunk per constructor plus the scrutinee."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex007-unsupported-custom-match-encoding" };
+  { code = "PYEX008"; title = "Custom constructor arity mismatch"; category = "custom-remap"; remediation = "Make every custom constructor expression accept the same arguments as the Rocq constructor."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex008-custom-constructor-arity-mismatch" };
+  { code = "PYEX009"; title = "Unknown monad marker"; category = "custom-remap"; remediation = "Use one of the supported __PYMONAD_* markers or extract the operation normally."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex009-unknown-monad-marker" };
+  { code = "PYEX010"; title = "Monad marker arity mismatch"; category = "custom-remap"; remediation = "Use the marker with the expected number of computational arguments."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex010-monad-marker-arity-mismatch" };
+  { code = "PYEX011"; title = "Record projection pattern is too complex"; category = "pattern"; remediation = "Split the nested match into separate matches or bind the record before matching."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex011-record-projection-pattern-is-too-complex" };
+  { code = "PYEX012"; title = "Nested wildcard binder escaped erasure"; category = "pattern"; remediation = "Name the computational field explicitly or keep the wildcard proof-only."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex012-nested-wildcard-binder-escaped-erasure" };
+  { code = "PYEX013"; title = "Coinductive packet is not stream-shaped"; category = "coinductive"; remediation = "Expose a one-step destructor or avoid relying on Python iterator synthesis."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex013-coinductive-packet-is-not-stream-shaped" };
+  { code = "PYEX014"; title = "Coinductive constructor arity mismatch"; category = "coinductive"; remediation = "Use native coinductive constructors without custom erasure for this extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex014-coinductive-constructor-arity-mismatch" };
+  { code = "PYEX015"; title = "Mutual cofixpoint shape is unsupported"; category = "coinductive"; remediation = "Extract a wrapper function around one cofixpoint or split the mutual block."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex015-mutual-cofixpoint-shape-is-unsupported" };
+  { code = "PYEX016"; title = "Higher-order module signature is unsupported"; category = "module"; remediation = "Extract the applied module result or simplify the functor signature."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex016-higher-order-module-signature-is-unsupported" };
+  { code = "PYEX017"; title = "Module alias could not be resolved"; category = "module"; remediation = "Extract the canonical module path or make the alias transparent before extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex017-module-alias-could-not-be-resolved" };
+  { code = "PYEX018"; title = "Module type with constraints is unsupported"; category = "module"; remediation = "Extract the constrained module after elaboration or remove the with-constraint."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex018-module-type-with-constraints-is-unsupported" };
+  { code = "PYEX019"; title = "Applicative functor cache key is unsupported"; category = "module"; remediation = "Pass a first-class module value or extract a non-functorized wrapper."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex019-applicative-functor-cache-key-is-unsupported" };
+  { code = "PYEX020"; title = "Expected an inductive or constructor reference"; category = "backend-invariant"; remediation = "Report this backend invariant with the extracted declaration and source map."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex020-expected-an-inductive-or-constructor-reference" };
+  { code = "PYEX021"; title = "Expected an inductive reference"; category = "backend-invariant"; remediation = "Report this backend invariant with the extracted declaration and source map."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex021-expected-an-inductive-reference" };
+  { code = "PYEX022"; title = "Pattern shorthand was not expanded"; category = "backend-invariant"; remediation = "Report this backend invariant; the printer should expand Pusual before rendering."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex022-pattern-shorthand-was-not-expanded" };
+  { code = "PYEX023"; title = "Unexpected coinductive constructor payload"; category = "backend-invariant"; remediation = "Report this backend invariant with the constructor and generated source map."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex023-unexpected-coinductive-constructor-payload" };
+  { code = "PYEX024"; title = "Unsupported primitive integer type alias"; category = "primitive"; remediation = "Keep the integer literal in a computational term or remap the type explicitly."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex024-unsupported-primitive-integer-type-alias" };
+  { code = "PYEX025"; title = "Unsupported primitive float type alias"; category = "primitive"; remediation = "Keep the float literal in a computational term or remap the type explicitly."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex025-unsupported-primitive-float-type-alias" };
+  { code = "PYEX026"; title = "Unsupported primitive string type alias"; category = "primitive"; remediation = "Keep the string literal in a computational term or remap the type explicitly."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex026-unsupported-primitive-string-type-alias" };
+  { code = "PYEX027"; title = "Unknown type annotation shape"; category = "type-annotation"; remediation = "Use an explicit extracted type remapping or simplify the polymorphic type."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex027-unknown-type-annotation-shape" };
+  { code = "PYEX028"; title = "Function protocol annotation is too complex"; category = "type-annotation"; remediation = "Name the higher-order argument type or specialize the extracted function."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex028-function-protocol-annotation-is-too-complex" };
+  { code = "PYEX029"; title = "Generic constructor could not be typed"; category = "type-annotation"; remediation = "Specialize the inductive parameters or add a primitive remapping."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex029-generic-constructor-could-not-be-typed" };
+  { code = "PYEX030"; title = "Logical inductive used computationally"; category = "prop-erasure"; remediation = "Move the inductive to Set/Type or erase the use before extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex030-logical-inductive-used-computationally" };
+  { code = "PYEX031"; title = "Logical record used computationally"; category = "prop-erasure"; remediation = "Separate computational fields into a Set/Type record before extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex031-logical-record-used-computationally" };
+  { code = "PYEX032"; title = "Proof-carrying pair leaked into Python"; category = "prop-erasure"; remediation = "Project the computational component before extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex032-proof-carrying-pair-leaked-into-python" };
+  { code = "PYEX033"; title = "Unsupported well-founded recursion shape"; category = "recursion"; remediation = "Expose the structurally recursive helper or simplify the Program Fixpoint obligation shape."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex033-unsupported-well-founded-recursion-shape" };
+  { code = "PYEX034"; title = "Local fixpoint escaped statement context"; category = "recursion"; remediation = "Eta-expand the definition so the local fixpoint appears inside a function body."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex034-local-fixpoint-escaped-statement-context" };
+  { code = "PYEX035"; title = "Mutual recursion has erased selected function"; category = "recursion"; remediation = "Extract a computational member of the mutual block or remove the proof-only member."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex035-mutual-recursion-has-erased-selected-function" };
+  { code = "PYEX036"; title = "Unsupported bytes literal encoding"; category = "primitive"; remediation = "Restrict extracted strings to byte strings or provide a Python remapping."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex036-unsupported-bytes-literal-encoding" };
+  { code = "PYEX037"; title = "Unsupported float literal"; category = "primitive"; remediation = "Avoid NaN/infinity payloads that cannot round-trip or remap the constant explicitly."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex037-unsupported-float-literal" };
+  { code = "PYEX038"; title = "Generated Python identifier is invalid"; category = "naming"; remediation = "Rename the Rocq identifier or add an extraction rename before Python extraction."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex038-generated-python-identifier-is-invalid" };
+  { code = "PYEX039"; title = "Generated Python name collision"; category = "naming"; remediation = "Rename one Rocq declaration or extract through a module namespace."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex039-generated-python-name-collision" };
+  { code = "PYEX040"; title = "Unclassified extraction failure"; category = "internal"; remediation = "Check the detail field, reduce the Rocq input, and add a catalogue entry for this failure."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex040-unclassified-extraction-failure" };
+]
+
+let diagnostic_prefix = "PYTHON_EXTRACTION_DIAGNOSTIC_JSON: "
+
+let json_escape s =
+  let buf = Buffer.create (String.length s + 8) in
+  String.iter
+    (function
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\b' -> Buffer.add_string buf "\\b"
+      | '\012' -> Buffer.add_string buf "\\f"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c ->
+          let code = Char.code c in
+          if code < 0x20 then Buffer.add_string buf (Printf.sprintf "\\u%04x" code)
+          else Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+let json_string s = "\"" ^ json_escape s ^ "\""
+
+let diagnostic_by_code code =
+  match List.find_opt (fun d -> String.equal d.code code) diagnostic_catalogue with
+  | Some d -> d
+  | None -> List.find (fun d -> String.equal d.code "PYEX040") diagnostic_catalogue
+
+let diagnostic_json ?symbol ?detail d =
+  let field name value = "\"" ^ name ^ "\": " ^ json_string value in
+  let optional =
+    (match symbol with None -> [] | Some s -> [field "symbol" s]) @
+    (match detail with None -> [] | Some s -> [field "detail" s])
+  in
+  "{" ^
+  String.concat ", "
+    ([
+      "\"version\": 1";
+      field "code" d.code;
+      field "title" d.title;
+      field "category" d.category;
+      field "message" d.title;
+      field "remediation" d.remediation;
+      field "docs" d.docs;
+    ] @ optional) ^
+  "}"
+
+let diagnostic_pp ?symbol ?detail code =
+  let d = diagnostic_by_code code in
+  str "Python ExtractionError [" ++ str d.code ++ str "]: " ++ str d.title ++ fnl () ++
+  str "Remediation: " ++ str d.remediation ++ fnl () ++
+  str "Docs: " ++ str d.docs ++ fnl () ++
+  (match detail with
+   | None -> mt ()
+   | Some detail -> str "Detail: " ++ str detail ++ fnl ()) ++
+  str diagnostic_prefix ++ str (diagnostic_json ?symbol ?detail d)
+
+let extraction_diagnostic_error ?symbol ?detail code =
+  user_err (diagnostic_pp ?symbol ?detail code)
+
+let diagnostic_comment ?detail code =
+  let d = diagnostic_by_code code in
+  let detail =
+    match detail with
+    | None -> ""
+    | Some detail -> " Detail: " ^ detail
+  in
+  str "# Python ExtractionDiagnostic [" ++ str d.code ++ str "]: " ++
+  str d.title ++ str " Remediation: " ++ str d.remediation ++
+  str detail ++ fnl ()
+
 let prop_extraction_error detail =
-  user_err Pp.(str "Python ExtractionError: " ++ str detail)
+  extraction_diagnostic_error ~detail "PYEX002"
 
 let marker_state_type = "__PYMONAD_STATE_TYPE__"
 let marker_state_pure = "__PYMONAD_STATE_PURE__"
@@ -374,7 +495,8 @@ let get_ind r =
   match r.glob with
   | IndRef _              -> r
   | ConstructRef (ind, _) -> { glob = IndRef ind; inst = r.inst }
-  | _                     -> assert false
+  | _                     ->
+      extraction_diagnostic_error "PYEX020"
 
 let coinductive_name state r =
   capitalize_first (pp_global state Term (get_ind r))
@@ -403,7 +525,8 @@ let kn_of_ind r =
   let open GlobRef in
   match r.glob with
   | IndRef (kn, _) -> MutInd.user kn
-  | _              -> assert false
+  | _              ->
+      extraction_diagnostic_error "PYEX021"
 
 (** Python keyword-argument name for record field at position [i].
     Uses [pp_global_with_key] for named fields, ["arg<i>"] for anonymous ones. *)
@@ -473,7 +596,7 @@ let rec pp_pattern state env' = function
       str ")"
   | Pusual _ ->
       (* Should have been expanded by [expand_pusual] before this call. *)
-      assert false
+      extraction_diagnostic_error "PYEX022"
   | Ptuple pats ->
       str "(" ++
       prlist_with_sep (fun () -> str ", ") (pp_pattern state env') pats ++
@@ -558,7 +681,7 @@ let rec pp_expr state env = function
   | MLstring s ->
       str "b\"" ++ str (py_escape_bytes (Pstring.to_string s)) ++ str "\""
   | MLparray _ ->
-      str "raise NotImplementedError(\"MLparray: persistent arrays not yet supported\")"
+      extraction_diagnostic_error "PYEX001"
   | MLapp (f, args) ->
       (* Flatten left-associative curried application:
          MLapp(MLapp(f,[a]),[b]) → f(a, b) *)
@@ -606,6 +729,11 @@ let rec pp_expr state env = function
             Some (pp_expr state env m ++ str ".bind(" ++ pp_expr state env f ++ str ")")
         | Some marker, [opt_expr; fn_expr] when String.equal marker marker_option_bind ->
             Some (pp_option_bind_expr opt_expr fn_expr)
+        | Some marker, _
+          when String.length marker >= String.length "__PYMONAD_" &&
+               String.equal "__PYMONAD_"
+                 (String.sub marker 0 (String.length "__PYMONAD_")) ->
+            extraction_diagnostic_error ~detail:marker "PYEX010"
         | _ ->
             None
       in
@@ -660,7 +788,9 @@ let rec pp_expr state env = function
         let step_expr =
           if String.equal "" cons_name then
             (* erased coinductive constructor — unusual but valid *)
-            (match args with [a] -> pp_expr state env a | _ -> assert false)
+            (match args with
+             | [a] -> pp_expr state env a
+             | _ -> extraction_diagnostic_error "PYEX023")
           else if List.is_empty args then
             str cons_name ++ str "()"
           else
@@ -1543,7 +1673,7 @@ let pp_ind_decl state (ind : ml_ind) =
 let pp_decl state = function
   | Dind  ind   -> pp_ind_decl state ind ++ fnl ()
   | Dtype (r, _, _) when is_custom r -> mt ()
-  | Dtype _     -> str "# UNIMPL Dtype" ++ fnl ()
+  | Dtype _     -> diagnostic_comment "PYEX003"
   | Dterm (r, a, typ) ->
       if is_prop_type typ then mt ()
       else if is_monad_marker_ref r then mt ()

--- a/rocq-python-extraction/test/test_core_terms_syntax.py
+++ b/rocq-python-extraction/test/test_core_terms_syntax.py
@@ -12,3 +12,11 @@ def test_core_terms_syntax(build_default) -> None:
         "todo_val.py",
     ]:
         py_compile.compile(str(build_default / filename), doraise=True)
+
+
+def test_unsupported_dtype_comments_are_catalogued(build_default) -> None:
+    for filename in ["uint_val.py", "float_val.py", "str_val.py"]:
+        source = (build_default / filename).read_text()
+
+        assert "Python ExtractionDiagnostic [PYEX003]" in source
+        assert "Remediation:" in source

--- a/tests/test_extraction_diagnostics_catalogue.py
+++ b/tests/test_extraction_diagnostics_catalogue.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_BACKEND = REPO_ROOT / "rocq-python-extraction" / "python.ml"
+DIAGNOSTICS_DOC = REPO_ROOT / "rocq-python-extraction" / "DIAGNOSTICS.md"
+
+
+@dataclass(frozen=True)
+class CatalogueEntry:
+    code: str
+    title: str
+    category: str
+    remediation: str
+    docs: str
+
+
+def _catalogue_entries() -> tuple[CatalogueEntry, ...]:
+    source = PYTHON_BACKEND.read_text()
+    pattern = re.compile(
+        r'\{ code = "(?P<code>PYEX\d{3})"; '
+        r'title = "(?P<title>[^"]+)"; '
+        r'category = "(?P<category>[^"]+)"; '
+        r'remediation = "(?P<remediation>[^"]+)"; '
+        r'docs = "(?P<docs>[^"]+)" \};'
+    )
+    return tuple(
+        CatalogueEntry(**match.groupdict()) for match in pattern.finditer(source)
+    )
+
+
+CATALOGUE = _catalogue_entries()
+
+
+def test_catalogue_has_at_least_forty_unique_entries() -> None:
+    codes = [entry.code for entry in CATALOGUE]
+
+    assert len(CATALOGUE) >= 40
+    assert len(codes) == len(set(codes))
+    assert codes == sorted(codes)
+
+
+@pytest.mark.parametrize("entry", CATALOGUE, ids=lambda entry: entry.code)
+def test_catalogue_entry_has_remediation_and_docs(entry: CatalogueEntry) -> None:
+    docs = DIAGNOSTICS_DOC.read_text()
+    anchor = entry.docs.split("#", 1)[1]
+
+    assert entry.title
+    assert entry.category
+    assert entry.remediation.endswith(".")
+    assert entry.docs.startswith("rocq-python-extraction/DIAGNOSTICS.md#")
+    assert f"## {entry.code} " in docs
+    assert anchor in docs.lower().replace(" ", "-")
+
+
+def test_structured_diagnostic_renderer_fields_are_present() -> None:
+    source = PYTHON_BACKEND.read_text()
+
+    assert "PYTHON_EXTRACTION_DIAGNOSTIC_JSON: " in source
+    assert '\\"version\\": 1' in source
+    for field in ("code", "title", "category", "message", "remediation", "docs"):
+        assert f'field "{field}"' in source
+    for field in ("symbol", "detail"):
+        assert f'field "{field}"' in source
+
+
+def test_structured_diagnostic_output_from_failed_extraction() -> None:
+    script = textwrap.dedent(
+        """
+        cat > test/diagnostics_negative_tmp.v <<'EOF'
+        Declare ML Module "rocq-python-extraction".
+        Declare ML Module "rocq-runtime.plugins.extraction".
+        Extract Inductive nat => "int"
+          [ "0" "(lambda x: x + 1)" ]
+          "(lambda fO, fS, n: fO() if n == 0 else fS(n - 1))".
+        Definition bad_get (n : nat) : nat := n.
+        Extract Constant bad_get => "__PYMONAD_STATE_GET__".
+        Definition bad_monad_marker : nat := bad_get 0.
+        Python Extraction bad_monad_marker.
+        EOF
+        sed -i "s/source_maps))/source_maps diagnostics_negative_tmp))/" test/dune
+        opam exec -- dune build test/diagnostics_negative_tmp.vo
+        """
+    )
+
+    result = subprocess.run(
+        [
+            str(REPO_ROOT / "rocq-python-extraction" / "run_in_docker.sh"),
+            "rocq-python-extraction",
+            "bash",
+            "-euo",
+            "pipefail",
+            "-c",
+            script,
+        ],
+        check=False,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+    output = result.stdout + result.stderr
+    json_line = next(
+        line.removeprefix("PYTHON_EXTRACTION_DIAGNOSTIC_JSON: ")
+        for line in output.splitlines()
+        if line.startswith("PYTHON_EXTRACTION_DIAGNOSTIC_JSON: ")
+    )
+    payload = json.loads(json_line)
+
+    assert result.returncode != 0
+    assert "Python ExtractionError [PYEX010]" in output
+    assert "Remediation:" in output
+    assert payload["version"] == 1
+    assert payload["code"] == "PYEX010"
+    assert payload["remediation"]
+    assert payload["docs"].endswith("#pyex010-monad-marker-arity-mismatch")


### PR DESCRIPTION
Fixes #729

## Summary
- add a 40-entry Python extraction diagnostics catalogue with remediation/docs links
- emit human-readable diagnostics plus a JSON diagnostic line for extraction failures
- route known backend failures and uncatalogued extraction exceptions through structured diagnostics
- add catalogue tests, generated diagnostic-comment coverage, and a Docker-backed negative extraction check

## Verification
- make -C rocq-python-extraction docker-test
- generated extraction pyright via export_generated_python.sh + run_generated_pyright.sh
- uv run tests
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright
- git commit pre-commit hook