### PR TITLE
Split BuildKit mount caches by id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,20 +44,111 @@ jobs:
           key: buildx-rocq-model-context-${{ runner.os }}-${{ hashFiles('dune-workspace', 'models/*.v', 'models/Dockerfile', 'models/dune', 'models/dune-project', 'rocq-python-extraction/Dockerfile', 'rocq-python-extraction/META.rocq-python-extraction.template', 'rocq-python-extraction/dune', 'rocq-python-extraction/dune-project', 'rocq-python-extraction/g_python_extraction.mlg', 'rocq-python-extraction/python.ml', 'rocq-python-extraction/rocq-python-extraction.opam') }}
           restore-keys: |
             buildx-rocq-model-context-${{ runner.os }}-
-      - name: Restore buildkit cache mounts
-        id: restore-buildkit-mounts
+      - name: Cache fido-npm BuildKit mount
+        id: cache-buildkit_mount_fido_npm
         uses: actions/cache@v4
         with:
-          path: .cache/buildkit-mounts
-          key: buildkit-mounts-${{ runner.os }}-${{ hashFiles('.dockerignore', '.githooks/pre-commit', '.github/workflows/ci.yml', '.python-version', 'docker-bake.hcl', 'dune-workspace', 'fido', 'models/*.v', 'models/Dockerfile', 'models/dune', 'models/dune-project', 'package-lock.json', 'package.json', 'pyproject.toml', 'pyrightconfig.json', 'rocq-python-extraction/DIAGNOSTICS.md', 'rocq-python-extraction/Dockerfile', 'rocq-python-extraction/META.rocq-python-extraction.template', 'rocq-python-extraction/dune', 'rocq-python-extraction/dune-project', 'rocq-python-extraction/export_pytest_generated.sh', 'rocq-python-extraction/g_python_extraction.mlg', 'rocq-python-extraction/python.ml', 'rocq-python-extraction/rocq-python-extraction.opam', 'rocq-python-extraction/run_generated_pyright.sh', 'rocq-python-extraction/run_in_docker.sh', 'rocq-python-extraction/test/*.py', 'rocq-python-extraction/test/*.v', 'rocq-python-extraction/test/dune', 'rocq-python-extraction/test/generated_pyright_targets.txt', 'rocq-python-extraction/test/generated_pytest_targets.txt', 'src/**', 'tests/**', 'tools/build_graph.sh', 'tools/gen_workflows.py', 'uv.lock') }}
+          path: .cache/buildkit-mounts/fido-npm
+          key: buildkit-mount-fido-npm-${{ runner.os }}-${{ hashFiles('models/Dockerfile', 'package-lock.json', 'package.json') }}
           restore-keys: |
-            buildkit-mounts-${{ runner.os }}-
-      - name: Inject buildkit cache mounts
+            buildkit-mount-fido-npm-${{ runner.os }}-
+      - name: Inject fido-npm BuildKit mount
         uses: reproducible-containers/buildkit-cache-dance@v3.3.2
         with:
           builder: ${{ steps.setup-buildx.outputs.name }}
-          cache-dir: .cache/buildkit-mounts
-          dockerfile: models/Dockerfile
+          cache-map: |
+            {
+              ".cache/buildkit-mounts/fido-npm": {
+                "id": "fido-npm",
+                "target": "/root/.npm"
+              }
+            }
+          scratch-dir: .cache/buildkit-mounts-scratch/fido-npm
+          skip-extraction: ${{ steps.cache-buildkit_mount_fido_npm.outputs.cache-hit }}
+      - name: Cache fido-pyright BuildKit mount
+        id: cache-buildkit_mount_fido_pyright
+        uses: actions/cache@v4
+        with:
+          path: .cache/buildkit-mounts/fido-pyright
+          key: buildkit-mount-fido-pyright-${{ runner.os }}-${{ hashFiles('.python-version', 'models/Dockerfile', 'pyproject.toml', 'pyrightconfig.json', 'uv.lock') }}
+          restore-keys: |
+            buildkit-mount-fido-pyright-${{ runner.os }}-
+      - name: Inject fido-pyright BuildKit mount
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              ".cache/buildkit-mounts/fido-pyright": {
+                "id": "fido-pyright",
+                "target": "/root/.cache/pyright-python"
+              }
+            }
+          scratch-dir: .cache/buildkit-mounts-scratch/fido-pyright
+          skip-extraction: ${{ steps.cache-buildkit_mount_fido_pyright.outputs.cache-hit }}
+      - name: Cache fido-uv-check BuildKit mount
+        id: cache-buildkit_mount_fido_uv_check
+        uses: actions/cache@v4
+        with:
+          path: .cache/buildkit-mounts/fido-uv-check
+          key: buildkit-mount-fido-uv-check-${{ runner.os }}-${{ hashFiles('.python-version', 'models/Dockerfile', 'pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            buildkit-mount-fido-uv-check-${{ runner.os }}-
+      - name: Inject fido-uv-check BuildKit mount
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              ".cache/buildkit-mounts/fido-uv-check": {
+                "id": "fido-uv-check",
+                "target": "/root/.cache/uv"
+              }
+            }
+          scratch-dir: .cache/buildkit-mounts-scratch/fido-uv-check
+          skip-extraction: ${{ steps.cache-buildkit_mount_fido_uv_check.outputs.cache-hit }}
+      - name: Cache fido-uv-dev BuildKit mount
+        id: cache-buildkit_mount_fido_uv_dev
+        uses: actions/cache@v4
+        with:
+          path: .cache/buildkit-mounts/fido-uv-dev
+          key: buildkit-mount-fido-uv-dev-${{ runner.os }}-${{ hashFiles('.python-version', 'models/Dockerfile', 'pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            buildkit-mount-fido-uv-dev-${{ runner.os }}-
+      - name: Inject fido-uv-dev BuildKit mount
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              ".cache/buildkit-mounts/fido-uv-dev": {
+                "id": "fido-uv-dev",
+                "target": "/tmp/uv-cache"
+              }
+            }
+          scratch-dir: .cache/buildkit-mounts-scratch/fido-uv-dev
+          skip-extraction: ${{ steps.cache-buildkit_mount_fido_uv_dev.outputs.cache-hit }}
+      - name: Cache fido-uv-prod BuildKit mount
+        id: cache-buildkit_mount_fido_uv_prod
+        uses: actions/cache@v4
+        with:
+          path: .cache/buildkit-mounts/fido-uv-prod
+          key: buildkit-mount-fido-uv-prod-${{ runner.os }}-${{ hashFiles('.python-version', 'models/Dockerfile', 'pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            buildkit-mount-fido-uv-prod-${{ runner.os }}-
+      - name: Inject fido-uv-prod BuildKit mount
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              ".cache/buildkit-mounts/fido-uv-prod": {
+                "id": "fido-uv-prod",
+                "target": "/tmp/uv-cache"
+              }
+            }
+          scratch-dir: .cache/buildkit-mounts-scratch/fido-uv-prod
+          skip-extraction: ${{ steps.cache-buildkit_mount_fido_uv_prod.outputs.cache-hit }}
       - run: ./.githooks/pre-commit
       - name: Check committed model mirrors
         run: |

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -201,16 +201,11 @@ class TestModelsBuildScript:
         rocq_models_key = workflow.split("key: buildx-rocq-model-buildx-", maxsplit=1)[
             1
         ].split("      - name: Restore rocq-model-context", maxsplit=1)[0]
-        buildkit_mounts_key = workflow.split("key: buildkit-mounts-", maxsplit=1)[
-            1
-        ].split("      - name: Inject buildkit cache mounts", maxsplit=1)[0]
         assert "uv.lock" not in rocq_image_key
         assert "uv.lock" not in rocq_models_key
         assert "package-lock.json" not in rocq_image_key
         assert "package-lock.json" not in rocq_models_key
         assert "models/*.v" in rocq_models_key
-        assert "uv.lock" in buildkit_mounts_key
-        assert "package-lock.json" in buildkit_mounts_key
         assert "docker buildx" in generator
         assert "bake" in generator
         for target in (
@@ -237,10 +232,53 @@ class TestModelsBuildScript:
                 "if: success() && "
                 f"steps.restore-rocq_model_{cache}.outputs.cache-hit != 'true'"
             ) in workflow
-        assert "path: .cache/buildkit-mounts" in workflow
-        assert ("key: buildkit-mounts-${{ runner.os }}-${{ hashFiles(") in workflow
-        assert "buildkit-mounts-${{ runner.os }}-" in workflow
+        assert "Restore buildkit cache mounts" not in workflow
+        assert "key: buildkit-mounts-${{ runner.os }}-" not in workflow
+        assert "cache-dir: .cache/buildkit-mounts" not in workflow
+        assert "dockerfile: models/Dockerfile" not in workflow
         assert "reproducible-containers/buildkit-cache-dance@v3.3.2" in workflow
+        assert "parse_cache_mounts" in generator
+        assert "cache_mounts_for_targets" in generator
+        assert "cache_mount_key_inputs" in generator
+        expected_mounts = {
+            "fido-npm": ("/root/.npm", ("package-lock.json", "package.json")),
+            "fido-pyright": (
+                "/root/.cache/pyright-python",
+                ("pyrightconfig.json", "uv.lock"),
+            ),
+            "fido-uv-check": ("/root/.cache/uv", ("uv.lock",)),
+            "fido-uv-dev": ("/tmp/uv-cache", ("uv.lock",)),
+            "fido-uv-prod": ("/tmp/uv-cache", ("uv.lock",)),
+        }
+        for mount_id, (target, key_inputs) in expected_mounts.items():
+            step_id = mount_id.replace("-", "_")
+            assert f"name: Cache {mount_id} BuildKit mount" in workflow
+            assert f"id: cache-buildkit_mount_{step_id}" in workflow
+            assert f"path: .cache/buildkit-mounts/{mount_id}" in workflow
+            assert f"key: buildkit-mount-{mount_id}-${{{{ runner.os }}}}-" in workflow
+            assert f"buildkit-mount-{mount_id}-${{{{ runner.os }}}}-" in workflow
+            assert f"name: Inject {mount_id} BuildKit mount" in workflow
+            assert f'".cache/buildkit-mounts/{mount_id}": {{' in workflow
+            assert f'"id": "{mount_id}"' in workflow
+            assert f'"target": "{target}"' in workflow
+            assert f"scratch-dir: .cache/buildkit-mounts-scratch/{mount_id}" in workflow
+            assert (
+                "skip-extraction: "
+                f"${{{{ steps.cache-buildkit_mount_{step_id}.outputs.cache-hit }}}}"
+                in workflow
+            )
+            mount_key = workflow.split(
+                f"key: buildkit-mount-{mount_id}-${{{{ runner.os }}}}-",
+                maxsplit=1,
+            )[1].split("          restore-keys:", maxsplit=1)[0]
+            assert "models/Dockerfile" in mount_key
+            for key_input in key_inputs:
+                assert key_input in mount_key
+        npm_key = workflow.split(
+            "key: buildkit-mount-fido-npm-${{ runner.os }}-", maxsplit=1
+        )[1].split("          restore-keys:", maxsplit=1)[0]
+        assert "uv.lock" not in npm_key
+        assert "pyproject.toml" not in npm_key
 
 
 class TestFidoLauncher:

--- a/tools/gen_workflows.py
+++ b/tools/gen_workflows.py
@@ -26,7 +26,17 @@ class CopyInstruction:
 
 @dataclass
 class RunInstruction:
-    uses_cache_mount: bool
+    cache_mounts: list["CacheMount"] = field(default_factory=list)
+
+    @property
+    def uses_cache_mount(self) -> bool:
+        return bool(self.cache_mounts)
+
+
+@dataclass(frozen=True)
+class CacheMount:
+    id: str
+    target: str
 
 
 Instruction = CopyInstruction | RunInstruction
@@ -142,10 +152,28 @@ def parse_dockerfile(path: Path) -> list[Stage]:
                     CopyInstruction(sources=args[:-1], from_name=from_name)
                 )
         elif keyword == "RUN":
-            stages[-1].instructions.append(
-                RunInstruction(uses_cache_mount="--mount=type=cache" in line)
-            )
+            stages[-1].instructions.append(RunInstruction(parse_cache_mounts(parts)))
     return stages
+
+
+def parse_cache_mounts(parts: list[str]) -> list[CacheMount]:
+    mounts: list[CacheMount] = []
+    for part in parts:
+        if not part.startswith("--mount="):
+            continue
+        options: dict[str, str] = {}
+        for option in part.removeprefix("--mount=").split(","):
+            key, separator, value = option.partition("=")
+            if separator:
+                options[key] = value
+        if options.get("type") != "cache":
+            continue
+        target = options.get("target")
+        if target is None:
+            continue
+        mount_id = options.get("id", target.strip("/").replace("/", "-"))
+        mounts.append(CacheMount(id=mount_id, target=target))
+    return mounts
 
 
 def stage_map(stages: list[Stage]) -> dict[str, Stage]:
@@ -277,18 +305,87 @@ def target_inputs(
 
 def cache_key_inputs(plan: dict[str, object]) -> dict[str, list[str]]:
     warm_targets = cache_scopes(plan)
-    mount_inputs: set[str] = {"docker-bake.hcl"}
-    for target in warm_targets:
-        mount_inputs.update(
-            target_inputs(plan, target, include_cache_mount_stages=True)
-        )
-    return {
+    keys = {
         "rocq-image": sorted(target_inputs(plan, "rocq-image")),
         "rocq-models": sorted(
             target_inputs(plan, "format", target_stage_override="extract")
         ),
-        "buildkit-mounts": sorted(mount_inputs),
     }
+    for mount in cache_mounts_for_targets(plan, warm_targets):
+        keys[f"buildkit-mount-{mount.id}"] = cache_mount_key_inputs(mount)
+    return keys
+
+
+def cache_mounts_for_targets(
+    plan: dict[str, object], bake_targets: list[str]
+) -> list[CacheMount]:
+    mounts: dict[str, CacheMount] = {}
+    visited: set[tuple[str, str]] = set()
+
+    def visit_stage(
+        context: str,
+        stages_by_name: dict[str, Stage],
+        bake_target: str,
+        stage_name: str,
+    ) -> None:
+        key = (bake_target, stage_name)
+        if key in visited:
+            return
+        visited.add(key)
+        stage = stages_by_name[stage_name]
+        if stage.base in stages_by_name:
+            visit_stage(context, stages_by_name, bake_target, stage.base)
+        elif stage.base.startswith("${") and stage.base.endswith("}"):
+            if target := arg_named_target(plan, bake_target, stage.base[2:-1]):
+                visit_target(target)
+        for instruction in stage.instructions:
+            if isinstance(instruction, CopyInstruction):
+                if instruction.from_name in stages_by_name:
+                    visit_stage(
+                        context,
+                        stages_by_name,
+                        bake_target,
+                        instruction.from_name,
+                    )
+                elif instruction.from_name is not None and (
+                    target := named_target(plan, bake_target, instruction.from_name)
+                ):
+                    visit_target(target)
+            elif isinstance(instruction, RunInstruction):
+                for mount in instruction.cache_mounts:
+                    existing = mounts.get(mount.id)
+                    if existing is not None and existing.target != mount.target:
+                        sys.exit(
+                            f"cache mount id {mount.id!r} has conflicting targets: "
+                            f"{existing.target!r} and {mount.target!r}"
+                        )
+                    mounts[mount.id] = mount
+
+    def visit_target(name: str) -> None:
+        context, dockerfile, target_stage = dockerfile_for_bake_target(plan, name)
+        stages = parse_dockerfile(dockerfile)
+        stages_by_name = stage_map(stages)
+        if not target_stage:
+            target_stage = stages[-1].name
+        visit_stage(context, stages_by_name, name, target_stage)
+
+    for target in bake_targets:
+        visit_target(target)
+    return [mounts[name] for name in sorted(mounts)]
+
+
+def cache_mount_key_inputs(mount: CacheMount) -> list[str]:
+    base = {"models/Dockerfile"}
+    if mount.id.startswith("fido-uv-"):
+        return sorted(base | {".python-version", "pyproject.toml", "uv.lock"})
+    if mount.id == "fido-npm":
+        return sorted(base | {"package.json", "package-lock.json"})
+    if mount.id == "fido-pyright":
+        return sorted(
+            base
+            | {".python-version", "pyproject.toml", "uv.lock", "pyrightconfig.json"}
+        )
+    return sorted(base)
 
 
 def hashfiles_pattern(path: str) -> str:
@@ -447,9 +544,53 @@ def save_step(name: str, path: str, key_expression: str) -> str:
 """
 
 
+def cache_step_id(name: str) -> str:
+    return "cache-" + name.replace("-", "_")
+
+
+def buildkit_mount_cache_step(mount: CacheMount, key_expression: str) -> str:
+    name = f"buildkit-mount-{mount.id}"
+    step_id = cache_step_id(name)
+    path = f".cache/buildkit-mounts/{mount.id}"
+    cache_map = json.dumps(
+        {path: {"target": mount.target, "id": mount.id}},
+        indent=2,
+        sort_keys=True,
+    )
+    indented_cache_map = "\n".join(
+        f"            {line}" for line in cache_map.splitlines()
+    )
+    return f"""\
+      - name: Cache {mount.id} BuildKit mount
+        id: {step_id}
+        uses: actions/cache@v4
+        with:
+          path: {path}
+          key: buildkit-mount-{mount.id}-${{{{ runner.os }}}}-{key_expression}
+          restore-keys: |
+            buildkit-mount-{mount.id}-${{{{ runner.os }}}}-
+      - name: Inject {mount.id} BuildKit mount
+        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
+        with:
+          builder: ${{{{ steps.setup-buildx.outputs.name }}}}
+          cache-map: |
+{indented_cache_map}
+          scratch-dir: .cache/buildkit-mounts-scratch/{mount.id}
+          skip-extraction: ${{{{ steps.{step_id}.outputs.cache-hit }}}}
+"""
+
+
 def render(plan: dict[str, object]) -> str:
     keys = cache_key_inputs(plan)
     key_expressions = {key: hashfiles_expression(paths) for key, paths in keys.items()}
+    buildkit_mounts = cache_mounts_for_targets(plan, cache_scopes(plan))
+    buildkit_mount_steps = "".join(
+        buildkit_mount_cache_step(
+            mount,
+            key_expressions[f"buildkit-mount-{mount.id}"],
+        )
+        for mount in buildkit_mounts
+    )
     restores = "".join(
         restore_step(name, path, key_expressions[key])
         for name, path, key in cache_entries(plan)
@@ -482,21 +623,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
         id: setup-buildx
-{restores}      - name: Restore buildkit cache mounts
-        id: restore-buildkit-mounts
-        uses: actions/cache@v4
-        with:
-          path: .cache/buildkit-mounts
-          key: buildkit-mounts-${{{{ runner.os }}}}-{key_expressions["buildkit-mounts"]}
-          restore-keys: |
-            buildkit-mounts-${{{{ runner.os }}}}-
-      - name: Inject buildkit cache mounts
-        uses: reproducible-containers/buildkit-cache-dance@v3.3.2
-        with:
-          builder: ${{{{ steps.setup-buildx.outputs.name }}}}
-          cache-dir: .cache/buildkit-mounts
-          dockerfile: models/Dockerfile
-      - run: ./.githooks/pre-commit
+{restores}{buildkit_mount_steps}      - run: ./.githooks/pre-commit
       - name: Check committed model mirrors
         run: |
           ./fido make-rocq


### PR DESCRIPTION
## Summary

- generate one BuildKit cache mount cache per discovered Dockerfile cache mount id
- replace the broad `.cache/buildkit-mounts` cache with per-id `actions/cache` + `cache-dance` pairs
- wire `skip-extraction` to each matching exact cache hit so hot caches do not get re-extracted/tarred unnecessarily

Closes #884.

## Verification

- `./fido pytest tests/test_build_wrapper.py -q`
- `./fido gen-workflows` idempotence by before/after hash
- `./fido warm`
- parsed `.github/workflows/ci.yml` with PyYAML
