### PR TITLE
Add Rocq IO async extraction

### DIFF
--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -198,7 +198,14 @@ RUN opam exec -- dune build rocq-python-extraction/test/python.vo \
         exit 1; \
     fi \
     && grep -F "PYTHON_EXTRACTION_DIAGNOSTIC_JSON:" /tmp/reals-unsupported.log \
-    && grep -F '"code": "PYEX041"' /tmp/reals-unsupported.log
+    && grep -F '"code": "PYEX041"' /tmp/reals-unsupported.log \
+    && if opam exec -- dune build rocq-python-extraction/test/io_run_unsupported.vo > /tmp/io-run-unsupported.log 2>&1; then \
+        cat /tmp/io-run-unsupported.log; \
+        echo "expected io_run_unsupported.v extraction to fail with PYEX042" >&2; \
+        exit 1; \
+    fi \
+    && grep -F "PYTHON_EXTRACTION_DIAGNOSTIC_JSON:" /tmp/io-run-unsupported.log \
+    && grep -F '"code": "PYEX042"' /tmp/io-run-unsupported.log
 
 FROM python-base AS python-deps
 

--- a/rocq-python-extraction/DIAGNOSTICS.md
+++ b/rocq-python-extraction/DIAGNOSTICS.md
@@ -132,3 +132,6 @@ Remediation: Check the detail field, reduce the Rocq input, and add a catalogue 
 
 ## PYEX041 Unsupported Real Number Extraction
 Remediation: Use nat, positive, N, Z, or Q for extracted computation; Rocq R has no faithful Python runtime mapping.
+
+## PYEX042 Unsupported IO Effect Extraction
+Remediation: Keep IO values at an async boundary or provide an explicit IO adapter remapping.

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -270,6 +270,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()
@@ -790,6 +797,7 @@ let diagnostic_catalogue = [
   { code = "PYEX039"; title = "Generated Python name collision"; category = "naming"; remediation = "Rename one Rocq declaration or extract through a module namespace."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex039-generated-python-name-collision" };
   { code = "PYEX040"; title = "Unclassified extraction failure"; category = "internal"; remediation = "Check the detail field, reduce the Rocq input, and add a catalogue entry for this failure."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex040-unclassified-extraction-failure" };
   { code = "PYEX041"; title = "Unsupported real number extraction"; category = "numeric"; remediation = "Use nat, positive, N, Z, or Q for extracted computation; Rocq R has no faithful Python runtime mapping."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex041-unsupported-real-number-extraction" };
+  { code = "PYEX042"; title = "Unsupported IO effect extraction"; category = "io"; remediation = "Keep IO values at an async boundary or provide an explicit IO adapter remapping."; docs = "rocq-python-extraction/DIAGNOSTICS.md#pyex042-unsupported-io-effect-extraction" };
 ]
 
 let diagnostic_prefix = "PYTHON_EXTRACTION_DIAGNOSTIC_JSON: "
@@ -877,6 +885,7 @@ let marker_reader_ask = "__PYMONAD_READER_ASK__"
 let marker_io_type = "__PYMONAD_IO_TYPE__"
 let marker_io_pure = "__PYMONAD_IO_PURE__"
 let marker_io_bind = "__PYMONAD_IO_BIND__"
+let marker_io_run = "__PYMONAD_IO_RUN__"
 
 let is_monad_marker_string s =
   let prefix = "__PYMONAD_" in
@@ -1320,6 +1329,8 @@ let rec pp_expr state env expr =
             Some (str "IO.pure(" ++ pp_expr state env value ++ str ")")
         | Some marker, [m; f] when String.equal marker marker_io_bind ->
             Some (pp_expr state env m ++ str ".bind(" ++ pp_expr state env f ++ str ")")
+        | Some marker, _ when String.equal marker marker_io_run ->
+            extraction_diagnostic_error ~detail:marker "PYEX042"
         | Some marker, [opt_expr; fn_expr] when String.equal marker marker_option_bind ->
             Some (pp_option_bind_expr opt_expr fn_expr)
         | Some marker, _
@@ -2558,6 +2569,7 @@ let rec pp_type_with state pp_tvar = function
         else if is_positive_set_type_ref r then "frozenset[int]"
         else if is_string_map_type_ref r then "dict[str, object]"
         else if is_string_set_type_ref r then "frozenset[str]"
+        else if is_custom r && String.equal (find_custom r) marker_io_type then "IO"
         else if is_custom r then find_custom r
         else
           let n = pp_global state Term r in
@@ -2586,6 +2598,10 @@ let rec pp_type_with state pp_tvar = function
         (match args with
          | [arg] -> str "dict[str, " ++ pp_type_with state pp_tvar arg ++ str "]"
          | _ -> str "dict[str, object]")
+      else if is_custom r && String.equal (find_custom r) marker_io_type then
+        (match args with
+         | [arg] -> str "IO[" ++ pp_type_with state pp_tvar arg ++ str "]"
+         | _ -> str "IO[object]")
       else if is_positive_set_type_ref r || is_string_set_type_ref r then str name
       else if List.is_empty args then str name
       else
@@ -2601,6 +2617,18 @@ let rec pp_type_with state pp_tvar = function
 
 let pp_type state typ =
   pp_type_with state ml_typevar_name typ
+
+let rec type_ends_in_io = function
+  | Tarr (_, ret) -> type_ends_in_io ret
+  | Tglob (r, [value]) when is_custom r && String.equal (find_custom r) marker_io_type ->
+      Some value
+  | _ ->
+      None
+
+let rec arrow_type args ret =
+  match args with
+  | [] -> ret
+  | arg :: rest -> Tarr (arg, arrow_type rest ret)
 
 let pp_protocol_decl state spec =
   let n = List.length spec.protocol_arg_types in
@@ -2748,9 +2776,87 @@ let pp_annotated_params names annots =
        pp_param (List.nth names i) ++ str ": " ++ List.nth annots i)
     (List.init (List.length names) Fun.id)
 
+let pp_io_term_decl state env name a typ ret_typ =
+  let builder_name = "_io_" ^ name in
+  let args, _io_ret = type_decomp typ in
+  let facade_typ = arrow_type args ret_typ in
+  let facade_prefix, facade_arg_annots, facade_ret_annot =
+    signature_data state name facade_typ
+  in
+  let builder_prefix, builder_arg_annots, builder_ret_annot =
+    signature_data state builder_name typ
+  in
+  let facade_call pp_arg args =
+    str "return await " ++ str builder_name ++ str "(" ++
+    prlist_with_sep (fun () -> str ", ")
+      pp_arg
+      args ++
+    str ").run()"
+  in
+  let lam_ids, body = collect_lams a in
+  match lam_ids with
+  | [] ->
+      let builder =
+        match pp_function_wrapper state env builder_name a typ with
+        | Some pp -> pp
+        | None ->
+            builder_prefix ++
+            str builder_name ++ str ": " ++ builder_ret_annot ++
+            str " = " ++ pp_expr state env a ++ fnl ()
+      in
+      if List.is_empty args then
+        builder ++ fnl () ++ facade_prefix ++
+        str "async def " ++ str name ++ str "() -> " ++ facade_ret_annot ++
+        str ":" ++ fnl () ++
+        str "    return await " ++ str builder_name ++ str ".run()" ++ fnl ()
+      else
+        let arg_names =
+          if Int.equal (List.length args) 1 then ["x"]
+          else List.init (List.length args) (fun i -> "arg" ^ string_of_int i)
+        in
+        builder ++ fnl () ++ facade_prefix ++
+        str "async def " ++ str name ++ str "(" ++
+        prlist_with_sep (fun () -> str ", ")
+          (fun i ->
+             pp_pyname (List.nth arg_names i) ++ str ": " ++
+             List.nth facade_arg_annots i)
+          (List.init (List.length arg_names) Fun.id) ++
+        str ") -> " ++ facade_ret_annot ++ str ":" ++ fnl () ++
+        str "    " ++ facade_call pp_pyname arg_names ++ fnl ()
+  | _ ->
+      let params = List.map id_of_mlid lam_ids in
+      let params', env' = push_vars params env in
+      let visible_params_rev = List.rev (visible_params params') in
+      let pp_builder_params =
+        if Int.equal (List.length visible_params_rev) (List.length builder_arg_annots) then
+          pp_annotated_params visible_params_rev builder_arg_annots
+        else
+          pp_param_list (List.rev params')
+      in
+      let pp_facade_params =
+        if Int.equal (List.length visible_params_rev) (List.length facade_arg_annots) then
+          pp_annotated_params visible_params_rev facade_arg_annots
+        else
+          pp_param_list (List.rev params')
+      in
+      let builder =
+        builder_prefix ++
+        str "def " ++ str builder_name ++ str "(" ++ pp_builder_params ++
+        str ") -> " ++ builder_ret_annot ++ str ":" ++ fnl () ++
+        str "    " ++ pp_return_body state env' 4 body ++ fnl ()
+      in
+      builder ++ fnl () ++ facade_prefix ++
+      str "async def " ++ str name ++ str "(" ++ pp_facade_params ++
+      str ") -> " ++ facade_ret_annot ++ str ":" ++ fnl () ++
+      str "    " ++ facade_call pp_pyid visible_params_rev ++ fnl ()
+
 let pp_term_decl state env name a typ =
   let lam_ids, body = collect_lams a in
   let pp_prefix, arg_annots, ret_annot = signature_data state name typ in
+  match type_ends_in_io typ with
+  | Some ret_typ ->
+      pp_io_term_decl state env name a typ ret_typ
+  | None ->
   if List.is_empty lam_ids then
     (* Non-function value: simple assignment — unless the body is a [raise]
        expression (MLaxiom / MLexn / MLparray), which cannot appear as the

--- a/rocq-python-extraction/test/dune
+++ b/rocq-python-extraction/test/dune
@@ -1,6 +1,6 @@
 (rocq.theory
  (name PyExtractTest)
- (synopsis "Python extraction acceptance tests — core terms, primitive remapping, datatypes, nested patterns, records, Acc-erasure, polymorphism, coinductives, modules, strings/bytes, numbers, and finite collections")
+ (synopsis "Python extraction acceptance tests — core terms, primitive remapping, datatypes, nested patterns, records, Acc-erasure, polymorphism, coinductives, modules, strings/bytes, numbers, finite collections, and IO boundaries")
  (plugins rocq-python-extraction)
  (theories Stdlib)
  (modules
@@ -22,4 +22,6 @@
   strings_bytes
   numbers
   finite_collections
-  reals_unsupported))
+  io_boundaries
+  reals_unsupported
+  io_run_unsupported))

--- a/rocq-python-extraction/test/generated_pyright_targets.txt
+++ b/rocq-python-extraction/test/generated_pyright_targets.txt
@@ -17,3 +17,5 @@ q_half.py
 q_num.py
 q_den.py
 FiniteCollectionFixtures.py
+read_file_echo.py
+http_status_ok.py

--- a/rocq-python-extraction/test/generated_pytest_targets.txt
+++ b/rocq-python-extraction/test/generated_pytest_targets.txt
@@ -64,3 +64,5 @@ q_half.py
 q_num.py
 q_den.py
 FiniteCollectionFixtures.py
+read_file_echo.py
+http_status_ok.py

--- a/rocq-python-extraction/test/io_boundaries.v
+++ b/rocq-python-extraction/test/io_boundaries.v
@@ -1,0 +1,53 @@
+(** IO boundary extraction acceptance tests.
+
+    Coordination models should remain pure.  This fixture models adapter-facing
+    effects only: Rocq describes sequencing through [IO], while Python supplies
+    explicit boundary implementations through extraction remappings. *)
+
+Declare ML Module "rocq-python-extraction".
+Declare ML Module "rocq-runtime.plugins.extraction".
+
+From Stdlib Require Import Strings.String.
+
+Open Scope string_scope.
+
+(** [IO] is intentionally opaque at the Rocq boundary.  The Python backend maps
+    it to an async-aware [IO] wrapper rather than pretending effects are pure. *)
+Definition IO (A : Type) : Type := A.
+
+(** [io_pure] injects a pure value into the IO wrapper. *)
+Definition io_pure {A : Type} (value : A) : IO A := value.
+
+(** [io_bind] sequences IO actions. *)
+Definition io_bind {A B : Type} (action : IO A) (next : A -> IO B) : IO B :=
+  next action.
+
+(** [read_text] is a file-style adapter boundary supplied by Python. *)
+Parameter read_text : String.string -> IO String.string.
+
+(** [http_status] is an HTTP-style adapter boundary supplied by Python. *)
+Parameter http_status : String.string -> IO nat.
+
+(** [read_file_echo] sequences a file read and returns its text payload. *)
+Definition read_file_echo (path : String.string) : IO String.string :=
+  io_bind (read_text path) (fun contents => io_pure contents).
+
+(** [http_status_ok] maps a boundary status code to a pure boolean result. *)
+Definition http_status_ok (url : String.string) : IO bool :=
+  io_bind (http_status url) (fun code =>
+  io_pure
+    (match code with
+     | S (S O) => true
+     | _ => false
+     end)).
+
+Extract Constant IO "'a" => "__PYMONAD_IO_TYPE__".
+Extract Constant io_pure => "__PYMONAD_IO_PURE__".
+Extract Constant io_bind => "__PYMONAD_IO_BIND__".
+Extract Constant read_text =>
+  "(lambda path: IO.from_sync(lambda: open(path, encoding=""utf-8"").read()))".
+Extract Constant http_status =>
+  "(lambda url: IO.from_sync(lambda: 2 if url == ""https://ok.example"" else 0))".
+
+Python Extraction read_file_echo.
+Python Extraction http_status_ok.

--- a/rocq-python-extraction/test/io_run_unsupported.v
+++ b/rocq-python-extraction/test/io_run_unsupported.v
@@ -1,0 +1,15 @@
+Declare ML Module "rocq-python-extraction".
+Declare ML Module "rocq-runtime.plugins.extraction".
+
+(** Directly unwrapping IO inside generated sync code would hide effects.
+    The backend must reject this marker with a structured diagnostic. *)
+Definition IO (A : Type) : Type := A.
+
+Parameter io_run : forall {A : Type}, IO A -> A.
+
+Definition bad_io_unwrap : nat := io_run 0.
+
+Extract Constant IO "'a" => "__PYMONAD_IO_TYPE__".
+Extract Constant io_run => "__PYMONAD_IO_RUN__".
+
+Python Extraction bad_io_unwrap.

--- a/rocq-python-extraction/test/pyright_io_boundaries_check.py
+++ b/rocq-python-extraction/test/pyright_io_boundaries_check.py
@@ -1,0 +1,22 @@
+from http_status_ok import IO as HttpIO
+from http_status_ok import _io_http_status_ok, http_status_ok
+from read_file_echo import IO as ReadIO
+from read_file_echo import _io_read_file_echo, read_file_echo
+
+
+async def check_file_boundary(path: str) -> None:
+    text: str = await read_file_echo(path)
+    io_text: ReadIO[str] = _io_read_file_echo(path)
+    text_again: str = await io_text.run()
+
+    assert isinstance(text, str)
+    assert isinstance(text_again, str)
+
+
+async def check_http_boundary() -> None:
+    ok: bool = await http_status_ok("https://ok.example")
+    io_ok: HttpIO[bool] = _io_http_status_ok("https://ok.example")
+    ok_again: bool = await io_ok.run()
+
+    assert isinstance(ok, bool)
+    assert isinstance(ok_again, bool)

--- a/rocq-python-extraction/test/python.v
+++ b/rocq-python-extraction/test/python.v
@@ -20,4 +20,5 @@ From PyExtractTest Require Export
   source_maps
   strings_bytes
   numbers
-  finite_collections.
+  finite_collections
+  io_boundaries.

--- a/rocq-python-extraction/test/test_io_boundaries.py
+++ b/rocq-python-extraction/test/test_io_boundaries.py
@@ -1,0 +1,36 @@
+import asyncio
+from pathlib import Path
+
+from http_status_ok import IO as HttpIO
+from http_status_ok import _io_http_status_ok, http_status_ok
+from read_file_echo import IO as ReadIO
+from read_file_echo import _io_read_file_echo, read_file_echo
+
+
+def test_file_style_io_boundary_extracts_to_async_facade(tmp_path: Path) -> None:
+    payload = tmp_path / "payload.txt"
+    payload.write_text("hello from fido\n", encoding="utf-8")
+
+    assert asyncio.run(read_file_echo(str(payload))) == "hello from fido\n"
+
+    io_value = _io_read_file_echo(str(payload))
+    assert isinstance(io_value, ReadIO)
+    assert asyncio.run(io_value.run()) == "hello from fido\n"
+
+
+def test_http_style_io_boundary_maps_effect_result() -> None:
+    assert asyncio.run(http_status_ok("https://ok.example")) is True
+    assert asyncio.run(http_status_ok("https://not-ok.example")) is False
+
+    io_value = _io_http_status_ok("https://ok.example")
+    assert isinstance(io_value, HttpIO)
+    assert asyncio.run(io_value.run()) is True
+
+
+def test_generated_io_source_uses_async_await(build_default: Path) -> None:
+    source = (build_default / "read_file_echo.py").read_text()
+
+    assert "def _io_read_file_echo" in source
+    assert "async def read_file_echo" in source
+    assert "return await _io_read_file_echo(path).run()" in source
+    assert "IO.from_sync" in source

--- a/src/fido/rocq/bool_not.py
+++ b/src/fido/rocq/bool_not.py
@@ -231,6 +231,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()

--- a/src/fido/rocq/bool_not.pymap
+++ b/src/fido/rocq/bool_not.pymap
@@ -3,9 +3,9 @@
   "python_file": "bool_not.py",
   "entries": [
     {
-      "python_start_line": 270,
+      "python_start_line": 277,
       "python_start_col": 0,
-      "python_end_line": 271,
+      "python_end_line": 278,
       "python_end_col": 55,
       "source_file": "seed.v",
       "source_start_line": 21,

--- a/src/fido/rocq/coord_index.py
+++ b/src/fido/rocq/coord_index.py
@@ -231,6 +231,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()

--- a/src/fido/rocq/coord_index.pymap
+++ b/src/fido/rocq/coord_index.pymap
@@ -3,9 +3,9 @@
   "python_file": "coord_index.py",
   "entries": [
     {
-      "python_start_line": 304,
+      "python_start_line": 311,
       "python_start_col": 0,
-      "python_end_line": 305,
+      "python_end_line": 312,
       "python_end_col": 60,
       "source_file": "coord_index.v",
       "source_start_line": 24,
@@ -16,9 +16,9 @@
       "symbol": "add_claim"
     },
     {
-      "python_start_line": 308,
+      "python_start_line": 315,
       "python_start_col": 0,
-      "python_end_line": 309,
+      "python_end_line": 316,
       "python_end_col": 63,
       "source_file": "coord_index.v",
       "source_start_line": 30,
@@ -29,9 +29,9 @@
       "symbol": "remove_claim"
     },
     {
-      "python_start_line": 312,
+      "python_start_line": 319,
       "python_start_col": 0,
-      "python_end_line": 313,
+      "python_end_line": 320,
       "python_end_col": 47,
       "source_file": "coord_index.v",
       "source_start_line": 34,
@@ -42,9 +42,9 @@
       "symbol": "has_claim"
     },
     {
-      "python_start_line": 316,
+      "python_start_line": 323,
       "python_start_col": 0,
-      "python_end_line": 317,
+      "python_end_line": 324,
       "python_end_col": 66,
       "source_file": "coord_index.v",
       "source_start_line": 40,
@@ -55,9 +55,9 @@
       "symbol": "assign_issue"
     },
     {
-      "python_start_line": 320,
+      "python_start_line": 327,
       "python_start_col": 0,
-      "python_end_line": 321,
+      "python_end_line": 328,
       "python_end_col": 62,
       "source_file": "coord_index.v",
       "source_start_line": 46,
@@ -68,9 +68,9 @@
       "symbol": "unassign_issue"
     },
     {
-      "python_start_line": 324,
+      "python_start_line": 331,
       "python_start_col": 0,
-      "python_end_line": 325,
+      "python_end_line": 332,
       "python_end_col": 48,
       "source_file": "coord_index.v",
       "source_start_line": 51,
@@ -81,9 +81,9 @@
       "symbol": "issue_owner"
     },
     {
-      "python_start_line": 341,
+      "python_start_line": 348,
       "python_start_col": 0,
-      "python_end_line": 347,
+      "python_end_line": 354,
       "python_end_col": 55,
       "source_file": "coord_index.v",
       "source_start_line": 70,
@@ -94,9 +94,9 @@
       "symbol": "repo_providers"
     },
     {
-      "python_start_line": 350,
+      "python_start_line": 357,
       "python_start_col": 0,
-      "python_end_line": 351,
+      "python_end_line": 358,
       "python_end_col": 24,
       "source_file": "coord_index.v",
       "source_start_line": 77,

--- a/src/fido/rocq/payload_text.py
+++ b/src/fido/rocq/payload_text.py
@@ -231,6 +231,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()

--- a/src/fido/rocq/payload_text.pymap
+++ b/src/fido/rocq/payload_text.pymap
@@ -3,9 +3,9 @@
   "python_file": "payload_text.py",
   "entries": [
     {
-      "python_start_line": 273,
+      "python_start_line": 280,
       "python_start_col": 0,
-      "python_end_line": 273,
+      "python_end_line": 280,
       "python_end_col": 32,
       "source_file": "payload_text.v",
       "source_start_line": 21,
@@ -16,9 +16,9 @@
       "symbol": "event_name"
     },
     {
-      "python_start_line": 276,
+      "python_start_line": 283,
       "python_start_col": 0,
-      "python_end_line": 276,
+      "python_end_line": 283,
       "python_end_col": 41,
       "source_file": "payload_text.v",
       "source_start_line": 25,
@@ -29,9 +29,9 @@
       "symbol": "event_name_bytes"
     },
     {
-      "python_start_line": 279,
+      "python_start_line": 286,
       "python_start_col": 0,
-      "python_end_line": 279,
+      "python_end_line": 286,
       "python_end_col": 22,
       "source_file": "payload_text.v",
       "source_start_line": 28,
@@ -42,9 +42,9 @@
       "symbol": "newline_byte"
     },
     {
-      "python_start_line": 282,
+      "python_start_line": 289,
       "python_start_col": 0,
-      "python_end_line": 289,
+      "python_end_line": 296,
       "python_end_col": 12,
       "source_file": "payload_text.v",
       "source_start_line": 33,

--- a/src/fido/rocq/retry_budget.py
+++ b/src/fido/rocq/retry_budget.py
@@ -231,6 +231,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()

--- a/src/fido/rocq/retry_budget.pymap
+++ b/src/fido/rocq/retry_budget.pymap
@@ -3,9 +3,9 @@
   "python_file": "retry_budget.py",
   "entries": [
     {
-      "python_start_line": 274,
+      "python_start_line": 281,
       "python_start_col": 0,
-      "python_end_line": 274,
+      "python_end_line": 281,
       "python_end_col": 36,
       "source_file": "retry_budget.v",
       "source_start_line": 18,
@@ -16,9 +16,9 @@
       "symbol": "max_retries"
     },
     {
-      "python_start_line": 277,
+      "python_start_line": 284,
       "python_start_col": 0,
-      "python_end_line": 277,
+      "python_end_line": 284,
       "python_end_col": 29,
       "source_file": "retry_budget.v",
       "source_start_line": 22,
@@ -29,9 +29,9 @@
       "symbol": "retry_budget"
     },
     {
-      "python_start_line": 280,
+      "python_start_line": 287,
       "python_start_col": 0,
-      "python_end_line": 287,
+      "python_end_line": 294,
       "python_end_col": 47,
       "source_file": "retry_budget.v",
       "source_start_line": 27,
@@ -42,9 +42,9 @@
       "symbol": "retry_delta"
     },
     {
-      "python_start_line": 290,
+      "python_start_line": 297,
       "python_start_col": 0,
-      "python_end_line": 290,
+      "python_end_line": 297,
       "python_end_col": 44,
       "source_file": "retry_budget.v",
       "source_start_line": 35,

--- a/src/fido/rocq/transition.py
+++ b/src/fido/rocq/transition.py
@@ -231,6 +231,13 @@ class IO(Generic[_IOValue]):
 
         return IO(run_pure)
 
+    @classmethod
+    def from_sync(cls, thunk: Callable[[], _IOValue]) -> IO[_IOValue]:
+        async def run_sync() -> _IOValue:
+            return thunk()
+
+        return IO(run_sync)
+
 
 def coforce(value: Callable[[], _CoForceT]) -> _CoForceT:
     return value()

--- a/src/fido/rocq/transition.pymap
+++ b/src/fido/rocq/transition.pymap
@@ -3,9 +3,9 @@
   "python_file": "transition.py",
   "entries": [
     {
-      "python_start_line": 325,
+      "python_start_line": 332,
       "python_start_col": 0,
-      "python_end_line": 370,
+      "python_end_line": 377,
       "python_end_col": 38,
       "source_file": "session_lock.v",
       "source_start_line": 67,


### PR DESCRIPTION
Closes #737

## Summary
- add IO boundary extraction that emits an `_io_*` builder plus public async facade
- add `IO.from_sync` runtime support and `PYEX042` structured diagnostics for unsupported IO unwraps
- add Rocq acceptance fixtures, pytest coverage, and generated pyright coverage for file-style and HTTP-style IO examples

## Verification
- ./fido gen-workflows
- ./fido ci