### PR TITLE
Drop in-container _startup_pull; host supervisor already syncs the runner (closes #917)

### DIFF
--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -36,7 +36,6 @@ from fido.infra import (
     Clock,
     Filesystem,
     Infra,
-    OsProcess,
     ProcessRunner,
     real_infra,
 )
@@ -497,21 +496,6 @@ def preflight_gh_auth(gh: GitHub) -> None:
     except Exception as e:
         raise PreflightError(f"preflight: gh auth check failed: {e}") from e
     log.info("preflight: gh auth confirmed — bot user is %r", bot_user)
-
-
-def _get_head(runner_dir: Path, proc: ProcessRunner) -> str | None:
-    """Return the current HEAD commit hash of the runner clone, or None on error."""
-    try:
-        result = proc.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=str(runner_dir),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError, FileNotFoundError:
-        return None
 
 
 def _pull_with_backoff(
@@ -1249,28 +1233,6 @@ def bootstrap_issue_caches(
             )
 
 
-def _startup_pull(proc: ProcessRunner, clock: Clock, os_proc: OsProcess) -> None:
-    """Sync the runner clone on startup and exit for host rebuild if HEAD changed."""
-    runner_dir = _runner_dir()
-    head_before = _get_head(runner_dir, proc)
-    if not _pull_with_backoff(runner_dir, proc, clock):
-        log.warning("startup: runner sync failed — continuing with current code")
-        return
-    head_after = _get_head(runner_dir, proc)
-    if head_before and head_after and head_before != head_after:
-        log.info(
-            "startup: runner updated %s → %s — exiting %d for host rebuild",
-            head_before[:12],
-            head_after[:12],
-            _RESTART_EXIT_CODE,
-        )
-        os_proc.exit(_RESTART_EXIT_CODE)
-    elif head_before and head_after:
-        log.info("startup: runner already up to date at %s", head_before[:12])
-    else:
-        log.info("startup: runner synced (could not compare HEAD)")
-
-
 def run(
     *,
     _from_args: Callable[..., Config] = Config.from_args,
@@ -1282,7 +1244,6 @@ def run(
     _populate_memberships: Callable[..., None] = populate_memberships,
     _signal: Callable[..., Any] = signal.signal,
     _kill_active_children: Callable[..., None] = kill_active_children,
-    _startup_pull: Callable[..., None] = _startup_pull,
     _Watchdog: type[Watchdog] = Watchdog,
     _ReconcileWatchdog: type[ReconcileWatchdog] = ReconcileWatchdog,
     _RateLimitMonitor: type[RateLimitMonitor] = RateLimitMonitor,
@@ -1329,7 +1290,6 @@ def run(
     WebhookHandler.infra = infra
 
     gh = _GitHub()
-    _startup_pull(infra.proc, infra.clock, infra.os_proc)
     try:
         _preflight_tools(infra.fs)
         _preflight_sub_dir(config, infra.fs)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3063,7 +3063,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3089,7 +3088,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3120,7 +3118,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3151,7 +3148,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3192,7 +3188,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3223,7 +3218,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3252,7 +3246,6 @@ class TestRun:
             _basic_config=MagicMock(),
             _stderr=mock_stderr,
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3294,7 +3287,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3339,7 +3331,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3368,7 +3359,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3398,7 +3388,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3433,7 +3422,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3470,7 +3458,6 @@ class TestRun:
                 _path_home=lambda: tmp_path,
                 _basic_config=MagicMock(),
                 _populate_memberships=MagicMock(),
-                _startup_pull=MagicMock(),
                 _preflight_repo_identity=MagicMock(),
                 _preflight_tools=MagicMock(),
                 _preflight_sub_dir=MagicMock(),
@@ -3533,7 +3520,6 @@ class TestRun:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3770,7 +3756,6 @@ class TestPreflightRepoIdentity:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=mock_preflight,
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3802,7 +3787,6 @@ class TestPreflightRepoIdentity:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=mock_preflight,
             _preflight_sub_dir=MagicMock(),
@@ -3834,7 +3818,6 @@ class TestPreflightRepoIdentity:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=MagicMock(),
@@ -3866,7 +3849,6 @@ class TestPreflightRepoIdentity:
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
-            _startup_pull=MagicMock(),
             _preflight_repo_identity=MagicMock(),
             _preflight_tools=MagicMock(),
             _preflight_sub_dir=mock_preflight,
@@ -3897,7 +3879,6 @@ class TestPreflightRepoIdentity:
                 _path_home=lambda: tmp_path,
                 _basic_config=MagicMock(),
                 _populate_memberships=MagicMock(),
-                _startup_pull=MagicMock(),
                 _preflight_tools=MagicMock(
                     side_effect=PreflightError("something went wrong")
                 ),
@@ -4074,26 +4055,6 @@ class TestGetSelfRepo:
         assert _get_self_repo(tmp_path, proc) is None
 
 
-class TestGetHead:
-    def test_returns_sha(self, tmp_path: Path) -> None:
-        from fido.server import _get_head
-
-        proc = _FakeProcessRunner([MagicMock(stdout="abc123def456\n")])
-        assert _get_head(tmp_path, proc) == "abc123def456"
-
-    def test_returns_none_on_subprocess_error(self, tmp_path: Path) -> None:
-        from fido.server import _get_head
-
-        proc = _FakeProcessRunner([subprocess.CalledProcessError(128, [])])
-        assert _get_head(tmp_path, proc) is None
-
-    def test_returns_none_on_file_not_found(self, tmp_path: Path) -> None:
-        from fido.server import _get_head
-
-        proc = _FakeProcessRunner([FileNotFoundError()])
-        assert _get_head(tmp_path, proc) is None
-
-
 class TestRunnerDir:
     def test_returns_package_parent(self) -> None:
         from fido.server import _runner_dir
@@ -4190,66 +4151,6 @@ class TestPullWithBackoff:
         proc = _FakeProcessRunner(error=FileNotFoundError())
         clock = _FakeClock(times=[0.0, 1.0, 12.0, 43.0, 104.0])
         assert not _pull_with_backoff(tmp_path, proc, clock)
-
-
-class TestStartupPull:
-    def test_exits_for_supervisor_when_head_changes(self) -> None:
-        from fido.server import _startup_pull
-
-        # rev-parse before, fetch, reset, rev-parse after — different SHAs
-        proc = _FakeProcessRunner(
-            [
-                MagicMock(stdout="sha1\n"),
-                MagicMock(),
-                MagicMock(),
-                MagicMock(stdout="sha2\n"),
-            ]
-        )
-        clock = _FakeClock(times=[0.0, 0.0])  # start + success log
-        os_proc = _FakeOsProcess()
-        _startup_pull(proc, clock, os_proc)
-        assert os_proc.exit_calls == [75]
-
-    def test_skips_exit_when_head_unchanged(self) -> None:
-        from fido.server import _startup_pull
-
-        proc = _FakeProcessRunner(
-            [
-                MagicMock(stdout="same\n"),
-                MagicMock(),
-                MagicMock(),
-                MagicMock(stdout="same\n"),
-            ]
-        )
-        clock = _FakeClock(times=[0.0, 0.0])
-        os_proc = _FakeOsProcess()
-        _startup_pull(proc, clock, os_proc)
-        assert os_proc.exit_calls == []
-
-    def test_continues_on_pull_failure(self) -> None:
-        from fido.server import _startup_pull
-
-        # get_head fails → None; fetch fails with budget exhausted immediately
-        proc = _FakeProcessRunner(
-            [FileNotFoundError(), subprocess.CalledProcessError(1, [])]
-        )
-        clock = _FakeClock(times=[0.0, 601.0])  # budget exhausted on first attempt
-        os_proc = _FakeOsProcess()
-        _startup_pull(proc, clock, os_proc)
-        assert os_proc.exit_calls == []
-
-    def test_does_not_exit_when_head_unknown(self) -> None:
-        from fido.server import _startup_pull
-
-        # Both rev-parse calls fail → head_before and head_after are None
-        proc = _FakeProcessRunner(
-            [FileNotFoundError(), MagicMock(), MagicMock(), FileNotFoundError()]
-        )
-        clock = _FakeClock(times=[0.0, 0.0])
-        os_proc = _FakeOsProcess()
-        _startup_pull(proc, clock, os_proc)
-        # Can't compare HEAD — pull succeeded, log and continue without exit
-        assert os_proc.exit_calls == []
 
 
 class TestSelfRestart:


### PR DESCRIPTION
Fixes #917.

## The bug

`_startup_pull` at `src/fido/server.py:1252` ran inside the container and tried `git fetch origin main` against the bind-mounted runner clone.  The container has no SSH creds, so the fetch returned exit 128 on every cold boot and sent `_pull_with_backoff` into its 10-minute backoff loop.  During that window `./fido status` reported DOWN and no workers came up — observed as a 10-minute maiden-voyage stall.

## The fix

Delete `_startup_pull`.  The host-side `supervise_up` already syncs the runner before launching the container (it is the only place with credentials to do so) — the in-container sync was dead-defensive duplication.

Also drops:
- `_get_head` (only caller was `_startup_pull`)
- `OsProcess` import and the `_startup_pull` kwarg on `run()`
- `TestStartupPull` and `TestGetHead` test classes
- `_startup_pull=MagicMock()` stubs in `run()`-call tests

Keeps `_pull_with_backoff` — still used by the webhook-driven `_self_restart` path, which signals via exit 75 and lets the host supervisor re-sync.

## Test plan

- `./fido ci` green locally
- Manual maiden-voyage retry planned after merge