### PR TITLE
Fix sub_dir default after kennel→fido package rename (closes #919)

### DIFF
--- a/src/fido/config.py
+++ b/src/fido/config.py
@@ -111,5 +111,5 @@ class Config:
                 b.strip() for b in args.allowed_bots.split(",") if b.strip()
             ),
             log_level=args.log_level.upper(),
-            sub_dir=Path(__file__).resolve().parent.parent / "sub",
+            sub_dir=Path(__file__).resolve().parents[2] / "sub",
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,6 +140,32 @@ class TestFromArgs:
         )
         assert cfg.sub_dir.name == "sub"
 
+    def test_sub_dir_resolves_to_real_skill_files(self, tmp_path: Path) -> None:
+        """The default sub_dir must point at the actual sub/ directory at
+        the repo root, containing the canonical sub-skill markdown files.
+
+        Regression test for #919: a leftover ``parent.parent`` from the
+        kennel→fido rename made the default path ``src/sub`` instead of
+        ``sub``, which passed unit tests that only checked the directory
+        name but failed preflight at boot time.
+        """
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("s")
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        cfg = Config.from_args(
+            [
+                "--secret-file",
+                str(secret_file),
+                f"owner/repo:{repo_dir}:claude-code",
+            ]
+        )
+        assert cfg.sub_dir.is_dir(), f"default sub_dir {cfg.sub_dir} does not exist"
+        for name in ("persona.md", "setup.md", "task.md", "ci.md", "resume.md"):
+            assert (cfg.sub_dir / name).is_file(), (
+                f"expected sub-skill {name} under {cfg.sub_dir}"
+            )
+
     def test_repo_provider_parses_from_args(self, tmp_path: Path) -> None:
         secret_file = tmp_path / "secret"
         secret_file.write_text("s")


### PR DESCRIPTION
Fixes #919.

Default `sub_dir` was walking `Path(__file__).resolve().parent.parent`, which yielded `/workspace/src/sub` now that the package lives at `src/fido/` — the real `sub/` is at the repo root (`/workspace/sub`).  Preflight rejected the missing directory and the supervisor marked the container `action=fail`, refusing to auto-retry.

Switches to `parents[2] / "sub"` and adds a regression test that the default path actually contains the five canonical sub-skill markdown files.  The existing name-only test would have kept passing with the broken path.

`./fido ci` green locally.