### PR TITLE
Drain ClaudeSession stderr into the logger (progress on #921)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -632,7 +632,7 @@ class ClaudeSession(OwnedSession):
         ]
         if self._session_id:
             cmd += ["--resume", self._session_id]
-        return self._popen_fn(
+        proc = self._popen_fn(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -640,6 +640,41 @@ class ClaudeSession(OwnedSession):
             text=True,
             cwd=self._work_dir,
         )
+        self._start_stderr_pump(proc)
+        return proc
+
+    def _start_stderr_pump(self, proc: subprocess.Popen[str]) -> None:
+        """Drain the subprocess's stderr into the logger.
+
+        Without this drain, ``stderr=subprocess.PIPE`` leaves the pipe buffer
+        unread.  Once the buffer fills, the claude subprocess blocks on its
+        next stderr write and eventually deadlocks — symptom: the first
+        ``set_status`` prompt finds the session dead with no diagnostic.
+
+        Runs as a daemon thread so it terminates naturally when the
+        subprocess exits (stderr EOF) or when the process shuts down.
+        """
+        pid = proc.pid
+        stderr = proc.stderr
+        if stderr is None:  # pragma: no cover — Popen with PIPE always sets this
+            return
+
+        def pump() -> None:
+            try:
+                for raw in stderr:
+                    line = raw.rstrip()
+                    if line:
+                        log.info("ClaudeSession[pid=%d] stderr: %s", pid, line)
+            except OSError, ValueError:
+                # ValueError on closed file; OSError on broken pipe.
+                # Both mean the subprocess is gone — stop pumping.
+                pass
+
+        threading.Thread(
+            target=pump,
+            name=f"claude-stderr-pump-{pid}",
+            daemon=True,
+        ).start()
 
     def is_alive(self) -> bool:
         """Return True if the claude subprocess is still running."""


### PR DESCRIPTION
Progress on #921.

`ClaudeSession._spawn` sets `stderr=subprocess.PIPE` but nothing ever reads it.  Once the pipe buffer fills, the claude subprocess blocks on its next stderr write and eventually dies silently.  Symptom: on boot, the first `set_status` prompt finds the session dead with no diagnostic, and both workers crash-loop on `Claude session died during prompt`.

This PR starts a daemon reader thread from `_spawn` that reads stderr line-by-line and forwards each line through the repo's logger at INFO with a `ClaudeSession[pid=N] stderr:` prefix.  The thread exits on stderr EOF (subprocess gone) or on OSError/ValueError (pipe closed), so no manual cleanup is needed.

Primarily an instrumentation fix — claude's own complaint will now land in `~/log/fido.log` instead of being swallowed.  It also removes the pipe-buffer-fills-and-claude-blocks failure mode as a side effect, which may be the root cause of #921 on its own.

The shared-state-contention theory (host claude-code + container claude writing to the same `~/.claude.json`) was ruled out by a manual test: user killed the host claude-code session, started fido from a plain shell, and got the identical crash.

`./fido ci` green.