### PR TITLE
Consolidate sub/ path into one helper; fixes #921

### DIFF
--- a/src/fido/config.py
+++ b/src/fido/config.py
@@ -8,6 +8,25 @@ from fido.provider import ProviderID
 log = logging.getLogger(__name__)
 
 
+def default_sub_dir() -> Path:
+    """Return the default path to the ``sub/`` skill-instructions directory.
+
+    Single source of truth for the filesystem walk from the ``fido`` Python
+    package back to the repo-root ``sub/`` tree.  The formula is
+    ``parents[2]`` because this module lives at ``src/fido/config.py`` and
+    ``sub/`` lives at the repo root:
+
+    - ``parents[0]`` → ``src/fido/``
+    - ``parents[1]`` → ``src/``
+    - ``parents[2]`` → repo root, which contains ``sub/``
+
+    Every module that needs this path must import this helper — do not
+    redo the walk inline.  #919 and its follow-up crash were both caused
+    by copies of this formula going stale during the kennel→fido rename.
+    """
+    return Path(__file__).resolve().parents[2] / "sub"
+
+
 @dataclass(frozen=True)
 class RepoMembership:
     """Cached membership info for a repo — who gets to direct fido's work.
@@ -111,5 +130,5 @@ class Config:
                 b.strip() for b in args.allowed_bots.split(",") if b.strip()
             ),
             log_level=args.log_level.upper(),
-            sub_dir=Path(__file__).resolve().parents[2] / "sub",
+            sub_dir=default_sub_dir(),
         )

--- a/src/fido/gh_status.py
+++ b/src/fido/gh_status.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from fido.claude import ClaudeClient
-from fido.config import RepoConfig
+from fido.config import RepoConfig, default_sub_dir
 from fido.github import GitHub
 from fido.provider import ProviderAgent
 from fido.provider_factory import DefaultProviderFactory
@@ -15,7 +15,7 @@ from fido.status import running_repo_configs
 
 log = logging.getLogger(__name__)
 
-_SUB_DIR = Path(__file__).resolve().parent.parent / "sub"
+_SUB_DIR = default_sub_dir()
 _PERSONA_PATH = _SUB_DIR / "persona.md"
 
 _STATUS_SYSTEM = (

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -31,7 +31,7 @@ from fido.color import (
     wrap_bg_line,
     wrap_raw,
 )
-from fido.config import RepoConfig
+from fido.config import RepoConfig, default_sub_dir
 from fido.provider import (
     ProviderID,
     ProviderPressureStatus,
@@ -358,7 +358,7 @@ def running_repo_configs(
 
 
 def _status_persona_path() -> Path:
-    return Path(__file__).resolve().parents[1] / "sub" / "persona.md"
+    return default_sub_dir() / "persona.md"
 
 
 def provider_statuses_for_repo_configs(

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -18,7 +18,7 @@ import requests as _requests
 
 from fido import hooks, tasks
 from fido.claude import ClaudeCode
-from fido.config import Config, RepoConfig, RepoMembership
+from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.prompts import Prompts
@@ -194,7 +194,7 @@ class WorkerContext:
 
 def _sub_dir() -> Path:
     """Return the path to the sub/ skill-instructions directory."""
-    return Path(__file__).parent.parent / "sub"
+    return default_sub_dir()
 
 
 def acquire_lock(fido_dir: Path) -> IO[str]:


### PR DESCRIPTION
Fixes #921.

Three separate modules (`gh_status.py`, `status.py`, `worker.py`) still had their own pre-rename copies of the filesystem walk to `sub/`.  Only `config.py` was updated when the package moved from `kennel/` to `src/fido/` (#920).  The other three kept pointing at the non-existent `/workspace/src/sub/`, which is why ClaudeSession launched claude with `--system-prompt-file /workspace/src/sub/persona.md` and claude exited silently with:

```
ClaudeSession[pid=54] stderr: Error: System prompt file not found: /workspace/src/sub/persona.md
```

That error was hidden behind an unread stderr pipe until #922 landed the stderr drain and made it visible.  This PR fixes the actual crash by moving all four callers onto a single `fido.config.default_sub_dir()` helper — inline `parents[N] / "sub"` is now a review-time smell.

`./fido ci` green.