### PR TITLE
Container: add ssh + docker + buildx for real worker iterations

### DIFF
--- a/fido
+++ b/fido
@@ -509,6 +509,17 @@ run_container() {
   add_mount_if_exists "$HOME/.claude.json"
   add_mount_if_exists "$HOME/.config/gh"
   add_mount_if_exists "$HOME/.cache/copilot"
+  # SSH keys are needed for git push/fetch on SSH-origin workspace clones.
+  # Mounted read-only so the container can use them without mutating.
+  if [ -d "$HOME/.ssh" ]; then
+    run_args+=(--volume "$HOME/.ssh:$HOME/.ssh:ro")
+  fi
+  # Docker socket passthrough — workers need `docker`/`buildx` to run
+  # `./fido ci` and `./fido make-rocq` against the host daemon.  The CLI
+  # binaries are in the image; the daemon stays on the host.
+  if [ -S /var/run/docker.sock ]; then
+    run_args+=(--volume "/var/run/docker.sock:/var/run/docker.sock")
+  fi
 
   log INFO "starting container image=$run_image"
   docker run "${run_args[@]}" "$run_image" "$@"

--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -4,9 +4,19 @@ ARG ROCQ_IMAGE=rocq-python-extraction:ci
 
 FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS python-base
 
+ARG DOCKER_BUILDX_VERSION=0.17.1
+
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl git jq libatomic1 \
+    && apt-get install -y --no-install-recommends \
+        curl git jq libatomic1 openssh-client docker.io \
     && rm -rf /var/lib/apt/lists/*
+
+# buildx is not packaged in bookworm; pull the plugin binary directly.
+# docker.io from apt gives us the CLI; buildx extends it as a subcommand.
+RUN mkdir -p /usr/local/libexec/docker/cli-plugins \
+    && curl -fsSL -o /usr/local/libexec/docker/cli-plugins/docker-buildx \
+        "https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-amd64" \
+    && chmod +x /usr/local/libexec/docker/cli-plugins/docker-buildx
 
 ENV UV_PROJECT_ENVIRONMENT=/tmp/fido-venv
 ENV UV_LINK_MODE=copy


### PR DESCRIPTION
Workers crashed on the first real issue pickup because the fido container had neither `openssh-client` (workspace clones use SSH origin for git fetch) nor `docker` + `buildx` (workers validate PRs by running `./fido ci` which shells out to `docker buildx bake`).  Both surfaced during the maiden voyage's pickup of #898:

```
error: cannot run ssh: No such file or directory
fatal: unable to fork
git fetch origin → exit 128
```

## Fixes

- `models/Dockerfile`: install `openssh-client` and `docker.io` via apt (bookworm main).  Pull the `buildx` plugin binary directly into `/usr/local/libexec/docker/cli-plugins/` because `docker-buildx` is not packaged in bookworm or bookworm-backports.
- `fido` launcher: bind-mount `~/.ssh` read-only when present, and the host `/var/run/docker.sock` when present, so the container can reach both the SSH keychain and the host docker daemon for buildx bake.

`gh` CLI was already installed in `fido-base` and `~/.config/gh` was already bind-mounted — no change needed on that side.

`./fido ci` green locally after image rebuild.