### PR TITLE
Fall back to plain-text on empty voice reply in _notify_thread_change (fixes #935)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1369,15 +1369,46 @@ def _notify_thread_change(
             "has been updated. Reference the comment URL."
         )
 
-    body = agent.run_turn(
-        prompts.persona_wrap(instruction),
-        model=agent.voice_model,
-        system_prompt=prompts.reply_system_prompt(),
-    )
-    if not body:
-        raise ValueError(
-            f"_notify_thread_change: run_turn returned empty for comment {comment_id}"
+    try:
+        body = agent.run_turn(
+            prompts.persona_wrap(instruction),
+            model=agent.voice_model,
+            system_prompt=prompts.reply_system_prompt(),
         )
+    except Exception:
+        log.exception(
+            "_notify_thread_change: run_turn failed for comment %s — "
+            "falling back to plain-text notice",
+            comment_id,
+        )
+        body = ""
+
+    if not body:
+        # Opus came back empty (or raised) — post a plain-text fallback so the
+        # reviewer still sees *something*, and so a single empty reply can't
+        # kill the caller.  Both _on_changes call sites run on threads whose
+        # death costs real state: the background reorder-<repo> thread loses
+        # all remaining notifications in that cycle, and the worker's
+        # synchronous rescope_before_pick takes down the worker itself.
+        log.warning(
+            "_notify_thread_change: empty voice reply for comment %s (%s) — "
+            "posting plain-text fallback",
+            comment_id,
+            kind,
+        )
+        new_title = change.get("new_title", "")
+        if kind == "completed":
+            body = (
+                f'Fido: your task "{original_title}" has been marked done — '
+                f"a recent commit already covered it, so it was removed from "
+                f"the active queue. Ref: {url}"
+            )
+        else:
+            body = (
+                f'Fido: your task "{original_title}" has been rewritten to '
+                f'"{new_title}" to reflect the updated requirements. '
+                f"Ref: {url}"
+            )
 
     try:
         gh.reply_to_review_comment(repo, pr, body, comment_id)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4170,18 +4170,28 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, mock_gh, agent=_client())
         mock_gh.comment_issue.assert_not_called()
 
-    def test_review_comment_empty_opus_raises_for_completed(
+    def test_review_comment_empty_opus_falls_back_for_completed(
         self, tmp_path: Path
     ) -> None:
+        """Opus empty reply must not raise — #935.
+
+        An empty voice reply used to raise ValueError, which killed both the
+        background reorder daemon and the synchronous worker via
+        rescope_before_pick.  Now it falls back to a plain-text notification
+        so the reviewer still sees the status change.
+        """
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
-        with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        mock_gh.reply_to_review_comment.assert_called_once()
+        body = mock_gh.reply_to_review_comment.call_args.args[2]
+        assert "marked done" in body
+        assert task["title"] in body
 
-    def test_review_comment_empty_opus_raises_for_modified(
+    def test_review_comment_empty_opus_falls_back_for_modified(
         self, tmp_path: Path
     ) -> None:
         cfg = self._cfg(tmp_path)
@@ -4194,8 +4204,11 @@ class TestNotifyThreadChange:
             "new_title": "New title",
             "new_description": "",
         }
-        with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        mock_gh.reply_to_review_comment.assert_called_once()
+        body = mock_gh.reply_to_review_comment.call_args.args[2]
+        assert "rewritten" in body
+        assert "New title" in body
 
     def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)


### PR DESCRIPTION
Fixes #935.

`_notify_thread_change` was raising `ValueError` when the Opus voice call came back empty.  Two call sites reach it, both on threads without surrounding try/except:

1. The background `reorder-<repo>` daemon — kills the thread and silently drops remaining notifications in the rescope cycle.
2. The worker's synchronous `rescope_before_pick` — kills the worker.  Watchdog respawns, next iteration hits the same rescope, crashes again.  Tight loop.

Both observed in production this afternoon after #922's stderr drain made the previously-hidden failure mode visible.

This PR falls back to a plain-text notification ("Fido: your task ... has been marked done / rewritten to ...") so the reviewer still sees *something*, and one empty Opus reply can no longer take down either the daemon or the worker.

`./fido ci` green.