### PR TITLE
Don't treat preempted voice turn as Opus failure (fixes #935)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1369,15 +1369,41 @@ def _notify_thread_change(
             "has been updated. Reference the comment URL."
         )
 
+    # retry_on_preempt=True: if a webhook handler preempts this voice turn
+    # mid-flight (cancelled=True, result_len=0), wait for the preempter and
+    # retry the same prompt.  Without this, empty-because-cancelled comes
+    # back indistinguishable from empty-because-Opus-broke, and the old
+    # `raise ValueError` took down either the reorder-<repo> daemon or the
+    # worker thread that owned rescope_before_pick (fixes #935).
     body = agent.run_turn(
         prompts.persona_wrap(instruction),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
+        retry_on_preempt=True,
     )
     if not body:
-        raise ValueError(
-            f"_notify_thread_change: run_turn returned empty for comment {comment_id}"
+        # Genuinely empty after any preempt retries — post a plain-text
+        # fallback so the reviewer still sees the status change, and so one
+        # silent provider failure can't kill the caller thread.
+        log.warning(
+            "_notify_thread_change: empty voice reply for comment %s (%s) — "
+            "posting plain-text fallback",
+            comment_id,
+            kind,
         )
+        new_title = change.get("new_title", "")
+        if kind == "completed":
+            body = (
+                f'Fido: your task "{original_title}" has been marked done — '
+                f"a recent commit already covered it, so it was removed from "
+                f"the active queue. Ref: {url}"
+            )
+        else:
+            body = (
+                f'Fido: your task "{original_title}" has been rewritten to '
+                f'"{new_title}" to reflect the updated requirements. '
+                f"Ref: {url}"
+            )
 
     try:
         gh.reply_to_review_comment(repo, pr, body, comment_id)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4170,18 +4170,48 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, mock_gh, agent=_client())
         mock_gh.comment_issue.assert_not_called()
 
-    def test_review_comment_empty_opus_raises_for_completed(
+    def test_review_comment_run_turn_uses_retry_on_preempt(
         self, tmp_path: Path
     ) -> None:
+        """run_turn must pass retry_on_preempt=True — #935.
+
+        A webhook handler arriving while this voice turn runs preempts it,
+        yielding result_len=0, cancelled=True.  Without retry_on_preempt,
+        that empty string was indistinguishable from a real provider
+        failure and used to raise ValueError, killing either the
+        reorder-<repo> daemon or the worker's rescope_before_pick path.
+        """
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
-        with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        agent = _client("Reply text")
+        _notify_thread_change(change, cfg, mock_gh, agent=agent)
+        # _client wraps a MagicMock — capture the run_turn kwargs.
+        run_turn_kwargs = agent.run_turn.call_args.kwargs
+        assert run_turn_kwargs.get("retry_on_preempt") is True
 
-    def test_review_comment_empty_opus_raises_for_modified(
+    def test_review_comment_empty_opus_falls_back_for_completed(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty Opus reply after any preempt retries falls back to a plain
+        text notification rather than raising.  Callers of _on_changes run
+        on threads without surrounding try/except, so a raise here kills
+        either the reorder daemon or the worker (see #935).
+        """
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        task = self._task()
+        task["thread"]["comment_type"] = "pulls"
+        change = {"task": task, "kind": "completed"}
+        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        mock_gh.reply_to_review_comment.assert_called_once()
+        body = mock_gh.reply_to_review_comment.call_args.args[2]
+        assert "marked done" in body
+        assert task["title"] in body
+
+    def test_review_comment_empty_opus_falls_back_for_modified(
         self, tmp_path: Path
     ) -> None:
         cfg = self._cfg(tmp_path)
@@ -4194,8 +4224,11 @@ class TestNotifyThreadChange:
             "new_title": "New title",
             "new_description": "",
         }
-        with pytest.raises(ValueError, match="_notify_thread_change"):
-            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
+        mock_gh.reply_to_review_comment.assert_called_once()
+        body = mock_gh.reply_to_review_comment.call_args.args[2]
+        assert "rewritten" in body
+        assert "New title" in body
 
     def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)


### PR DESCRIPTION
Fixes #935.

Wrong diagnosis in the earlier closed PR #936 led me back to the log.  The empty voice reply was a preempted turn (`result_len=0, cancelled=True`), not a broken Opus call:

```
20:33:26 webhook handler: ENTER ... handling review thread
20:33:26 ClaudeSession: cancelled — exiting turn early
20:33:26 session.prompt: turn complete (result_len=0, cancelled=True)
20:36:39 ERROR [home] WorkerThread worker-home: unexpected error
    ValueError: _notify_thread_change: run_turn returned empty for comment 3140150090
```

A webhook arrived mid-voice-turn, preempt fired, `run_turn` returned `''`, the caller couldn't distinguish that from a genuine empty-Opus-reply, and `raise ValueError` took down whichever thread called `_on_changes`.

## Fix

- Pass `retry_on_preempt=True` to `run_turn` at this call site.  `ClaudeClient.run_turn` already knows how to wait for the preempter and retry — it just defaults to off.
- After retries, if the provider still returns empty, fall back to a plain-text notification ("Fido: your task ... has been marked done / rewritten to ...") so a real provider failure can't kill the caller either.

## Tests

- New `test_review_comment_run_turn_uses_retry_on_preempt` asserts the flag reaches `run_turn` — this is the load-bearing bit.
- The two prior `test_review_comment_empty_opus_raises_*` tests become `..._falls_back_*` and assert the fallback text.

`./fido ci` green.