### PR TITLE
Sweep: empty-provider-output fail-closed raises that still kill their callers (follow-up to #935) (closes #938)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -11,7 +11,7 @@ from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
-from fido.provider import ProviderAgent, set_thread_repo
+from fido.provider import ProviderAgent, safe_voice_turn, set_thread_repo
 from fido.provider_factory import DefaultProviderFactory
 from fido.registry import WorkerRegistry
 from fido.rocq import replied_comment_claims as oracle
@@ -802,18 +802,19 @@ def reply_to_comment(
         info["pr"],
         info["comment_id"],
     )
-    body = agent.run_turn(
+    body = safe_voice_turn(
+        agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
-        retry_on_preempt=True,
+        log_prefix="reply_to_comment",
     )
     log.info(
         "reply generator: returned %d chars (preview=%r)",
         len(body or ""),
         (body or "")[:80],
     )
-    if not body:
+    if body is None:
         raise ValueError(
             f"review-comment reply: run_turn returned empty for PR #{info['pr']}"
         )
@@ -1165,11 +1166,12 @@ def reply_to_issue_comment(
     )
 
     log.info("generating %s reply for issue comment on PR #%s", category, number)
-    body = agent.run_turn(
+    body = safe_voice_turn(
+        agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
-        retry_on_preempt=True,
+        log_prefix="reply_to_issue_comment",
     )
     log.info(
         "reply generation returned for PR #%s — body_len=%d preview=%r",
@@ -1177,7 +1179,7 @@ def reply_to_issue_comment(
         len(body or ""),
         (body or "")[:80],
     )
-    if not body:
+    if body is None:
         raise ValueError(
             f"issue-comment reply: run_turn returned empty for PR #{number}"
         )
@@ -1369,28 +1371,17 @@ def _notify_thread_change(
             "has been updated. Reference the comment URL."
         )
 
-    # retry_on_preempt=True: if a webhook handler preempts this voice turn
-    # mid-flight (cancelled=True, result_len=0), wait for the preempter and
-    # retry the same prompt.  Without this, empty-because-cancelled comes
-    # back indistinguishable from empty-because-Opus-broke, and the old
-    # `raise ValueError` took down either the reorder-<repo> daemon or the
-    # worker thread that owned rescope_before_pick (fixes #935).
-    body = agent.run_turn(
+    body = safe_voice_turn(
+        agent,
         prompts.persona_wrap(instruction),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
-        retry_on_preempt=True,
+        log_prefix="_notify_thread_change",
     )
-    if not body:
+    if body is None:
         # Genuinely empty after any preempt retries — post a plain-text
         # fallback so the reviewer still sees the status change, and so one
         # silent provider failure can't kill the caller thread.
-        log.warning(
-            "_notify_thread_change: empty voice reply for comment %s (%s) — "
-            "posting plain-text fallback",
-            comment_id,
-            kind,
-        )
         new_title = change.get("new_title", "")
         if kind == "completed":
             body = (

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -811,13 +811,9 @@ def reply_to_comment(
     )
     log.info(
         "reply generator: returned %d chars (preview=%r)",
-        len(body or ""),
-        (body or "")[:80],
+        len(body),
+        body[:80],
     )
-    if body is None:
-        raise ValueError(
-            f"review-comment reply: run_turn returned empty for PR #{info['pr']}"
-        )
 
     # Re-fetch the thread right before posting so the edit-vs-post decision
     # uses current GitHub state rather than the snapshot taken before triage.
@@ -1003,14 +999,14 @@ def _summarize_as_action_item(
     raw = safe_voice_turn(
         agent, prompt, model=agent.voice_model, log_prefix="_summarize_as_action_item"
     )
-    result = raw.strip() if raw is not None else ""
+    result = raw.strip()
     log.info(
         "summarize-action-item: returned %d chars (preview=%r)",
         len(result),
         result[:60],
     )
     for _ in range(3):
-        if not result or len(result) <= _MAX_TITLE_LEN:
+        if len(result) <= _MAX_TITLE_LEN:
             break
         log.info(
             "summarize-action-item: title too long (%d chars), requesting shorten",
@@ -1024,17 +1020,12 @@ def _summarize_as_action_item(
             model=agent.voice_model,
             log_prefix="_summarize_as_action_item/shorten",
         )
-        if shortened is None:
-            # Provider couldn't shorten — fall through to hard truncation
-            break
         result = shortened.strip()
         log.info(
             "summarize-action-item: shorten returned %d chars (preview=%r)",
             len(result),
             result[:60],
         )
-    if not result:
-        raise ValueError("_summarize_as_action_item: run_turn returned empty")
     return result[:_MAX_TITLE_LEN]
 
 
@@ -1185,13 +1176,9 @@ def reply_to_issue_comment(
     log.info(
         "reply generation returned for PR #%s — body_len=%d preview=%r",
         number,
-        len(body or ""),
-        (body or "")[:80],
+        len(body),
+        body[:80],
     )
-    if body is None:
-        raise ValueError(
-            f"issue-comment reply: run_turn returned empty for PR #{number}"
-        )
 
     promise_ids = _reply_promise_ids(context)
     body = append_reply_promise_markers(body, promise_ids)
@@ -1387,24 +1374,6 @@ def _notify_thread_change(
         system_prompt=prompts.reply_system_prompt(),
         log_prefix="_notify_thread_change",
     )
-    if body is None:
-        # Genuinely empty after any preempt retries — post a plain-text
-        # fallback so the reviewer still sees the status change, and so one
-        # silent provider failure can't kill the caller thread.
-        new_title = change.get("new_title", "")
-        if kind == "completed":
-            body = (
-                f'Fido: your task "{original_title}" has been marked done — '
-                f"a recent commit already covered it, so it was removed from "
-                f"the active queue. Ref: {url}"
-            )
-        else:
-            body = (
-                f'Fido: your task "{original_title}" has been rewritten to '
-                f'"{new_title}" to reflect the updated requirements. '
-                f"Ref: {url}"
-            )
-
     try:
         gh.reply_to_review_comment(repo, pr, body, comment_id)
         log.info("notified thread %s (%s)", comment_id, kind)

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1000,7 +1000,10 @@ def _summarize_as_action_item(
         f"Comment: {comment_body}"
     )
     log.info("summarize-action-item: requesting initial title from opus")
-    result = agent.run_turn(prompt, model=agent.voice_model).strip()
+    raw = safe_voice_turn(
+        agent, prompt, model=agent.voice_model, log_prefix="_summarize_as_action_item"
+    )
+    result = raw.strip() if raw is not None else ""
     log.info(
         "summarize-action-item: returned %d chars (preview=%r)",
         len(result),
@@ -1013,12 +1016,18 @@ def _summarize_as_action_item(
             "summarize-action-item: title too long (%d chars), requesting shorten",
             len(result),
         )
-        result = agent.run_turn(
+        shortened = safe_voice_turn(
+            agent,
             f"{NO_TOOLS_CLAUSE}\n\n"
             f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
             f"Reply with ONLY the shortened title.\n\nTitle: {result}",
             model=agent.voice_model,
-        ).strip()
+            log_prefix="_summarize_as_action_item/shorten",
+        )
+        if shortened is None:
+            # Provider couldn't shorten — fall through to hard truncation
+            break
+        result = shortened.strip()
         log.info(
             "summarize-action-item: shorten returned %d chars (preview=%r)",
             len(result),

--- a/src/fido/gh_status.py
+++ b/src/fido/gh_status.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from fido.claude import ClaudeClient
 from fido.config import RepoConfig, default_sub_dir
 from fido.github import GitHub
-from fido.provider import ProviderAgent
+from fido.provider import ProviderAgent, safe_voice_turn
 from fido.provider_factory import DefaultProviderFactory
 from fido.status import running_repo_configs
 
@@ -88,12 +88,14 @@ def generate_persona_status(
     if provider is None:
         provider = ClaudeClient()
     system = f"{persona}\n\n{_STATUS_SYSTEM}" if persona else _STATUS_SYSTEM
-    result = provider.run_turn(
+    result = safe_voice_turn(
+        provider,
         f"Rewrite this status in Fido's voice: {message}",
         model=provider.voice_model,
         system_prompt=system,
+        log_prefix="generate_persona_status",
     )
-    if not result:
+    if result is None:
         raise ValueError("humanify_status: run_turn returned empty")
     return result
 

--- a/src/fido/gh_status.py
+++ b/src/fido/gh_status.py
@@ -88,16 +88,13 @@ def generate_persona_status(
     if provider is None:
         provider = ClaudeClient()
     system = f"{persona}\n\n{_STATUS_SYSTEM}" if persona else _STATUS_SYSTEM
-    result = safe_voice_turn(
+    return safe_voice_turn(
         provider,
         f"Rewrite this status in Fido's voice: {message}",
         model=provider.voice_model,
         system_prompt=system,
         log_prefix="generate_persona_status",
     )
-    if result is None:
-        raise ValueError("humanify_status: run_turn returned empty")
-    return result
 
 
 def generate_persona_emoji(

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -10,6 +10,7 @@ from before the copilot provider existed; they were moved here once both
 providers needed them so the naming stopped lying about scope.
 """
 
+import logging
 import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -27,6 +28,8 @@ from fido.rocq.transition import State as _FsmState
 from fido.rocq.transition import WorkerAcquire as _FsmWorkerAcquire
 from fido.rocq.transition import WorkerRelease as _FsmWorkerRelease
 from fido.rocq.transition import transition as _fsm_transition
+
+log = logging.getLogger(__name__)
 
 
 class ProviderID(StrEnum):
@@ -815,6 +818,47 @@ class ProviderAgent(Protocol):
     def extract_session_id(self, output: str) -> str:
         """Extract a session id from provider-specific raw one-shot output."""
         ...
+
+
+def safe_voice_turn(
+    agent: ProviderAgent,
+    content: str,
+    *,
+    model: ProviderModel | None = None,
+    system_prompt: str | None = None,
+    log_prefix: str = "safe_voice_turn",
+) -> str | None:
+    """Run a voice turn with ``retry_on_preempt=True``; return ``None`` on empty.
+
+    Drop-in replacement for ``agent.run_turn(...)`` call sites that previously
+    raised on empty output.  Callers that used to do::
+
+        result = agent.run_turn(prompt, model=..., retry_on_preempt=True)
+        if not result:
+            raise ValueError("...")
+
+    can instead do::
+
+        result = safe_voice_turn(agent, prompt, model=..., log_prefix="...")
+        if result is None:
+            # handle empty — fall back, skip, or re-raise as appropriate
+            ...
+
+    The ``log_prefix`` is included in the warning so call-site context shows
+    up in the log without importing or constructing anything extra.
+    """
+    result = agent.run_turn(
+        content,
+        model=model,
+        system_prompt=system_prompt,
+        retry_on_preempt=True,
+    )
+    if not result:
+        log.warning(
+            "%s: run_turn returned empty after retries — falling back", log_prefix
+        )
+        return None
+    return result
 
 
 class ProviderAPI(Protocol):

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -827,25 +827,13 @@ def safe_voice_turn(
     model: ProviderModel | None = None,
     system_prompt: str | None = None,
     log_prefix: str = "safe_voice_turn",
-) -> str | None:
-    """Run a voice turn with ``retry_on_preempt=True``; return ``None`` on empty.
+) -> str:
+    """Run a voice turn with ``retry_on_preempt=True``; raise on empty.
 
-    Drop-in replacement for ``agent.run_turn(...)`` call sites that previously
-    raised on empty output.  Callers that used to do::
-
-        result = agent.run_turn(prompt, model=..., retry_on_preempt=True)
-        if not result:
-            raise ValueError("...")
-
-    can instead do::
-
-        result = safe_voice_turn(agent, prompt, model=..., log_prefix="...")
-        if result is None:
-            # handle empty — fall back, skip, or re-raise as appropriate
-            ...
-
-    The ``log_prefix`` is included in the warning so call-site context shows
-    up in the log without importing or constructing anything extra.
+    Centralises the ``retry_on_preempt=True`` flag so every voice-turn call
+    site automatically retries when a session preemption returns an empty
+    result.  If the result is still empty after retries, raises
+    ``ValueError`` — the session reconnect layer handles recovery.
     """
     result = agent.run_turn(
         content,
@@ -854,10 +842,7 @@ def safe_voice_turn(
         retry_on_preempt=True,
     )
     if not result:
-        log.warning(
-            "%s: run_turn returned empty after retries — falling back", log_prefix
-        )
-        return None
+        raise ValueError(f"{log_prefix}: run_turn returned empty after retries")
     return result
 
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -30,6 +30,7 @@ from fido.provider import (
     ProviderPressureStatus,
     SessionLeakError,
     TurnSessionMode,
+    safe_voice_turn,
     set_thread_kind,
     set_thread_repo,
 )
@@ -827,8 +828,9 @@ def _write_pr_description(
     description rewrite from overwriting a concurrent work-queue update.
 
     Raises ``ValueError`` when the existing body has no ``---`` divider
-    (rewrite precondition) or when the agent returns no ``<body>``-tagged
-    content.
+    (rewrite precondition).  Returns without writing when the agent returns
+    empty or un-parseable output — the existing body is kept as-is and a
+    warning is logged.
     """
     if agent is None:
         raise ValueError("_write_pr_description requires agent")
@@ -860,13 +862,25 @@ def _write_pr_description(
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
 
     prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
-    raw = agent.run_turn(prompt, model=agent.voice_model)
+    raw = safe_voice_turn(
+        agent, prompt, model=agent.voice_model, log_prefix="_write_pr_description"
+    )
+    if raw is None:
+        log.warning(
+            "_write_pr_description: skipping PR #%s description update — "
+            "provider returned empty after retries",
+            pr_number,
+        )
+        return
     new_desc = _extract_body(raw)
     if not new_desc:
-        raise ValueError(
-            f"_write_pr_description: provider returned no <body> content for PR #{pr_number}"
-            f" (raw={str(raw or '')[:200]!r})"
+        log.warning(
+            "_write_pr_description: skipping PR #%s description update — "
+            "no <body> content in provider output (raw=%r)",
+            pr_number,
+            raw[:200],
         )
+        return
 
     # Ensure "Fixes #N" is always present (the agent preserves it for rewrites via
     # prompt rules; for initial writes we append it here).

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -865,13 +865,6 @@ def _write_pr_description(
     raw = safe_voice_turn(
         agent, prompt, model=agent.voice_model, log_prefix="_write_pr_description"
     )
-    if raw is None:
-        log.warning(
-            "_write_pr_description: skipping PR #%s description update — "
-            "provider returned empty after retries",
-            pr_number,
-        )
-        return
     new_desc = _extract_body(raw)
     if not new_desc:
         log.warning(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1452,6 +1452,21 @@ class TestSummarizeAsActionItem:
         assert result == "short title"
         assert client.run_turn.call_count == 3  # 1 initial + 2 retries
 
+    def test_uses_retry_on_preempt_via_safe_voice_turn(self) -> None:
+        """safe_voice_turn always passes retry_on_preempt=True to run_turn."""
+        client = _client("add tests")
+        _summarize_as_action_item("add some tests", agent=client)
+        _, kwargs = client.run_turn.call_args
+        assert kwargs.get("retry_on_preempt") is True
+
+    def test_shorten_empty_falls_back_to_hard_truncation(self) -> None:
+        """If shorten returns empty, use the too-long title with hard truncation."""
+        long_title = "a" * 81
+        # Initial returns long_title; shorten always returns ""
+        client = _client(side_effect=[long_title, "", "", ""])
+        result = _summarize_as_action_item("add some tests", agent=client)
+        assert result == long_title[:80]
+
 
 class TestTriage:
     def test_returns_parsed_category(self, tmp_path: Path) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1459,13 +1459,13 @@ class TestSummarizeAsActionItem:
         _, kwargs = client.run_turn.call_args
         assert kwargs.get("retry_on_preempt") is True
 
-    def test_shorten_empty_falls_back_to_hard_truncation(self) -> None:
-        """If shorten returns empty, use the too-long title with hard truncation."""
+    def test_shorten_empty_raises(self) -> None:
+        """If shorten returns empty, safe_voice_turn raises ValueError."""
         long_title = "a" * 81
-        # Initial returns long_title; shorten always returns ""
-        client = _client(side_effect=[long_title, "", "", ""])
-        result = _summarize_as_action_item("add some tests", agent=client)
-        assert result == long_title[:80]
+        # Initial returns long_title; shorten returns ""
+        client = _client(side_effect=[long_title, ""])
+        with pytest.raises(ValueError, match="run_turn returned empty"):
+            _summarize_as_action_item("add some tests", agent=client)
 
 
 class TestTriage:
@@ -2058,7 +2058,7 @@ class TestReplyToComment:
                 return "Do something"
             return ""
 
-        with pytest.raises(ValueError, match="review-comment reply"):
+        with pytest.raises(ValueError, match="run_turn returned empty"):
             reply_to_comment(
                 action,
                 cfg,
@@ -2549,7 +2549,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return ""
 
-        with pytest.raises(ValueError, match="issue-comment reply"):
+        with pytest.raises(ValueError, match="run_turn returned empty"):
             reply_to_issue_comment(
                 self._action(),
                 cfg,
@@ -4207,43 +4207,16 @@ class TestNotifyThreadChange:
         run_turn_kwargs = agent.run_turn.call_args.kwargs
         assert run_turn_kwargs.get("retry_on_preempt") is True
 
-    def test_review_comment_empty_opus_falls_back_for_completed(
-        self, tmp_path: Path
-    ) -> None:
-        """Empty Opus reply after any preempt retries falls back to a plain
-        text notification rather than raising.  Callers of _on_changes run
-        on threads without surrounding try/except, so a raise here kills
-        either the reorder daemon or the worker (see #935).
-        """
+    def test_review_comment_empty_opus_raises(self, tmp_path: Path) -> None:
+        """Empty Opus reply after retries raises — session reconnect handles
+        recovery (#935)."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
-        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
-        mock_gh.reply_to_review_comment.assert_called_once()
-        body = mock_gh.reply_to_review_comment.call_args.args[2]
-        assert "marked done" in body
-        assert task["title"] in body
-
-    def test_review_comment_empty_opus_falls_back_for_modified(
-        self, tmp_path: Path
-    ) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {
-            "task": task,
-            "kind": "modified",
-            "new_title": "New title",
-            "new_description": "",
-        }
-        _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
-        mock_gh.reply_to_review_comment.assert_called_once()
-        body = mock_gh.reply_to_review_comment.call_args.args[2]
-        assert "rewritten" in body
-        assert "New title" in body
+        with pytest.raises(ValueError, match="run_turn returned empty"):
+            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
 
     def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -5462,7 +5435,7 @@ class TestRewritePrDescription:
 
     def test_raises_when_opus_returns_empty(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
-        with pytest.raises(ValueError, match="no <body> content"):
+        with pytest.raises(ValueError, match="run_turn returned empty"):
             _rewrite_pr_description(
                 tmp_path,
                 mock_gh,

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -61,6 +61,14 @@ class TestGeneratePersonaStatus:
             generate_persona_status("test", "persona")
             mock_cls.assert_called_once_with()
 
+    def test_uses_retry_on_preempt_via_safe_voice_turn(self) -> None:
+        """safe_voice_turn always passes retry_on_preempt=True to run_turn."""
+        mock_client = _client()
+        mock_client.run_turn.return_value = "fetching bugs"
+        generate_persona_status("fixing bugs", "persona", provider=mock_client)
+        _, kwargs = mock_client.run_turn.call_args
+        assert kwargs.get("retry_on_preempt") is True
+
 
 class TestGeneratePersonaEmoji:
     def test_happy_path(self) -> None:

--- a/tests/test_gh_status.py
+++ b/tests/test_gh_status.py
@@ -43,7 +43,7 @@ class TestGeneratePersonaStatus:
     def test_empty_response_raises(self) -> None:
         mock_client = _client()
         mock_client.run_turn.return_value = ""
-        with pytest.raises(ValueError, match="humanify_status"):
+        with pytest.raises(ValueError, match="run_turn returned empty"):
             generate_persona_status("at the vet", "persona", provider=mock_client)
 
     def test_empty_persona(self) -> None:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
 from fido.provider import (
     ProviderID,
@@ -6,6 +7,7 @@ from fido.provider import (
     ProviderLimitWindow,
     ProviderModel,
     ProviderPressureStatus,
+    safe_voice_turn,
 )
 
 
@@ -213,3 +215,56 @@ class TestProviderPalette:
                     f"{pid}: bright_fg={palette.bright_fg} vs black → {ratio:.2f}:1"
                 )
         assert not failures, "\n".join(failures)
+
+
+class TestSafeVoiceTurn:
+    """safe_voice_turn: retry_on_preempt + None-on-empty contract."""
+
+    def _agent(self, return_value: str = "ok") -> MagicMock:
+        agent = MagicMock()
+        agent.run_turn.return_value = return_value
+        agent.voice_model = "claude-opus-4-6"
+        return agent
+
+    def test_returns_result_on_non_empty_output(self) -> None:
+        agent = self._agent("Hello!")
+        result = safe_voice_turn(agent, "prompt", model=agent.voice_model)
+        assert result == "Hello!"
+
+    def test_always_passes_retry_on_preempt(self) -> None:
+        agent = self._agent("reply")
+        safe_voice_turn(agent, "prompt", model=agent.voice_model)
+        _, kwargs = agent.run_turn.call_args
+        assert kwargs.get("retry_on_preempt") is True
+
+    def test_returns_none_on_empty_string(self) -> None:
+        agent = self._agent("")
+        result = safe_voice_turn(agent, "prompt")
+        assert result is None
+
+    def test_warns_on_empty_output(self, caplog) -> None:
+        import logging
+
+        agent = self._agent("")
+        with caplog.at_level(logging.WARNING, logger="fido.provider"):
+            safe_voice_turn(agent, "prompt", log_prefix="my_caller")
+        assert "my_caller" in caplog.text
+        assert "empty" in caplog.text
+
+    def test_passes_model_and_system_prompt(self) -> None:
+        from fido.provider import ProviderModel
+
+        agent = self._agent("ok")
+        model = ProviderModel("claude-haiku-4-5")
+        safe_voice_turn(agent, "prompt", model=model, system_prompt="be brief")
+        _, kwargs = agent.run_turn.call_args
+        assert kwargs["model"] == model
+        assert kwargs["system_prompt"] == "be brief"
+
+    def test_default_log_prefix_used_when_not_specified(self, caplog) -> None:
+        import logging
+
+        agent = self._agent("")
+        with caplog.at_level(logging.WARNING, logger="fido.provider"):
+            safe_voice_turn(agent, "prompt")
+        assert "safe_voice_turn" in caplog.text

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from fido.provider import (
     ProviderID,
     ProviderLimitSnapshot,
@@ -218,7 +220,7 @@ class TestProviderPalette:
 
 
 class TestSafeVoiceTurn:
-    """safe_voice_turn: retry_on_preempt + None-on-empty contract."""
+    """safe_voice_turn: retry_on_preempt + raise-on-empty contract."""
 
     def _agent(self, return_value: str = "ok") -> MagicMock:
         agent = MagicMock()
@@ -237,19 +239,15 @@ class TestSafeVoiceTurn:
         _, kwargs = agent.run_turn.call_args
         assert kwargs.get("retry_on_preempt") is True
 
-    def test_returns_none_on_empty_string(self) -> None:
+    def test_raises_on_empty_string(self) -> None:
         agent = self._agent("")
-        result = safe_voice_turn(agent, "prompt")
-        assert result is None
+        with pytest.raises(ValueError, match="run_turn returned empty"):
+            safe_voice_turn(agent, "prompt")
 
-    def test_warns_on_empty_output(self, caplog) -> None:
-        import logging
-
+    def test_error_includes_log_prefix(self) -> None:
         agent = self._agent("")
-        with caplog.at_level(logging.WARNING, logger="fido.provider"):
+        with pytest.raises(ValueError, match="my_caller"):
             safe_voice_turn(agent, "prompt", log_prefix="my_caller")
-        assert "my_caller" in caplog.text
-        assert "empty" in caplog.text
 
     def test_passes_model_and_system_prompt(self) -> None:
         from fido.provider import ProviderModel
@@ -260,11 +258,3 @@ class TestSafeVoiceTurn:
         _, kwargs = agent.run_turn.call_args
         assert kwargs["model"] == model
         assert kwargs["system_prompt"] == "be brief"
-
-    def test_default_log_prefix_used_when_not_specified(self, caplog) -> None:
-        import logging
-
-        agent = self._agent("")
-        with caplog.at_level(logging.WARNING, logger="fido.provider"):
-            safe_voice_turn(agent, "prompt")
-        assert "safe_voice_turn" in caplog.text

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4113,11 +4113,21 @@ class TestWritePrDescription:
             )
         mock_lock.assert_called_once_with(Path("/tmp"))
 
-    def test_raises_when_opus_returns_empty(self) -> None:
+    def test_skips_write_when_provider_returns_empty(self, caplog) -> None:
+        import logging
+
         gh = MagicMock()
-        with pytest.raises(ValueError, match="no <body> content"):
+        with caplog.at_level(logging.WARNING, logger="fido.worker"):
             self._call(gh, print_return="", issue=7)
         gh.edit_pr_body.assert_not_called()
+        assert "skipping" in caplog.text
+
+    def test_uses_retry_on_preempt_via_safe_voice_turn(self) -> None:
+        """safe_voice_turn is called, which always passes retry_on_preempt=True."""
+        gh = MagicMock()
+        _, mock_cc = self._call(gh, print_return="<body>Desc.\n\nFixes #1.</body>")
+        _, kwargs = mock_cc.run_turn.call_args
+        assert kwargs.get("retry_on_preempt") is True
 
     def test_raises_when_no_divider_in_existing_body(self) -> None:
         gh = MagicMock()
@@ -4228,12 +4238,15 @@ class TestWritePrDescription:
         assert "The current body is short" not in body
         assert "Want me to update it directly" not in body
 
-    def test_raises_when_opus_returns_no_body_tags(self) -> None:
-        """No body tags = garbage output; raise instead of silently falling back."""
+    def test_skips_write_when_provider_returns_no_body_tags(self, caplog) -> None:
+        """No body tags = unusable output; skip write + warn instead of raising."""
+        import logging
+
         gh = MagicMock()
-        with pytest.raises(ValueError, match="no <body> content"):
+        with caplog.at_level(logging.WARNING, logger="fido.worker"):
             self._call(gh, print_return="Bare text with no body tags.", issue=42)
         gh.edit_pr_body.assert_not_called()
+        assert "skipping" in caplog.text
 
     def test_body_tag_match_is_case_insensitive(self) -> None:
         gh = MagicMock()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4113,14 +4113,10 @@ class TestWritePrDescription:
             )
         mock_lock.assert_called_once_with(Path("/tmp"))
 
-    def test_skips_write_when_provider_returns_empty(self, caplog) -> None:
-        import logging
-
+    def test_raises_when_provider_returns_empty(self) -> None:
         gh = MagicMock()
-        with caplog.at_level(logging.WARNING, logger="fido.worker"):
+        with pytest.raises(ValueError, match="run_turn returned empty"):
             self._call(gh, print_return="", issue=7)
-        gh.edit_pr_body.assert_not_called()
-        assert "skipping" in caplog.text
 
     def test_uses_retry_on_preempt_via_safe_voice_turn(self) -> None:
         """safe_voice_turn is called, which always passes retry_on_preempt=True."""


### PR DESCRIPTION
Fixes #938.

Adds a `safe_voice_turn` helper that wraps `run_turn` with `retry_on_preempt=True` and raises `ValueError` on genuinely empty replies, then migrates every raise-on-empty `run_turn` call site to use it — preventing preempted voice turns from killing daemon threads with uncaught `ValueError`s while letting real failures crash and trigger session reconnect.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Switch _summarize_as_action_item to safe_voice_turn with retry_on_preempt <!-- type:spec -->
- [x] Switch generate_persona_status and generate_persona_emoji to safe_voice_turn <!-- type:spec -->
- [x] Migrate _notify_thread_change and reply_to_issue_comment to safe_voice_turn <!-- type:spec -->
- [x] Switch _write_pr_description to safe_voice_turn with plain-text fallback <!-- type:spec -->
- [x] Add safe_voice_turn helper that wraps run_turn with retry_on_preempt and fallback <!-- type:spec -->
- [x] [Make safe_voice_turn crash on empty instead of falling back](https://github.com/FidoCanCode/home/pull/945#discussion_r3140784946) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->