### PR TITLE
Bug: webhook handlers run implementation inline instead of queueing thread tasks (closes #950)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1557,13 +1557,16 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         *,
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
+        allowed_tools: tuple[str, ...] | None = None,
     ) -> str:
-        """Run a one-shot ``claude --print`` turn with no tool access.
+        """Run a one-shot ``claude --print`` turn.
 
         Writes *content* (and optionally *system_prompt*) to temporary files and
-        invokes ``claude --print`` via :attr:`_streaming_runner`.  Because
-        ``--print`` mode has no tool access by design, the provider cannot use
-        Edit, Bash, or git tools regardless of prompt instructions.
+        invokes ``claude --print`` via :attr:`_streaming_runner`.
+
+        When *allowed_tools* is ``None`` the turn has no tool access at all.
+        When a tuple of tool specifiers is provided, those tools are enabled via
+        ``--allowedTools`` so the provider can read code and search but not write.
 
         Unlike :meth:`run_turn`, this does **not** touch the persistent session.
         """
@@ -1582,6 +1585,8 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
                 "--dangerously-skip-permissions",
                 "--print",
             ]
+            if allowed_tools is not None:
+                cmd += ["--allowedTools", *allowed_tools]
             if system_prompt is not None:
                 system_file = tmp / "system.md"
                 system_file.write_text(system_prompt)

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -6,6 +6,7 @@ import os
 import re
 import select
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -1549,6 +1550,45 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             session.wait_for_pending_preempt()
             attempt += 1
             log.info("ClaudeClient.run_turn: preempted mid-flight — retry %d", attempt)
+
+    def run_toolless_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run a one-shot ``claude --print`` turn with no tool access.
+
+        Writes *content* (and optionally *system_prompt*) to temporary files and
+        invokes ``claude --print`` via :attr:`_streaming_runner`.  Because
+        ``--print`` mode has no tool access by design, the provider cannot use
+        Edit, Bash, or git tools regardless of prompt instructions.
+
+        Unlike :meth:`run_turn`, this does **not** touch the persistent session.
+        """
+        effective_model = self.voice_model if model is None else model
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            prompt_file = tmp / "prompt.txt"
+            prompt_file.write_text(content)
+            cmd = [
+                "claude",
+                "--model",
+                model_name(effective_model),
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--dangerously-skip-permissions",
+                "--print",
+            ]
+            if system_prompt is not None:
+                system_file = tmp / "system.md"
+                system_file.write_text(system_prompt)
+                cmd += ["--system-prompt-file", str(system_file)]
+            output = "".join(self._streaming_runner(cmd, prompt_file)).strip()
+        raise_for_provider_error_output(output)
+        return output
 
     def generate_status(
         self,

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1260,13 +1260,15 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         *,
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
+        allowed_tools: tuple[str, ...] | None = None,
     ) -> str:
-        """Run a one-shot Copilot CLI turn with no tool access.
+        """Run a one-shot Copilot CLI turn.
 
         Copilot CLI is a text-only tool that does not have file-system tool access,
-        so this uses :meth:`_run_cli_prompt` directly.  If *system_prompt* is given,
-        it is prepended via :func:`_combine_prompt`.
+        so *allowed_tools* is accepted for protocol compatibility but has no effect.
+        If *system_prompt* is given, it is prepended via :func:`_combine_prompt`.
         """
+        del allowed_tools  # Copilot CLI has no tool support
         effective_model = self.voice_model if model is None else model
         prompt = _combine_prompt(content, system_prompt=system_prompt)
         return self._run_cli_prompt(prompt, model=effective_model, timeout=30)

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1254,6 +1254,23 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
                 "CopilotCLIClient.run_turn: preempted mid-flight — retry %d", attempt
             )
 
+    def run_toolless_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run a one-shot Copilot CLI turn with no tool access.
+
+        Copilot CLI is a text-only tool that does not have file-system tool access,
+        so this uses :meth:`_run_cli_prompt` directly.  If *system_prompt* is given,
+        it is prepended via :func:`_combine_prompt`.
+        """
+        effective_model = self.voice_model if model is None else model
+        prompt = _combine_prompt(content, system_prompt=system_prompt)
+        return self._run_cli_prompt(prompt, model=effective_model, timeout=30)
+
     def print_prompt_from_file(
         self,
         system_file: Path,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -21,6 +21,22 @@ from fido.types import TaskType
 
 log = logging.getLogger(__name__)
 
+# Read-only tools available to webhook voice turns.  These let triage and
+# reply generation read code, search the web, and query GitHub — but cannot
+# write files, run arbitrary commands, or push to git.
+WEBHOOK_ALLOWED_TOOLS: tuple[str, ...] = (
+    "Read",
+    "Grep",
+    "Glob",
+    "WebSearch",
+    "WebFetch",
+    "Bash(git log*)",
+    "Bash(git show*)",
+    "Bash(git diff*)",
+    "Bash(gh issue*)",
+    "Bash(gh pr*)",
+)
+
 # Per-work_dir coalescing state for _reorder_tasks_background.
 # Ensures at most one Opus call in-flight + one pending per repo.
 _reorder_coalesce: dict[str, dict[str, Any]] = {}
@@ -666,7 +682,9 @@ def maybe_react(
         prompts = Prompts(_load_persona(config))
     reaction = (
         agent.run_toolless_turn(
-            prompts.react_prompt(comment_body), model=agent.voice_model
+            prompts.react_prompt(comment_body),
+            model=agent.voice_model,
+            allowed_tools=WEBHOOK_ALLOWED_TOOLS,
         )
         .lower()
         .split("\n")[0]
@@ -802,6 +820,7 @@ def reply_to_comment(
         prompts.persona_wrap(instr),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
+        allowed_tools=WEBHOOK_ALLOWED_TOOLS,
         log_prefix="reply_to_comment",
     )
     log.info(
@@ -961,7 +980,9 @@ def needs_more_context(
         "Reply with exactly YES or NO."
     )
     log.info("needs-more-context check: requesting haiku")
-    answer = agent.run_toolless_turn(prompt, model=agent.brief_model).upper()
+    answer = agent.run_toolless_turn(
+        prompt, model=agent.brief_model, allowed_tools=WEBHOOK_ALLOWED_TOOLS
+    ).upper()
     log.info(
         "needs-more-context check: returned %d chars (answer=%r)",
         len(answer),
@@ -990,7 +1011,11 @@ def _summarize_as_action_item(
     )
     log.info("summarize-action-item: requesting initial title from opus")
     raw = safe_toolless_turn(
-        agent, prompt, model=agent.voice_model, log_prefix="_summarize_as_action_item"
+        agent,
+        prompt,
+        model=agent.voice_model,
+        allowed_tools=WEBHOOK_ALLOWED_TOOLS,
+        log_prefix="_summarize_as_action_item",
     )
     result = raw.strip()
     log.info(
@@ -1010,6 +1035,7 @@ def _summarize_as_action_item(
             f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
             f"Reply with ONLY the shortened title.\n\nTitle: {result}",
             model=agent.voice_model,
+            allowed_tools=WEBHOOK_ALLOWED_TOOLS,
             log_prefix="_summarize_as_action_item/shorten",
         )
         result = shortened.strip()
@@ -1041,7 +1067,9 @@ def _triage(
         prompts = Prompts("")
     prompt = prompts.triage_prompt(comment_body, is_bot, context)
     log.info("triage classifier: requesting category from opus")
-    text = agent.run_toolless_turn(prompt, model=agent.voice_model)
+    text = agent.run_toolless_turn(
+        prompt, model=agent.voice_model, allowed_tools=WEBHOOK_ALLOWED_TOOLS
+    )
     log.info(
         "triage classifier: returned %d chars (preview=%r)",
         len(text or ""),
@@ -1163,6 +1191,7 @@ def reply_to_issue_comment(
         prompts.persona_wrap(instr),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
+        allowed_tools=WEBHOOK_ALLOWED_TOOLS,
         log_prefix="reply_to_issue_comment",
     )
     log.info(
@@ -1362,6 +1391,7 @@ def _notify_thread_change(
         prompts.persona_wrap(instruction),
         model=agent.voice_model,
         system_prompt=prompts.reply_system_prompt(),
+        allowed_tools=WEBHOOK_ALLOWED_TOOLS,
         log_prefix="_notify_thread_change",
     )
     try:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -10,8 +10,8 @@ from typing import Any
 from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
-from fido.prompts import NO_TOOLS_CLAUSE, Prompts
-from fido.provider import ProviderAgent, safe_voice_turn, set_thread_repo
+from fido.prompts import Prompts
+from fido.provider import ProviderAgent, safe_toolless_turn, set_thread_repo
 from fido.provider_factory import DefaultProviderFactory
 from fido.registry import WorkerRegistry
 from fido.rocq import replied_comment_claims as oracle
@@ -672,7 +672,9 @@ def maybe_react(
     if prompts is None:
         prompts = Prompts(_load_persona(config))
     reaction = (
-        agent.run_turn(prompts.react_prompt(comment_body), model=agent.voice_model)
+        agent.run_toolless_turn(
+            prompts.react_prompt(comment_body), model=agent.voice_model
+        )
         .lower()
         .split("\n")[0]
         .strip()
@@ -802,7 +804,7 @@ def reply_to_comment(
         info["pr"],
         info["comment_id"],
     )
-    body = safe_voice_turn(
+    body = safe_toolless_turn(
         agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
@@ -958,7 +960,6 @@ def needs_more_context(
     if agent is None:
         raise ValueError("needs_more_context requires agent")
     prompt = (
-        f"{NO_TOOLS_CLAUSE}\n\n"
         "A reviewer left this comment on a pull request:\n\n"
         f"{comment_body!r}\n\n"
         "Does this comment need context from sibling review threads to be understood "
@@ -967,7 +968,7 @@ def needs_more_context(
         "Reply with exactly YES or NO."
     )
     log.info("needs-more-context check: requesting haiku")
-    answer = agent.run_turn(prompt, model=agent.brief_model).upper()
+    answer = agent.run_toolless_turn(prompt, model=agent.brief_model).upper()
     log.info(
         "needs-more-context check: returned %d chars (answer=%r)",
         len(answer),
@@ -990,13 +991,12 @@ def _summarize_as_action_item(
     if agent is None:
         raise ValueError("_summarize_as_action_item requires agent")
     prompt = (
-        f"{NO_TOOLS_CLAUSE}\n\n"
         "Convert this PR review comment into a short, imperative task title starting with a verb. "
         "Reply with ONLY the title — no category prefix, no punctuation at the end.\n\n"
         f"Comment: {comment_body}"
     )
     log.info("summarize-action-item: requesting initial title from opus")
-    raw = safe_voice_turn(
+    raw = safe_toolless_turn(
         agent, prompt, model=agent.voice_model, log_prefix="_summarize_as_action_item"
     )
     result = raw.strip()
@@ -1012,9 +1012,8 @@ def _summarize_as_action_item(
             "summarize-action-item: title too long (%d chars), requesting shorten",
             len(result),
         )
-        shortened = safe_voice_turn(
+        shortened = safe_toolless_turn(
             agent,
-            f"{NO_TOOLS_CLAUSE}\n\n"
             f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
             f"Reply with ONLY the shortened title.\n\nTitle: {result}",
             model=agent.voice_model,
@@ -1049,7 +1048,7 @@ def _triage(
         prompts = Prompts("")
     prompt = prompts.triage_prompt(comment_body, is_bot, context)
     log.info("triage classifier: requesting category from opus")
-    text = agent.run_turn(prompt, model=agent.voice_model)
+    text = agent.run_toolless_turn(prompt, model=agent.voice_model)
     log.info(
         "triage classifier: returned %d chars (preview=%r)",
         len(text or ""),
@@ -1166,7 +1165,7 @@ def reply_to_issue_comment(
     )
 
     log.info("generating %s reply for issue comment on PR #%s", category, number)
-    body = safe_voice_turn(
+    body = safe_toolless_turn(
         agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
@@ -1367,7 +1366,7 @@ def _notify_thread_change(
             "has been updated. Reference the comment URL."
         )
 
-    body = safe_voice_turn(
+    body = safe_toolless_turn(
         agent,
         prompts.persona_wrap(instruction),
         model=agent.voice_model,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import Prompts
@@ -28,14 +27,8 @@ _reorder_coalesce: dict[str, dict[str, Any]] = {}
 _reorder_coalesce_lock = threading.Lock()
 
 
-def _configured_agent(config: Config, repo_cfg: RepoConfig) -> ProviderAgent:
-    return DefaultProviderFactory(
-        session_system_file=config.sub_dir / "persona.md"
-    ).create_agent(
-        repo_cfg,
-        work_dir=repo_cfg.work_dir,
-        repo_name=repo_cfg.name,
-    )
+def _configured_agent(repo_cfg: RepoConfig) -> ProviderAgent:
+    return DefaultProviderFactory().create_toolless_agent(repo_cfg)
 
 
 @dataclass
@@ -668,7 +661,7 @@ def maybe_react(
     comment_type: 'pulls' for review comments, 'issues' for issue comments.
     """
     if agent is None:
-        agent = _configured_agent(config, config.repos[repo])
+        agent = _configured_agent(config.repos[repo])
     if prompts is None:
         prompts = Prompts(_load_persona(config))
     reaction = (
@@ -710,7 +703,7 @@ def reply_to_comment(
     Raises on reply-post failure so callers fail closed.
     """
     if agent is None:
-        agent = _configured_agent(config, repo_cfg)
+        agent = _configured_agent(repo_cfg)
     if prompts is None:
         prompts = Prompts(_load_persona(config))
     info = action.reply_to
@@ -1094,7 +1087,7 @@ def reply_to_issue_comment(
     Raises on reply-post failure so callers fail closed.
     """
     if agent is None:
-        agent = _configured_agent(config, repo_cfg)
+        agent = _configured_agent(repo_cfg)
     if prompts is None:
         prompts = Prompts(_load_persona(config))
     comment = action.comment_body or ""
@@ -1334,9 +1327,7 @@ def _notify_thread_change(
         return
 
     if agent is None:
-        agent = _configured_agent(
-            config, config.repos[change["task"]["thread"]["repo"]]
-        )
+        agent = _configured_agent(config.repos[change["task"]["thread"]["repo"]])
     if prompts is None:
         prompts = Prompts(_load_persona(config))
 
@@ -1569,11 +1560,11 @@ def _reorder_tasks_background(
     rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
     state = _coalesce_state if _coalesce_state is not None else _reorder_coalesce
     if agent is None:
-        agent = (
-            _configured_agent(config, repo_cfg)
-            if repo_cfg is not None
-            else ClaudeClient()
-        )
+        if repo_cfg is None:
+            raise ValueError(
+                "_reorder_tasks_background: repo_cfg is required when agent is not provided"
+            )
+        agent = _configured_agent(repo_cfg)
     if prompts is None:
         prompts = Prompts(_load_persona(config))
 

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -741,13 +741,18 @@ class ProviderAgent(Protocol):
         *,
         model: ProviderModel | None = None,
         system_prompt: str | None = None,
+        allowed_tools: tuple[str, ...] | None = None,
     ) -> str:
-        """Run a one-shot text-only turn without tool access and return the result.
+        """Run a one-shot turn and return the result.
 
         Unlike :meth:`run_turn`, this method uses a one-shot subprocess invocation
-        (``claude --print`` for Claude, the CLI tool for Copilot) that has no tool
-        access by design.  Webhook handlers must use this method for triage and reply
-        generation so that Claude cannot use Edit, Bash, or git tools inline.
+        (``claude --print`` for Claude, the CLI tool for Copilot) that does **not**
+        use the persistent session.
+
+        When *allowed_tools* is ``None`` (the default), the turn has no tool access
+        at all.  When a tuple of tool specifiers is provided, only those tools are
+        available — use this for webhook handlers that need read-only tools (e.g.
+        ``("Read", "Grep", "Bash(git log*)")``).
         """
         ...
 
@@ -868,14 +873,16 @@ def safe_toolless_turn(
     *,
     model: ProviderModel | None = None,
     system_prompt: str | None = None,
+    allowed_tools: tuple[str, ...] | None = None,
     log_prefix: str = "safe_toolless_turn",
 ) -> str:
-    """Run a toolless one-shot turn; raise on empty.
+    """Run a one-shot turn; raise on empty.
 
     Calls :meth:`~ProviderAgent.run_toolless_turn` which uses a one-shot subprocess
-    with no tool access (``claude --print`` for Claude).  Webhook handlers should use
-    this instead of :func:`safe_voice_turn` for triage and reply generation so that
-    the provider cannot use Edit, Bash, or git tools inline.
+    (``claude --print`` for Claude).  When *allowed_tools* is ``None``, no tools are
+    available; when provided, only the listed tools are enabled.  Webhook handlers
+    pass a curated read-only tool set so that triage can read code and search but
+    cannot use Edit, Bash (write), or git push.
 
     Raises :exc:`ValueError` if the provider returns an empty result.
     """
@@ -883,6 +890,7 @@ def safe_toolless_turn(
         content,
         model=model,
         system_prompt=system_prompt,
+        allowed_tools=allowed_tools,
     )
     if not result:
         raise ValueError(f"{log_prefix}: run_toolless_turn returned empty")

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -735,6 +735,22 @@ class ProviderAgent(Protocol):
         """Run one interactive turn through the persistent session and return text."""
         ...
 
+    def run_toolless_turn(
+        self,
+        content: str,
+        *,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run a one-shot text-only turn without tool access and return the result.
+
+        Unlike :meth:`run_turn`, this method uses a one-shot subprocess invocation
+        (``claude --print`` for Claude, the CLI tool for Copilot) that has no tool
+        access by design.  Webhook handlers must use this method for triage and reply
+        generation so that Claude cannot use Edit, Bash, or git tools inline.
+        """
+        ...
+
     def print_prompt_from_file(
         self,
         system_file: Path,
@@ -843,6 +859,33 @@ def safe_voice_turn(
     )
     if not result:
         raise ValueError(f"{log_prefix}: run_turn returned empty after retries")
+    return result
+
+
+def safe_toolless_turn(
+    agent: ProviderAgent,
+    content: str,
+    *,
+    model: ProviderModel | None = None,
+    system_prompt: str | None = None,
+    log_prefix: str = "safe_toolless_turn",
+) -> str:
+    """Run a toolless one-shot turn; raise on empty.
+
+    Calls :meth:`~ProviderAgent.run_toolless_turn` which uses a one-shot subprocess
+    with no tool access (``claude --print`` for Claude).  Webhook handlers should use
+    this instead of :func:`safe_voice_turn` for triage and reply generation so that
+    the provider cannot use Edit, Bash, or git tools inline.
+
+    Raises :exc:`ValueError` if the provider returns an empty result.
+    """
+    result = agent.run_toolless_turn(
+        content,
+        model=model,
+        system_prompt=system_prompt,
+    )
+    if not result:
+        raise ValueError(f"{log_prefix}: run_toolless_turn returned empty")
     return result
 
 

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -18,7 +18,7 @@ from fido.provider import (
 class DefaultProviderFactory:
     """Create repo-configured provider instances."""
 
-    def __init__(self, *, session_system_file: Path) -> None:
+    def __init__(self, *, session_system_file: Path | None = None) -> None:
         self._session_system_file = session_system_file
         self._api_lock = threading.Lock()
         self._apis: dict[ProviderID, ProviderAPI] = {}
@@ -46,6 +46,10 @@ class DefaultProviderFactory:
         repo_name: str,
         session: PromptSession | None,
     ) -> Provider:
+        if self._session_system_file is None:
+            raise ValueError(
+                "DefaultProviderFactory.create_provider requires session_system_file"
+            )
         match repo_cfg.provider:
             case ProviderID.CLAUDE_CODE:
                 return ClaudeCode(
@@ -81,3 +85,18 @@ class DefaultProviderFactory:
             repo_name=repo_name,
             session=None,
         ).agent
+
+    def create_toolless_agent(self, repo_cfg: RepoConfig) -> ProviderAgent:
+        """Create an agent for toolless one-shot turns — no persistent session possible.
+
+        Omits ``session_system_file`` and ``work_dir`` so the agent cannot
+        accidentally start a persistent interactive session via ``run_turn``.
+        Only ``run_toolless_turn`` works on the returned agent.
+        """
+        match repo_cfg.provider:
+            case ProviderID.CLAUDE_CODE:
+                return ClaudeCode(agent=ClaudeClient()).agent
+            case ProviderID.COPILOT_CLI:
+                return CopilotCLI(agent=CopilotCLIClient()).agent
+            case _:
+                raise ValueError(f"unsupported provider: {repo_cfg.provider}")

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -526,7 +526,7 @@ def reorder_tasks(
 
     original_ids = frozenset(t["id"] for t in task_list)
     prompt = prompts.rescope_prompt(task_list, commit_summary)
-    raw = agent.run_turn(prompt, model=agent.voice_model)
+    raw = agent.run_toolless_turn(prompt, model=agent.voice_model)
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -3028,6 +3028,21 @@ class TestClaudeClientRunToollessTurn:
         with pytest.raises(ClaudeStreamError):
             client.run_toolless_turn("hi", model="claude-opus-4-6")
 
+    def test_allowed_tools_passed_as_flag(self) -> None:
+        client, mock_stream = self._client("ok")
+        tools = ("Read", "Grep", "Bash(git log*)")
+        client.run_toolless_turn("hi", model="claude-opus-4-6", allowed_tools=tools)
+        cmd = mock_stream.call_args[0][0]
+        assert "--allowedTools" in cmd
+        idx = cmd.index("--allowedTools")
+        assert cmd[idx + 1 : idx + 4] == ["Read", "Grep", "Bash(git log*)"]
+
+    def test_no_allowed_tools_flag_by_default(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi", model="claude-opus-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--allowedTools" not in cmd
+
     def test_content_written_to_stdin_file(self) -> None:
         """The prompt content must reach the streaming runner as the stdin file arg."""
         captured: list[str] = []

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2955,6 +2955,94 @@ class TestClaudeClientPrintPromptFromFile:
             client.print_prompt_from_file(sys, prompt, "claude-sonnet-4-6")
 
 
+class TestClaudeClientRunToollessTurn:
+    """ClaudeClient.run_toolless_turn: --print mode, no session, no tool access."""
+
+    def _client(
+        self, output: str = "result text"
+    ) -> tuple["ClaudeClient", "MagicMock"]:
+        mock_stream = MagicMock(return_value=iter([output]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        return client, mock_stream
+
+    def test_returns_output_text(self) -> None:
+        client, _ = self._client("triage: ACT")
+        assert client.run_toolless_turn("classify this") == "triage: ACT"
+
+    def test_command_includes_print_flag(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi", model="claude-opus-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--print" in cmd
+
+    def test_command_does_not_include_session_args(self) -> None:
+        """Toolless turns must not use --resume or session flags."""
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi", model="claude-opus-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--resume" not in cmd
+        assert "--input-format" not in cmd
+
+    def test_command_includes_model(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi", model="claude-sonnet-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+
+    def test_system_prompt_passed_via_file(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn(
+            "hi", model="claude-opus-4-6", system_prompt="be a dog"
+        )
+        cmd = mock_stream.call_args[0][0]
+        assert "--system-prompt-file" in cmd
+
+    def test_no_system_prompt_file_without_system_prompt(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi", model="claude-opus-4-6")
+        cmd = mock_stream.call_args[0][0]
+        assert "--system-prompt-file" not in cmd
+
+    def test_defaults_to_voice_model(self) -> None:
+        client, mock_stream = self._client("ok")
+        client.run_toolless_turn("hi")
+        cmd = mock_stream.call_args[0][0]
+        assert client.voice_model.model in cmd
+
+    def test_strips_whitespace_from_output(self) -> None:
+        client, _ = self._client("  trimmed  \n")
+        assert client.run_toolless_turn("hi", model="claude-opus-4-6") == "trimmed"
+
+    def test_raises_on_provider_error_output(self) -> None:
+        mock_stream = MagicMock(
+            return_value=iter(['API Error: 500 {"type":"error","message":"boom"}'])
+        )
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeProviderError, match="500"):
+            client.run_toolless_turn("hi", model="claude-opus-4-6")
+
+    def test_raises_on_stream_error(self) -> None:
+        mock_stream = MagicMock(side_effect=ClaudeStreamError(1))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        with pytest.raises(ClaudeStreamError):
+            client.run_toolless_turn("hi", model="claude-opus-4-6")
+
+    def test_content_written_to_stdin_file(self) -> None:
+        """The prompt content must reach the streaming runner as the stdin file arg."""
+        captured: list[str] = []
+
+        def fake_stream(
+            cmd: list[str], stdin_file: "Path", *args: object, **kwargs: object
+        ) -> object:
+            captured.append(stdin_file.read_text())
+            return iter(["ok"])
+
+        client = ClaudeClient(streaming_runner=fake_stream)
+        client.run_toolless_turn("my prompt text", model="claude-opus-4-6")
+        assert captured == ["my prompt text"]
+
+
 class TestRaiseForProviderErrorOutput:
     def test_parses_plain_text_api_error(self) -> None:
         with pytest.raises(ClaudeProviderError) as exc_info:

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1555,6 +1555,17 @@ class TestCopilotCLIClientRunToollessTurn:
         assert "sys" in captured[0]
         assert "content" in captured[0]
 
+    def test_allowed_tools_accepted_but_ignored(self, tmp_path: Path) -> None:
+        """Copilot CLI has no tool support; allowed_tools is accepted for protocol compat."""
+        runner = MagicMock(return_value=_completed(_copilot_output("ok")))
+        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
+        result = client.run_toolless_turn(
+            "hi",
+            model=client.voice_model,
+            allowed_tools=("Read", "Grep"),
+        )
+        assert extract_result_text(result) == "ok"
+
 
 class TestCopilotCLI:
     def test_default_provider_id_and_injected_components(self) -> None:

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1514,6 +1514,48 @@ class TestCopilotCLIClient:
         assert "copilot result >>>\ncli result\n<<< copilot result" in caplog.text
 
 
+class TestCopilotCLIClientRunToollessTurn:
+    """CopilotCLIClient.run_toolless_turn: uses _run_cli_prompt, no session."""
+
+    def test_returns_cli_output(self, tmp_path: Path) -> None:
+        runner = MagicMock(return_value=_completed(_copilot_output("triage: ACT")))
+        client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
+        result = client.run_toolless_turn("classify this", model=client.voice_model)
+        assert extract_result_text(result) == "triage: ACT"
+
+    def test_does_not_use_session(self, tmp_path: Path) -> None:
+        """run_toolless_turn must not touch a persistent session."""
+        session = MagicMock()
+        session.prompt.return_value = "session reply"
+        runner = MagicMock(return_value=_completed(_copilot_output("cli reply")))
+        client = CopilotCLIClient(
+            runner=runner, session=session, work_dir=tmp_path, repo_name="test/repo"
+        )
+        client.run_toolless_turn("hi", model=client.voice_model)
+        session.prompt.assert_not_called()
+
+    def test_system_prompt_prepended_to_content(self, tmp_path: Path) -> None:
+        captured: list[str] = []
+
+        def fake_runner(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            for i, arg in enumerate(cmd):
+                if arg == "-p" and i + 1 < len(cmd):
+                    captured.append(cmd[i + 1])
+            return _completed(_copilot_output("ok"))
+
+        client = CopilotCLIClient(
+            runner=fake_runner, work_dir=tmp_path, repo_name="test/repo"
+        )
+        client.run_toolless_turn(
+            "content", model=client.voice_model, system_prompt="sys"
+        )
+        assert captured, "prompt was not captured"
+        assert "sys" in captured[0]
+        assert "content" in captured[0]
+
+
 class TestCopilotCLI:
     def test_default_provider_id_and_injected_components(self) -> None:
         api = MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,6 +7,7 @@ from fido.claude import ClaudeClient
 from fido.config import Config, RepoMembership
 from fido.config import RepoConfig as _RepoConfig
 from fido.events import (
+    WEBHOOK_ALLOWED_TOOLS,
     Action,
     _apply_reply_result,
     _configured_agent,
@@ -146,6 +147,14 @@ class TestNeedsMoreContext:
         client = _client("YES")
         needs_more_context("same", agent=client)
         assert client.run_toolless_turn.call_args.kwargs["model"] == "claude-haiku-4-5"
+
+    def test_passes_webhook_allowed_tools(self) -> None:
+        client = _client("YES")
+        needs_more_context("same", agent=client)
+        assert (
+            client.run_toolless_turn.call_args.kwargs["allowed_tools"]
+            == WEBHOOK_ALLOWED_TOOLS
+        )
 
     def test_requires_agent(self) -> None:
         with pytest.raises(ValueError, match="needs_more_context requires agent"):
@@ -1460,6 +1469,12 @@ class TestSummarizeAsActionItem:
         client.run_toolless_turn.assert_called()
         client.run_turn.assert_not_called()
 
+    def test_passes_webhook_allowed_tools(self) -> None:
+        client = _client("add tests")
+        _summarize_as_action_item("add some tests", agent=client)
+        for call in client.run_toolless_turn.call_args_list:
+            assert call.kwargs.get("allowed_tools") == WEBHOOK_ALLOWED_TOOLS
+
     def test_shorten_empty_raises(self) -> None:
         """If shorten returns empty, safe_toolless_turn raises ValueError."""
         long_title = "a" * 81
@@ -1533,6 +1548,14 @@ class TestTriage:
         assert cat == "DO"
         assert "DO" in captured["prompt"]
         assert "TASK" not in captured["prompt"]
+
+    def test_passes_webhook_allowed_tools(self) -> None:
+        agent = _client("ACT: add tests")
+        _triage("please add tests", is_bot=False, agent=agent)
+        assert (
+            agent.run_toolless_turn.call_args.kwargs["allowed_tools"]
+            == WEBHOOK_ALLOWED_TOOLS
+        )
 
     def test_requires_agent(self) -> None:
         with pytest.raises(ValueError, match="_triage requires agent"):
@@ -1677,12 +1700,23 @@ class TestMaybeReact:
     def test_defaults_to_repo_configured_agent(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         with patch("fido.events.DefaultProviderFactory") as factory_cls:
-            factory_cls.return_value.create_agent.return_value = _client("NONE")
+            factory_cls.return_value.create_toolless_agent.return_value = _client(
+                "NONE"
+            )
             maybe_react("hi", 1, "pulls", "owner/repo", cfg, MagicMock())
-        factory_cls.return_value.create_agent.assert_called_once_with(
+        factory_cls.return_value.create_toolless_agent.assert_called_once_with(
             cfg.repos["owner/repo"],
-            work_dir=tmp_path,
-            repo_name="owner/repo",
+        )
+
+    def test_passes_webhook_allowed_tools(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        agent = _client("heart")
+        maybe_react(
+            "great work!", 99, "pulls", "owner/repo", cfg, MagicMock(), agent=agent
+        )
+        assert (
+            agent.run_toolless_turn.call_args.kwargs["allowed_tools"]
+            == WEBHOOK_ALLOWED_TOOLS
         )
 
     def test_missing_repo_config_raises(self, tmp_path: Path) -> None:
@@ -2360,6 +2394,9 @@ class TestReplyToComment:
         )
         agent.run_toolless_turn.assert_called()
         agent.run_turn.assert_not_called()
+        # All webhook voice turns must pass the read-only tool set.
+        for call in agent.run_toolless_turn.call_args_list:
+            assert call.kwargs.get("allowed_tools") == WEBHOOK_ALLOWED_TOOLS
 
 
 class TestReplyToReview:
@@ -2614,16 +2651,14 @@ class TestReplyToIssueComment:
             return "ok"
 
         with patch("fido.events.DefaultProviderFactory") as factory_cls:
-            factory_cls.return_value.create_agent.return_value = _client(
+            factory_cls.return_value.create_toolless_agent.return_value = _client(
                 side_effect=fake_pp
             )
             cat, titles = reply_to_issue_comment(
                 action, cfg, self._repo_cfg(tmp_path), MagicMock()
             )
-        factory_cls.return_value.create_agent.assert_called_once_with(
+        factory_cls.return_value.create_toolless_agent.assert_called_once_with(
             self._repo_cfg(tmp_path),
-            work_dir=tmp_path,
-            repo_name="owner/repo",
         )
         assert cat == "ACT"
 
@@ -2724,6 +2759,8 @@ class TestReplyToIssueComment:
         )
         agent.run_toolless_turn.assert_called()
         agent.run_turn.assert_not_called()
+        for call in agent.run_toolless_turn.call_args_list:
+            assert call.kwargs.get("allowed_tools") == WEBHOOK_ALLOWED_TOOLS
 
     def test_writes_durable_claim_after_reply(self, tmp_path: Path) -> None:
         """After posting a reply, the comment id is completed in SQLite."""
@@ -4213,6 +4250,8 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, mock_gh, agent=agent)
         agent.run_toolless_turn.assert_called()
         agent.run_turn.assert_not_called()
+        for call in agent.run_toolless_turn.call_args_list:
+            assert call.kwargs.get("allowed_tools") == WEBHOOK_ALLOWED_TOOLS
 
     def test_review_comment_empty_opus_raises(self, tmp_path: Path) -> None:
         """Empty toolless reply raises — no silent swallowing."""
@@ -4303,12 +4342,12 @@ class TestNotifyThreadChange:
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
         with patch("fido.events.DefaultProviderFactory") as factory_cls:
-            factory_cls.return_value.create_agent.return_value = _client("Auto reply")
+            factory_cls.return_value.create_toolless_agent.return_value = _client(
+                "Auto reply"
+            )
             _notify_thread_change(change, cfg, mock_gh)
-        factory_cls.return_value.create_agent.assert_called_once_with(
+        factory_cls.return_value.create_toolless_agent.assert_called_once_with(
             cfg.repos["owner/repo"],
-            work_dir=tmp_path,
-            repo_name="owner/repo",
         )
         mock_gh.reply_to_review_comment.assert_called_once_with(
             "owner/repo", 42, "Auto reply", 999

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -76,15 +76,17 @@ def _payload(repo_owner: str = "owner") -> dict:
 
 
 def _client(return_value: str = "", *, side_effect=None) -> MagicMock:
-    """Build a mock ClaudeClient with run_turn configured."""
+    """Build a mock ClaudeClient with run_turn and run_toolless_turn configured."""
     client = MagicMock(spec=ClaudeClient)
     client.voice_model = "claude-opus-4-6"
     client.work_model = "claude-sonnet-4-6"
     client.brief_model = "claude-haiku-4-5"
     if side_effect is not None:
         client.run_turn.side_effect = side_effect
+        client.run_toolless_turn.side_effect = side_effect
     else:
         client.run_turn.return_value = return_value
+        client.run_toolless_turn.return_value = return_value
     return client
 
 
@@ -143,7 +145,7 @@ class TestNeedsMoreContext:
     def test_uses_haiku_model(self) -> None:
         client = _client("YES")
         needs_more_context("same", agent=client)
-        assert client.run_turn.call_args.kwargs["model"] == "claude-haiku-4-5"
+        assert client.run_toolless_turn.call_args.kwargs["model"] == "claude-haiku-4-5"
 
     def test_requires_agent(self) -> None:
         with pytest.raises(ValueError, match="needs_more_context requires agent"):
@@ -1428,7 +1430,7 @@ class TestSummarizeAsActionItem:
         client = _client(short_title)
         result = _summarize_as_action_item("add some tests", agent=client)
         assert result == short_title
-        client.run_turn.assert_called_once()  # no retry needed
+        client.run_toolless_turn.assert_called_once()  # no retry needed
 
     def test_retries_when_result_too_long(self) -> None:
         long_title = "a" * 81
@@ -1436,35 +1438,35 @@ class TestSummarizeAsActionItem:
         client = _client(side_effect=[long_title, short_title])
         result = _summarize_as_action_item("add some tests", agent=client)
         assert result == short_title
-        assert client.run_turn.call_count == 2
+        assert client.run_toolless_turn.call_count == 2
 
     def test_retries_up_to_three_times_then_truncates(self) -> None:
         long_title = "a" * 81
         client = _client(long_title)
         result = _summarize_as_action_item("add some tests", agent=client)
         assert result == long_title[:80]
-        assert client.run_turn.call_count == 4  # 1 initial + 3 retries
+        assert client.run_toolless_turn.call_count == 4  # 1 initial + 3 retries
 
     def test_stops_retrying_once_short_enough(self) -> None:
         titles = ["a" * 81, "b" * 81, "short title"]
         client = _client(side_effect=titles)
         result = _summarize_as_action_item("add some tests", agent=client)
         assert result == "short title"
-        assert client.run_turn.call_count == 3  # 1 initial + 2 retries
+        assert client.run_toolless_turn.call_count == 3  # 1 initial + 2 retries
 
-    def test_uses_retry_on_preempt_via_safe_voice_turn(self) -> None:
-        """safe_voice_turn always passes retry_on_preempt=True to run_turn."""
+    def test_uses_toolless_turn_not_run_turn(self) -> None:
+        """Summarize runs via run_toolless_turn — no tool access in webhook context."""
         client = _client("add tests")
         _summarize_as_action_item("add some tests", agent=client)
-        _, kwargs = client.run_turn.call_args
-        assert kwargs.get("retry_on_preempt") is True
+        client.run_toolless_turn.assert_called()
+        client.run_turn.assert_not_called()
 
     def test_shorten_empty_raises(self) -> None:
-        """If shorten returns empty, safe_voice_turn raises ValueError."""
+        """If shorten returns empty, safe_toolless_turn raises ValueError."""
         long_title = "a" * 81
         # Initial returns long_title; shorten returns ""
         client = _client(side_effect=[long_title, ""])
-        with pytest.raises(ValueError, match="run_turn returned empty"):
+        with pytest.raises(ValueError, match="run_toolless_turn returned empty"):
             _summarize_as_action_item("add some tests", agent=client)
 
 
@@ -2058,7 +2060,7 @@ class TestReplyToComment:
                 return "Do something"
             return ""
 
-        with pytest.raises(ValueError, match="run_turn returned empty"):
+        with pytest.raises(ValueError, match="run_toolless_turn returned empty"):
             reply_to_comment(
                 action,
                 cfg,
@@ -2330,10 +2332,8 @@ class TestReplyToComment:
         assert "fido:reply-promise:" in reply_args[2]
         mock_gh.edit_review_comment.assert_not_called()
 
-    def test_reply_run_turn_uses_retry_on_preempt(self, tmp_path: Path) -> None:
-        """Reply generation run_turn must pass retry_on_preempt=True so a
-        session preemption mid-generation retries rather than silently
-        returning an empty or truncated body."""
+    def test_reply_uses_toolless_turn(self, tmp_path: Path) -> None:
+        """Reply generation uses run_toolless_turn — no tool access in webhook context."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -2341,10 +2341,8 @@ class TestReplyToComment:
             comment_body="please add logging",
             is_bot=False,
         )
-        all_run_turn_kwargs: list[dict] = []
 
         def fake_pp(prompt, model, **kwargs):
-            all_run_turn_kwargs.append(kwargs)
             if model == "claude-haiku-4-5":
                 return "NO"
             if "Triage" in prompt:
@@ -2353,16 +2351,16 @@ class TestReplyToComment:
                 return "Add logging"
             return "I will add logging."
 
+        agent = _client(side_effect=fake_pp)
         reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            agent=_client(side_effect=fake_pp),
+            agent=agent,
         )
-        # At least one run_turn call must carry retry_on_preempt=True — that is
-        # the reply generation call, which must survive session preemption.
-        assert any(kw.get("retry_on_preempt") is True for kw in all_run_turn_kwargs)
+        agent.run_toolless_turn.assert_called()
+        agent.run_turn.assert_not_called()
 
 
 class TestReplyToReview:
@@ -2549,7 +2547,7 @@ class TestReplyToIssueComment:
                 return "ACT: do it"
             return ""
 
-        with pytest.raises(ValueError, match="run_turn returned empty"):
+        with pytest.raises(ValueError, match="run_toolless_turn returned empty"):
             reply_to_issue_comment(
                 self._action(),
                 cfg,
@@ -2708,29 +2706,25 @@ class TestReplyToIssueComment:
         assert cat == "ACT"
         assert titles == ["add unit tests", "update documentation"]
 
-    def test_reply_run_turn_uses_retry_on_preempt(self, tmp_path: Path) -> None:
-        """Reply generation run_turn must pass retry_on_preempt=True so a
-        session preemption mid-generation retries rather than silently
-        returning an empty or truncated body."""
+    def test_reply_uses_toolless_turn(self, tmp_path: Path) -> None:
+        """Reply generation uses run_toolless_turn — no tool access in webhook context."""
         cfg = self._cfg(tmp_path)
-        all_run_turn_kwargs: list[dict] = []
 
         def fake_pp(prompt, model, **kwargs):
-            all_run_turn_kwargs.append(kwargs)
             if "Triage" in prompt:
                 return "ACT: fix the bug"
             return "I'll fix that."
 
+        agent = _client(side_effect=fake_pp)
         reply_to_issue_comment(
             self._action(),
             cfg,
             self._repo_cfg(tmp_path),
             MagicMock(),
-            agent=_client(side_effect=fake_pp),
+            agent=agent,
         )
-        # At least one run_turn call must carry retry_on_preempt=True — that is
-        # the reply generation call, which must survive session preemption.
-        assert any(kw.get("retry_on_preempt") is True for kw in all_run_turn_kwargs)
+        agent.run_toolless_turn.assert_called()
+        agent.run_turn.assert_not_called()
 
     def test_writes_durable_claim_after_reply(self, tmp_path: Path) -> None:
         """After posting a reply, the comment id is completed in SQLite."""
@@ -4185,17 +4179,8 @@ class TestNotifyThreadChange:
         _notify_thread_change(change, cfg, mock_gh, agent=_client())
         mock_gh.comment_issue.assert_not_called()
 
-    def test_review_comment_run_turn_uses_retry_on_preempt(
-        self, tmp_path: Path
-    ) -> None:
-        """run_turn must pass retry_on_preempt=True — #935.
-
-        A webhook handler arriving while this voice turn runs preempts it,
-        yielding result_len=0, cancelled=True.  Without retry_on_preempt,
-        that empty string was indistinguishable from a real provider
-        failure and used to raise ValueError, killing either the
-        reorder-<repo> daemon or the worker's rescope_before_pick path.
-        """
+    def test_notify_uses_toolless_turn(self, tmp_path: Path) -> None:
+        """Notification reply uses run_toolless_turn — no tool access in webhook context."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
@@ -4203,19 +4188,17 @@ class TestNotifyThreadChange:
         change = {"task": task, "kind": "completed"}
         agent = _client("Reply text")
         _notify_thread_change(change, cfg, mock_gh, agent=agent)
-        # _client wraps a MagicMock — capture the run_turn kwargs.
-        run_turn_kwargs = agent.run_turn.call_args.kwargs
-        assert run_turn_kwargs.get("retry_on_preempt") is True
+        agent.run_toolless_turn.assert_called()
+        agent.run_turn.assert_not_called()
 
     def test_review_comment_empty_opus_raises(self, tmp_path: Path) -> None:
-        """Empty Opus reply after retries raises — session reconnect handles
-        recovery (#935)."""
+        """Empty toolless reply raises — no silent swallowing."""
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         task = self._task()
         task["thread"]["comment_type"] = "pulls"
         change = {"task": task, "kind": "completed"}
-        with pytest.raises(ValueError, match="run_turn returned empty"):
+        with pytest.raises(ValueError, match="run_toolless_turn returned empty"):
             _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
 
     def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -152,16 +152,15 @@ class TestNeedsMoreContext:
             needs_more_context("some comment")
 
     def test_configured_agent_uses_provider_factory(self, tmp_path: Path) -> None:
-        cfg = _config(tmp_path)
-        cfg.repos["owner/repo"] = RepoConfig(
+        repo_cfg = RepoConfig(
             name="owner/repo",
             work_dir=tmp_path,
             provider=ProviderID.COPILOT_CLI,
         )
         sentinel = MagicMock()
         with patch("fido.events.DefaultProviderFactory") as factory_cls:
-            factory_cls.return_value.create_agent.return_value = sentinel
-            assert _configured_agent(cfg, cfg.repos["owner/repo"]) is sentinel
+            factory_cls.return_value.create_toolless_agent.return_value = sentinel
+            assert _configured_agent(repo_cfg) is sentinel
 
 
 class TestRecoverReplyPromises:
@@ -3534,6 +3533,10 @@ class TestReorderTasksBackground:
 
         return calls, mock_reorder
 
+    def _agent(self) -> MagicMock:
+        """Return a minimal mock agent for tests that don't need a real agent."""
+        return _client()
+
     def test_starts_daemon_thread(self, tmp_path: Path) -> None:
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
@@ -3544,6 +3547,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         assert len(started) == 1
@@ -3560,6 +3564,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         assert tmp_path.name in started[0].name
@@ -3576,6 +3581,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3594,6 +3600,7 @@ class TestReorderTasksBackground:
             mock_gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3655,6 +3662,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3681,6 +3689,7 @@ class TestReorderTasksBackground:
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3737,6 +3746,7 @@ class TestReorderTasksBackground:
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3758,6 +3768,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _rewrite_fn=lambda *a, **kw: None,
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -3780,6 +3791,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         assert len(started) == 1
@@ -3793,6 +3805,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         assert len(started) == 1  # no second thread spawned
@@ -3812,6 +3825,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         # Simulate a second trigger arriving before the thread runs
@@ -3822,6 +3836,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         # Run the single thread — should execute reorder twice (cs1 then cs2)
@@ -3846,6 +3861,7 @@ class TestReorderTasksBackground:
                 MagicMock(),
                 _start=lambda t: started.append(t),
                 _reorder_fn=mock_reorder,
+                agent=self._agent(),
                 _coalesce_state=state,
             )
         # Only one thread spawned; pending holds cs4 (the latest)
@@ -3869,6 +3885,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         self._run_thread(started)
@@ -3889,6 +3906,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         self._run_thread(started)  # first thread completes
@@ -3900,6 +3918,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         assert len(started) == 2  # new thread spawned
@@ -3919,6 +3938,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         _reorder_tasks_background(
@@ -3928,6 +3948,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state=state,
         )
         assert len(started) == 2  # each dir gets its own thread
@@ -4016,6 +4037,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)
@@ -4110,6 +4132,7 @@ class TestReorderTasksBackground:
             MagicMock(),
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
+            agent=self._agent(),
             _coalesce_state={},
         )
         self._run_thread(started)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -299,3 +299,16 @@ class TestSafeToollessTurn:
         safe_toolless_turn(agent, "prompt")
         _, kwargs = agent.run_toolless_turn.call_args
         assert "retry_on_preempt" not in kwargs
+
+    def test_passes_allowed_tools(self) -> None:
+        agent = self._agent("ok")
+        tools = ("Read", "Grep", "Bash(git log*)")
+        safe_toolless_turn(agent, "prompt", allowed_tools=tools)
+        _, kwargs = agent.run_toolless_turn.call_args
+        assert kwargs["allowed_tools"] == tools
+
+    def test_allowed_tools_defaults_to_none(self) -> None:
+        agent = self._agent("ok")
+        safe_toolless_turn(agent, "prompt")
+        _, kwargs = agent.run_toolless_turn.call_args
+        assert kwargs["allowed_tools"] is None

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -9,6 +9,7 @@ from fido.provider import (
     ProviderLimitWindow,
     ProviderModel,
     ProviderPressureStatus,
+    safe_toolless_turn,
     safe_voice_turn,
 )
 
@@ -258,3 +259,43 @@ class TestSafeVoiceTurn:
         _, kwargs = agent.run_turn.call_args
         assert kwargs["model"] == model
         assert kwargs["system_prompt"] == "be brief"
+
+
+class TestSafeToollessTurn:
+    """safe_toolless_turn: delegates to run_toolless_turn; raise-on-empty contract."""
+
+    def _agent(self, return_value: str = "ok") -> MagicMock:
+        agent = MagicMock()
+        agent.run_toolless_turn.return_value = return_value
+        agent.voice_model = "claude-opus-4-6"
+        return agent
+
+    def test_returns_result_on_non_empty_output(self) -> None:
+        agent = self._agent("Hello!")
+        result = safe_toolless_turn(agent, "prompt")
+        assert result == "Hello!"
+
+    def test_raises_on_empty_string(self) -> None:
+        agent = self._agent("")
+        with pytest.raises(ValueError, match="run_toolless_turn returned empty"):
+            safe_toolless_turn(agent, "prompt")
+
+    def test_error_includes_log_prefix(self) -> None:
+        agent = self._agent("")
+        with pytest.raises(ValueError, match="my_caller"):
+            safe_toolless_turn(agent, "prompt", log_prefix="my_caller")
+
+    def test_passes_model_and_system_prompt(self) -> None:
+        agent = self._agent("ok")
+        model = ProviderModel("claude-haiku-4-5")
+        safe_toolless_turn(agent, "prompt", model=model, system_prompt="be brief")
+        _, kwargs = agent.run_toolless_turn.call_args
+        assert kwargs["model"] == model
+        assert kwargs["system_prompt"] == "be brief"
+
+    def test_does_not_pass_retry_on_preempt(self) -> None:
+        """Toolless turns are one-shot and do not support preempt-retry."""
+        agent = self._agent("result")
+        safe_toolless_turn(agent, "prompt")
+        _, kwargs = agent.run_toolless_turn.call_args
+        assert "retry_on_preempt" not in kwargs

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -24,12 +24,13 @@ from fido.types import TaskStatus, TaskType
 
 
 def _client(run_turn_return: str = "") -> MagicMock:
-    """Create a mock ClaudeClient with a configurable run_turn return."""
+    """Create a mock ClaudeClient with a configurable run_toolless_turn return."""
     client = MagicMock(spec=ClaudeClient)
     client.voice_model = "claude-opus-4-6"
     client.work_model = "claude-sonnet-4-6"
     client.brief_model = "claude-haiku-4-5"
     client.run_turn.return_value = run_turn_return
+    client.run_toolless_turn.return_value = run_turn_return
     return client
 
 
@@ -545,7 +546,7 @@ class TestReorderTasks:
     def test_skips_when_no_tasks(self, tmp_path: Path) -> None:
         client = _client("")
         reorder_tasks(tmp_path, "", agent=client)
-        client.run_turn.assert_not_called()
+        client.run_toolless_turn.assert_not_called()
 
     def test_creates_default_client_when_none(self, tmp_path: Path) -> None:
         from unittest.mock import patch
@@ -648,7 +649,7 @@ class TestReorderTasks:
             )
 
         client = _client()
-        client.run_turn.side_effect = slow_run_turn
+        client.run_toolless_turn.side_effect = slow_run_turn
         reorder_tasks(tmp_path, "", agent=client)
         result = list_tasks(tmp_path)
         ids = [t["id"] for t in result]


### PR DESCRIPTION
## Summary

Webhook handlers were using `run_turn` with full tool access, letting Claude run Edit/Bash/git inline during triage — sometimes for 10+ minutes. That's the worker's job, not the webhook handler's!

This PR switches all webhook voice turns to one-shot `claude --print` mode with a **curated read-only tool set**: Read, Grep, Glob, WebSearch, WebFetch, and restricted Bash patterns for `git log/show/diff` and `gh issue/pr`. Triage can still sniff around the codebase and search the web, but cannot write files, run arbitrary commands, or push to git.

### Changes

- **Protocol layer**: `run_toolless_turn` now accepts optional `allowed_tools` parameter — when `None` (default), fully toolless; when provided, only those tools are available via `--allowedTools`
- **Webhook handlers**: all voice turns in `events.py` pass `WEBHOOK_ALLOWED_TOOLS` — a curated tuple of read-only tool specifiers
- **Task reordering**: `reorder_tasks` in `tasks.py` stays fully toolless (no tools needed for text-only task reordering)
- **Factory**: `_configured_agent()` uses `create_toolless_agent()` instead of `create_agent()` — no persistent session machinery needed for webhook context
- **Both providers**: `ClaudeClient` passes `--allowedTools` to the CLI; `CopilotCLIClient` accepts the parameter for protocol compatibility (no tool support)

### Test plan

- [x] All webhook voice turn tests verify `allowed_tools=WEBHOOK_ALLOWED_TOOLS` is passed
- [x] `ClaudeClient` tests verify `--allowedTools` flag appears in CLI command with correct tool names
- [x] `CopilotCLIClient` test verifies `allowed_tools` is accepted without error
- [x] `safe_toolless_turn` tests verify `allowed_tools` passthrough and default `None`
- [x] `reorder_tasks` stays toolless (no `allowed_tools` passed)
- [x] Factory tests use `create_toolless_agent` (fixed three stale tests)
- [x] Full CI passes: format, lint, typecheck, tests

Closes #950