### PR TITLE
Bug: webhooks no longer preempt the worker — they queue behind the session lock (closes #955)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -820,6 +820,11 @@ class ClaudeSession(OwnedSession):
         """
         if self._in_turn:
             self._drain_to_boundary()
+        if self._cancel.is_set():
+            # A preempt fired during (or just before) the drain — do not write
+            # a new message onto the dirty stream.  iter_events will see
+            # _cancel and break; _last_turn_cancelled lets run_turn retry.
+            return
         msg = json.dumps(
             {"type": "user", "message": {"role": "user", "content": content}}
         )
@@ -857,6 +862,13 @@ class ClaudeSession(OwnedSession):
                 [self._proc.stdout, self._wakeup_r], [], [], _SELECT_POLL_INTERVAL
             )
             self._drain_wakeup()
+            if self._cancel.is_set():
+                # Preempt fired — exit early without clearing _in_turn so
+                # send() skips writing and iter_events() breaks on the cancel.
+                log.debug(
+                    "ClaudeSession._drain_to_boundary: cancel set — aborting drain early"
+                )
+                return
             if self._proc.stdout in ready:
                 line = self._proc.stdout.readline()
                 if not line:

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1034,7 +1034,22 @@ class CopilotCLISession(OwnedSession):
             # worker — matches the shared decision gate used for claude.
             # Another webhook waiting behind a webhook just queues on the
             # lock; workers never cancel anyone.
-            provider.try_preempt_worker(self._repo_name, self._fire_worker_cancel)
+            preempted, current_kind = provider.try_preempt_worker(
+                self._repo_name, self._fire_worker_cancel
+            )
+            if preempted:
+                log.info(
+                    "CopilotCLISession: preempting worker (tid=%d, repo=%s)",
+                    threading.get_ident(),
+                    self._repo_name,
+                )
+            else:
+                log.info(
+                    "CopilotCLISession: queuing behind %s holder (tid=%d, repo=%s)",
+                    current_kind or "none",
+                    threading.get_ident(),
+                    self._repo_name,
+                )
             self._lock.acquire()
         self._thread_state.waited = waited
         with self._owner_lock:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -11,7 +11,12 @@ from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
-from fido.provider import ProviderAgent, safe_voice_turn, set_thread_repo
+from fido.provider import (
+    ProviderAgent,
+    safe_voice_turn,
+    set_thread_kind,
+    set_thread_repo,
+)
 from fido.provider_factory import DefaultProviderFactory
 from fido.registry import WorkerRegistry
 from fido.rocq import replied_comment_claims as oracle
@@ -1595,6 +1600,12 @@ def _reorder_tasks_background(
     def run_loop() -> None:
         cs = commit_summary
         kw = kwargs
+        # Register as "webhook" so the session talker reflects the true nature of
+        # this thread: it is triggered by webhooks and should not be treated as the
+        # worker for preemption purposes.  Without this, current_thread_kind()
+        # defaults to "worker", causing real webhooks to fire _fire_worker_cancel
+        # against the reorder thread and misidentify it as the running worker (#955).
+        set_thread_kind("webhook")
         if repo_cfg is not None:
             set_thread_repo(repo_cfg.name)
         if registry is not None and repo_cfg is not None:
@@ -1614,6 +1625,7 @@ def _reorder_tasks_background(
                 registry.set_rescoping(repo_cfg.name, False)
             if repo_cfg is not None:
                 set_thread_repo(None)
+            set_thread_kind(None)
 
     t = threading.Thread(
         target=run_loop,

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -649,10 +649,28 @@ class OwnedSession:
         When *preempt_worker* is true, fires the caller's
         :meth:`_fire_worker_cancel` once upfront (via
         :func:`try_preempt_worker`) so a currently-running worker turn
-        aborts immediately rather than being waited out.
+        aborts immediately rather than being waited out.  Logs the
+        outcome — preempted vs. queuing — so webhook latency spikes
+        are visible in the log without needing to trace ``session.prompt``
+        calls (fixes the missing diagnostic from #955).
         """
         if preempt_worker:
-            try_preempt_worker(self._repo_name, self._fire_worker_cancel)
+            preempted, current_kind = try_preempt_worker(
+                self._repo_name, self._fire_worker_cancel
+            )
+            if preempted:
+                log.info(
+                    "hold_for_handler: preempting worker (tid=%d, repo=%s)",
+                    threading.get_ident(),
+                    self._repo_name,
+                )
+            else:
+                log.info(
+                    "hold_for_handler: queuing behind %s holder (tid=%d, repo=%s)",
+                    current_kind or "none",
+                    threading.get_ident(),
+                    self._repo_name,
+                )
         with self:  # type: ignore[attr-defined]
             yield self
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -848,6 +848,26 @@ class TestClaudeSessionSend:
         user_idx = next(i for i, w in enumerate(writes) if '"fresh message"' in w)
         assert control_idx < user_idx
 
+    def test_skips_write_when_cancel_set_after_drain(self, tmp_path: Path) -> None:
+        """If a preempt fires during _drain_to_boundary, send() must not write
+        the new message to the dirty stream (#955)."""
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._in_turn = True  # prior turn in flight
+        # selector returns no data; we rely on _cancel short-circuiting drain
+        session._selector = MagicMock(return_value=([], [], []))
+
+        # Simulate preempt firing: drain returns early, _cancel stays set
+        session._cancel.set()
+        session._preempt_pending.set()
+
+        session.send("should not be written")
+        # No user message written to stdin — only the control_request
+        writes = [c.args[0] for c in proc.stdin.write.call_args_list]
+        assert not any('"should not be written"' in w for w in writes)
+        # _in_turn left True (drain bailed early) — iter_events will handle it
+        assert session._in_turn is True
+
 
 class TestClaudeSessionDrainToBoundary:
     def test_returns_early_when_proc_dead(self, tmp_path: Path) -> None:
@@ -939,6 +959,24 @@ class TestClaudeSessionDrainToBoundary:
             session._drain_to_boundary(deadline=0.01)
         mock_recover.assert_called_once()
         assert session._in_turn is False
+
+    def test_returns_early_on_cancel_set(self, tmp_path: Path) -> None:
+        """When _cancel fires mid-drain, _drain_to_boundary exits without
+        clearing _in_turn so send() can detect the cancel and skip writing."""
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        session._in_turn = True
+        # selector returns no-data so we hit the cancel check on each loop
+        session._selector = MagicMock(return_value=([], [], []))
+        # Set cancel immediately — simulates preempt arriving during drain
+        session._cancel.set()
+        session._preempt_pending.set()
+        with patch.object(session, "recover") as mock_recover:
+            session._drain_to_boundary(deadline=5.0)
+        # _in_turn stays True so send() knows not to write
+        assert session._in_turn is True
+        # recover was NOT called — we exited early, not via timeout
+        mock_recover.assert_not_called()
 
     def test_select_includes_wakeup_pipe(self, tmp_path: Path) -> None:
         import json as _json

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -115,6 +115,27 @@ def test_hold_preempt_fires_cancel_when_worker_holds(
     assert cancel_calls == [1]
 
 
+def test_hold_preempt_no_fire_when_no_worker_holder(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """preempt_worker=True with no current holder — try_preempt_worker returns
+    (False, None) and no cancel fires.  Exercises the ``else`` branch of the
+    new preempt outcome logging in hold_for_handler (#955)."""
+    session = _setup_session(tmp_path)
+    # No holder registered — try_preempt_worker sees current_kind=None.
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: None)
+    cancel_calls = []
+    monkeypatch.setattr(session, "_fire_worker_cancel", lambda: cancel_calls.append(1))
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler(preempt_worker=True):
+            pass
+    finally:
+        provider.set_thread_kind(None)
+        session.stop()
+    assert cancel_calls == []
+
+
 def test_hold_preempt_skipped_when_no_preempt_worker_flag(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -207,6 +207,100 @@ def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
     session.stop()
 
 
+def test_webhook_preempts_worker_mid_turn(tmp_path: Path) -> None:
+    """End-to-end: webhook calling hold_for_handler(preempt_worker=True)
+    wakes a worker that is blocked inside iter_events, causing the worker to
+    exit its turn and release the lock so the webhook can acquire it (#955)."""
+    import time
+
+    system_file = tmp_path / "system.md"
+    system_file.write_text("sys")
+    proc = MagicMock()
+    proc.pid = 55555
+    proc.poll = MagicMock(return_value=None)
+    proc.wait = MagicMock(return_value=0)
+    proc.returncode = 0
+    proc.stdin = MagicMock()
+    proc.stdin.closed = False
+    proc.stdout = MagicMock()
+    proc.stderr = MagicMock()
+
+    # Worker turn: readline blocks until cancel fires, then returns EOF.
+    worker_blocked = threading.Event()
+    cancel_received = threading.Event()
+
+    def blocking_readline() -> str:
+        worker_blocked.set()
+        cancel_received.wait(timeout=5.0)
+        return ""  # EOF — worker exits iter_events
+
+    proc.stdout.readline = MagicMock(side_effect=blocking_readline)
+
+    # Selector: immediately returns stdout as ready so iter_events calls readline.
+    session = ClaudeSession(
+        system_file,
+        work_dir=tmp_path,
+        popen=MagicMock(return_value=proc),
+        selector=MagicMock(return_value=([proc.stdout], [], [])),
+        repo_name="owner/repo",
+        model="claude-opus-4-6",
+    )
+
+    worker_in_turn = threading.Event()
+    worker_done = threading.Event()
+    webhook_acquired = threading.Event()
+    webhook_done = threading.Event()
+
+    def worker() -> None:
+        provider.set_thread_kind("worker")
+        try:
+            with session:
+                worker_in_turn.set()
+                # consume_until_result drives iter_events; readline blocks
+                session.consume_until_result()
+            worker_done.set()
+        finally:
+            provider.set_thread_kind(None)
+
+    def webhook() -> None:
+        provider.set_thread_kind("webhook")
+        try:
+            # Wait until worker is actually blocked, then preempt.
+            worker_blocked.wait(timeout=2.0)
+            # Signal readline to unblock after cancel fires.
+            original_fire = session._fire_worker_cancel
+
+            def fire_and_unblock() -> None:
+                original_fire()
+                cancel_received.set()
+
+            session._fire_worker_cancel = fire_and_unblock  # type: ignore[method-assign]
+            t_start = time.monotonic()
+            with session.hold_for_handler(preempt_worker=True):
+                webhook_acquired.set()
+                elapsed = time.monotonic() - t_start
+                assert elapsed < 2.0, (
+                    f"webhook took too long to acquire: {elapsed:.2f}s"
+                )
+            webhook_done.set()
+        finally:
+            provider.set_thread_kind(None)
+
+    t_worker = threading.Thread(target=worker, daemon=True)
+    t_worker.start()
+    worker_in_turn.wait(timeout=2.0)
+
+    t_webhook = threading.Thread(target=webhook, daemon=True)
+    t_webhook.start()
+
+    assert webhook_acquired.wait(timeout=5.0), "webhook never acquired lock"
+    assert webhook_done.wait(timeout=5.0)
+    assert worker_done.wait(timeout=5.0)
+    t_worker.join(timeout=2.0)
+    t_webhook.join(timeout=2.0)
+    session.stop()
+
+
 def test_hold_reraises_leak_error_and_releases_lock(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4121,6 +4121,76 @@ class TestReorderTasksBackground:
         self._run_thread(started)
         assert seen == [None]
 
+    def test_sets_thread_kind_webhook_during_reorder(self, tmp_path: Path) -> None:
+        """Thread kind is set to 'webhook' while the reorder loop runs (#955).
+
+        The reorder thread must not register as 'worker' in the session talker —
+        real webhooks would fire the cancel mechanism against it thinking it is
+        the actual worker."""
+        from fido.provider import current_thread_kind
+
+        started: list = []
+        seen: list = []
+
+        def mock_reorder(work_dir, commit_summary, **kwargs):
+            seen.append(current_thread_kind())
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        assert seen == ["webhook"]
+
+    def test_clears_thread_kind_after_reorder(self, tmp_path: Path) -> None:
+        """Thread kind is cleared in the finally block after the reorder loop."""
+        from fido.provider import current_thread_kind, set_thread_kind
+
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+
+        set_thread_kind("webhook")  # pre-set to confirm the finally block clears it
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+        )
+        self._run_thread(started)
+        # run_loop must clear kind in its finally block so the caller's
+        # thread-local state is not polluted.
+        assert current_thread_kind() == "worker"  # default when not set
+
+    def test_clears_thread_kind_on_reorder_exception(self, tmp_path: Path) -> None:
+        """Thread kind is cleared even when reorder raises."""
+        from fido.provider import current_thread_kind
+
+        started: list = []
+
+        def boom(work_dir, commit_summary, **kwargs):
+            raise RuntimeError("reorder exploded")
+
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=boom,
+            _coalesce_state={},
+        )
+        with pytest.raises(RuntimeError, match="reorder exploded"):
+            self._run_thread(started)
+        assert current_thread_kind() == "worker"  # default when not set
+
 
 class TestNotifyThreadChange:
     def _cfg(self, tmp_path: Path) -> Config:


### PR DESCRIPTION
## Root cause

Three separate issues combined to break webhook preemption:

1. **`_drain_to_boundary` was not cancel-aware** — when a preempt fired while the worker was draining a prior cancelled turn, the drain blocked for up to 10 seconds before the webhook could acquire the session lock.
2. **The background reorder thread was inadvertently classified as a `worker`** — `_reorder_tasks_background` never called `set_thread_kind()`, so it defaulted to `"worker"`, causing `try_preempt_worker` to misidentify it as a competing worker and firing spurious cancels.
3. **Preempt outcomes were invisible** — no logging when preemption fired or was skipped, making it hard to diagnose timing issues in production.

## Changes

- ✅ **Add preempt outcome logging** to `hold_for_handler` and all `try_preempt_worker` call sites — structured log lines for both the preempt-fired and queue-behind paths
- ✅ **Fix background reorder thread** — `_reorder_tasks_background` now calls `set_thread_kind("webhook")` so it's not mistaken for a worker by the preempt gate
- ✅ **Make `_drain_to_boundary` cancel-aware** — the drain loop now checks `_cancel` on each iteration and exits early without clearing `_in_turn`; `send()` also checks `_cancel` after drain returns and skips writing so the dirty stream is never extended
- ✅ **End-to-end preemption test** — `test_webhook_preempts_worker_mid_turn` verifies the full flow: worker blocked in `iter_events`, webhook fires `hold_for_handler(preempt_worker=True)`, worker wakes and releases lock, webhook acquires promptly

## Test plan

- [x] `./fido ci` — format, lint, typecheck, tests all green
- [x] `test_hold_preempt_fires_cancel_when_worker_holds` — preempt path fires cancel
- [x] `test_hold_preempt_no_fire_when_no_worker_holder` — else branch of preempt logging
- [x] `test_sets_thread_kind_webhook_during_reorder` / `_clears_*` / `_on_exception` — reorder thread kind
- [x] `test_returns_early_on_cancel_set` — drain exits early on cancel, `_in_turn` stays True
- [x] `test_skips_write_when_cancel_set_after_drain` — send() is a no-op after cancelled drain
- [x] `test_webhook_preempts_worker_mid_turn` — full threading integration test