### PR TITLE
Regression: status task counter stuck at 1/X — counter doesn't count up as tasks complete (closes #954)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2359,6 +2359,7 @@ class Worker:
         )
         with State(fido_dir).modify() as state:
             state["current_task_id"] = task["id"]
+        self._tasks.update(task["id"], TaskStatus.IN_PROGRESS)
         session_id, _output = provider_run(
             fido_dir,
             agent=self._provider_agent,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1346,6 +1346,76 @@ class TestStatusXml:
         data = json.loads(resp.read())
         assert data["fido_uptime_seconds"] is None
 
+    def test_status_xml_task_number_from_in_progress(
+        self, server: tuple, tmp_path: Path
+    ) -> None:
+        """task_number and task_total in the /status XML reflect in_progress position.
+
+        When a task is in_progress (not just pending), its index within the
+        non-completed list is reported — so the counter can show "2/3" rather
+        than always "1/N".
+        """
+        from datetime import datetime, timezone
+
+        from fido.registry import WorkerActivity
+
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        tasks = [
+            {
+                "id": "1",
+                "title": "done",
+                "type": "spec",
+                "status": "completed",
+                "description": "",
+            },
+            {
+                "id": "2",
+                "title": "first pending",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+            {
+                "id": "3",
+                "title": "active task",
+                "type": "spec",
+                "status": "in_progress",
+                "description": "",
+            },
+            {
+                "id": "4",
+                "title": "later task",
+                "type": "spec",
+                "status": "pending",
+                "description": "",
+            },
+        ]
+        (fido_dir / "tasks.json").write_text(json.dumps(tasks))
+
+        url, _ = server
+        WebhookHandler.registry.get_all_activities.return_value = [
+            WorkerActivity(
+                repo_name="owner/repo",
+                what="Working on: #10",
+                busy=True,
+                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        WebhookHandler.registry.get_crash_info.return_value = None
+        WebhookHandler.registry.is_stale.return_value = False
+        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_webhook_activities.return_value = []
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+        resp = urllib.request.urlopen(f"{url}/status")
+        body = resp.read().decode()
+        # Non-completed: [pending, in_progress, pending] → total=3; in_progress is #2.
+        assert "<task_number>2</task_number>" in body
+        assert "<task_total>3</task_total>" in body
+
     def test_status_xml_includes_issue_cache_as_nested_elements(
         self, server: tuple
     ) -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1078,6 +1078,39 @@ class TestRepoStatus:
         assert result.provider is ProviderID.CLAUDE_CODE
         assert result.provider_status == status
 
+    def test_in_progress_task_propagates_position(self, tmp_path: Path) -> None:
+        """repo_status() surfaces the in_progress task's position and total correctly.
+
+        When the worker marks a task in_progress, _task_position() picks it up
+        and the position is reflected in task_number / task_total on RepoStatus.
+        An in_progress task that is not first in the non-completed list must
+        still report its actual position, not 1.
+        """
+        git_dir = tmp_path / ".git"
+        fido_dir = git_dir / "fido"
+        fido_dir.mkdir(parents=True)
+        tasks = [
+            {"status": "completed", "title": "done", "type": "spec"},
+            {"status": "pending", "title": "first pending", "type": "spec"},
+            {"status": "in_progress", "title": "active task", "type": "spec"},
+            {"status": "pending", "title": "last pending", "type": "spec"},
+        ]
+        (fido_dir / "tasks.json").write_text(json.dumps(tasks))
+
+        cfg = self._make_config(tmp_path)
+        with (
+            patch("fido.status._git_dir", return_value=git_dir),
+            patch("fido.status._fido_running", return_value=True),
+            patch("fido.status._claude_pid", return_value=None),
+            patch("fido.status._process_uptime_seconds", return_value=None),
+        ):
+            result = repo_status(cfg)
+
+        # Non-completed: [pending, in_progress, pending] → 3 total; in_progress is #2.
+        assert result.current_task == "active task"
+        assert result.task_number == 2
+        assert result.task_total == 3
+
 
 class TestCollect:
     def _fake_repo_status(self, name: str = "owner/repo") -> RepoStatus:


### PR DESCRIPTION
Fixes #954.

The status task counter is stuck at 1/X because `execute_task()` never sets the active task's status to `in_progress` — so `_task_position()` always falls through to its default. Adds the missing `IN_PROGRESS` transition when a task starts and covers the counting behavior with tests.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Add test coverage for _task_position with in_progress tasks and verify propagation through status endpoints <!-- type:spec -->
- [x] [Add test that in_progress status propagates through status JSON and plain-text endpoints](https://github.com/FidoCanCode/home/pull/965#issuecomment-4319683470) <!-- type:thread -->
- [x] Set task status to in_progress when worker starts executing a task <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->