### PR TITLE
Bug: fido closes own PR after webhook preempt — empty post-cancel retry misclassified as task completion (closes #969)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2383,8 +2383,8 @@ class Worker:
             # complete`) while we were waiting, stop retrying — the work is
             # already recorded as done and no commits will ever appear.
             current_task_list = self._tasks.list()
-            if not any(
-                t["id"] == task["id"] and t.get("status") == TaskStatus.PENDING
+            if any(
+                t["id"] == task["id"] and t.get("status") == TaskStatus.COMPLETED
                 for t in current_task_list
             ):
                 log.info(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8822,6 +8822,56 @@ class TestExecuteTask:
         # complete_with_resolve still called (idempotent — task already completed externally)
         mock_complete.assert_called_once_with(task["id"], worker.gh)
 
+    def test_does_not_treat_in_progress_task_as_externally_completed(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression for #969: after #965 transitions tasks to IN_PROGRESS at
+        # start, the resume loop must not treat IN_PROGRESS as "externally
+        # completed". Only COMPLETED counts as external completion. Without
+        # this fix the worker breaks out of the resume loop on the first
+        # iteration and (downstream) closes its own PR.
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Real work")
+        in_progress_task = {**task, "status": "in_progress"}
+        # HEAD changes on the second rev-parse so the resume loop terminates
+        # naturally after one retry — proving it did not short-circuit on
+        # the IN_PROGRESS status check.
+        head_calls = iter(["aaa", "aaa", "bbb", "bbb", "bbb"])
+        git_mock = MagicMock(
+            side_effect=lambda args, **kw: MagicMock(
+                returncode=0,
+                stdout=next(head_calls) if args == ["rev-parse", "HEAD"] else "",
+                stderr="",
+            )
+        )
+        # Picker sees PENDING; resume loop's re-check sees IN_PROGRESS.
+        list_tasks_calls = iter([[task], [in_progress_task]])
+        with (
+            patch(
+                "fido.tasks.Tasks.list",
+                side_effect=lambda *a, **kw: next(list_tasks_calls),
+            ),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch(
+                "fido.worker.provider_run",
+                side_effect=[
+                    ("sess-1", "o1"),
+                    ("sess-1", "o2"),
+                ],
+            ) as mock_run,
+            patch.object(worker, "_git", git_mock),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve") as mock_complete,
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
+        # Initial dispatch + the retry — proves the resume loop did NOT
+        # short-circuit on the IN_PROGRESS status check.
+        assert mock_run.call_count == 2
+        mock_complete.assert_called_once()
+
     def test_uses_fresh_session_mode_once_after_repeated_no_commit_nudges(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #969.

## Root cause: collision between #965 and #967

`Worker._execute_task`'s resume loop checked at worker.py:2387:

```python
if not any(
    t["id"] == task["id"] and t.get("status") == TaskStatus.PENDING
    for t in current_task_list
):
    log.info("task externally completed — stopping retry ...")
    break
```

The intent was always *"task was marked COMPLETED by an external action"*, but the implementation was *"status is anything other than PENDING"*. Pre-#965 those were equivalent. #965 added `self._tasks.update(task_id, IN_PROGRESS)` at task start (worker.py:2362), so the running task is now IN_PROGRESS — the check breaks out immediately on every resume-loop iteration.

The bug was latent until #967 added synchronous webhook preempt: a preempted turn returns empty without commits, `while head_before == head_after` runs, the check misclassifies, the worker breaks the resume loop, and downstream logic closes the in-flight PR.

## Fix

Compare for COMPLETED directly. One-line change.

## Test

Adds `test_does_not_treat_in_progress_task_as_externally_completed` that drives `execute_task` through one resume-loop retry with an IN_PROGRESS task and asserts the loop does not short-circuit.

## Trace from the wild

```
14:42:02 task XXX → in_progress
14:42:18 webhook: preempting worker synchronously
14:42:18 ClaudeSession: cancelled — exiting turn early
14:42:18 session.prompt: turn complete (cancelled=True)
14:42:18 ClaudeClient.run_turn: preempted mid-flight — retry 1
14:42:18 session.prompt: turn complete (total=0.01s, result_len=0)   ← empty
14:42:18 task done (session=)
14:42:18 task externally completed — stopping retry (id=XXX)         ← bug fires
14:42:22 PR #968 closed by FidoCanCode                                ← self-close
```