### PR TITLE
Use control_request set_model for mid-session model switch instead of session restart (closes #852)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -475,11 +475,10 @@ class ClaudeSession(OwnedSession):
         self._system_file = system_file
         self._work_dir = work_dir
         self._popen_fn = popen
-        # Reentrant so :meth:`switch_model` and :meth:`restart` can
-        # reacquire while called from inside a ``with session:`` block
-        # (e.g. ``prompt()`` acquires the lock, then calls switch_model
-        # which also needs to serialize with other sessions' access —
-        # a plain threading.Lock self-deadlocks).
+        # Reentrant so :meth:`switch_model` can reacquire while called from
+        # inside a ``with session:`` block (e.g. ``prompt()`` acquires the
+        # lock, then calls switch_model which also needs to serialize with
+        # other sessions' access — a plain threading.Lock self-deadlocks).
         self._lock = threading.RLock()
         self._cancel = threading.Event()
         self._repo_name = repo_name
@@ -487,9 +486,10 @@ class ClaudeSession(OwnedSession):
             ProviderModel("claude-opus-4-6") if model is None else model
         )
         # Latest session_id seen in a stream-json event.  Updated inside
-        # :meth:`iter_events` so a subsequent :meth:`switch_model` can
-        # restart with ``--resume <sid>`` and keep conversation context
-        # across the model swap.  Seeded from the *session_id* constructor
+        # :meth:`iter_events` and :meth:`_send_control_set_model` so
+        # :meth:`recover` and :meth:`reset` can pass ``--resume <sid>``
+        # to :meth:`_spawn` and keep conversation context across a
+        # subprocess restart.  Seeded from the *session_id* constructor
         # kwarg so the first :meth:`_spawn` can ``--resume`` a durable
         # claude conversation persisted across fido restarts (#649).
         # Empty until the first claude event with a session_id arrives.
@@ -615,12 +615,10 @@ class ClaudeSession(OwnedSession):
     def _spawn(self) -> subprocess.Popen[str]:
         """Spawn the claude subprocess with bidirectional stream-json I/O.
 
-        Model is set via ``--model`` at spawn time — the runtime ``/model``
-        slash command isn't honored in stream-json mode (claude echoes
-        "Unknown command: /model" and hangs without producing a turn
-        boundary).  When :attr:`_session_id` is non-empty the new process
-        resumes the prior conversation via ``--resume`` so context
-        survives a model swap.
+        Model is set via ``--model`` at spawn time.  When
+        :attr:`_session_id` is non-empty the new process resumes the
+        prior conversation via ``--resume`` so context survives a
+        subprocess restart (e.g. :meth:`recover` or :meth:`reset`).
         """
         cmd = [
             "claude",
@@ -1211,9 +1209,9 @@ class ClaudeSession(OwnedSession):
                 obj = json.loads(line)
                 self._log_event(obj)
                 last_activity = time.monotonic()
-                # Track the latest session_id so :meth:`switch_model` can
-                # restart with ``--resume <sid>`` and keep conversation
-                # context across the swap.
+                # Track the latest session_id so :meth:`recover` and
+                # :meth:`reset` can resume via ``--resume <sid>`` on the
+                # next :meth:`_spawn`.
                 sid = obj.get("session_id")
                 if isinstance(sid, str) and sid:
                     self._session_id = sid

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -202,6 +202,11 @@ _RETURNCODE_IDLE_TIMEOUT = -1
 """Sentinel returncode used in :class:`ClaudeStreamError` when the process is
 killed due to an idle timeout rather than exiting with a real non-zero code."""
 
+_RETURNCODE_SET_MODEL_TIMEOUT = -2
+"""Sentinel returncode used in :class:`ClaudeStreamError` when a
+``control_request`` ``set_model`` times out waiting for the matching
+``control_response``, or the subprocess exits unexpectedly during the wait."""
+
 
 class ClaudeStreamError(Exception):
     """Raised by _run_streaming when the subprocess exits with a non-zero code or times out."""
@@ -950,6 +955,61 @@ class ClaudeSession(OwnedSession):
         assert self._proc.stdin is not None
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
+
+    def _send_control_set_model(self, model: str) -> None:
+        """Write a ``control_request`` ``set_model`` to stdin and drain stdout
+        until the matching ``control_response`` arrives.
+
+        Switches the model on the running subprocess in-place — no kill, no
+        restart, no init-handshake delay, no session-id loss.  Call while
+        holding :attr:`_lock` and between turns (``_in_turn`` must be
+        ``False``).
+
+        Raises :class:`ClaudeStreamError` with
+        :data:`_RETURNCODE_SET_MODEL_TIMEOUT` if the subprocess exits or the
+        ``control_response`` is not received within :attr:`_idle_timeout`
+        seconds.
+        """
+        request_id = str(uuid.uuid4())
+        msg = json.dumps(
+            {
+                "type": "control_request",
+                "request_id": request_id,
+                "request": {"subtype": "set_model", "model": model},
+            }
+        )
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+        self._proc.stdin.write(msg + "\n")
+        self._proc.stdin.flush()
+        deadline = time.monotonic() + self._idle_timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
+            ready, _, _ = self._selector(
+                [self._proc.stdout], [], [], min(remaining, _SELECT_POLL_INTERVAL)
+            )
+            if self._proc.stdout not in ready:
+                if self._proc.poll() is not None:
+                    raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
+                continue
+            line = self._proc.stdout.readline()
+            if not line:
+                raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            self._log_event(obj)
+            sid = obj.get("session_id")
+            if isinstance(sid, str) and sid:
+                self._session_id = sid
+            if (
+                obj.get("type") == "control_response"
+                and obj.get("request_id") == request_id
+            ):
+                return
 
     def interrupt(self, content: str) -> None:
         """Interrupt the in-flight turn at the protocol level, then send *content*.

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1090,16 +1090,13 @@ class ClaudeSession(OwnedSession):
             self._preempt_pending.clear()
 
     def switch_model(self, model: ProviderModel | str) -> None:
-        """Switch the active model.  Restart-based — stream-json does not
-        accept ``/model`` or any slash command (claude echoes "Unknown
-        command" and never emits a turn boundary, hanging the reader).
+        """Switch the active model via a ``control_request`` ``set_model``
+        message — no kill, no respawn, no init-handshake delay, no
+        session-id loss.
 
-        Holds :attr:`_lock` for the full swap so callers waiting on
-        :meth:`__enter__` block gracefully until the new subprocess is
-        listening.  When a prior ``session_id`` is known we pass
-        ``--resume`` to the new subprocess so the conversation transcript
-        carries over across the swap — no context loss when phase
-        transitions flip opus → sonnet or vice versa.
+        Holds :attr:`_lock` for the duration so callers waiting on
+        :meth:`__enter__` block gracefully until the switch is complete.
+        Must be called between turns (``_in_turn`` must be ``False``).
 
         No-op when *model* equals the current model.
         """
@@ -1107,33 +1104,14 @@ class ClaudeSession(OwnedSession):
         if target_model == self._model:
             return
         log.info(
-            "switch_model: %s → %s (restart-based, resume=%s)",
+            "switch_model: %s → %s (control_request)",
             self._model,
             target_model,
-            self._session_id or "—",
         )
         with self._lock:
-            _unregister_child(self._proc)
-            if self._proc.poll() is None:
-                try:
-                    self._proc.kill()
-                    self._proc.wait(timeout=1.0)
-                except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
-                    log.warning(
-                        "switch_model: kill/wait of old subprocess failed: %s", exc
-                    )
-                    raise
+            self._send_control_set_model(target_model)
             self._model = target_model
-            # Fresh subprocess — any in-flight turn on the old one died
-            # with it, so next send() has nothing to drain.
-            self._in_turn = False
-            self._proc = self._spawn()
-            _register_child(self._proc)
-        log.info(
-            "switch_model: new pid %d ready (model=%s)",
-            self._proc.pid,
-            target_model,
-        )
+        log.info("switch_model: now on model=%s", target_model)
 
     def _log_event(self, obj: dict[str, Any]) -> None:
         """Emit a human-readable INFO log line for a stream-json *obj*.

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -282,7 +282,8 @@ class PromptSession(Protocol):
         ...
 
     def switch_model(self, model: ProviderModel) -> None:
-        """Switch the live session to *model* without resetting session state."""
+        """Switch the live session to *model* in-place without kill, respawn,
+        or session-state loss."""
         ...
 
     def recover(self) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -12,6 +12,7 @@ from fido import provider
 from fido.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
+    _RETURNCODE_SET_MODEL_TIMEOUT,
     ClaudeAPI,
     ClaudeClient,
     ClaudeCode,
@@ -2189,6 +2190,257 @@ class TestClaudeSessionSendControlInterrupt:
         session._send_control_interrupt()
         obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
         assert isinstance(obj.get("request_id"), str) and obj["request_id"]
+        session.stop()
+
+
+class TestClaudeSessionSendControlSetModel:
+    """Tests for ClaudeSession._send_control_set_model."""
+
+    _REQUEST_ID = "12345678-1234-5678-1234-567812345678"
+
+    def _make_response_line(self, request_id: str, **extra: object) -> str:
+        import json as _json
+
+        return (
+            _json.dumps({"type": "control_response", "request_id": request_id, **extra})
+            + "\n"
+        )
+
+    def _make_custom_session(
+        self,
+        tmp_path: Path,
+        proc: MagicMock,
+        *,
+        idle_timeout: float = 1800.0,
+        selector_side_effect: object = None,
+    ) -> ClaudeSession:
+        """Build a ClaudeSession with an injectable selector side_effect."""
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        fake_popen = MagicMock(return_value=proc)
+        if selector_side_effect is not None:
+            fake_selector = MagicMock(side_effect=selector_side_effect)
+        else:
+            fake_selector = MagicMock(return_value=([proc.stdout], [], []))
+        return ClaudeSession(
+            system_file,
+            work_dir=tmp_path,
+            popen=fake_popen,
+            selector=fake_selector,
+            idle_timeout=idle_timeout,
+        )
+
+    def test_writes_control_request_type(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert obj["type"] == "control_request"
+        session.stop()
+
+    def test_writes_set_model_subtype(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert obj["request"]["subtype"] == "set_model"
+        session.stop()
+
+    def test_writes_model_in_request(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert obj["request"]["model"] == "claude-sonnet-4-6"
+        session.stop()
+
+    def test_includes_request_id(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc([])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert isinstance(obj.get("request_id"), str) and obj["request_id"]
+        session.stop()
+
+    def test_returns_on_matching_control_response(self, tmp_path: Path) -> None:
+        """Returns without raising when a matching control_response arrives."""
+        proc = _make_session_proc([])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        session.stop()
+
+    def test_skips_non_matching_response_and_reads_next(self, tmp_path: Path) -> None:
+        """Keeps reading past a control_response with a different request_id."""
+        proc = _make_session_proc([])
+        wrong_response = self._make_response_line(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        )
+        right_response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(
+            side_effect=[wrong_response, right_response, ""]
+        )
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        assert proc.stdout.readline.call_count == 2
+        session.stop()
+
+    def test_skips_non_control_response_events(self, tmp_path: Path) -> None:
+        """Skips unrelated event types before the control_response."""
+        import json as _json
+
+        proc = _make_session_proc([])
+        other_event = _json.dumps({"type": "system", "subtype": "init"}) + "\n"
+        right_response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[other_event, right_response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        assert proc.stdout.readline.call_count == 2
+        session.stop()
+
+    def test_skips_empty_lines(self, tmp_path: Path) -> None:
+        """Empty (whitespace-only) stdout lines are skipped without error."""
+        proc = _make_session_proc([])
+        right_response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=["\n", right_response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        session.stop()
+
+    def test_raises_on_eof_while_waiting(self, tmp_path: Path) -> None:
+        """EOF (empty readline) before control_response raises ClaudeStreamError."""
+        proc = _make_session_proc([])
+        proc.stdout.readline = MagicMock(return_value="")
+        session = _make_session(tmp_path, proc)
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            session._send_control_set_model("claude-sonnet-4-6")
+        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
+        session.stop()
+
+    def test_raises_on_timeout(self, tmp_path: Path) -> None:
+        """ClaudeStreamError raised when idle_timeout expires before response."""
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=None)
+        session = self._make_custom_session(
+            tmp_path,
+            proc,
+            idle_timeout=0.0,
+            selector_side_effect=[([], [], [])],
+        )
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            session._send_control_set_model("claude-sonnet-4-6")
+        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
+        session.stop()
+
+    def test_raises_when_process_exits_while_waiting(self, tmp_path: Path) -> None:
+        """ClaudeStreamError raised when subprocess exits without sending response."""
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=1)
+        session = self._make_custom_session(
+            tmp_path,
+            proc,
+            selector_side_effect=[([], [], [])],
+        )
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            session._send_control_set_model("claude-sonnet-4-6")
+        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
+        session.stop()
+
+    def test_continues_when_stdout_not_ready_and_proc_alive(
+        self, tmp_path: Path
+    ) -> None:
+        """Loops past a not-ready select() if the subprocess is still alive."""
+        proc = _make_session_proc([])
+        proc.poll = MagicMock(return_value=None)
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = self._make_custom_session(
+            tmp_path,
+            proc,
+            selector_side_effect=[
+                ([], [], []),  # first call: not ready, proc alive
+                ([proc.stdout], [], []),  # second call: ready
+            ],
+        )
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        session.stop()
+
+    def test_updates_session_id_from_response(self, tmp_path: Path) -> None:
+        """session_id in control_response is tracked on the session."""
+        import json as _json
+
+        proc = _make_session_proc([])
+        response = (
+            _json.dumps(
+                {
+                    "type": "control_response",
+                    "request_id": self._REQUEST_ID,
+                    "session_id": "new-session-42",
+                }
+            )
+            + "\n"
+        )
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")
+        assert session._session_id == "new-session-42"
         session.stop()
 
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1515,6 +1515,15 @@ class TestClaudeSessionStop:
 
 
 class TestClaudeSessionSwitchModel:
+    _REQUEST_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    def _make_response_line(self, request_id: str) -> str:
+        import json as _json
+
+        return (
+            _json.dumps({"type": "control_response", "request_id": request_id}) + "\n"
+        )
+
     def test_same_model_is_noop(self, tmp_path: Path) -> None:
         """When the target matches the current model, nothing happens."""
         proc = _make_session_proc([])
@@ -1522,79 +1531,45 @@ class TestClaudeSessionSwitchModel:
         current_proc = session._proc
         session.switch_model("claude-opus-4-6")
         assert session._proc is current_proc
-        # stdin.write should NOT have been called for a /model slash command.
+        # No control_request is written for a noop switch.
         assert proc.stdin.write.call_count == 0
 
-    def test_different_model_respawns_with_new_flag(self, tmp_path: Path) -> None:
-        """Switching model kills the old proc and spawns a new one with
-        --model <new>, passing --resume when session_id is known."""
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        old_proc = _make_session_proc([])
-        old_proc.pid = 1001
-        new_proc = _make_session_proc([])
-        new_proc.pid = 1002
-        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
-        session = ClaudeSession(
-            system_file,
-            work_dir=tmp_path,
-            popen=fake_popen,
-            selector=MagicMock(return_value=([], [], [])),
-            model="claude-opus-4-6",
-            repo_name="owner/repo",
-        )
-        # Prior turn established a session_id — switch_model must preserve
-        # conversation by passing --resume to the new subprocess.
-        session._session_id = "sid-123"
-        session.switch_model("claude-sonnet-4-6")
-        old_proc.kill.assert_called_once()
-        assert session._proc is new_proc
-        assert session._model == "claude-sonnet-4-6"
-        # Second spawn call had --model claude-sonnet-4-6 and --resume sid-123.
-        second_cmd = fake_popen.call_args_list[1].args[0]
-        assert "--model" in second_cmd
-        assert second_cmd[second_cmd.index("--model") + 1] == "claude-sonnet-4-6"
-        assert "--resume" in second_cmd
-        assert second_cmd[second_cmd.index("--resume") + 1] == "sid-123"
+    def test_different_model_sends_control_request(self, tmp_path: Path) -> None:
+        """Switching model writes a set_model control_request to stdin and
+        updates _model — no kill, no respawn."""
+        import json as _json
 
-    def test_switch_raises_when_kill_fails(self, tmp_path: Path) -> None:
-        """kill/wait failure during switch_model re-raises so the caller
-        can decide how to recover."""
-        import subprocess
+        response = self._make_response_line(self._REQUEST_ID)
+        proc = _make_session_proc([])
+        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        session = _make_session(tmp_path, proc)
+        original_proc = session._proc
 
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        old_proc = _make_session_proc([], poll_returns=None)
-        old_proc.kill = MagicMock()
-        old_proc.wait = MagicMock(side_effect=subprocess.TimeoutExpired("claude", 1.0))
-        fake_popen = MagicMock(side_effect=[old_proc, _make_session_proc([])])
-        session = ClaudeSession(
-            system_file,
-            work_dir=tmp_path,
-            popen=fake_popen,
-            selector=MagicMock(return_value=([], [], [])),
-            model="claude-opus-4-6",
-        )
-        with pytest.raises(subprocess.TimeoutExpired):
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
             session.switch_model("claude-sonnet-4-6")
 
-    def test_switch_with_no_prior_session_id_omits_resume(self, tmp_path: Path) -> None:
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        old_proc = _make_session_proc([])
-        new_proc = _make_session_proc([])
-        fake_popen = MagicMock(side_effect=[old_proc, new_proc])
-        session = ClaudeSession(
-            system_file,
-            work_dir=tmp_path,
-            popen=fake_popen,
-            selector=MagicMock(return_value=([], [], [])),
-            model="claude-opus-4-6",
-        )
-        # No prior session_id (fresh session) — no --resume flag.
-        session.switch_model("claude-sonnet-4-6")
-        second_cmd = fake_popen.call_args_list[1].args[0]
-        assert "--resume" not in second_cmd
+        # Proc is unchanged — no kill, no respawn.
+        assert session._proc is original_proc
+        assert session._model == "claude-sonnet-4-6"
+        # stdin got a control_request with set_model subtype and correct model.
+        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
+        assert obj["type"] == "control_request"
+        assert obj["request"]["subtype"] == "set_model"
+        assert obj["request"]["model"] == "claude-sonnet-4-6"
+        session.stop()
+
+    def test_switch_propagates_stream_error(self, tmp_path: Path) -> None:
+        """ClaudeStreamError from _send_control_set_model propagates to the caller."""
+        # EOF immediately → _RETURNCODE_SET_MODEL_TIMEOUT
+        proc = _make_session_proc([])
+        proc.stdout.readline = MagicMock(return_value="")
+        session = _make_session(tmp_path, proc)
+        with pytest.raises(ClaudeStreamError) as exc_info:
+            session.switch_model("claude-sonnet-4-6")
+        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
 
 
 class TestClaudeSessionConsumeUntilResult:


### PR DESCRIPTION
Fixes #852.

Replaces the restart-based model switch in `ClaudeSession` with a `control_request` `set_model` message sent over the existing subprocess stdin pipe — no more kill/respawn cycle, no init-handshake hang window, no cache-cold re-read of system prompts. Deletes the restart-to-switch fallback entirely and updates all callers and docstrings to match.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Update callers and delete restart-to-switch-model fallback <!-- type:spec -->
- [x] Clean up stale spawn/resume comments and docstrings <!-- type:spec -->
- [x] Replace restart-based switch_model with set_model control_request <!-- type:spec -->
- [x] Add set_model control_request method to ClaudeSession <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->