### PR TITLE
Bug: webhook handler's first prompt aborted by leftover cancel flag from worker preempt (closes #973)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -481,6 +481,13 @@ class ClaudeSession(OwnedSession):
         # other sessions' access — a plain threading.Lock self-deadlocks).
         self._lock = threading.RLock()
         self._cancel = threading.Event()
+        # Thread id that most recently fired :attr:`_cancel` via
+        # :meth:`_fire_worker_cancel`.  Used by :meth:`__enter__` to clear
+        # the signal when the firing thread itself acquires the lock — that
+        # cancel was meant for the previous holder (who has since released),
+        # not for the firer's own first turn (#973).  ``None`` when no
+        # outstanding firing.
+        self._cancel_fired_by_tid: int | None = None
         self._repo_name = repo_name
         self._model = model_name(
             ProviderModel("claude-opus-4-6") if model is None else model
@@ -776,6 +783,15 @@ class ClaudeSession(OwnedSession):
         # We hold the lock now; any preempter waiting on this
         # (wait_for_pending_preempt) can wake.
         self._preempt_pending.clear()
+        # If the entering thread is the same one that fired the most recent
+        # cancel, that signal was meant for the previous holder (who has
+        # since released the lock).  Clear it so the firer's own first turn
+        # is not aborted by it (#973).  When the cancel was fired by some
+        # other thread (the #786 lock-handoff race), leave it set —
+        # iter_events will gate on _preempt_pending and consume it.
+        if self._cancel_fired_by_tid == threading.get_ident():
+            self._cancel.clear()
+            self._cancel_fired_by_tid = None
         depth = self._bump_entry_depth()
         if depth == 1:
             kind = self._pending_talker_kind or provider.current_thread_kind()
@@ -927,6 +943,7 @@ class ClaudeSession(OwnedSession):
         hang the next :meth:`consume_until_result` indefinitely.
         """
         self._cancel.set()
+        self._cancel_fired_by_tid = threading.get_ident()
         self._preempt_pending.set()
         self._wake()
         if self._in_turn:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -301,6 +301,72 @@ def test_webhook_preempts_worker_mid_turn(tmp_path: Path) -> None:
     session.stop()
 
 
+def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Regression for #973: after hold_for_handler(preempt_worker=True) fires
+    the cancel signal at the worker, the handler's own prompt() must run to
+    completion — _cancel was meant for the previous holder, not for the
+    handler's first turn."""
+    session = _setup_session(tmp_path)
+
+    # Simulate the worker as the current talker so preempt_worker fires.
+    def fake_talker(kind: str) -> SessionTalker:
+        return SessionTalker(
+            repo_name="owner/repo",
+            thread_id=999_999,
+            kind=kind,  # type: ignore[arg-type]
+            description="fake",
+            claude_pid=55555,
+            started_at=talker_now(),
+        )
+
+    monkeypatch.setattr(provider, "get_talker", lambda _repo: fake_talker("worker"))
+
+    # Simulate the state immediately after a worker turn was cancelled:
+    # _in_turn is True (worker was mid-turn) and the proc still has a stale
+    # leftover result event in the pipe from the cancelled turn.
+    proc = _make_session_proc(
+        [
+            # First readline: stale empty result from the cancelled turn.
+            '{"type":"result","result":""}\n',
+            # Second readline: the handler's actual triage response.
+            '{"type":"result","result":"triage-reply"}\n',
+        ]
+    )
+    proc.pid = 55555
+    monkeypatch.setattr(session, "_proc", proc)
+    monkeypatch.setattr(
+        session, "_selector", MagicMock(return_value=([proc.stdout], [], []))
+    )
+    session._in_turn = True  # worker had an in-flight turn that was cancelled
+
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler(preempt_worker=True):
+            # _fire_worker_cancel set _cancel + _preempt_pending.
+            # Handler's first prompt() must actually send and read its own
+            # response — not be aborted by leftover cancel and silently
+            # return the stale result from the previous (worker) turn.
+            result = session.prompt("triage this please")
+    finally:
+        provider.set_thread_kind(None)
+        session.stop()
+
+    # The handler's prompt must have written its own user message to stdin.
+    write_calls = [c.args[0] for c in proc.stdin.write.call_args_list]
+    user_writes = [w for w in write_calls if "triage this please" in w]
+    assert user_writes, (
+        f"handler prompt never wrote its message — cancel-leak aborted send. "
+        f"writes={write_calls}"
+    )
+    # And the result returned must be the handler's own response, not the
+    # stale empty result from the cancelled worker turn.
+    assert result == "triage-reply", (
+        f"handler prompt got stale result from previous turn — got {result!r}"
+    )
+
+
 def test_hold_reraises_leak_error_and_releases_lock(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Fixes #973.

## Root cause

After #967 (synchronous webhook preempt) and #971 (in-place model switch), webhook handlers consistently aborted their first prompt with an empty result. Production trace at 15:24:24:

```
hold_for_handler: preempting worker
ClaudeClient.run_turn: preempted mid-flight — retry 2
triage classifier: requesting category from opus
session.prompt: lock acquired (waited=0.00s)
switch_model: sonnet → opus (control_request)
claude result:                                      ← empty, instant
(silence)
```

The #786 fix added the `_preempt_pending` gate in `iter_events` to prevent clobbering an in-flight cancel signal. That gate is correct for its scenario (thread A fires cancel while thread B is mid-turn). But after lock turnover — thread A fires cancel, previous holder yields, **thread A itself acquires the lock** — A's own prompt was getting aborted by A's own signal.

`_drain_to_boundary` saw cancel set, aborted early. `send()` saw cancel set, returned without writing. `iter_events` gated on `_preempt_pending` (still set from preempt), refused to clear cancel, broke immediately.

## Fix

Track which thread fired the most recent cancel (`_cancel_fired_by_tid`). In `__enter__`, clear the cancel signal when the entering thread is the same as the firer — that signal was meant for the previous holder, not for the firer's own first turn.

Different-thread acquisition (the #786 lock-handoff race) preserves the cancel and lets `iter_events` consume it.

## Test

Adds `test_handler_prompt_runs_after_preempt_does_not_inherit_cancel` that drives a real preempt → hold_for_handler → prompt sequence and asserts the handler's user message actually reaches stdin. The pre-fix behavior was that `proc.stdin.write` only saw `control_request interrupt` writes from drain — never the handler's content.

All 263 claude-related tests pass including #786's invariant tests (`test_enter_preserves_cancel_event`, `test_cancel_survives_lock_handoff`).

## Related

- #955 — synchronous preempt regression
- #967 — landed synchronous preempt
- #971 — landed in-place model switch (fixed init-handshake deadlock; this PR fixes the next-layer hang)
- #786 — original cancel-survival fix; this PR is compatible
- #949 — silent ANSWER cycles. Same surface; #973 is the precise root cause.