### PR TITLE
Fix control_response request_id check — read from nested response (closes #975)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1020,11 +1020,17 @@ class ClaudeSession(OwnedSession):
             sid = obj.get("session_id")
             if isinstance(sid, str) and sid:
                 self._session_id = sid
-            if (
-                obj.get("type") == "control_response"
-                and obj.get("request_id") == request_id
-            ):
-                return
+            if obj.get("type") == "control_response":
+                # Real claude-code (verified against 2.1.120) emits
+                # request_id nested inside the response payload, not at the
+                # top level:
+                #   {"type": "control_response",
+                #    "response": {"subtype": "success", "request_id": "..."}}
+                # Without this, the predicate never matches and every
+                # switch_model call hangs until idle_timeout (#975).
+                response = obj.get("response") or {}
+                if response.get("request_id") == request_id:
+                    return
 
     def interrupt(self, content: str) -> None:
         """Interrupt the in-flight turn at the protocol level, then send *content*.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1520,8 +1520,15 @@ class TestClaudeSessionSwitchModel:
     def _make_response_line(self, request_id: str) -> str:
         import json as _json
 
+        # Real claude-code emits request_id nested under response (#975).
         return (
-            _json.dumps({"type": "control_response", "request_id": request_id}) + "\n"
+            _json.dumps(
+                {
+                    "type": "control_response",
+                    "response": {"subtype": "success", "request_id": request_id},
+                }
+            )
+            + "\n"
         )
 
     def test_same_model_is_noop(self, tmp_path: Path) -> None:
@@ -2176,8 +2183,18 @@ class TestClaudeSessionSendControlSetModel:
     def _make_response_line(self, request_id: str, **extra: object) -> str:
         import json as _json
 
+        # Real claude-code emits request_id nested under response (#975).
         return (
-            _json.dumps({"type": "control_response", "request_id": request_id, **extra})
+            _json.dumps(
+                {
+                    "type": "control_response",
+                    "response": {
+                        "subtype": "success",
+                        "request_id": request_id,
+                        **extra,
+                    },
+                }
+            )
             + "\n"
         )
 
@@ -2318,6 +2335,33 @@ class TestClaudeSessionSendControlSetModel:
         assert proc.stdout.readline.call_count == 2
         session.stop()
 
+    def test_ignores_top_level_request_id_in_control_response(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #975: real claude-code emits request_id nested under
+        ``response``, not at the top level.  A malformed top-level placement
+        must NOT match — otherwise we silently accept stale or mis-routed
+        responses.  Sequence: malformed top-level shape, then the real nested
+        shape — only the nested one should satisfy the wait."""
+        import json as _json
+
+        proc = _make_session_proc([])
+        malformed = (
+            _json.dumps({"type": "control_response", "request_id": self._REQUEST_ID})
+            + "\n"
+        )
+        correct = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[malformed, correct, ""])
+        session = _make_session(tmp_path, proc)
+        with patch(
+            "fido.claude.uuid.uuid4",
+            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
+        ):
+            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
+        # Both lines were read — the malformed one was skipped.
+        assert proc.stdout.readline.call_count == 2
+        session.stop()
+
     def test_skips_empty_lines(self, tmp_path: Path) -> None:
         """Empty (whitespace-only) stdout lines are skipped without error."""
         proc = _make_session_proc([])
@@ -2394,21 +2438,26 @@ class TestClaudeSessionSendControlSetModel:
         session.stop()
 
     def test_updates_session_id_from_response(self, tmp_path: Path) -> None:
-        """session_id in control_response is tracked on the session."""
+        """session_id at the top level of a stream-json event is tracked on
+        the session.  Real claude-code emits session_id on system/result
+        events, not control_response — but the wait loop processes any event
+        that lands while it polls, so an event with session_id must update
+        the session before the matching control_response closes the wait."""
         import json as _json
 
         proc = _make_session_proc([])
-        response = (
+        side_event = (
             _json.dumps(
                 {
-                    "type": "control_response",
-                    "request_id": self._REQUEST_ID,
+                    "type": "system",
+                    "subtype": "init",
                     "session_id": "new-session-42",
                 }
             )
             + "\n"
         )
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
+        response = self._make_response_line(self._REQUEST_ID)
+        proc.stdout.readline = MagicMock(side_effect=[side_event, response, ""])
         session = _make_session(tmp_path, proc)
         with patch(
             "fido.claude.uuid.uuid4",


### PR DESCRIPTION
Fixes #975.

## Real bug

Probed the actual claude-code subprocess (`claude --version` → 2.1.120). Its `control_response` shape is:

```json
{"type": "control_response",
 "response": {"subtype": "success", "request_id": "..."}}
```

`request_id` is nested under `response`. Fido's `_send_control_set_model` checked `obj.get("request_id")` at the top level. Always None. Predicate never matched. Every `switch_model` call hung until the subprocess was killed.

## Proof

```
$ grep -c 'switch_model: now on model=' ~/log/fido.log
0
$ grep -c 'switch_model:.*(control_request)' ~/log/fido.log
9
```

Zero successful returns. Nine attempts. Every one hung. Concrete trace:

- 15:40:23 `[home] switch_model: opus → haiku`
- (no [home] log lines for 5 minutes)
- 15:45:23 `[home] worker started` (fresh thread post-fido-restart)

The session was wedged the entire window. Same shape across every `switch_model` log line in the file.

## Why fido seemed to work anyway

Many `switch_model` calls are no-ops (target == current model) and return at line 1102 before sending the control_request — so sessions that didn't need an actual model change kept working. The 15:40:30 webhook test that succeeded landed on a freshly-booted confusio session that was already on opus from spawn — no switch needed. Bug only fires on real model changes.

## Fix

claude.py:1023-1028:

```python
if obj.get("type") == "control_response":
    response = obj.get("response") or {}
    if response.get("request_id") == request_id:
        return
```

## Test

Existing test fixtures had the wrong shape too — they put `request_id` at the top level, matching fido's broken expectation. Both helpers (`TestClaudeSessionSwitchModel._make_response_line` and `TestClaudeSessionSendControlSetModel._make_response_line`) updated to emit the real nested shape.

New regression test `test_ignores_top_level_request_id_in_control_response` explicitly emits a malformed top-level placement first, then the correct nested one — asserts the malformed one is skipped and the wait completes only on the nested response. This catches any future regression that re-introduces top-level lookup.

All 264 claude tests pass.

## Related

- #975 — this issue
- #971 — landed control_request set_model with the broken predicate
- #973 / #974 — cancel-leak fix; uncovered the hang underneath
- #976 — silent .get linter (would have caught this at write time)