### PR TITLE
Serialize claude stdin writes; drain cancelled turns to boundary (closes #979)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -203,6 +203,16 @@ _RETURNCODE_IDLE_TIMEOUT = -1
 killed due to an idle timeout rather than exiting with a real non-zero code."""
 
 _RETURNCODE_SET_MODEL_TIMEOUT = -2
+# Returned by :class:`ClaudeStreamError` when ``iter_events`` was draining a
+# cancelled turn to its ``type=result`` boundary but claude did not emit one
+# within :data:`_CANCEL_DRAIN_TIMEOUT` seconds.  Treated as a wedged
+# subprocess by the caller; triggers :meth:`recover`.
+_RETURNCODE_CANCEL_DRAIN_TIMEOUT = -3
+# How long ``iter_events`` waits, after the cancel signal arrives, for
+# claude to emit the ``type=result`` event that closes the cancelled turn.
+# Claude normally responds to ``control_request interrupt`` in <1s, so 5s
+# is generous; if it elapses the subprocess is wedged and must be recovered.
+_CANCEL_DRAIN_TIMEOUT = 5.0
 """Sentinel returncode used in :class:`ClaudeStreamError` when a
 ``control_request`` ``set_model`` times out waiting for the matching
 ``control_response``, or the subprocess exits unexpectedly during the wait."""
@@ -480,6 +490,17 @@ class ClaudeSession(OwnedSession):
         # lock, then calls switch_model which also needs to serialize with
         # other sessions' access — a plain threading.Lock self-deadlocks).
         self._lock = threading.RLock()
+        # Byte-level serialization lock for stdin writes.  Held BRIEFLY per
+        # write+flush, separately from :attr:`_lock` (which guards the
+        # whole-turn ownership).  Required because :meth:`_fire_worker_cancel`
+        # must write a ``control_request`` interrupt while a worker thread
+        # holds :attr:`_lock` for its in-flight turn — the worker can't be
+        # asked to release its lock first (it's the one being cancelled).
+        # Without this lock the cancel write interleaves with the worker's
+        # mid-turn writes at the kernel pipe layer (Linux only guarantees
+        # atomicity under PIPE_BUF=4096 bytes), corrupting the protocol
+        # stream and silently wedging claude (#979).
+        self._stdin_lock = threading.Lock()
         self._cancel = threading.Event()
         # Thread id that most recently fired :attr:`_cancel` via
         # :meth:`_fire_worker_cancel`.  Used by :meth:`__enter__` to clear
@@ -830,26 +851,19 @@ class ClaudeSession(OwnedSession):
     def send(self, content: str) -> None:
         """Write a user message to the session stdin, flushing immediately.
 
-        If the prior turn was cancelled without draining (:attr:`_in_turn`
-        still True), abort it via ``control_request`` and read events until
-        the turn boundary first — otherwise the next
-        :meth:`consume_until_result` would return that prior turn's
-        ``type=result`` and the caller would receive stale content as its
-        own (the stream-leak in #499).
+        Any prior cancelled turn is drained to its ``type=result`` boundary
+        inside :meth:`iter_events` itself (cancel no longer breaks early —
+        see #979 / #955 cascade).  By the time :meth:`send` is called the
+        previous turn is closed and the stream is clean, so this method
+        only needs to atomically place a single user message on stdin.
         """
-        if self._in_turn:
-            self._drain_to_boundary()
-        if self._cancel.is_set():
-            # A preempt fired during (or just before) the drain — do not write
-            # a new message onto the dirty stream.  iter_events will see
-            # _cancel and break; _last_turn_cancelled lets run_turn retry.
-            return
         msg = json.dumps(
             {"type": "user", "message": {"role": "user", "content": content}}
         )
         assert self._proc.stdin is not None
-        self._proc.stdin.write(msg + "\n")
-        self._proc.stdin.flush()
+        with self._stdin_lock:
+            self._proc.stdin.write(msg + "\n")
+            self._proc.stdin.flush()
         self._in_turn = True
 
     def _drain_to_boundary(self, deadline: float = 10.0) -> None:
@@ -957,8 +971,10 @@ class ClaudeSession(OwnedSession):
 
         Tells the Claude subprocess to abort the current turn at the protocol
         level.  The subprocess responds with a ``control_response`` on stdout
-        and then emits a ``type=result`` to close the turn.  Call this while
-        holding the session lock so it does not race with other stdin writes.
+        and then emits a ``type=result`` to close the turn.  Atomicity is
+        guaranteed via :attr:`_stdin_lock` so this can be called from a
+        thread that does not hold :attr:`_lock` (e.g. the webhook thread
+        firing a preempt while the worker still owns the session).
         """
         msg = json.dumps(
             {
@@ -968,8 +984,9 @@ class ClaudeSession(OwnedSession):
             }
         )
         assert self._proc.stdin is not None
-        self._proc.stdin.write(msg + "\n")
-        self._proc.stdin.flush()
+        with self._stdin_lock:
+            self._proc.stdin.write(msg + "\n")
+            self._proc.stdin.flush()
 
     def _send_control_set_model(self, model: str) -> None:
         """Write a ``control_request`` ``set_model`` to stdin and drain stdout
@@ -995,8 +1012,9 @@ class ClaudeSession(OwnedSession):
         )
         assert self._proc.stdin is not None
         assert self._proc.stdout is not None
-        self._proc.stdin.write(msg + "\n")
-        self._proc.stdin.flush()
+        with self._stdin_lock:
+            self._proc.stdin.write(msg + "\n")
+            self._proc.stdin.flush()
         deadline = time.monotonic() + self._idle_timeout
         while True:
             remaining = deadline - time.monotonic()
@@ -1207,15 +1225,36 @@ class ClaudeSession(OwnedSession):
             self._cancel.clear()
         self._last_turn_cancelled = False
         last_activity = time.monotonic()
+        cancelled_at: float | None = None
 
         while True:
-            if self._cancel.is_set():
-                log.debug("ClaudeSession: cancelled — exiting turn early")
+            # NOTE: do NOT break on _cancel.is_set() here.  When a preempt
+            # fires, claude has already received the control_request
+            # interrupt and is about to emit ``control_response`` and
+            # ``type=result`` to close the turn.  We need to KEEP READING
+            # so the boundary is consumed inside this turn — otherwise the
+            # next send() inherits stale events on stdout (#979).  Record
+            # the cancel time so a wedged subprocess (no type=result after
+            # _CANCEL_DRAIN_TIMEOUT) gets killed instead of looping
+            # forever; caller's run_turn checks ``_last_turn_cancelled``
+            # to decide whether to retry.
+            if self._cancel.is_set() and not self._last_turn_cancelled:
+                log.debug("ClaudeSession: cancel signal seen, draining to boundary")
                 self._last_turn_cancelled = True
-                # Intentionally leave _in_turn = True: the caller who set
-                # _cancel will have the next send() drain the boundary
-                # we're abandoning here.
-                break
+                cancelled_at = time.monotonic()
+            if (
+                cancelled_at is not None
+                and time.monotonic() - cancelled_at > _CANCEL_DRAIN_TIMEOUT
+            ):
+                log.warning(
+                    "ClaudeSession: no type=result %.1fs after cancel — recovering",
+                    _CANCEL_DRAIN_TIMEOUT,
+                )
+                self._proc.kill()
+                self._proc.wait()
+                self._in_turn = False
+                self.recover()
+                raise ClaudeStreamError(_RETURNCODE_CANCEL_DRAIN_TIMEOUT)
             ready, _, _ = self._selector(
                 [self._proc.stdout, self._wakeup_r], [], [], _SELECT_POLL_INTERVAL
             )

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -826,47 +826,24 @@ class TestClaudeSessionSend:
         session.send("hi")
         assert session._in_turn is True
 
-    def test_drains_stale_turn_before_sending_new(self, tmp_path: Path) -> None:
-        """Send() must drain any unfinished prior turn so the next
-        consume_until_result doesn't read stale events as its own (#499)."""
-        import json as _json
-
-        stale_result = (
-            _json.dumps({"type": "result", "result": "stale", "session_id": "s1"})
-            + "\n"
-        )
-        proc = _make_session_proc([stale_result])
-        session = _make_session(tmp_path, proc)
-        session._in_turn = True  # simulate cancelled-prior-turn state
-        session.send("fresh message")
-        assert session._in_turn is True
-        # control_request was written before the new user message
-        writes = [c.args[0] for c in proc.stdin.write.call_args_list]
-        assert any("control_request" in w for w in writes)
-        assert any('"fresh message"' in w for w in writes)
-        # The control_request must come first
-        control_idx = next(i for i, w in enumerate(writes) if "control_request" in w)
-        user_idx = next(i for i, w in enumerate(writes) if '"fresh message"' in w)
-        assert control_idx < user_idx
-
-    def test_skips_write_when_cancel_set_after_drain(self, tmp_path: Path) -> None:
-        """If a preempt fires during _drain_to_boundary, send() must not write
-        the new message to the dirty stream (#955)."""
+    def test_send_uses_stdin_lock_for_atomic_write(self, tmp_path: Path) -> None:
+        """Post-#979: send() acquires _stdin_lock around write+flush so it
+        cannot interleave with a concurrent _send_control_interrupt fired
+        by a preempting webhook thread."""
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._in_turn = True  # prior turn in flight
-        # selector returns no data; we rely on _cancel short-circuiting drain
-        session._selector = MagicMock(return_value=([], [], []))
+        # Verify lock is acquired during the write+flush.
+        held_during_write = []
 
-        # Simulate preempt firing: drain returns early, _cancel stays set
-        session._cancel.set()
-        session._preempt_pending.set()
+        original_write = proc.stdin.write
 
-        session.send("should not be written")
-        # No user message written to stdin — only the control_request
-        writes = [c.args[0] for c in proc.stdin.write.call_args_list]
-        assert not any('"should not be written"' in w for w in writes)
-        # _in_turn left True (drain bailed early) — iter_events will handle it
+        def tracking_write(s):
+            held_during_write.append(session._stdin_lock.locked())
+            return original_write(s)
+
+        proc.stdin.write = MagicMock(side_effect=tracking_write)
+        session.send("hello")
+        assert held_during_write == [True]
         assert session._in_turn is True
 
 
@@ -1289,11 +1266,11 @@ class TestClaudeSessionIterEvents:
         assert not session._cancel.is_set()
         session.stop()
 
-    def test_cancel_preserved_when_preempt_pending(self, tmp_path: Path) -> None:
-        """Fix for #786: when a preempter is actively waiting, the cancel
-        signal targeting the current holder must survive iter_events' start
-        so the first poll cycle respects it — otherwise the turn runs to
-        full completion before the preempter ever gets the lock.
+    def test_cancel_drains_to_boundary(self, tmp_path: Path) -> None:
+        """Post-#979: iter_events on cancel does NOT break early — it keeps
+        reading until ``type=result`` so the cancelled turn closes cleanly
+        with no stale events in the pipe.  Just sets ``_last_turn_cancelled``
+        so callers (run_turn) know to retry.
         """
         import json as _json
 
@@ -1303,16 +1280,16 @@ class TestClaudeSessionIterEvents:
         ]
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
-        # Simulate the exact webhook preempt race: _fire_worker_cancel has
-        # set both events on the target thread's side.
         session._cancel.set()
         session._preempt_pending.set()
         events = list(session.iter_events())
-        # Loop must bail immediately — no events consumed — because the
-        # pending-preempter branch kept the cancel signal intact.
-        assert events == []
-        assert session._cancel.is_set()
+        # Both events were consumed — pipe is clean for the next holder.
+        assert len(events) == 2
+        assert events[0]["type"] == "assistant"
+        assert events[1]["type"] == "result"
         assert session._last_turn_cancelled is True
+        # _in_turn cleared by the type=result event, not by cancel.
+        assert session._in_turn is False
         session.stop()
 
     def test_cancel_still_cleared_when_no_preempt_pending(self, tmp_path: Path) -> None:
@@ -1340,13 +1317,21 @@ class TestClaudeSessionIterEvents:
         assert session._preempt_pending.is_set()
         session.stop()
 
-    def test_stops_when_cancel_set_during_turn(self, tmp_path: Path) -> None:
-        # A cancel set AFTER iter_events() starts (i.e., during polling) must
-        # abort the loop on the next cycle.
+    def test_recovers_when_cancel_drain_times_out(self, tmp_path: Path) -> None:
+        """Post-#979: iter_events drains to ``type=result`` after cancel.
+        If claude is wedged and never emits the boundary, the drain times
+        out at ``_CANCEL_DRAIN_TIMEOUT`` seconds and the subprocess is
+        killed + recovered (raises ``ClaudeStreamError``).
+        """
+        import fido.claude as _claude_mod
+        from fido.claude import _RETURNCODE_CANCEL_DRAIN_TIMEOUT
+
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")
         proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=None)  # never exits on its own
+        proc.poll = MagicMock(return_value=None)
+        proc.kill = MagicMock()
+        proc.wait = MagicMock(return_value=0)
         fake_popen = MagicMock(return_value=proc)
 
         session_ref: list[ClaudeSession] = []
@@ -1354,17 +1339,26 @@ class TestClaudeSessionIterEvents:
         def selector_that_cancels(
             *_args: object, **_kwargs: object
         ) -> tuple[list, list, list]:
-            # Set cancel on first poll — simulates an interrupt arriving mid-turn
             session_ref[0]._cancel.set()
             return ([], [], [])
 
-        session = ClaudeSession(
-            system_file, popen=fake_popen, selector=selector_that_cancels
-        )
-        session_ref.append(session)
-        events = list(session.iter_events())
-        assert events == []
-        session.stop()
+        # Use a fast deadline so the test doesn't wait 5 real seconds.
+        fast_drain = _claude_mod._CANCEL_DRAIN_TIMEOUT
+        try:
+            _claude_mod._CANCEL_DRAIN_TIMEOUT = 0.05
+            session = ClaudeSession(
+                system_file, popen=fake_popen, selector=selector_that_cancels
+            )
+            session_ref.append(session)
+            session._recover = MagicMock()  # type: ignore[method-assign]
+            session.recover = MagicMock()  # type: ignore[method-assign]
+            with pytest.raises(ClaudeStreamError) as exc_info:
+                list(session.iter_events())
+            assert exc_info.value.returncode == _RETURNCODE_CANCEL_DRAIN_TIMEOUT
+            assert proc.kill.called
+            session.stop()
+        finally:
+            _claude_mod._CANCEL_DRAIN_TIMEOUT = fast_drain
 
     def test_select_includes_wakeup_pipe(self, tmp_path: Path) -> None:
         import json as _json
@@ -1392,16 +1386,23 @@ class TestClaudeSessionIterEvents:
         assert all(session._wakeup_r in inputs for inputs in select_inputs)
         session.stop()
 
-    def test_wakeup_only_ready_continues_to_cancel_check(self, tmp_path: Path) -> None:
-        """When only the wakeup pipe fires, iter_events loops back and checks cancel."""
+    def test_wakeup_only_ready_marks_cancel(self, tmp_path: Path) -> None:
+        """When only the wakeup pipe fires, iter_events records the cancel
+        but keeps reading until the boundary or the cancel-drain timeout.
+        Post-#979 the loop no longer breaks early on cancel; the wedged
+        subprocess case is handled via the cancel-drain timeout instead.
+        """
+        import fido.claude as _claude_mod
+
         system_file = tmp_path / "system.md"
         system_file.write_text("sys")
         proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=None)  # never exits
+        proc.poll = MagicMock(return_value=None)
+        proc.kill = MagicMock()
+        proc.wait = MagicMock(return_value=0)
         fake_popen = MagicMock(return_value=proc)
 
         session_ref: list[ClaudeSession] = []
-        call_count = [0]
 
         def staged_selector(
             rlist: list[object],
@@ -1409,24 +1410,27 @@ class TestClaudeSessionIterEvents:
             xlist: list[object],
             timeout: float,
         ) -> tuple[list[object], list[object], list[object]]:
-            call_count[0] += 1
-            if call_count[0] == 1:
-                # First call: only wakeup pipe ready, then set cancel so next
-                # iteration exits cleanly
-                wakeup_r = next(x for x in rlist if x != proc.stdout)
-                session_ref[0]._cancel.set()
-                return ([wakeup_r], [], [])
-            return ([], [], [])  # should not reach here
+            wakeup_r = next(x for x in rlist if x != proc.stdout)
+            session_ref[0]._cancel.set()
+            return ([wakeup_r], [], [])
 
-        session = ClaudeSession(system_file, popen=fake_popen, selector=staged_selector)
-        session_ref.append(session)
-        os.write(session._wakeup_w, b"\x00")
-        events = list(session.iter_events())
-        assert events == []
-        assert session._last_turn_cancelled is True
-        # readline was never called because stdout was not in the ready list
-        assert proc.stdout.readline.call_count == 0
-        session.stop()
+        fast_drain = _claude_mod._CANCEL_DRAIN_TIMEOUT
+        try:
+            _claude_mod._CANCEL_DRAIN_TIMEOUT = 0.05
+            session = ClaudeSession(
+                system_file, popen=fake_popen, selector=staged_selector
+            )
+            session_ref.append(session)
+            session.recover = MagicMock()  # type: ignore[method-assign]
+            os.write(session._wakeup_w, b"\x00")
+            with pytest.raises(ClaudeStreamError):
+                list(session.iter_events())
+            assert session._last_turn_cancelled is True
+            # readline was never called because stdout was not in the ready list
+            assert proc.stdout.readline.call_count == 0
+            session.stop()
+        finally:
+            _claude_mod._CANCEL_DRAIN_TIMEOUT = fast_drain
 
 
 class TestClaudeSessionStop:
@@ -2123,9 +2127,13 @@ class TestClaudeSessionPreemptLatency:
         # Wait for worker to actually be blocking in select
         assert worker_in_select.wait(timeout=2.0), "worker never entered select"
 
-        # Now preempt — this is the critical path we're measuring
+        # Now preempt and feed claude's response to the interrupt — in
+        # production claude emits type=result within <1s of receiving
+        # the control_request interrupt.  iter_events drains to that
+        # boundary and exits cleanly (post-#979).
         start = time.monotonic()
         session._cancel.set()
+        os.write(stdout_w, b'{"type":"result","result":"interrupted"}\n')
         session._wake()
 
         assert worker_exited_lock.wait(timeout=5.0), "worker did not release lock"
@@ -2141,6 +2149,93 @@ class TestClaudeSessionPreemptLatency:
         t.join(timeout=2.0)
         os.close(stdout_w)
         session.stop()
+
+
+class TestClaudeSessionStdinAtomicity:
+    """Regression for #979: stdin writes from concurrent threads must not
+    interleave at the byte level.  Worker thread holds session ``_lock``
+    for the whole turn but the webhook thread fires
+    ``_send_control_interrupt`` without ``_lock`` (can't acquire it — the
+    worker is the cancellation target).  ``_stdin_lock`` serializes the
+    actual byte writes regardless of which lock the caller holds."""
+
+    def test_concurrent_writes_do_not_interleave(self, tmp_path: Path) -> None:
+        import threading
+        import time as _time
+
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+
+        # Wrap stdin.write to track byte ordering.  Any actual interleaving
+        # would manifest as fragments of the worker's write inside the
+        # webhook's write, or vice versa.  We simulate write+flush taking
+        # measurable time so threads have a chance to race without the lock.
+        write_events: list[str] = []
+
+        def slow_write(s: str) -> int:
+            write_events.append(f"start:{s[:30]}")
+            _time.sleep(0.005)
+            write_events.append(f"end:{s[:30]}")
+            return len(s)
+
+        proc.stdin.write = MagicMock(side_effect=slow_write)
+        proc.stdin.flush = MagicMock()
+
+        n_iterations = 50
+        worker_done = threading.Event()
+        webhook_done = threading.Event()
+
+        def worker() -> None:
+            try:
+                for i in range(n_iterations):
+                    session.send(f"worker-msg-{i}")
+            finally:
+                worker_done.set()
+
+        def webhook() -> None:
+            try:
+                for i in range(n_iterations):
+                    session._send_control_interrupt()
+            finally:
+                webhook_done.set()
+
+        t_w = threading.Thread(target=worker, daemon=True)
+        t_h = threading.Thread(target=webhook, daemon=True)
+        t_w.start()
+        t_h.start()
+        assert worker_done.wait(timeout=10.0)
+        assert webhook_done.wait(timeout=10.0)
+
+        # Verify: every "start:X" is immediately followed by "end:X".  Any
+        # interleave would put a different "start:" between them.
+        for i in range(0, len(write_events), 2):
+            start = write_events[i]
+            end = write_events[i + 1] if i + 1 < len(write_events) else None
+            assert start.startswith("start:"), write_events[i : i + 2]
+            assert end is not None and end.startswith("end:"), write_events[i : i + 2]
+            assert start[len("start:") :] == end[len("end:") :], (
+                f"interleaved write detected: {start} → {end}"
+            )
+
+    def test_send_holds_stdin_lock(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        held: list[bool] = []
+        proc.stdin.write = MagicMock(
+            side_effect=lambda _s: held.append(session._stdin_lock.locked())
+        )
+        session.send("x")
+        assert held == [True]
+
+    def test_send_control_interrupt_holds_stdin_lock(self, tmp_path: Path) -> None:
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        held: list[bool] = []
+        proc.stdin.write = MagicMock(
+            side_effect=lambda _s: held.append(session._stdin_lock.locked())
+        )
+        session._send_control_interrupt()
+        assert held == [True]
 
 
 class TestClaudeSessionSendControlInterrupt:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -304,13 +304,15 @@ def test_webhook_preempts_worker_mid_turn(tmp_path: Path) -> None:
 def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """Regression for #973: after hold_for_handler(preempt_worker=True) fires
-    the cancel signal at the worker, the handler's own prompt() must run to
-    completion — _cancel was meant for the previous holder, not for the
-    handler's first turn."""
+    """Post-#979: after hold_for_handler(preempt_worker=True) fires the
+    cancel signal, the handler's own prompt() must run to completion.  In
+    the new design the prior turn's boundary is drained inside iter_events
+    itself (cancel no longer breaks early), so by the time the handler
+    enters the stream is clean.  The cancel signal that was set for the
+    previous holder is consumed at the start of the handler's iter_events
+    via the existing ``_preempt_pending`` gate."""
     session = _setup_session(tmp_path)
 
-    # Simulate the worker as the current talker so preempt_worker fires.
     def fake_talker(kind: str) -> SessionTalker:
         return SessionTalker(
             repo_name="owner/repo",
@@ -323,48 +325,32 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
 
     monkeypatch.setattr(provider, "get_talker", lambda _repo: fake_talker("worker"))
 
-    # Simulate the state immediately after a worker turn was cancelled:
-    # _in_turn is True (worker was mid-turn) and the proc still has a stale
-    # leftover result event in the pipe from the cancelled turn.
-    proc = _make_session_proc(
-        [
-            # First readline: stale empty result from the cancelled turn.
-            '{"type":"result","result":""}\n',
-            # Second readline: the handler's actual triage response.
-            '{"type":"result","result":"triage-reply"}\n',
-        ]
-    )
+    # Pipe contains exactly the handler's own response — no stale events
+    # from the prior turn (those were drained inside iter_events when the
+    # worker turn closed cleanly on type=result).
+    proc = _make_session_proc(['{"type":"result","result":"triage-reply"}\n'])
     proc.pid = 55555
     monkeypatch.setattr(session, "_proc", proc)
     monkeypatch.setattr(
         session, "_selector", MagicMock(return_value=([proc.stdout], [], []))
     )
-    session._in_turn = True  # worker had an in-flight turn that was cancelled
 
     provider.set_thread_kind("webhook")
     try:
         with session.hold_for_handler(preempt_worker=True):
-            # _fire_worker_cancel set _cancel + _preempt_pending.
-            # Handler's first prompt() must actually send and read its own
-            # response — not be aborted by leftover cancel and silently
-            # return the stale result from the previous (worker) turn.
+            # _fire_worker_cancel set _cancel + _preempt_pending.  Handler's
+            # first prompt() must actually send and read its own response.
             result = session.prompt("triage this please")
     finally:
         provider.set_thread_kind(None)
         session.stop()
 
-    # The handler's prompt must have written its own user message to stdin.
+    # The handler must have written its user message to stdin (atomicity
+    # guaranteed by _stdin_lock — see #979).
     write_calls = [c.args[0] for c in proc.stdin.write.call_args_list]
     user_writes = [w for w in write_calls if "triage this please" in w]
-    assert user_writes, (
-        f"handler prompt never wrote its message — cancel-leak aborted send. "
-        f"writes={write_calls}"
-    )
-    # And the result returned must be the handler's own response, not the
-    # stale empty result from the cancelled worker turn.
-    assert result == "triage-reply", (
-        f"handler prompt got stale result from previous turn — got {result!r}"
-    )
+    assert user_writes, f"handler prompt never wrote its message — writes={write_calls}"
+    assert result == "triage-reply", f"handler prompt got wrong result — got {result!r}"
 
 
 def test_hold_reraises_leak_error_and_releases_lock(


### PR DESCRIPTION
Fixes #979.

## Real root cause

`_fire_worker_cancel` writes `control_request interrupt` to claude's stdin **without holding the session `_lock`**. The worker thread holds `_lock` for its in-flight turn — can't release until it sees the cancel — so the webhook firing the preempt has no choice but to skirt the lock.

Linux pipe writes are only atomic up to `PIPE_BUF=4096 bytes`. Worker mid-write of a multi-KB user message gets its bytes interleaved with the webhook's tiny `control_request`, producing malformed JSON. claude consumes the corrupt bytes and goes idle in `epoll_wait` waiting for valid input — the wedged state we kept observing in production.

This is the underlying cause of the entire post-#955 cascade (#963, #967, #971, #973, #974, #975). Each prior fix addressed a downstream symptom; this addresses the source.

## Two changes that close the race

**1. `_stdin_lock` (separate from `_lock`)**

Held briefly around every `proc.stdin.write` + `flush`. Both lock-holding callers and the unlocked cancel path acquire it, so byte-level writes from concurrent threads cannot interleave. Worker still holds `_lock` for its whole turn; webhook still fires interrupt without `_lock`. The byte-level invariant is restored regardless of the protocol-level lock state.

**2. iter_events drains to boundary on cancel**

Old behavior: cancel → break immediately. Left claude's response (`control_response` + `type=result`) in the pipe as stale events, requiring `_drain_to_boundary` on the next send to clean up.

New behavior: cancel → keep reading until `type=result` (just record `_last_turn_cancelled=True`). Same iter_events call drains the response. Next holder gets a clean session.

A new `_CANCEL_DRAIN_TIMEOUT` (5s) bounds the drain — if claude is wedged and never emits the boundary, kill subprocess + recover. Replaces the 10s drain-to-boundary in send() and the `_in_turn`-based stale-turn detection.

## Tests

- `TestClaudeSessionStdinAtomicity` (new): drives concurrent `send` + `_send_control_interrupt` at byte granularity and asserts no interleave. Plus per-method tests that each write site holds `_stdin_lock`.
- `test_cancel_drains_to_boundary` (rewritten): asserts events ARE consumed past cancel and `_in_turn=False` at end.
- `test_recovers_when_cancel_drain_times_out` (rewritten): asserts `ClaudeStreamError(_RETURNCODE_CANCEL_DRAIN_TIMEOUT)` when claude doesn't emit the boundary.
- `test_handler_prompt_runs_after_preempt_does_not_inherit_cancel` (simplified): the cancel-leak bug from #973 is structurally impossible in the new design.

All 263 claude tests pass. The single failing copilotcli test (`test_webhook_preempts_worker_cancels_runtime`) is pre-existing and unrelated.

## Follow-ups

- The cancel-firer-tid tracking from #974 (`_cancel_fired_by_tid` + `__enter__`) is now redundant — iter_events naturally clears the cancel state via the existing `_preempt_pending` gate. Worth removing in a follow-up.
- `_drain_to_boundary` is no longer called from production code, only from its own tests. Worth deleting.
- Both follow-ups would simplify the codebase further; left out of this PR to keep the scope tight.