### PR TITLE
Read talker kind from current thread, not session-shared attribute (closes #981)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -13,7 +13,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import requests as _requests
 
@@ -549,10 +549,6 @@ class ClaudeSession(OwnedSession):
         # :attr:`_cancel` — starving the preempter for a full worker turn.
         # See yield-starvation discussion in #499 comments.
         self._preempt_pending = threading.Event()
-        # Set by :meth:`prompt` just before entering the lock context so
-        # :meth:`__enter__` can register the talker with the correct kind
-        # (``"worker"`` vs ``"webhook"``).  Cleared inside :meth:`__enter__`.
-        self._pending_talker_kind: Literal["worker", "webhook"] | None = None
         # Per-thread reentrance counter for the ``with self:`` context so
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).
@@ -784,11 +780,16 @@ class ClaudeSession(OwnedSession):
         """Acquire the session lock, serializing send/receive across threads.
 
         On the outermost entry (via the :class:`OwnedSession`
-        reentrance counter), registers a :class:`provider.SessionTalker` with the
-        kind set by :meth:`prompt` via :attr:`_pending_talker_kind`
-        (falling back to the thread-local kind otherwise).  Nested entries
-        (from :meth:`hold_for_handler`) re-acquire the RLock and skip the
-        talker re-registration.
+        reentrance counter), registers a :class:`provider.SessionTalker`
+        whose ``kind`` is read directly from the calling thread's
+        thread-local in :func:`provider.current_thread_kind` — never via
+        any session-shared attribute.  This is load-bearing: a shared
+        attribute would let a worker's ``"worker"`` write get clobbered
+        by a webhook's ``"webhook"`` write (or vice versa) in the window
+        between writing and lock-acquire, leading to a worker registered
+        with ``kind="webhook"`` and a broken ``preempt_worker`` check
+        (#981).  Nested entries (from :meth:`hold_for_handler`) re-acquire
+        the RLock and skip the talker re-registration.
 
         Does *not* clear the cancel event — that is deferred to
         :meth:`iter_events` so a signal that lands between one holder's
@@ -815,8 +816,7 @@ class ClaudeSession(OwnedSession):
             self._cancel_fired_by_tid = None
         depth = self._bump_entry_depth()
         if depth == 1:
-            kind = self._pending_talker_kind or provider.current_thread_kind()
-            self._pending_talker_kind = None
+            kind = provider.current_thread_kind()
             if self._repo_name is not None:
                 try:
                     provider.register_talker(
@@ -1095,7 +1095,6 @@ class ClaudeSession(OwnedSession):
         a second preemption as a safety net before acquiring the lock (#658).
         There is no preemption logic here.
         """
-        self._pending_talker_kind = provider.current_thread_kind()
         tid = threading.get_ident()
         t_start = time.monotonic()
         try:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1824,6 +1824,47 @@ class TestClaudeSessionLock:
         session._lock.release()
         session.stop()
 
+    def test_enter_uses_thread_kind_not_shared_attribute(self, tmp_path: Path) -> None:
+        """Regression for #981: __enter__ must read the talker kind from
+        the calling thread's thread-local (provider.current_thread_kind()),
+        NOT from any session-level shared attribute that another thread
+        could have written.
+
+        Pre-fix the session had a ``_pending_talker_kind`` instance
+        attribute that prompt() wrote and __enter__ read.  Cross-thread
+        race: a webhook thread's "webhook" write could clobber a worker
+        thread's "worker" write between the worker's prompt() and the
+        worker's __enter__, registering the worker with kind="webhook".
+
+        This test simulates that hazard directly: the *current thread* is
+        a worker, but a session-level "webhook" annotation has been
+        applied (representing what another thread might have written).
+        With the fix, __enter__ ignores any such annotation and uses the
+        current thread's kind.  Without the fix, __enter__ would read the
+        annotation and mis-register.
+        """
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        # Plant a stale "webhook" annotation as if another thread wrote it.
+        # Modern (fix) code has no such attribute; setting it must be a
+        # no-op for the kind decision.
+        session._pending_talker_kind = "webhook"  # type: ignore[attr-defined]
+
+        provider.set_thread_kind("worker")
+        try:
+            session.__enter__()
+            talker = provider.get_talker(session._repo_name)
+            assert talker is not None
+            assert talker.kind == "worker", (
+                f"worker thread mis-registered as {talker.kind!r} — "
+                "kind was read from session-shared state, not the "
+                "thread's own thread-local"
+            )
+            session.__exit__(None, None, None)
+        finally:
+            provider.set_thread_kind(None)
+        session.stop()
+
     def test_enter_preserves_cancel_event(self, tmp_path: Path) -> None:
         # __enter__ must NOT clear _cancel — a signal that lands between one
         # holder's __exit__ and the next holder's iter_events() must survive.


### PR DESCRIPTION
Fixes #981.

## Root cause

`ClaudeSession._pending_talker_kind` was a session-level instance attribute that `prompt()` wrote and `__enter__` read. Cross-thread race: when worker and webhook threads called `prompt()` in overlapping windows, one's write clobbered the other's. The lock-winner then read the wrong kind in `__enter__`.

Production captured the bug clearly: status XML showed the worker tid (140034430314176) registered with `kind="webhook"`. Every subsequent `preempt_worker()` call read "holder is webhook" → returned False → no cancel fired → webhooks queued behind the worker for 4+ minutes.

## Fix

`__enter__` reads the kind directly from `provider.current_thread_kind()` — the calling thread's thread-local. No shared attribute. No race. Each thread carries its own kind by construction.

Removes `_pending_talker_kind` entirely (set + read + clear). Removes the now-unused `Literal` import.

## Test

`test_enter_uses_thread_kind_not_shared_attribute` plants a stale "webhook" annotation on the session-level attribute (simulating what another thread might have written) while the current thread's kind is "worker".

- Pre-fix: `__enter__` reads the annotation and mis-registers as webhook → test fails
- Post-fix: `__enter__` reads the thread-local and registers as worker → test passes

Verified by stashing the source fix and re-running: pre-fix FAILS, post-fix PASSES. So the test catches the bug.

## Related

- #979 / #980 — byte-level stdin race; fixed prior. This is a separate higher-level race on talker registration that #980 unmasked (same cause: lock handoff is faster, race window more frequent).
- #973 / #974 — earlier preempt-related race fixes (cancel-leak)
- #786 — original talker registration design