### PR TITLE
Webhook-priority lock handoff via Condition mutex (closes #983)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -549,6 +549,15 @@ class ClaudeSession(OwnedSession):
         # :attr:`_cancel` — starving the preempter for a full worker turn.
         # See yield-starvation discussion in #499 comments.
         self._preempt_pending = threading.Event()
+        # Condition that serializes the "set pending → check pending → acquire
+        # lock" handshake between webhook (priority) and worker (yields)
+        # threads at lock-handoff time.  Webhooks set ``_preempt_pending`` and
+        # ``notify_all`` under this mutex; workers ``wait_for(not pending)``
+        # under it.  After acquiring the lock, workers re-check pending under
+        # this mutex and yield (release+retry) if a webhook arrived during
+        # the gap — closes the race that #983 reported (worker won the lock
+        # handoff between two webhooks because RLock isn't FIFO).
+        self._preempt_cond = threading.Condition()
         # Per-thread reentrance counter for the ``with self:`` context so
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).
@@ -801,10 +810,34 @@ class ClaudeSession(OwnedSession):
         session lock is released before raising so the prior holder isn't
         deadlocked.
         """
-        self._lock.acquire()
-        # We hold the lock now; any preempter waiting on this
-        # (wait_for_pending_preempt) can wake.
-        self._preempt_pending.clear()
+        is_worker = provider.current_thread_kind() == "worker"
+        # Webhook-priority handoff (#983): worker threads yield to any
+        # queued webhook by waiting on _preempt_cond before acquiring
+        # _lock, AND re-checking under the cond mutex after acquiring —
+        # if a webhook set _preempt_pending during the gap, release the
+        # lock and retry.  Webhook callers skip the wait (they're the
+        # priority lane).
+        while True:
+            if is_worker:
+                with self._preempt_cond:
+                    self._preempt_cond.wait_for(
+                        lambda: not self._preempt_pending.is_set(),
+                        timeout=30.0,
+                    )
+            self._lock.acquire()
+            if is_worker:
+                with self._preempt_cond:
+                    if self._preempt_pending.is_set():
+                        # A webhook arrived between our wait and acquire —
+                        # let it in.  Release and re-wait.
+                        self._lock.release()
+                        continue
+            break
+        # We hold the lock now; clear the pending flag (under the cond
+        # mutex so a concurrent webhook setting it sees a coherent state).
+        with self._preempt_cond:
+            self._preempt_pending.clear()
+            self._preempt_cond.notify_all()
         # If the entering thread is the same one that fired the most recent
         # cancel, that signal was meant for the previous holder (who has
         # since released the lock).  Clear it so the firer's own first turn
@@ -958,13 +991,27 @@ class ClaudeSession(OwnedSession):
         """
         self._cancel.set()
         self._cancel_fired_by_tid = threading.get_ident()
-        self._preempt_pending.set()
+        self._signal_pending_preempt()
         self._wake()
         if self._in_turn:
             try:
                 self._send_control_interrupt()
             except (BrokenPipeError, OSError) as exc:
                 log.warning("session.prompt: early control_request failed: %s", exc)
+
+    def _signal_pending_preempt(self) -> None:
+        """Set :attr:`_preempt_pending` and wake any worker waiting in
+        :meth:`__enter__` so the worker yields to the queued webhook.
+
+        Held under :attr:`_preempt_cond` so the worker's wait+acquire
+        handshake sees a coherent state (closes #983 — RLock isn't FIFO,
+        so a webhook arriving while another webhook is the holder needs
+        an explicit signal to make the next worker re-acquire wait its
+        turn).
+        """
+        with self._preempt_cond:
+            self._preempt_pending.set()
+            self._preempt_cond.notify_all()
 
     def _send_control_interrupt(self) -> None:
         """Write a stream-json ``control_request`` interrupt to subprocess stdin.
@@ -1124,8 +1171,11 @@ class ClaudeSession(OwnedSession):
         finally:
             # If an exception blew us out of `with self:` before __enter__
             # could clear the event, do it here so a stuck event doesn't
-            # trap the worker forever.
-            self._preempt_pending.clear()
+            # trap the worker forever.  Notify under _preempt_cond so any
+            # worker blocked in __enter__'s wait_for is unblocked.
+            with self._preempt_cond:
+                self._preempt_pending.clear()
+                self._preempt_cond.notify_all()
 
     def switch_model(self, model: ProviderModel | str) -> None:
         """Switch the active model via a ``control_request`` ``set_model``

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -643,6 +643,16 @@ class OwnedSession:
         with their provider-specific cancel mechanism."""
         raise NotImplementedError  # pragma: no cover — abstract hook
 
+    def _signal_pending_preempt(self) -> None:
+        """Signal that a webhook caller is queued for the lock so workers
+        contending for the same lock yield (#983).  Distinct from
+        :meth:`_fire_worker_cancel`, which only fires when there is an
+        active worker to interrupt — this signal also covers the case
+        where the current holder is itself a webhook and a second webhook
+        is queueing behind it.  Subclasses with priority-aware locking
+        override; default is a no-op for backends that don't need it."""
+        return
+
     def preempt_worker(self) -> bool:
         """Fire the cancel signal synchronously if a worker currently holds
         the session.
@@ -709,6 +719,11 @@ class OwnedSession:
                     self._repo_name,
                 )
             else:
+                # No worker to cancel (holder is another webhook, or no
+                # one).  Still signal pending preempt so worker threads
+                # contending for the same lock yield to this webhook
+                # (#983 — webhook→webhook handoff has to skip the worker).
+                self._signal_pending_preempt()
                 log.info(
                     "hold_for_handler: queuing behind %s holder (tid=%d, repo=%s)",
                     current_kind or "none",

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1824,6 +1824,56 @@ class TestClaudeSessionLock:
         session._lock.release()
         session.stop()
 
+    def test_hold_for_handler_signals_pending_when_queueing_behind_webhook(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #983: when ``hold_for_handler(preempt_worker=True)``
+        finds the current holder is itself a webhook (no worker to cancel),
+        it must still call ``_signal_pending_preempt`` to set
+        ``_preempt_pending``.  Without this signal, a worker thread
+        contending for the same lock would freely re-acquire between
+        webhook A and webhook B, breaking the webhook→webhook handoff.
+
+        Deterministic: drives ``hold_for_handler`` synchronously with
+        ``try_preempt_worker`` patched to return ``(False, "webhook")``
+        (the queueing case) and the session's ``__enter__``/``__exit__``
+        no-op'd so we don't actually contend for a lock.  Asserts:
+
+        - ``_signal_pending_preempt`` was called exactly once.
+        - ``_preempt_pending`` is set after the call.
+        """
+        proc = _make_session_proc([])
+        session = _make_session(tmp_path, proc)
+        provider.set_thread_kind("webhook")
+        try:
+            with patch(
+                "fido.provider.try_preempt_worker", return_value=(False, "webhook")
+            ):
+                with patch.object(
+                    session,
+                    "_signal_pending_preempt",
+                    wraps=session._signal_pending_preempt,
+                ) as mock_signal:
+                    # __enter__/__exit__ no-op'd so the test doesn't depend
+                    # on real lock contention.
+                    with (
+                        patch.object(type(session), "__enter__", return_value=session),
+                        patch.object(type(session), "__exit__", return_value=False),
+                    ):
+                        with session.hold_for_handler(preempt_worker=True):
+                            pass
+                    assert mock_signal.call_count == 1, (
+                        f"_signal_pending_preempt called {mock_signal.call_count}x "
+                        "— expected 1 (hold_for_handler queueing branch must "
+                        "signal pending so workers yield, #983)"
+                    )
+                    assert session._preempt_pending.is_set(), (
+                        "_preempt_pending should be set after queueing"
+                    )
+        finally:
+            provider.set_thread_kind(None)
+            session.stop()
+
     def test_enter_uses_thread_kind_not_shared_attribute(self, tmp_path: Path) -> None:
         """Regression for #981: __enter__ must read the talker kind from
         the calling thread's thread-local (provider.current_thread_kind()),


### PR DESCRIPTION
Fixes #983.

## Bug

When webhook A held the lock and webhook B queued behind it via `hold_for_handler`, the lock handoff at A→exit went into a free-for-all between B and any worker thread also waiting. Python's `RLock` isn't FIFO; the worker often won. Result: `A → worker → B` instead of `A → B → worker`. Every subsequent webhook in a flurry waited behind a full worker turn.

Production trace at 18:25:44: review submitted with two inline comments → three webhooks → handler 1 EXITs → worker grabs lock and runs Agent Explore tool → handler 3 still queued.

## Fix

**ClaudeSession** gains a `_preempt_cond` Condition. Webhook callers set `_preempt_pending` and `notify_all` under this mutex (via new `_signal_pending_preempt` method). Workers entering `__enter__` `wait_for(not pending)`, and **re-check after acquiring** the lock — if a webhook arrived in the gap, release and retry. Worker re-acquire is strictly gated on "no webhook waiting".

**OwnedSession** gains an abstract `_signal_pending_preempt` hook (default no-op). `hold_for_handler` calls it on the queueing branch (where `preempt_worker` returned False because the holder is also a webhook). ClaudeSession overrides.

The cond mutex is held only briefly per check/set/clear — never during session work. RLock semantics for the holder unchanged; only acquire-time prioritization changes.

## Test

`test_hold_for_handler_signals_pending_when_queueing_behind_webhook` patches `try_preempt_worker` to return `(False, "webhook")` and asserts `hold_for_handler` calls `_signal_pending_preempt` exactly once and `_preempt_pending` is set afterward. Deterministic — no `time.sleep`. Pre-fix: `AttributeError` (no such method). Post-fix: passes.

## Related

- #955, #963, #967, #971, #973, #974, #975, #979, #980, #981, #982 — all the prior fixes in this preempt cascade. Each peeled a layer; this one closes the lock-handoff prioritization.