### PR TITLE
Respawn claude subprocess on switch_model instead of in-place set_model

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -202,20 +202,12 @@ _RETURNCODE_IDLE_TIMEOUT = -1
 """Sentinel returncode used in :class:`ClaudeStreamError` when the process is
 killed due to an idle timeout rather than exiting with a real non-zero code."""
 
-_RETURNCODE_SET_MODEL_TIMEOUT = -2
-# Returned by :class:`ClaudeStreamError` when ``iter_events`` was draining a
-# cancelled turn to its ``type=result`` boundary but claude did not emit one
-# within :data:`_CANCEL_DRAIN_TIMEOUT` seconds.  Treated as a wedged
-# subprocess by the caller; triggers :meth:`recover`.
-_RETURNCODE_CANCEL_DRAIN_TIMEOUT = -3
+_RETURNCODE_CANCEL_DRAIN_TIMEOUT = -2
 # How long ``iter_events`` waits, after the cancel signal arrives, for
 # claude to emit the ``type=result`` event that closes the cancelled turn.
 # Claude normally responds to ``control_request interrupt`` in <1s, so 5s
 # is generous; if it elapses the subprocess is wedged and must be recovered.
 _CANCEL_DRAIN_TIMEOUT = 5.0
-"""Sentinel returncode used in :class:`ClaudeStreamError` when a
-``control_request`` ``set_model`` times out waiting for the matching
-``control_response``, or the subprocess exits unexpectedly during the wait."""
 
 
 class ClaudeStreamError(Exception):
@@ -503,8 +495,8 @@ class ClaudeSession(OwnedSession):
             ProviderModel("claude-opus-4-6") if model is None else model
         )
         # Latest session_id seen in a stream-json event.  Updated inside
-        # :meth:`iter_events` and :meth:`_send_control_set_model` so
-        # :meth:`recover` and :meth:`reset` can pass ``--resume <sid>``
+        # :meth:`iter_events` so :meth:`recover`, :meth:`reset`, and
+        # :meth:`switch_model` can pass ``--resume <sid>``
         # to :meth:`_spawn` and keep conversation context across a
         # subprocess restart.  Seeded from the *session_id* constructor
         # kwarg so the first :meth:`_spawn` can ``--resume`` a durable
@@ -1027,67 +1019,6 @@ class ClaudeSession(OwnedSession):
         self._proc.stdin.flush()
         return request_id
 
-    def _send_control_set_model(self, model: str) -> None:
-        """Write a ``control_request`` ``set_model`` to stdin and drain stdout
-        until the matching ``control_response`` arrives.
-
-        Switches the model on the running subprocess in-place — no kill, no
-        restart, no init-handshake delay, no session-id loss.  Call while
-        holding :attr:`_lock` and between turns (``_in_turn`` must be
-        ``False``).
-
-        Raises :class:`ClaudeStreamError` with
-        :data:`_RETURNCODE_SET_MODEL_TIMEOUT` if the subprocess exits or the
-        ``control_response`` is not received within :attr:`_idle_timeout`
-        seconds.
-        """
-        request_id = str(uuid.uuid4())
-        msg = json.dumps(
-            {
-                "type": "control_request",
-                "request_id": request_id,
-                "request": {"subtype": "set_model", "model": model},
-            }
-        )
-        assert self._proc.stdin is not None
-        assert self._proc.stdout is not None
-        self._proc.stdin.write(msg + "\n")
-        self._proc.stdin.flush()
-        deadline = time.monotonic() + self._idle_timeout
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
-            ready, _, _ = self._selector(
-                [self._proc.stdout], [], [], min(remaining, _SELECT_POLL_INTERVAL)
-            )
-            if self._proc.stdout not in ready:
-                if self._proc.poll() is not None:
-                    raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
-                continue
-            line = self._proc.stdout.readline()
-            if not line:
-                raise ClaudeStreamError(_RETURNCODE_SET_MODEL_TIMEOUT)
-            line = line.strip()
-            if not line:
-                continue
-            obj = json.loads(line)
-            self._log_event(obj)
-            sid = obj.get("session_id")
-            if isinstance(sid, str) and sid:
-                self._session_id = sid
-            if obj.get("type") == "control_response":
-                # Real claude-code (verified against 2.1.120) emits
-                # request_id nested inside the response payload, not at the
-                # top level:
-                #   {"type": "control_response",
-                #    "response": {"subtype": "success", "request_id": "..."}}
-                # Without this, the predicate never matches and every
-                # switch_model call hangs until idle_timeout (#975).
-                response = obj.get("response") or {}
-                if response.get("request_id") == request_id:
-                    return
-
     def interrupt(self, content: str) -> None:
         """Interrupt the in-flight turn at the protocol level, then send *content*.
 
@@ -1169,13 +1100,21 @@ class ClaudeSession(OwnedSession):
                 self._preempt_cond.notify_all()
 
     def switch_model(self, model: ProviderModel | str) -> None:
-        """Switch the active model via a ``control_request`` ``set_model``
-        message — no kill, no respawn, no init-handshake delay, no
-        session-id loss.
+        """Switch the active model by respawning the claude subprocess
+        with ``--model <new> --resume <session_id>``.
 
-        Holds :attr:`_lock` for the duration so callers waiting on
-        :meth:`__enter__` block gracefully until the switch is complete.
-        Must be called between turns (``_in_turn`` must be ``False``).
+        The in-place ``control_request`` ``set_model`` path was removed
+        because claude-code 2.1.114 wedges its set_model handler after
+        the first turn: any second real model switch on the same
+        subprocess never receives its ``control_response`` and hangs
+        until the idle timeout.  Probes against the raw claude binary
+        confirmed the wedge is independent of fido's protocol handling.
+
+        Respawn-with-resume preserves conversation context (claude
+        re-reads the session transcript via ``--resume``) at the cost of
+        one claude boot per switch (~1.4s).  Must be called between
+        turns (``_in_turn`` must be ``False``); :meth:`_respawn` clears
+        ``_in_turn`` defensively.
 
         No-op when *model* equals the current model.
         """
@@ -1183,13 +1122,16 @@ class ClaudeSession(OwnedSession):
         if target_model == self._model:
             return
         log.info(
-            "switch_model: %s → %s (control_request)",
+            "switch_model: %s → %s (respawn-with-resume)",
             self._model,
             target_model,
         )
         with self._lock:
-            self._send_control_set_model(target_model)
             self._model = target_model
+            self._respawn(
+                clear_session_id=False,
+                reason=f"switching model to {target_model}",
+            )
         log.info("switch_model: now on model=%s", target_model)
 
     def _log_event(self, obj: dict[str, Any]) -> None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -12,7 +12,6 @@ from fido import provider
 from fido.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
-    _RETURNCODE_SET_MODEL_TIMEOUT,
     ClaudeAPI,
     ClaudeClient,
     ClaudeCode,
@@ -1499,68 +1498,46 @@ class TestClaudeSessionStop:
 
 
 class TestClaudeSessionSwitchModel:
-    _REQUEST_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-
-    def _make_response_line(self, request_id: str) -> str:
-        import json as _json
-
-        # Real claude-code emits request_id nested under response (#975).
-        return (
-            _json.dumps(
-                {
-                    "type": "control_response",
-                    "response": {"subtype": "success", "request_id": request_id},
-                }
-            )
-            + "\n"
-        )
+    """switch_model now respawns the claude subprocess with
+    ``--model <new> --resume <session_id>``.  The in-place
+    ``control_request`` ``set_model`` path was removed because
+    claude-code 2.1.114 wedges its set_model handler after the first
+    turn (the second real switch never returns a ``control_response``).
+    """
 
     def test_same_model_is_noop(self, tmp_path: Path) -> None:
-        """When the target matches the current model, nothing happens."""
+        """When the target matches the current model, no respawn happens."""
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)  # default model claude-opus-4-6
-        current_proc = session._proc
-        session.switch_model("claude-opus-4-6")
-        assert session._proc is current_proc
-        # No control_request is written for a noop switch.
-        assert proc.stdin.write.call_count == 0
+        with patch.object(session, "_respawn") as mock_respawn:
+            session.switch_model("claude-opus-4-6")
+        mock_respawn.assert_not_called()
+        assert session._proc is proc
 
-    def test_different_model_sends_control_request(self, tmp_path: Path) -> None:
-        """Switching model writes a set_model control_request to stdin and
-        updates _model — no kill, no respawn."""
-        import json as _json
-
-        response = self._make_response_line(self._REQUEST_ID)
+    def test_different_model_respawns_preserving_session_id(
+        self, tmp_path: Path
+    ) -> None:
+        """Switching model updates ``_model`` and triggers ``_respawn``
+        with ``clear_session_id=False`` so ``--resume <sid>`` keeps
+        conversation context across the new boot."""
         proc = _make_session_proc([])
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
         session = _make_session(tmp_path, proc)
-        original_proc = session._proc
-
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
+        with patch.object(session, "_respawn") as mock_respawn:
             session.switch_model("claude-sonnet-4-6")
-
-        # Proc is unchanged — no kill, no respawn.
-        assert session._proc is original_proc
         assert session._model == "claude-sonnet-4-6"
-        # stdin got a control_request with set_model subtype and correct model.
-        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
-        assert obj["type"] == "control_request"
-        assert obj["request"]["subtype"] == "set_model"
-        assert obj["request"]["model"] == "claude-sonnet-4-6"
-        session.stop()
+        mock_respawn.assert_called_once()
+        kwargs = mock_respawn.call_args.kwargs
+        assert kwargs["clear_session_id"] is False
+        assert "claude-sonnet-4-6" in kwargs["reason"]
 
-    def test_switch_propagates_stream_error(self, tmp_path: Path) -> None:
-        """ClaudeStreamError from _send_control_set_model propagates to the caller."""
-        # EOF immediately → _RETURNCODE_SET_MODEL_TIMEOUT
+    def test_switch_propagates_respawn_error(self, tmp_path: Path) -> None:
+        """Errors raised by ``_respawn`` (e.g. kill timeout) propagate."""
         proc = _make_session_proc([])
-        proc.stdout.readline = MagicMock(return_value="")
         session = _make_session(tmp_path, proc)
-        with pytest.raises(ClaudeStreamError) as exc_info:
-            session.switch_model("claude-sonnet-4-6")
-        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
+        boom = OSError("kill failed")
+        with patch.object(session, "_respawn", side_effect=boom):
+            with pytest.raises(OSError, match="kill failed"):
+                session.switch_model("claude-sonnet-4-6")
 
 
 class TestClaudeSessionConsumeUntilResult:
@@ -2251,299 +2228,6 @@ class TestClaudeSessionSendControlInterrupt:
         session._send_control_interrupt()
         obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
         assert isinstance(obj.get("request_id"), str) and obj["request_id"]
-        session.stop()
-
-
-class TestClaudeSessionSendControlSetModel:
-    """Tests for ClaudeSession._send_control_set_model."""
-
-    _REQUEST_ID = "12345678-1234-5678-1234-567812345678"
-
-    def _make_response_line(self, request_id: str, **extra: object) -> str:
-        import json as _json
-
-        # Real claude-code emits request_id nested under response (#975).
-        return (
-            _json.dumps(
-                {
-                    "type": "control_response",
-                    "response": {
-                        "subtype": "success",
-                        "request_id": request_id,
-                        **extra,
-                    },
-                }
-            )
-            + "\n"
-        )
-
-    def _make_custom_session(
-        self,
-        tmp_path: Path,
-        proc: MagicMock,
-        *,
-        idle_timeout: float = 1800.0,
-        selector_side_effect: object = None,
-    ) -> ClaudeSession:
-        """Build a ClaudeSession with an injectable selector side_effect."""
-        system_file = tmp_path / "system.md"
-        system_file.write_text("sys")
-        fake_popen = MagicMock(return_value=proc)
-        if selector_side_effect is not None:
-            fake_selector = MagicMock(side_effect=selector_side_effect)
-        else:
-            fake_selector = MagicMock(return_value=([proc.stdout], [], []))
-        return ClaudeSession(
-            system_file,
-            work_dir=tmp_path,
-            popen=fake_popen,
-            selector=fake_selector,
-            idle_timeout=idle_timeout,
-        )
-
-    def test_writes_control_request_type(self, tmp_path: Path) -> None:
-        import json as _json
-
-        proc = _make_session_proc([])
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")
-        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
-        assert obj["type"] == "control_request"
-        session.stop()
-
-    def test_writes_set_model_subtype(self, tmp_path: Path) -> None:
-        import json as _json
-
-        proc = _make_session_proc([])
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")
-        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
-        assert obj["request"]["subtype"] == "set_model"
-        session.stop()
-
-    def test_writes_model_in_request(self, tmp_path: Path) -> None:
-        import json as _json
-
-        proc = _make_session_proc([])
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")
-        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
-        assert obj["request"]["model"] == "claude-sonnet-4-6"
-        session.stop()
-
-    def test_includes_request_id(self, tmp_path: Path) -> None:
-        import json as _json
-
-        proc = _make_session_proc([])
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")
-        obj = _json.loads(proc.stdin.write.call_args.args[0].strip())
-        assert isinstance(obj.get("request_id"), str) and obj["request_id"]
-        session.stop()
-
-    def test_returns_on_matching_control_response(self, tmp_path: Path) -> None:
-        """Returns without raising when a matching control_response arrives."""
-        proc = _make_session_proc([])
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        session.stop()
-
-    def test_skips_non_matching_response_and_reads_next(self, tmp_path: Path) -> None:
-        """Keeps reading past a control_response with a different request_id."""
-        proc = _make_session_proc([])
-        wrong_response = self._make_response_line(
-            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-        )
-        right_response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(
-            side_effect=[wrong_response, right_response, ""]
-        )
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        assert proc.stdout.readline.call_count == 2
-        session.stop()
-
-    def test_skips_non_control_response_events(self, tmp_path: Path) -> None:
-        """Skips unrelated event types before the control_response."""
-        import json as _json
-
-        proc = _make_session_proc([])
-        other_event = _json.dumps({"type": "system", "subtype": "init"}) + "\n"
-        right_response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[other_event, right_response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        assert proc.stdout.readline.call_count == 2
-        session.stop()
-
-    def test_ignores_top_level_request_id_in_control_response(
-        self, tmp_path: Path
-    ) -> None:
-        """Regression for #975: real claude-code emits request_id nested under
-        ``response``, not at the top level.  A malformed top-level placement
-        must NOT match — otherwise we silently accept stale or mis-routed
-        responses.  Sequence: malformed top-level shape, then the real nested
-        shape — only the nested one should satisfy the wait."""
-        import json as _json
-
-        proc = _make_session_proc([])
-        malformed = (
-            _json.dumps({"type": "control_response", "request_id": self._REQUEST_ID})
-            + "\n"
-        )
-        correct = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[malformed, correct, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        # Both lines were read — the malformed one was skipped.
-        assert proc.stdout.readline.call_count == 2
-        session.stop()
-
-    def test_skips_empty_lines(self, tmp_path: Path) -> None:
-        """Empty (whitespace-only) stdout lines are skipped without error."""
-        proc = _make_session_proc([])
-        right_response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=["\n", right_response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        session.stop()
-
-    def test_raises_on_eof_while_waiting(self, tmp_path: Path) -> None:
-        """EOF (empty readline) before control_response raises ClaudeStreamError."""
-        proc = _make_session_proc([])
-        proc.stdout.readline = MagicMock(return_value="")
-        session = _make_session(tmp_path, proc)
-        with pytest.raises(ClaudeStreamError) as exc_info:
-            session._send_control_set_model("claude-sonnet-4-6")
-        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
-        session.stop()
-
-    def test_raises_on_timeout(self, tmp_path: Path) -> None:
-        """ClaudeStreamError raised when idle_timeout expires before response."""
-        proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=None)
-        session = self._make_custom_session(
-            tmp_path,
-            proc,
-            idle_timeout=0.0,
-            selector_side_effect=[([], [], [])],
-        )
-        with pytest.raises(ClaudeStreamError) as exc_info:
-            session._send_control_set_model("claude-sonnet-4-6")
-        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
-        session.stop()
-
-    def test_raises_when_process_exits_while_waiting(self, tmp_path: Path) -> None:
-        """ClaudeStreamError raised when subprocess exits without sending response."""
-        proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=1)
-        session = self._make_custom_session(
-            tmp_path,
-            proc,
-            selector_side_effect=[([], [], [])],
-        )
-        with pytest.raises(ClaudeStreamError) as exc_info:
-            session._send_control_set_model("claude-sonnet-4-6")
-        assert exc_info.value.returncode == _RETURNCODE_SET_MODEL_TIMEOUT
-        session.stop()
-
-    def test_continues_when_stdout_not_ready_and_proc_alive(
-        self, tmp_path: Path
-    ) -> None:
-        """Loops past a not-ready select() if the subprocess is still alive."""
-        proc = _make_session_proc([])
-        proc.poll = MagicMock(return_value=None)
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[response, ""])
-        session = self._make_custom_session(
-            tmp_path,
-            proc,
-            selector_side_effect=[
-                ([], [], []),  # first call: not ready, proc alive
-                ([proc.stdout], [], []),  # second call: ready
-            ],
-        )
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")  # must not raise
-        session.stop()
-
-    def test_updates_session_id_from_response(self, tmp_path: Path) -> None:
-        """session_id at the top level of a stream-json event is tracked on
-        the session.  Real claude-code emits session_id on system/result
-        events, not control_response — but the wait loop processes any event
-        that lands while it polls, so an event with session_id must update
-        the session before the matching control_response closes the wait."""
-        import json as _json
-
-        proc = _make_session_proc([])
-        side_event = (
-            _json.dumps(
-                {
-                    "type": "system",
-                    "subtype": "init",
-                    "session_id": "new-session-42",
-                }
-            )
-            + "\n"
-        )
-        response = self._make_response_line(self._REQUEST_ID)
-        proc.stdout.readline = MagicMock(side_effect=[side_event, response, ""])
-        session = _make_session(tmp_path, proc)
-        with patch(
-            "fido.claude.uuid.uuid4",
-            return_value=MagicMock(__str__=lambda _: self._REQUEST_ID),
-        ):
-            session._send_control_set_model("claude-sonnet-4-6")
-        assert session._session_id == "new-session-42"
         session.stop()
 
 


### PR DESCRIPTION
## Summary

- Probes against raw claude-code 2.1.114 (no fido in the loop) showed the upstream `control_request set_model` handler wedges after the first turn: any second real model switch on the same subprocess never emits its matching `control_response`.
- Workaround: every model change now kills the claude subprocess and respawns with `--model <new> --resume <session_id>`. Conversation context survives via `--resume`. Cost is ~1.4s claude boot per switch.
- Removes the in-place `_send_control_set_model` helper, the `_RETURNCODE_SET_MODEL_TIMEOUT` sentinel, and 16 protocol tests for the broken path. Net **-374 lines**.

## What the probes proved

| pattern | result |
|---|---|
| `set_model(haiku)` then `set_model(opus)` (no turns) | second wedges (15s, no ack) |
| `spawn → turn → set_model` | first switch wedges immediately |
| `switch → tiny turn → switch` | wedges at cycle 1 |
| `switch → "ignore this" (fire-and-forget) → switch` | survives 8 cycles |
| `switch_to_current_model` (no-op) after first switch | 0.01s OK — only second-call survivor |
| `respawn(--resume <sid>) per switch` (this PR's pattern) | 6/6 stages OK, "remember 42" preserved |

The bug lives inside claude's set_model handler. Tail-drain, fire-and-forget messages, and no-op turns between switches all fail to prevent the wedge in subsequent real switches.

## What this PR does NOT touch

The cross-thread cancel-drain hardening from #979–#986 is unaffected — those guarded the worker/webhook handoff, not the model switch. The Copilot provider does not use `set_model` and is unchanged.

## Test plan

- [x] `./fido pytest tests/test_claude.py::TestClaudeSessionSwitchModel -v` (3 new tests pass)
- [x] `./fido pytest tests/test_claude.py` (240/240 pass)
- [x] `./fido ci` (format, lint, pyright, generated-typecheck, tests all green)
- [ ] Live verification: bring fido up, fire a webhook with the haiku→opus→opus→sonnet pattern, confirm no wedge across multiple cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)