### PR TITLE
Block PR promote/merge while a task is in_progress; sync after task complete (closes #988)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -700,8 +700,14 @@ class Tasks(JsonFileStore):
         so both the worker and CLI share one path.  If the task has no thread
         metadata, or we are not the last commenter, the resolve step is skipped
         silently.
+
+        Always triggers a background :func:`sync_tasks` after the completion
+        so the PR body checkbox flips even when the worker loop doesn't run
+        another sync between this completion and the PR-ready/merge step
+        (#988).
         """
         thread = self.complete_by_id(task_id)
+        sync_tasks_background(self._work_dir, gh)
         if not thread:
             return
         repo = thread.get("repo", "")

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2572,35 +2572,6 @@ class Worker:
         self.gh.comment_issue(repo, issue, body)
         log.info("posted pickup comment on issue #%s", issue)
 
-    def _has_substantive_branch_commits(
-        self,
-        commits: list[dict[str, Any]],
-        remote: str,
-        default_branch: str,
-    ) -> bool:
-        """Return True when the branch has work beyond the empty wip sentinel."""
-        if len(commits) > 1:
-            return True
-        if not commits:
-            return False
-        base = self._git(
-            ["merge-base", "HEAD", f"{remote}/{default_branch}"],
-            check=False,
-        )
-        if base.returncode != 0:
-            return False
-        base_sha = base.stdout.strip()
-        log_result = self._git(
-            ["log", "--format=%s", f"{base_sha}..HEAD", "--reverse"],
-            check=False,
-        )
-        if log_result.returncode != 0:
-            return False
-        subjects = [
-            line.strip() for line in log_result.stdout.splitlines() if line.strip()
-        ]
-        return any(subject != "wip: start" for subject in subjects)
-
     def handle_promote_merge(
         self,
         fido_dir: Path,
@@ -2643,9 +2614,18 @@ class Worker:
         )
         is_approved = latest_state == "APPROVED"
         task_list = self._tasks.list()
-        pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
+        # In-flight work (in_progress) blocks promote/merge as much as
+        # pending work — a task the worker is actively executing right
+        # now is unfinished, even though its status is not "pending".
+        # Without this, fido marks the PR ready (and runs the body
+        # checkbox sync) before the trailing task finishes (#988).
+        pending = [
+            t
+            for t in task_list
+            if t.get("status") in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)
+        ]
 
-        # Merge only if: approved + not draft + no pending tasks
+        # Merge only if: approved + not draft + no incomplete tasks
         if is_approved and not is_draft and not pending:
             pr_info = self.gh.get_pr(repo_ctx.repo, pr_number)
             merge_state = pr_info.get("mergeStateStatus", "")
@@ -2720,22 +2700,13 @@ class Worker:
                     pr_number,
                 )
                 return 0
-            has_real_branch_work = self._has_substantive_branch_commits(
-                commits, "origin", repo_ctx.default_branch
-            )
-            if pending and not has_real_branch_work:
+            if pending:
                 log.info(
-                    "PR #%s: %d tasks still pending — not promoting yet",
+                    "PR #%s: %d tasks still pending or in-progress — not promoting yet",
                     pr_number,
                     len(pending),
                 )
                 return 0
-            if pending:
-                log.info(
-                    "PR #%s: %d tasks still pending, but branch has real commits — continuing promote checks",
-                    pr_number,
-                    len(pending),
-                )
             checks = self.gh.pr_checks(repo_ctx.repo, pr_number)
             required = self.gh.get_required_checks(
                 repo_ctx.repo, repo_ctx.default_branch

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1080,6 +1080,26 @@ class TestTasksCompleteWithResolve:
     def test_nonexistent_id_does_not_raise(self, tmp_path: Path) -> None:
         work_dir = self._work_dir(tmp_path)
         Tasks(work_dir).complete_with_resolve("nonexistent-id", MagicMock())
+
+    def test_triggers_background_sync(self, tmp_path: Path) -> None:
+        """Every completion fires sync_tasks_background so the PR body
+        checkbox flips even when the worker loop doesn't sync between
+        the completion and the PR-ready/merge step (#988)."""
+        work_dir = self._work_dir(tmp_path)
+        task = add_task(work_dir, "task", TaskType.SPEC)
+        gh = MagicMock()
+        with patch("fido.tasks.sync_tasks_background") as mock_sync:
+            Tasks(work_dir).complete_with_resolve(task["id"], gh)
+        mock_sync.assert_called_once_with(work_dir, gh)
+
+    def test_triggers_background_sync_even_for_unknown_id(self, tmp_path: Path) -> None:
+        """Sync still fires even when the task_id isn't found — caller
+        intent ('I just tried to complete something') is the trigger."""
+        work_dir = self._work_dir(tmp_path)
+        gh = MagicMock()
+        with patch("fido.tasks.sync_tasks_background") as mock_sync:
+            Tasks(work_dir).complete_with_resolve("nonexistent-id", gh)
+        mock_sync.assert_called_once_with(work_dir, gh)
 
     def test_resolves_thread_when_we_are_last(self, tmp_path: Path, caplog) -> None:
         import logging

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10473,9 +10473,15 @@ class TestHandlePromoteMerge:
         assert result == 0
         gh.pr_ready.assert_not_called()
 
-    def test_draft_pending_tasks_with_real_commits_can_promote(
+    def test_draft_pending_tasks_block_promote_even_with_real_commits(
         self, tmp_path: Path
     ) -> None:
+        """Pending tasks block promote regardless of branch commit count.
+
+        The previous "branch has real commits → promote anyway" loophole
+        was removed (#988): the PR body literally lists the unchecked
+        task, so shipping past it is wrong. Workers retry on next loop.
+        """
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {
@@ -10483,9 +10489,6 @@ class TestHandlePromoteMerge:
             "commits": [{}, {}],
             "isDraft": True,
         }
-        gh.pr_checks.return_value = []
-        gh.get_required_checks.return_value = []
-        gh.get_review_threads.return_value = []
         tasks_list = [
             {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
             {"id": "t2", "title": "Next", "status": "pending", "type": "spec"},
@@ -10494,12 +10497,17 @@ class TestHandlePromoteMerge:
             result = worker.handle_promote_merge(
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
-        assert result == 1
-        gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
+        assert result == 0
+        gh.pr_ready.assert_not_called()
 
-    def test_draft_pending_tasks_with_real_commits_requests_review(
-        self, tmp_path: Path
-    ) -> None:
+    def test_draft_in_progress_task_blocks_promote(self, tmp_path: Path) -> None:
+        """A task the worker is actively executing (in_progress) blocks
+        promote even though its status is not 'pending'.
+
+        Without this, fido marks the PR ready while the trailing task is
+        mid-execution; the task completes seconds later but the PR body
+        checkbox never gets re-synced before reviewers see it (#988).
+        """
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {
@@ -10507,67 +10515,39 @@ class TestHandlePromoteMerge:
             "commits": [{}, {}],
             "isDraft": True,
         }
-        gh.pr_checks.return_value = []
-        gh.get_required_checks.return_value = []
-        gh.get_review_threads.return_value = []
         tasks_list = [
             {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
-            {"id": "t2", "title": "Next", "status": "pending", "type": "spec"},
+            {"id": "t2", "title": "Running", "status": "in_progress", "type": "spec"},
+        ]
+        with patch("fido.tasks.Tasks.list", return_value=tasks_list):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        assert result == 0
+        gh.pr_ready.assert_not_called()
+
+    def test_merge_blocked_while_task_in_progress(self, tmp_path: Path) -> None:
+        """Approved + ready PR with an in_progress task does NOT merge."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {
+                    "author": {"login": "rhencke"},
+                    "state": "APPROVED",
+                    "submittedAt": "2026-04-25T20:00:00Z",
+                }
+            ],
+            "commits": [{}],
+            "isDraft": False,
+        }
+        tasks_list = [
+            {"id": "t1", "title": "Done", "status": "completed", "type": "spec"},
+            {"id": "t2", "title": "Running", "status": "in_progress", "type": "spec"},
         ]
         with patch("fido.tasks.Tasks.list", return_value=tasks_list):
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
-        gh.add_pr_reviewers.assert_called_once_with("rhencke/myrepo", 9, ["rhencke"])
-
-    def test_has_substantive_branch_commits_true_for_multiple_commits(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        assert (
-            worker._has_substantive_branch_commits([{}, {}], "origin", "main") is True
-        )
-
-    def test_has_substantive_branch_commits_false_when_merge_base_fails(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        failed = MagicMock(returncode=1, stdout="")
-        with patch.object(worker, "_git", return_value=failed):
-            assert (
-                worker._has_substantive_branch_commits([{}], "origin", "main") is False
-            )
-
-    def test_has_substantive_branch_commits_false_when_log_fails(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        merge_base = MagicMock(returncode=0, stdout="base000\n")
-        failed_log = MagicMock(returncode=1, stdout="")
-        with patch.object(worker, "_git", side_effect=[merge_base, failed_log]):
-            assert (
-                worker._has_substantive_branch_commits([{}], "origin", "main") is False
-            )
-
-    def test_has_substantive_branch_commits_false_for_only_wip(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        merge_base = MagicMock(returncode=0, stdout="base000\n")
-        log_result = MagicMock(returncode=0, stdout="wip: start\n")
-        with patch.object(worker, "_git", side_effect=[merge_base, log_result]):
-            assert (
-                worker._has_substantive_branch_commits([{}], "origin", "main") is False
-            )
-
-    def test_has_substantive_branch_commits_true_for_single_real_commit(
-        self, tmp_path: Path
-    ) -> None:
-        worker, _ = self._make_worker(tmp_path)
-        merge_base = MagicMock(returncode=0, stdout="base000\n")
-        log_result = MagicMock(returncode=0, stdout="feat: real work\n")
-        with patch.object(worker, "_git", side_effect=[merge_base, log_result]):
-            assert (
-                worker._has_substantive_branch_commits([{}], "origin", "main") is True
-            )
+        gh.pr_merge.assert_not_called()
 
     # --- CI gate on draft promotion ---
 


### PR DESCRIPTION
## Summary

Two-part fix for [#988](https://github.com/FidoCanCode/home/issues/988): fido marked PR #978 ready for review while the trailing task was still actively running, and the PR body's unchecked checkbox never got synced before reviewers saw it.

### Bug 1 — `in_progress` slipped past the promote/merge gate

`worker.py:_maybe_promote_to_ready` was filtering tasks to `status == PENDING` only when deciding whether to block promote. A task the worker was actively running through claude (status `IN_PROGRESS`) didn't count, so the gate let through PRs whose final task was mid-execution. Both `PENDING` and `IN_PROGRESS` now block — in-flight work is unfinished work.

Same fix applied to the merge gate at line 2649.

Removed the dead `has_real_branch_work` loophole at 2733-2738 in the same pass: its distinguishing log line never fires in the 5h of history I have, and the new `in_progress` check covers any case where it might have been load-bearing.

### Bug 2 — `sync_tasks` never fires after `./fido task complete`

The PostToolUse sync hook in `hooks.py` only matches built-in `TaskCreate`/`TaskUpdate`/`TodoWrite`/`TodoRead` tools — none of which fido uses to mutate tasks. The real completion path is `Bash ./fido task complete <id>` (a Bash tool call), which never matches. Result: completing the trailing task leaves the PR body's checkbox unchecked until the worker loop happens to call `sync_tasks` again.

`Tasks.complete_with_resolve` now fires `sync_tasks_background` itself, so every completion (CLI or worker) re-syncs the PR body unconditionally. The dead PostToolUse hook is left in place — harmless, and removing it churns hook wiring beyond the scope of this fix.

## Diff stats

- 4 files changed, **+84 / −107**
- 5 `_has_substantive_branch_commits` tests deleted along with the helper
- 2 loophole tests replaced with 3 tests for the new in_progress semantics
- 2 tests added for `sync_tasks_background` firing on every completion

## Test plan

- [x] `./fido pytest tests/test_worker.py tests/test_tasks.py -q` — 913/913 pass
- [x] `./fido ci` — format, lint, pyright, generated-typecheck, tests all green
- [ ] Live verification: pick a small repro PR, confirm fido waits for `in_progress` to clear before `pr_ready`, and the PR body's checkboxes match `tasks.json` at promote time

Closes #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)