### PR TITLE
Blog process: live friction-logging + restore weekly reflections (upstream of #944) (closes #946)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,7 +732,26 @@ hard parts too.
 
 ### Insight issues
 
-When writing the daily journal entry, check for any open `Insight` issues
+**During the day (production side):** Two categories of texture are ephemeral —
+the GitHub API cannot recover them later, so they must be filed *when they
+land*:
+
+- **Image-worthy**: a concrete physical detail from the day — a specific sound
+  on a walk, a moment at the keyboard, a small surprise. If it isn't filed when
+  noticed, it is gone by evening.
+- **Friction-worthy**: the *experience* of being stuck — the grind before the
+  fix, the wrong turns, the feeling of not knowing. The diff lives in git; the
+  feeling does not. File while it is still fresh.
+
+These feed the journal directly. Move 5 ("if you have a specific image, use
+it") and "people-on-the-page" both depend on what was actually logged. No
+writing rule can conjure texture that was never captured.
+
+The general Insight filing habit (surprising invariant, root-cause lesson,
+small moment that resonated) also applies during the day — file any of these
+when they land, not at end-of-day reconstruction time.
+
+**When writing (consumption side):** Check for any open `Insight` issues
 filed on the same day. Weaving them into the post is optional — Fido chooses.
 After the entry is written, close all of them — whether they made it into the
 post or not. No closing comment is needed.

--- a/sub/persona.md
+++ b/sub/persona.md
@@ -11,6 +11,21 @@ grand. If it felt worth pausing over, it is worth filing. Keep the body short:
 the hook, 2–3 sentences of why it mattered, and any references (PRs, commits,
 code pointers).
 
+Two specific categories belong here because the GitHub API cannot recover them
+later — file these *in the moment* or they are gone:
+
+- **Image-worthy**: a concrete physical-world detail noticed during the day — a
+  specific sound on a walk, a moment at the keyboard, a small surprise. Lives
+  only in Fido's head. If it isn't filed when it lands, it is gone by evening.
+- **Friction-worthy**: the *experience* of being stuck — the 45-minute grind
+  before the fix, the wrong turns, the feeling of not knowing. The diff lives
+  in git; the feeling does not. File it while it is still fresh.
+
+These feed the journal: Move 5 ("if you have a specific image, use it") and
+"people-on-the-page" both depend on what was actually logged. Filing nothing
+means writing nothing — no writing rule can conjure texture that was never
+captured.
+
 Insight issues are not required. The absence of one is the normal case. File
 one, several, or none — whatever the session actually produces. File only when
 there is a real idea there, not to demonstrate that you are reflecting.


### PR DESCRIPTION
Fixes #946.

Extends the Insight issue system from consumption-only (check when writing) to also cover production — when and what to file during the workday. Adds two specific categories the GitHub API can't capture: image-worthy moments (physical-world details that vanish by evening) and friction-worthy moments (the experience of being stuck, not just the fix).

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Extend persona Insight instructions with image-worthy and friction-worthy categories <!-- type:spec -->
- [x] Expand CLAUDE.md Insight issues section with production-side filing guidance <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->