### PR TITLE
Bug: 60s pickup gap after restart — async issue-cache bootstrap doesn't wake workers when load completes (closes #995)

### DIFF
--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1225,6 +1225,9 @@ def bootstrap_issue_caches(
     whose worker resumes on an existing issue and never calls
     ``find_next_issue`` during the current fido run.
 
+    After each successful load, the worker thread is woken so it rescans
+    immediately rather than waiting out the 60-second idle timeout (#995).
+
     Per-repo failures are swallowed (logged, not raised): a single GitHub
     API hiccup must not prevent fido from starting.  The hourly
     :class:`~fido.watchdog.ReconcileWatchdog` will heal any cold repo
@@ -1238,6 +1241,7 @@ def bootstrap_issue_caches(
             log.info("startup: bootstrapping issue cache for %s", name)
             inventory = gh.find_all_open_issues(owner, repo_name)
             cache.load_inventory(inventory, snapshot_started_at=snapshot_started_at)
+            registry.wake(name)
         except Exception:
             log.exception(
                 "startup: failed to bootstrap issue cache for %s — "

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3210,6 +3210,56 @@ class TestBootstrapIssueCaches:
         # Second repo should still be bootstrapped.
         mock_cache_r2.load_inventory.assert_called_once()
 
+    def test_wakes_worker_after_successful_load(self, tmp_path: Path) -> None:
+        """Worker is woken after a successful cache load so it rescans immediately (#995)."""
+        from fido.server import bootstrap_issue_caches
+
+        repos = self._make_repos(tmp_path)
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.return_value = []
+        mock_registry = MagicMock()
+        mock_registry.get_issue_cache.return_value = MagicMock()
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        mock_registry.wake.assert_called_once_with("owner/repo")
+
+    def test_wakes_each_repo_worker_on_success(self, tmp_path: Path) -> None:
+        """Each successfully-loaded repo wakes its own worker thread (#995)."""
+        from fido.server import bootstrap_issue_caches
+
+        repos = {
+            "a/r1": RepoConfig(name="a/r1", work_dir=tmp_path),
+            "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
+        }
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.return_value = []
+        mock_registry = MagicMock()
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        assert mock_registry.wake.call_count == 2
+        mock_registry.wake.assert_any_call("a/r1")
+        mock_registry.wake.assert_any_call("b/r2")
+
+    def test_does_not_wake_worker_on_failed_load(self, tmp_path: Path) -> None:
+        """A failed bootstrap must not wake the worker — the cache is cold (#995)."""
+        from fido.server import bootstrap_issue_caches
+
+        repos = {
+            "a/r1": RepoConfig(name="a/r1", work_dir=tmp_path),
+            "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
+        }
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.side_effect = [RuntimeError("API down"), []]
+        mock_registry = MagicMock()
+        mock_registry.get_issue_cache.return_value = MagicMock()
+
+        bootstrap_issue_caches(repos, mock_gh, mock_registry)
+
+        # Only b/r2 succeeded — only that worker should be woken.
+        mock_registry.wake.assert_called_once_with("b/r2")
+
 
 class TestRun:
     """Tests for the run() entry point."""


### PR DESCRIPTION
Fixes #995.

After a restart, `bootstrap_issue_caches` loads each repo's issue cache but never wakes the worker threads — so any worker that already scanned an empty cache sleeps the full 60s idle timeout before picking up work. This adds a `registry.wake(name)` call after each successful `load_inventory`, cutting post-restart pickup latency from ~60s to <1s.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Wake workers after bootstrap_issue_caches loads each repo <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->