### PR TITLE
_pick_next_task resumes IN_PROGRESS tasks before scanning for PENDING (closes #999)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -669,27 +669,37 @@ def _descend_issue(
 
 
 def _pick_next_task(task_list: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Return the highest-priority eligible pending task, or ``None``.
+    """Return the highest-priority eligible task, or ``None``.
 
     Filters out completed tasks and those prefixed with ``ask:`` or ``defer:``
     (case-insensitive).  Among the remaining candidates the priority order is:
 
-    1. Tasks with ``type`` == ``TaskType.CI``
-    2. Everything else (first in list wins, including thread tasks)
+    1. Tasks with ``status`` == ``TaskStatus.IN_PROGRESS`` — resume work
+       in flight before scanning for new work.  Without this, a task left
+       IN_PROGRESS by an iteration that ended abnormally (subprocess
+       crash, fido self-restart) becomes invisible to the picker; combined
+       with #989's promote gate (which correctly blocks promote while any
+       IN_PROGRESS task exists) the worker deadlocks until the human marks
+       the task complete (#999).
+    2. Tasks with ``type`` == ``TaskType.CI``
+    3. Everything else (first in list wins, including thread tasks)
     """
-    pending = [
+    eligible = [
         t
         for t in task_list
-        if t.get("status") == TaskStatus.PENDING
+        if t.get("status") in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)
         and not t.get("title", "").lower().startswith("ask:")
         and not t.get("title", "").lower().startswith("defer:")
     ]
-    if not pending:
+    if not eligible:
         return None
-    for t in pending:
+    for t in eligible:
+        if t.get("status") == TaskStatus.IN_PROGRESS:
+            return t
+    for t in eligible:
         if t.get("type") == TaskType.CI:
             return t
-    return pending[0]
+    return eligible[0]
 
 
 def _has_pending_asks(task_list: list[dict[str, Any]]) -> bool:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7636,6 +7636,34 @@ class TestPickNextTask:
         result = _pick_next_task([spec])
         assert result is spec  # returned via fallthrough, not thread path
 
+    def test_resumes_in_progress_task_over_pending(self) -> None:
+        """An IN_PROGRESS task wins over later PENDING work — resume what
+        we already started before scanning for new tasks (#999)."""
+        in_progress = self._task("Mid-flight", status="in_progress")
+        pending = self._task("Next up")
+        assert _pick_next_task([pending, in_progress]) is in_progress
+
+    def test_resumes_in_progress_over_pending_ci(self) -> None:
+        """Even a CI task does not preempt resumption of an IN_PROGRESS
+        task — finishing what we started keeps tasks.json honest before
+        we reach for new work (#999)."""
+        in_progress = self._task("Mid-flight", status="in_progress")
+        ci = self._task("Fix lint", task_type="ci")
+        assert _pick_next_task([ci, in_progress]) is in_progress
+
+    def test_in_progress_alone_is_returned(self) -> None:
+        """A lone IN_PROGRESS task is picked — without this, the worker
+        deadlocks because the picker sees no candidates while the promote
+        gate (added in #989) refuses to promote past it (#999)."""
+        in_progress = self._task("Mid-flight", status="in_progress")
+        assert _pick_next_task([in_progress]) is in_progress
+
+    def test_in_progress_skipped_when_ask_prefixed(self) -> None:
+        """ASK/DEFER prefixes still suppress IN_PROGRESS — they're a
+        signal the task is awaiting a human, not a signal to resume."""
+        ask_in_progress = self._task("ask: clarify", status="in_progress")
+        assert _pick_next_task([ask_in_progress]) is None
+
 
 class TestRescopeBeforePick:
     """Tests for Worker.rescope_before_pick."""


### PR DESCRIPTION
## Summary

Closes [#999](https://github.com/FidoCanCode/home/issues/999) — confusio worker deadlock where an `IN_PROGRESS` task was invisible to `_pick_next_task` and the #989 promote gate (correctly) refused to promote past it.

## Diagnosis

Trace from `~/log/fido.log`, ~23:44Z–23:55Z (10 min stuck loop on PR #288):

```
rescope_before_pick: fewer than 2 pending tasks — skipping
checking: ci → green
checking: tasks
PR #288: 2 tasks still pending or in-progress — not promoting yet
   ← idle wait 60s → identical loop
```

`execute_task` returned 0 every cycle because `_pick_next_task` filtered to `status == PENDING` only. The active task was `IN_PROGRESS` (left there by an earlier iteration that ended without claude running `./fido task complete`). Combined with #989's promote gate, the worker had no way out.

Before #989 this was masked — the promote gate let the in_progress task slip through and the PR got marked ready while work was still in flight (the original #988 symptom). #989 closed that hole; this PR fixes the picker so the cycle completes.

## Fix

`_pick_next_task` now treats `IN_PROGRESS` as the highest-priority candidate (resume what we already started), then falls back to CI tasks, then list-order PENDING. ASK/DEFER prefixes still suppress IN_PROGRESS — those signals mean a task is waiting for a human, not a signal to resume.

## Test plan

- [x] 4 new `TestPickNextTask` cases: IN_PROGRESS over PENDING, IN_PROGRESS over CI, lone IN_PROGRESS returned, ASK-prefixed IN_PROGRESS still suppressed
- [x] 15 existing `TestPickNextTask` cases still pass
- [x] `./fido ci` green
- [ ] Live verification: bring fido up, confirm confusio's stuck `task 1/2 — Extend validation scripts` resumes within one worker cycle (≤60s) instead of looping indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)