### PR TITLE
Narrow concurrent-reply skip to in_reply_to_id match (closes #1004)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -835,18 +835,29 @@ def reply_to_comment(
                 len(thread_comments),
             )
 
-    # Skip posting if a concurrent handler already replied during triage.
-    # A Fido reply ID in the re-fetched thread that was not in the initial
-    # snapshot means another handler handled this comment — adding a second
-    # reply would be a duplicate.  Return early with the triage result so
-    # the caller can still queue tasks based on the category.
-    current_fido_ids: set[int] = {
-        c["id"] for c in thread_comments if c.get("author", "").lower() in _fido_logins
+    # Skip posting if a concurrent handler already replied to *this specific*
+    # comment during triage.  A Fido reply with ``in_reply_to_id`` matching
+    # this comment id, that wasn't in the initial snapshot, means another
+    # handler handled it — adding a second reply would be a duplicate.
+    #
+    # The check used to count *any* new Fido reply in the thread, but that
+    # false-positived on multi-inline-comment reviews: sibling handlers
+    # running in parallel posted to *their own* comments, and the slowest
+    # handler saw those siblings in the re-fetched snapshot, mistakenly
+    # concluded "someone replied to MY comment", and silently dropped its
+    # own reply while still ack'ing the promise.  Closes #1004; mirrors
+    # the original double-post fix in #518.
+    target_id = info.get("comment_id")
+    current_fido_target_ids: set[int] = {
+        c["id"]
+        for c in thread_comments
+        if c.get("author", "").lower() in _fido_logins
+        and c.get("in_reply_to_id") == target_id
     }
-    if current_fido_ids - initial_fido_ids:
+    if current_fido_target_ids - initial_fido_ids:
         log.info(
             "concurrent handler already replied — skipping post for comment %s",
-            info.get("comment_id"),
+            target_id,
         )
         if direct_promise is not None:
             FidoStore(repo_cfg.work_dir).ack_promise(direct_promise.promise_id)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5281,10 +5281,16 @@ class TestReplyToCommentThreadRefetch:
                     {"id": 507, "author": "reviewer", "body": "please add docstrings"}
                 ]
             else:
-                # Re-fetch: concurrent handler posted a Fido reply during triage
+                # Re-fetch: concurrent handler posted a Fido reply to THIS
+                # comment (in_reply_to_id == 507) during triage.
                 return [
                     {"id": 507, "author": "reviewer", "body": "please add docstrings"},
-                    {"id": 508, "author": "fidocancode", "body": "On it!"},
+                    {
+                        "id": 508,
+                        "author": "fidocancode",
+                        "body": "On it!",
+                        "in_reply_to_id": 507,
+                    },
                 ]
 
         mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
@@ -5303,6 +5309,64 @@ class TestReplyToCommentThreadRefetch:
         # Triage result is still returned so the caller can queue tasks
         assert cat == "ACT"
         assert titles == ["Add docstrings"]
+
+    def test_no_skip_when_concurrent_reply_is_to_sibling_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """A Fido reply that appeared during triage but targets a *different*
+        comment (sibling in the same review) must NOT trip the skip — that
+        was the #1004 silent-drop bug.  Closes #1004."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 507},
+            comment_body="please add docstrings",
+            is_bot=False,
+        )
+
+        def fake_pp(prompt, model, **kwargs):
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add docstrings"
+            if "Convert this PR review comment" in prompt:
+                return "Add docstrings"
+            return "Woof, on it!"
+
+        mock_gh = MagicMock()
+        call_count = 0
+
+        def fetch_side_effect(repo, pr, cid):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [
+                    {"id": 507, "author": "reviewer", "body": "please add docstrings"}
+                ]
+            # Re-fetch: a sibling comment (id 600) got a fido reply (id 601)
+            # while we were triaging — that's NOT a reply to OUR comment.
+            return [
+                {"id": 507, "author": "reviewer", "body": "please add docstrings"},
+                {
+                    "id": 601,
+                    "author": "fidocancode",
+                    "body": "Sibling reply",
+                    "in_reply_to_id": 600,
+                },
+            ]
+
+        mock_gh.fetch_comment_thread.side_effect = fetch_side_effect
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+
+        # Sibling-comment reply must NOT skip our post — we still reply.
+        mock_gh.reply_to_review_comment.assert_called_once()
 
     def test_no_skip_when_fido_reply_was_already_in_initial_fetch(
         self, tmp_path: Path
@@ -5376,10 +5440,16 @@ class TestReplyToCommentThreadRefetch:
             if call_count == 1:
                 return [{"id": 511, "author": "reviewer", "body": "fix the typo"}]
             else:
-                # Concurrent reply from the fido-can-code login variant
+                # Concurrent reply from the fido-can-code login variant,
+                # threaded under THIS comment.
                 return [
                     {"id": 511, "author": "reviewer", "body": "fix the typo"},
-                    {"id": 512, "author": "fido-can-code", "body": "Fixed!"},
+                    {
+                        "id": 512,
+                        "author": "fido-can-code",
+                        "body": "Fixed!",
+                        "in_reply_to_id": 511,
+                    },
                 ]
 
         mock_gh.fetch_comment_thread.side_effect = fetch_side_effect


### PR DESCRIPTION
## Summary

Closes [#1004](https://github.com/FidoCanCode/home/issues/1004) — fido silently dropped one of three sibling inline-comment replies on PR #998 because the "concurrent handler already replied" guard was too coarse.

## Root cause

`events.py:reply_to_comment` guards against duplicate posts by checking whether *any* new fido reply showed up in the thread snapshot between triage start and post time — added by #518 to prevent review-and-comment double-posting.

In a multi-inline-comment review, sibling handlers running in parallel each post replies to *their own* comments. The slowest handler then sees those siblings in the re-fetched snapshot, mistakenly concludes "someone replied to MY comment", silently skips its own post, and acks the promise anyway. From the reviewer's POV that comment was ignored.

## Fix

Narrow the guard from "any fido reply in the thread" to "fido reply whose `in_reply_to_id == info['comment_id']`". Sibling replies live on different `in_reply_to_id` chains and won't match. The genuine concurrent-same-target case (the original #518 scenario) still trips correctly.

## Test plan

- [x] `test_skips_post_when_concurrent_fido_reply_detected` updated — mock fido reply now has `in_reply_to_id: 507` to match the target. Still skips. ✅
- [x] `test_skips_post_fido_can_code_login_also_detected` updated similarly. Still skips. ✅
- [x] `test_no_skip_when_concurrent_reply_is_to_sibling_comment` added — mock fido reply has `in_reply_to_id: 600` (sibling comment, not target 507). Now posts correctly instead of dropping. ✅
- [x] `./fido ci` green
- [ ] Live verification: post a multi-comment review on a fido PR, confirm all comments get individual replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)