### PR TITLE
Bug: #1005's reply dedup is dead code — fetch_comment_thread strips in_reply_to_id, so the check never triggers (closes #1015)

### DIFF
--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -305,6 +305,7 @@ class GitHub:
                 "id": c["id"],
                 "author": c.get("user", {}).get("login", ""),
                 "body": c.get("body", ""),
+                "in_reply_to_id": c.get("in_reply_to_id"),
             }
             for c in raw
             if c["id"] == root_id or c.get("in_reply_to_id") == root_id

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -430,9 +430,14 @@ class TestGitHubClass:
         mock_s.get.return_value = mock_resp
         result = gh.fetch_comment_thread("o/r", 7, 10)
         assert result == [
-            {"id": 10, "author": "alice", "body": "root comment"},
-            {"id": 11, "author": "fido", "body": "reply one"},
-            {"id": 12, "author": "alice", "body": "reply two"},
+            {
+                "id": 10,
+                "author": "alice",
+                "body": "root comment",
+                "in_reply_to_id": None,
+            },
+            {"id": 11, "author": "fido", "body": "reply one", "in_reply_to_id": 10},
+            {"id": 12, "author": "alice", "body": "reply two", "in_reply_to_id": 10},
         ]
 
     def test_fetch_comment_thread_finds_thread_by_reply_id(self) -> None:
@@ -458,8 +463,8 @@ class TestGitHubClass:
         mock_s.get.return_value = mock_resp
         result = gh.fetch_comment_thread("o/r", 7, 11)
         assert result == [
-            {"id": 10, "author": "alice", "body": "root"},
-            {"id": 11, "author": "fido", "body": "reply"},
+            {"id": 10, "author": "alice", "body": "root", "in_reply_to_id": None},
+            {"id": 11, "author": "fido", "body": "reply", "in_reply_to_id": 10},
         ]
 
     def test_fetch_comment_thread_returns_empty_when_not_found(self) -> None:


### PR DESCRIPTION
Fixes #1015.

`fetch_comment_thread` strips `in_reply_to_id` from its return dicts, so the reply dedup check in `reply_to_comment` always sees `None` and never triggers — making the entire dedup path dead code. This adds the field back to the returned shape and fixes the tests that masked the bug by mocking in a field the real function never provided.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Include in_reply_to_id in fetch_comment_thread return dicts <!-- type:spec -->
- [x] Fix reply dedup tests to assert against real fetch_comment_thread shape <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->