### PR TITLE
Bug: webhook-priority lock handoff lost — worker won lock over queued webhook B, comment never answered (closes #1017)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -814,11 +814,17 @@ class ClaudeSession(OwnedSession):
                         self._lock.release()
                         continue
             break
-        # We hold the lock now; clear the pending flag (under the cond
-        # mutex so a concurrent webhook setting it sees a coherent state).
-        with self._preempt_cond:
-            self._preempt_pending.clear()
-            self._preempt_cond.notify_all()
+        # We hold the lock now; clear the pending flag — but only on the
+        # outermost acquire for this thread.  A reentrant acquire (e.g.
+        # prompt() called inside hold_for_handler, depth already ≥ 1) must
+        # not stomp on a pending signal that a second webhook set while the
+        # outer hold_for_handler is still running: clearing it here would
+        # let the worker's re-check see False and win the lock over the
+        # queued webhook (#1017).
+        if getattr(self._reentry_tls, "depth", 0) == 0:
+            with self._preempt_cond:
+                self._preempt_pending.clear()
+                self._preempt_cond.notify_all()
         # If the entering thread is the same one that fired the most recent
         # cancel, that signal was meant for the previous holder (who has
         # since released the lock).  Clear it so the firer's own first turn
@@ -1066,8 +1072,10 @@ class ClaudeSession(OwnedSession):
         """
         tid = threading.get_ident()
         t_start = time.monotonic()
+        _entered = False
         try:
             with self:
+                _entered = True
                 log.info(
                     "session.prompt: lock acquired (tid=%d, waited=%.2fs)",
                     tid,
@@ -1091,13 +1099,16 @@ class ClaudeSession(OwnedSession):
                 )
                 return result
         finally:
-            # If an exception blew us out of `with self:` before __enter__
-            # could clear the event, do it here so a stuck event doesn't
-            # trap the worker forever.  Notify under _preempt_cond so any
-            # worker blocked in __enter__'s wait_for is unblocked.
-            with self._preempt_cond:
-                self._preempt_pending.clear()
-                self._preempt_cond.notify_all()
+            # Safety net: if __enter__ raised before it could clear
+            # _preempt_pending, do it here so workers aren't stuck waiting.
+            # Skip on normal return (_entered=True) — __enter__ already
+            # cleared the flag, and re-clearing would stomp on a pending
+            # signal that a later-arriving webhook set while this prompt()
+            # was running inside hold_for_handler (#1017).
+            if not _entered:
+                with self._preempt_cond:
+                    self._preempt_pending.clear()
+                    self._preempt_cond.notify_all()
 
     def switch_model(self, model: ProviderModel | str) -> None:
         """Switch the active model by respawning the claude subprocess

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -353,6 +353,124 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     assert result == "triage-reply", f"handler prompt got wrong result — got {result!r}"
 
 
+def test_inner_prompt_preserves_queued_webhook_pending_flag(
+    tmp_path: Path,
+) -> None:
+    """Regression for #1017: _preempt_pending set by a second webhook
+    queuing behind an active hold_for_handler must survive inner prompt()
+    calls made by the holder.
+
+    The old code had two paths that unconditionally cleared _preempt_pending:
+    (1) reentrant __enter__ inside hold_for_handler, and (2) prompt()'s
+    finally block.  Either path wiped the second webhook's pending signal
+    while the first webhook's hold was still active.  When the hold released,
+    the worker saw _preempt_pending=False and won the lock over the queued
+    webhook, leaving the reviewer's comment unanswered."""
+    session = _setup_session(tmp_path)
+    provider.set_thread_kind("webhook")
+    try:
+        with session.hold_for_handler(preempt_worker=False):
+            # Simulate webhook B queuing behind this hold_for_handler.
+            session._signal_pending_preempt()
+            assert session._preempt_pending.is_set(), "sanity: pending set"
+            # Inner prompt() — old code cleared _preempt_pending here.
+            session.prompt("triage this issue")
+            # After returning, pending must still be set so the worker
+            # blocks in __enter__'s wait_for and yields to webhook B.
+            assert session._preempt_pending.is_set(), (
+                "_preempt_pending cleared by inner prompt() inside "
+                "hold_for_handler — worker would win lock over queued "
+                "webhook (bug #1017 regression)"
+            )
+    finally:
+        provider.set_thread_kind(None)
+        session.stop()
+
+
+def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
+    tmp_path: Path,
+) -> None:
+    """Regression for #1017 (threading): webhook B queuing behind an active
+    hold_for_handler acquires the lock before the worker, even after the
+    holder makes inner prompt() calls while B's pending signal is live.
+
+    Timing is made deterministic by ensuring _preempt_pending is already set
+    before the worker thread enters __enter__ — this forces the worker into
+    _preempt_cond.wait_for() rather than racing directly on _lock.acquire()."""
+    session = _setup_session(tmp_path)
+
+    webhook_a_holding = threading.Event()
+    webhook_b_queued = threading.Event()
+    order: list[str] = []
+    errors: list[Exception] = []
+
+    def webhook_a() -> None:
+        provider.set_thread_kind("webhook")
+        try:
+            with session.hold_for_handler(preempt_worker=False):
+                webhook_a_holding.set()
+                # Wait until webhook B has queued (pending set) before
+                # making the inner prompt — this is the ordering that
+                # triggers the bug: B sets pending, then A's inner prompt
+                # used to clear it.
+                assert webhook_b_queued.wait(timeout=2.0), "webhook_b_queued timed out"
+                session.prompt("inner turn from webhook A")
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            provider.set_thread_kind(None)
+
+    def webhook_b() -> None:
+        provider.set_thread_kind("webhook")
+        try:
+            assert webhook_a_holding.wait(timeout=2.0), "webhook_a_holding timed out"
+            # Queue behind webhook A — sets _preempt_pending so the worker
+            # yields priority.
+            session._signal_pending_preempt()
+            webhook_b_queued.set()
+            # Now block waiting for webhook A's hold to release.
+            with session:
+                order.append("webhook_b")
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            provider.set_thread_kind(None)
+
+    def worker() -> None:
+        provider.set_thread_kind("worker")
+        try:
+            # Wait until B has set _preempt_pending before entering __enter__.
+            # This guarantees the worker hits _preempt_cond.wait_for() instead
+            # of racing on _lock.acquire() — making the handoff deterministic.
+            assert webhook_b_queued.wait(timeout=2.0), "webhook_b_queued timed out"
+            with session:
+                order.append("worker")
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            provider.set_thread_kind(None)
+
+    t_a = threading.Thread(target=webhook_a, daemon=True)
+    t_b = threading.Thread(target=webhook_b, daemon=True)
+    t_w = threading.Thread(target=worker, daemon=True)
+
+    t_a.start()
+    t_b.start()
+    t_w.start()
+
+    t_a.join(timeout=5.0)
+    t_b.join(timeout=5.0)
+    t_w.join(timeout=5.0)
+
+    assert not errors, f"thread errors: {errors}"
+    assert len(order) == 2, f"not all threads completed: {order}"
+    assert order[0] == "webhook_b", (
+        f"worker won lock over queued webhook — got order {order} "
+        f"(bug #1017 regression)"
+    )
+    session.stop()
+
+
 def test_hold_reraises_leak_error_and_releases_lock(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Fixes #1017.

The `finally` block in `ClaudeSession.prompt()` unconditionally clears `_preempt_pending` on every return — including normal reentrant returns inside `hold_for_handler`. When webhook B queues behind webhook A and sets the pending flag, webhook A's inner prompt completion wipes it, so the worker's re-check sees clear and wins the lock over webhook B. The fix makes the clear conditional on whether `__enter__` was never reached (the actual exception-safety case), plus a regression test for the handoff race.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Fix prompt() finally clearing webhook B's _preempt_pending flag <!-- type:spec -->
- [x] Add regression test for webhook-to-webhook handoff under worker contention <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->