### PR TITLE
Counter-based _preempt_pending — stopgap fix for queued-handler starvation (closes #1022)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -521,15 +521,16 @@ class ClaudeSession(OwnedSession):
         # is dirty.  :meth:`send` drains to the boundary before writing new
         # content so every turn starts on a clean slate.
         self._in_turn = False
-        # Set by :meth:`prompt` right after :attr:`_cancel` and before it
-        # blocks on :attr:`_lock`.  Cleared inside :meth:`__enter__` once the
-        # preempter actually acquires the lock.  Workers check this in their
-        # retry loop to yield fairly: without it, a freshly-released worker
-        # thread can re-acquire :attr:`_lock` before the waiting webhook
-        # gets scheduled, and the next :meth:`iter_events` clears
-        # :attr:`_cancel` — starving the preempter for a full worker turn.
-        # See yield-starvation discussion in #499 comments.
-        self._preempt_pending = threading.Event()
+        # Counter of handlers that have signalled pending-preempt but not
+        # yet completed their outermost :meth:`__enter__`.  Workers wait
+        # for this to reach zero before acquiring :attr:`_lock`.  Was a
+        # binary :class:`threading.Event` before #1022 — switched to a
+        # counter so a *second* queued handler doesn't get starved when
+        # the first acquires (the Event would clear after one handler
+        # passed through, letting the worker race ahead of the second).
+        # The counter reflects queue length, so workers keep yielding
+        # while ANY handler is queued.
+        self._preempt_pending: int = 0
         # Condition that serializes the "set pending → check pending → acquire
         # lock" handshake between webhook (priority) and worker (yields)
         # threads at lock-handoff time.  Webhooks set ``_preempt_pending`` and
@@ -564,7 +565,7 @@ class ClaudeSession(OwnedSession):
         so the worker can otherwise race ahead and starve the preempter for
         a full turn.
         """
-        if not self._preempt_pending.is_set():
+        if not self._preempt_pending > 0:
             return False
         # Wait for the preempter's __enter__ to clear the event, meaning they
         # hold the lock now.  If they don't manage within the deadline, bail.
@@ -578,7 +579,7 @@ class ClaudeSession(OwnedSession):
             "session: worker ceding lock to pending preempter (tid=%d)",
             threading.get_ident(),
         )
-        while self._preempt_pending.is_set():
+        while self._preempt_pending > 0:
             if _time.monotonic() >= deadline:
                 log.warning(
                     "session: preempter still pending after %.2fs — worker "
@@ -802,13 +803,13 @@ class ClaudeSession(OwnedSession):
             if is_worker:
                 with self._preempt_cond:
                     self._preempt_cond.wait_for(
-                        lambda: not self._preempt_pending.is_set(),
+                        lambda: not self._preempt_pending > 0,
                         timeout=30.0,
                     )
             self._lock.acquire()
             if is_worker:
                 with self._preempt_cond:
-                    if self._preempt_pending.is_set():
+                    if self._preempt_pending > 0:
                         # A webhook arrived between our wait and acquire —
                         # let it in.  Release and re-wait.
                         self._lock.release()
@@ -821,9 +822,15 @@ class ClaudeSession(OwnedSession):
         # outer hold_for_handler is still running: clearing it here would
         # let the worker's re-check see False and win the lock over the
         # queued webhook (#1017).
-        if getattr(self._reentry_tls, "depth", 0) == 0:
+        # Decrement on the outermost handler entry only — workers don't
+        # decrement (they're not queued).  This is the #1022 fix: a
+        # second queued handler (counter still > 0 after the first
+        # decrements) keeps workers yielding, so the second handler
+        # gets the lock next instead of the worker.
+        if getattr(self._reentry_tls, "depth", 0) == 0 and not is_worker:
             with self._preempt_cond:
-                self._preempt_pending.clear()
+                if self._preempt_pending > 0:
+                    self._preempt_pending -= 1
                 self._preempt_cond.notify_all()
         # If the entering thread is the same one that fired the most recent
         # cancel, that signal was meant for the previous holder (who has
@@ -996,7 +1003,7 @@ class ClaudeSession(OwnedSession):
         turn).
         """
         with self._preempt_cond:
-            self._preempt_pending.set()
+            self._preempt_pending += 1
             self._preempt_cond.notify_all()
 
     def _send_control_interrupt(self) -> str:
@@ -1099,15 +1106,15 @@ class ClaudeSession(OwnedSession):
                 )
                 return result
         finally:
-            # Safety net: if __enter__ raised before it could clear
+            # Safety net: if __enter__ raised before it could decrement
             # _preempt_pending, do it here so workers aren't stuck waiting.
             # Skip on normal return (_entered=True) — __enter__ already
-            # cleared the flag, and re-clearing would stomp on a pending
-            # signal that a later-arriving webhook set while this prompt()
-            # was running inside hold_for_handler (#1017).
+            # decremented.  Decrement by 1 (not zero) so concurrent
+            # other-handler signals aren't over-cleared (#1022).
             if not _entered:
                 with self._preempt_cond:
-                    self._preempt_pending.clear()
+                    if self._preempt_pending > 0:
+                        self._preempt_pending -= 1
                     self._preempt_cond.notify_all()
 
     def switch_model(self, model: ProviderModel | str) -> None:
@@ -1214,7 +1221,7 @@ class ClaudeSession(OwnedSession):
         # (fix for #786).  Otherwise the signal fired by the preempter is
         # meant for the current holder — clobbering it here lets the turn
         # run to completion before the preempter ever gets the lock.
-        if not self._preempt_pending.is_set():
+        if not self._preempt_pending > 0:
             self._cancel.clear()
         self._last_turn_cancelled = False
         last_activity = time.monotonic()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -927,7 +927,7 @@ class TestClaudeSessionDrainToBoundary:
         session._selector = MagicMock(return_value=([], [], []))
         # Set cancel immediately — simulates preempt arriving during drain
         session._cancel.set()
-        session._preempt_pending.set()
+        session._preempt_pending = 1
         with patch.object(session, "recover") as mock_recover:
             session._drain_to_boundary(deadline=5.0)
         # _in_turn stays True so send() knows not to write
@@ -1107,14 +1107,14 @@ class TestClaudeSessionWaitForPendingPreempt:
 
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._preempt_pending.set()
+        session._preempt_pending = 1
 
         # Clear the event from another thread after a brief delay.
         def _clearer() -> None:
             import time as _time
 
             _time.sleep(0.02)
-            session._preempt_pending.clear()
+            session._preempt_pending = 0
 
         t = _t.Thread(target=_clearer)
         t.start()
@@ -1124,7 +1124,7 @@ class TestClaudeSessionWaitForPendingPreempt:
     def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._preempt_pending.set()
+        session._preempt_pending = 1
         # Never cleared → waits out the deadline.
         assert session.wait_for_pending_preempt(timeout=0.05) is False
 
@@ -1260,7 +1260,7 @@ class TestClaudeSessionIterEvents:
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
         session._cancel.set()
-        session._preempt_pending.set()
+        session._preempt_pending = 1
         events = list(session.iter_events())
         # Both events were consumed — pipe is clean for the next holder.
         assert len(events) == 2
@@ -1290,10 +1290,10 @@ class TestClaudeSessionIterEvents:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         assert not session._cancel.is_set()
-        assert not session._preempt_pending.is_set()
+        assert not (session._preempt_pending > 0)
         session._fire_worker_cancel()
         assert session._cancel.is_set()
-        assert session._preempt_pending.is_set()
+        assert session._preempt_pending > 0
         session.stop()
 
     def test_recovers_when_cancel_drain_times_out(self, tmp_path: Path) -> None:
@@ -1824,7 +1824,7 @@ class TestClaudeSessionLock:
                         "— expected 1 (hold_for_handler queueing branch must "
                         "signal pending so workers yield, #983)"
                     )
-                    assert session._preempt_pending.is_set(), (
+                    assert session._preempt_pending > 0, (
                         "_preempt_pending should be set after queueing"
                     )
         finally:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -353,6 +353,50 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     assert result == "triage-reply", f"handler prompt got wrong result — got {result!r}"
 
 
+def test_two_queued_handlers_keep_counter_above_zero_after_first_acquires(
+    tmp_path: Path,
+) -> None:
+    """Regression for #1022: when N handlers signal pending and the first
+    acquires the lock + decrements, the counter must still be > 0 (one
+    remaining queued handler), so a worker waiting on `_preempt_pending == 0`
+    keeps yielding to the second.
+
+    The old code used a binary :class:`threading.Event` for
+    ``_preempt_pending``; once one handler acquired and called ``clear()``,
+    the worker saw ``False`` and won the lock over the second queued
+    handler.  Switching to an int counter fixes the race: each signal
+    increments, each handler acquire decrements, worker waits for == 0."""
+    session = _setup_session(tmp_path)
+    try:
+        # Simulate two handlers signalling pending in arrival order.
+        session._signal_pending_preempt()
+        session._signal_pending_preempt()
+        assert session._preempt_pending == 2, "two pending after two signals"
+
+        # Simulate the first handler acquiring + completing its outermost
+        # __enter__ decrement.
+        provider.set_thread_kind("webhook")
+        try:
+            with session:
+                # Inside the hold, the first handler has decremented once;
+                # the second's signal still keeps the counter at 1, so the
+                # worker would still yield (the bug fix).
+                assert session._preempt_pending == 1, (
+                    "second handler's signal must remain — counter > 0 "
+                    "keeps the worker yielding"
+                )
+        finally:
+            provider.set_thread_kind(None)
+
+        # After the first handler exits, counter is still 1 (second handler
+        # hasn't been through its __enter__ yet).
+        assert session._preempt_pending == 1, (
+            "second handler still queued after first's exit"
+        )
+    finally:
+        session.stop()
+
+
 def test_inner_prompt_preserves_queued_webhook_pending_flag(
     tmp_path: Path,
 ) -> None:
@@ -372,12 +416,12 @@ def test_inner_prompt_preserves_queued_webhook_pending_flag(
         with session.hold_for_handler(preempt_worker=False):
             # Simulate webhook B queuing behind this hold_for_handler.
             session._signal_pending_preempt()
-            assert session._preempt_pending.is_set(), "sanity: pending set"
+            assert session._preempt_pending > 0, "sanity: pending set"
             # Inner prompt() — old code cleared _preempt_pending here.
             session.prompt("triage this issue")
             # After returning, pending must still be set so the worker
             # blocks in __enter__'s wait_for and yields to webhook B.
-            assert session._preempt_pending.is_set(), (
+            assert session._preempt_pending > 0, (
                 "_preempt_pending cleared by inner prompt() inside "
                 "hold_for_handler — worker would win lock over queued "
                 "webhook (bug #1017 regression)"


### PR DESCRIPTION
## Summary

Stopgap patch closing [#1022](https://github.com/FidoCanCode/home/issues/1022) (and the symptom of #984/#1017/#1019). Same root cause; smaller surgery than the full FSM rewrite (which remains tracked in #1022 as a focused-PR experiment).

## What changed

\`_preempt_pending\` was a \`threading.Event\` (binary: anyone-pending vs. none). It's now an \`int\` counter (queue length). All readers updated:

- Workers wait for \`_preempt_pending == 0\` (was \`not is_set()\`)
- Handlers' \`__enter__\` decrements once on outermost entry (was \`clear()\`)
- Workers \*don't\* decrement — they aren't queued
- \`_signal_pending_preempt\` increments (was \`set()\`)
- \`prompt()\` safety net decrements by 1 (was \`clear()\`) to avoid over-decrement of concurrent handlers

## Why this fixes #1022

Two handlers signal pending → counter = 2. Worker waits for ==0. First handler acquires + decrements → counter = 1. Worker still waits (counter != 0). First releases. Second handler acquires + decrements → counter = 0. Second releases. Worker finally acquires. **The second queued handler is no longer beat by the worker on the wake race.**

Under the old binary Event: first handler's \`clear()\` made the worker see \"no one pending\" while the second handler was still queued. Worker raced ahead. (See trace on PR #1021 04:43:05Z — comment 3142991935 went unanswered.)

## Why not the full FSM rewrite

Started that during the vet (this branch's earlier commits — now reverted). Surgery was ~300 lines across claude.py + 36 test updates + a new stress harness — too much for safe ship-tonight. #1022 stays open with the architectural rewrite as a focused next-day PR.

## Test plan

- [x] All 251 tests in \`test_claude.py\` + \`test_claude_hold_for_handler.py\` updated for the new API and pass
- [x] New \`test_two_queued_handlers_keep_counter_above_zero_after_first_acquires\` asserts the invariant directly
- [x] \`./fido ci\` green
- [ ] Live verification: bring fido up, fire two near-simultaneous review comments, confirm both get individual replies (not just the first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)