### PR TITLE
Bug: rescope rewrites thread-task titles, collapsing unrelated tasks under one title (closes #1024)

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -554,20 +554,35 @@ class Prompts:
             "No other text before or after the JSON."
         )
 
-    def rescope_duplicate_nudge(self, duplicate_titles: list[str]) -> str:
+    def rescope_duplicate_nudge(
+        self, duplicate_titles: list[str], *, attempts_remaining: int
+    ) -> str:
         """Build a follow-up nudge when Opus proposed duplicate task titles.
 
         Sent as the next turn in the same conversation so Opus sees its previous
         (flawed) response and can correct it.  The original rescope rules still
         apply; this turn adds only the uniqueness constraint.
+
+        *attempts_remaining* is the number of further nudge retries available
+        after this one.  Pass 0 when this is the last chance before the silent
+        fallback kicks in.
         """
         quoted = ", ".join(f'"{t}"' for t in duplicate_titles)
+        if attempts_remaining == 0:
+            attempt_line = (
+                "This is your final attempt — if you still propose duplicate "
+                "titles, they will be corrected automatically."
+            )
+        else:
+            attempt_line = (
+                f"You have {attempts_remaining} attempt(s) remaining after this one."
+            )
         return (
             f"Your previous response proposed the same title for multiple different "
             f"tasks: {quoted}.\n\n"
             "Task titles must be unique — each task needs a distinct title that "
             "clearly describes what that specific task does. Resubmit the full task "
-            "list with a unique title for every task.\n\n"
+            f"list with a unique title for every task. {attempt_line}\n\n"
             'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
             'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
             "No other text before or after the JSON."

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -554,6 +554,25 @@ class Prompts:
             "No other text before or after the JSON."
         )
 
+    def rescope_duplicate_nudge(self, duplicate_titles: list[str]) -> str:
+        """Build a follow-up nudge when Opus proposed duplicate task titles.
+
+        Sent as the next turn in the same conversation so Opus sees its previous
+        (flawed) response and can correct it.  The original rescope rules still
+        apply; this turn adds only the uniqueness constraint.
+        """
+        quoted = ", ".join(f'"{t}"' for t in duplicate_titles)
+        return (
+            f"Your previous response proposed the same title for multiple different "
+            f"tasks: {quoted}.\n\n"
+            "Task titles must be unique — each task needs a distinct title that "
+            "clearly describes what that specific task does. Resubmit the full task "
+            "list with a unique title for every task.\n\n"
+            'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
+            'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
+            "No other text before or after the JSON."
+        )
+
     def rewrite_description_prompt(
         self,
         pr_body: str,

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -578,7 +578,7 @@ def reorder_tasks(
             "reorder_tasks: Opus proposed duplicate titles %r — nudging",
             duplicates,
         )
-        nudge = prompts.rescope_duplicate_nudge(duplicates)
+        nudge = prompts.rescope_duplicate_nudge(duplicates, attempts_remaining=0)
         nudge_raw = agent.run_turn(nudge, model=agent.voice_model)
         if not nudge_raw:
             log.warning(

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -26,6 +26,9 @@ from fido.types import TaskStatus, TaskType
 
 log = logging.getLogger(__name__)
 
+# Maximum number of nudge retries when Opus proposes duplicate task titles.
+_RESCOPE_MAX_NUDGES = 3
+
 
 def _task_file(work_dir: Path) -> Path:
     return work_dir / ".git" / "fido" / "tasks.json"
@@ -568,32 +571,42 @@ def reorder_tasks(
         log.warning("reorder_tasks: could not parse Opus response — skipping")
         return
 
-    # Nudge Opus once if it proposed duplicate titles.  The next turn runs in
-    # the same conversation so the model sees its previous (flawed) response.
-    # If the nudge still yields duplicates, _apply_reorder's silent fallback
+    # Nudge Opus up to _RESCOPE_MAX_NUDGES times if it proposed duplicate
+    # titles.  Each turn runs in the same conversation so the model sees its
+    # prior responses and the remaining-attempt count in each nudge.
+    # If duplicates remain after all nudges, _apply_reorder's silent fallback
     # handles them as a last resort.
-    duplicates = _find_duplicate_titles(ordered_items)
-    if duplicates:
+    for nudge_attempt in range(_RESCOPE_MAX_NUDGES):
+        duplicates = _find_duplicate_titles(ordered_items)
+        if not duplicates:
+            break
+        attempts_remaining = _RESCOPE_MAX_NUDGES - nudge_attempt - 1
         log.warning(
-            "reorder_tasks: Opus proposed duplicate titles %r — nudging",
+            "reorder_tasks: Opus proposed duplicate titles %r — nudging "
+            "(attempt %d/%d, %d remaining after this)",
             duplicates,
+            nudge_attempt + 1,
+            _RESCOPE_MAX_NUDGES,
+            attempts_remaining,
         )
-        nudge = prompts.rescope_duplicate_nudge(duplicates, attempts_remaining=0)
+        nudge = prompts.rescope_duplicate_nudge(
+            duplicates, attempts_remaining=attempts_remaining
+        )
         nudge_raw = agent.run_turn(nudge, model=agent.voice_model)
         if not nudge_raw:
             log.warning(
                 "reorder_tasks: empty response after duplicate nudge — "
                 "proceeding with fallback"
             )
-        else:
-            nudge_items = _parse_reorder_response(nudge_raw)
-            if nudge_items is None:
-                log.warning(
-                    "reorder_tasks: unparseable response after duplicate nudge — "
-                    "proceeding with fallback"
-                )
-            else:
-                ordered_items = nudge_items
+            break
+        nudge_items = _parse_reorder_response(nudge_raw)
+        if nudge_items is None:
+            log.warning(
+                "reorder_tasks: unparseable response after duplicate nudge — "
+                "proceeding with fallback"
+            )
+            break
+        ordered_items = nudge_items
 
     path = _task_file(work_dir)
     inprogress_affected = False

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -366,6 +366,24 @@ def _parse_reorder_response(raw: str) -> list[dict[str, Any]] | None:
     return None
 
 
+def _find_duplicate_titles(ordered_items: list[dict[str, Any]]) -> list[str]:
+    """Return non-empty titles that appear more than once in *ordered_items*.
+
+    Each duplicated title is listed exactly once in the result, in the order
+    of its first repeated occurrence.
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for item in ordered_items:
+        title = item.get("title") or ""
+        if not title:
+            continue
+        if title in seen and title not in duplicates:
+            duplicates.append(title)
+        seen.add(title)
+    return duplicates
+
+
 def _apply_reorder(
     current: list[dict[str, Any]],
     ordered_items: list[dict[str, Any]],
@@ -549,6 +567,33 @@ def reorder_tasks(
     if ordered_items is None:
         log.warning("reorder_tasks: could not parse Opus response — skipping")
         return
+
+    # Nudge Opus once if it proposed duplicate titles.  The next turn runs in
+    # the same conversation so the model sees its previous (flawed) response.
+    # If the nudge still yields duplicates, _apply_reorder's silent fallback
+    # handles them as a last resort.
+    duplicates = _find_duplicate_titles(ordered_items)
+    if duplicates:
+        log.warning(
+            "reorder_tasks: Opus proposed duplicate titles %r — nudging",
+            duplicates,
+        )
+        nudge = prompts.rescope_duplicate_nudge(duplicates)
+        nudge_raw = agent.run_turn(nudge, model=agent.voice_model)
+        if not nudge_raw:
+            log.warning(
+                "reorder_tasks: empty response after duplicate nudge — "
+                "proceeding with fallback"
+            )
+        else:
+            nudge_items = _parse_reorder_response(nudge_raw)
+            if nudge_items is None:
+                log.warning(
+                    "reorder_tasks: unparseable response after duplicate nudge — "
+                    "proceeding with fallback"
+                )
+            else:
+                ordered_items = nudge_items
 
     path = _task_file(work_dir)
     inprogress_affected = False

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -383,11 +383,15 @@ def _apply_reorder(
       appended at the end so they are never silently dropped.
     - Completed tasks are always preserved at the end in their original order.
     - Title/description are updated from Opus's output; all other fields kept.
+    - If Opus proposes a title already used by an earlier task in the output,
+      the duplicate rewrite is rejected and the original title is kept (first
+      occurrence wins).  A warning is logged.
     - Opus-returned IDs absent from *current* or duplicated are ignored.
     """
     by_id = {t["id"]: t for t in current}
     merged: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
+    seen_titles: set[str] = set()
 
     for item in ordered_items:
         tid = item.get("id", "")
@@ -397,10 +401,20 @@ def _apply_reorder(
             continue
         seen_ids.add(tid)
         orig = dict(by_id[tid])
-        if item.get("title"):
-            orig["title"] = item["title"]
+        proposed_title = item.get("title") or ""
+        if proposed_title:
+            if proposed_title in seen_titles:
+                log.warning(
+                    "_apply_reorder: rejecting rewrite — title %r would duplicate "
+                    "another task; preserving original title for %s",
+                    proposed_title,
+                    tid,
+                )
+            else:
+                orig["title"] = proposed_title
         if "description" in item:
             orig["description"] = item["description"]
+        seen_titles.add(orig["title"])
         merged.append(orig)
 
     ci = [t for t in merged if t.get("type") == TaskType.CI]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -765,25 +765,37 @@ class TestRescopePrompt:
 
 class TestRescopeDuplicateNudge:
     def test_includes_duplicate_titles(self) -> None:
-        result = Prompts("").rescope_duplicate_nudge(["Same name"])
+        result = Prompts("").rescope_duplicate_nudge(
+            ["Same name"], attempts_remaining=0
+        )
         assert "Same name" in result
 
     def test_includes_multiple_duplicate_titles(self) -> None:
-        result = Prompts("").rescope_duplicate_nudge(["Title A", "Title B"])
+        result = Prompts("").rescope_duplicate_nudge(
+            ["Title A", "Title B"], attempts_remaining=0
+        )
         assert "Title A" in result
         assert "Title B" in result
 
     def test_asks_for_unique_titles(self) -> None:
-        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)
         assert "unique" in result.lower()
 
     def test_includes_json_format_instruction(self) -> None:
-        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)
         assert '{"tasks": [...]}' in result
 
     def test_no_other_text_instruction_present(self) -> None:
-        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)
         assert "No other text" in result
+
+    def test_final_attempt_message_when_zero_remaining(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)
+        assert "final attempt" in result.lower()
+
+    def test_remaining_count_when_nonzero(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=2)
+        assert "2" in result
 
 
 # ── Prompts.stores_persona ────────────────────────────────────────────────────

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -760,6 +760,32 @@ class TestRescopePrompt:
         assert "(none)" in result  # both completed and commit summary
 
 
+# ── Prompts.rescope_duplicate_nudge ──────────────────────────────────────────
+
+
+class TestRescopeDuplicateNudge:
+    def test_includes_duplicate_titles(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Same name"])
+        assert "Same name" in result
+
+    def test_includes_multiple_duplicate_titles(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Title A", "Title B"])
+        assert "Title A" in result
+        assert "Title B" in result
+
+    def test_asks_for_unique_titles(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        assert "unique" in result.lower()
+
+    def test_includes_json_format_instruction(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        assert '{"tasks": [...]}' in result
+
+    def test_no_other_text_instruction_present(self) -> None:
+        result = Prompts("").rescope_duplicate_nudge(["Dup"])
+        assert "No other text" in result
+
+
 # ── Prompts.stores_persona ────────────────────────────────────────────────────
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -531,6 +531,36 @@ class TestApplyReorder:
         result = _apply_reorder([t], items)
         assert result[0]["thread"] == thread
 
+    def test_rejects_duplicate_title_preserves_original_when_different(self) -> None:
+        # Opus renames both tasks to the same new name; second keeps its own original
+        current = [self._t("1", "Alpha task"), self._t("2", "Beta task")]
+        items = [self._item("1", "Shared name"), self._item("2", "Shared name")]
+        result = _apply_reorder(current, items)
+        assert next(t for t in result if t["id"] == "1")["title"] == "Shared name"
+        assert next(t for t in result if t["id"] == "2")["title"] == "Beta task"
+
+    def test_unique_titles_all_applied(self) -> None:
+        # No duplicates → all Opus-proposed titles go through unchanged
+        current = [self._t("1", "Old A"), self._t("2", "Old B"), self._t("3", "Old C")]
+        items = [
+            self._item("1", "New A"),
+            self._item("2", "New B"),
+            self._item("3", "New C"),
+        ]
+        result = _apply_reorder(current, items)
+        titles = {t["id"]: t["title"] for t in result}
+        assert titles == {"1": "New A", "2": "New B", "3": "New C"}
+
+    def test_duplicate_title_logs_warning(self, caplog) -> None:
+        import logging
+
+        current = [self._t("1", "Alpha task"), self._t("2", "Beta task")]
+        items = [self._item("1", "Shared name"), self._item("2", "Shared name")]
+        with caplog.at_level(logging.WARNING, logger="fido.tasks"):
+            _apply_reorder(current, items)
+        assert "rejecting rewrite" in caplog.text
+        assert "Shared name" in caplog.text
+
 
 # ── reorder_tasks ─────────────────────────────────────────────────────────────
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -968,7 +968,9 @@ class TestReorderTasks:
         mock_prompts.rescope_prompt.return_value = "prompt"
         mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
-        mock_prompts.rescope_duplicate_nudge.assert_called_once_with(["Shared name"])
+        mock_prompts.rescope_duplicate_nudge.assert_called_once_with(
+            ["Shared name"], attempts_remaining=0
+        )
         assert client.run_turn.call_count == 2
         tasks = list_tasks(tmp_path)
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Fixed Alpha"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -969,7 +969,7 @@ class TestReorderTasks:
         mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
         mock_prompts.rescope_duplicate_nudge.assert_called_once_with(
-            ["Shared name"], attempts_remaining=0
+            ["Shared name"], attempts_remaining=2
         )
         assert client.run_turn.call_count == 2
         tasks = list_tasks(tmp_path)
@@ -988,15 +988,42 @@ class TestReorderTasks:
             ]
         )
         client = _client()
-        client.run_turn.side_effect = [dup_response, dup_response]
+        # All 3 nudge responses still have duplicates → exhaust all retries
+        client.run_turn.side_effect = [dup_response] * 4
         mock_prompts = MagicMock(spec=Prompts)
         mock_prompts.rescope_prompt.return_value = "prompt"
         mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        # All 3 nudges fired (1 initial + 3 nudge calls = 4 total)
+        assert client.run_turn.call_count == 4
         # _apply_reorder's silent fallback: first occurrence wins, second keeps original
         tasks = list_tasks(tmp_path)
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Shared name"
         assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
+
+    def test_attempts_remaining_decrements_across_nudges(self, tmp_path: Path) -> None:
+        from unittest.mock import call
+
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        dup_response = self._response(
+            [
+                {"id": t1["id"], "title": "Shared name", "description": ""},
+                {"id": t2["id"], "title": "Shared name", "description": ""},
+            ]
+        )
+        client = _client()
+        client.run_turn.side_effect = [dup_response] * 4
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        # Nudge calls: attempts_remaining 2 → 1 → 0
+        assert mock_prompts.rescope_duplicate_nudge.call_count == 3
+        calls = mock_prompts.rescope_duplicate_nudge.call_args_list
+        assert calls[0] == call(["Shared name"], attempts_remaining=2)
+        assert calls[1] == call(["Shared name"], attempts_remaining=1)
+        assert calls[2] == call(["Shared name"], attempts_remaining=0)
 
     def test_proceeds_with_original_when_nudge_returns_empty(
         self, tmp_path: Path

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -10,6 +10,7 @@ from fido.tasks import (
     Tasks,
     _apply_reorder,
     _compute_thread_changes,
+    _find_duplicate_titles,
     _parse_reorder_response,
     add_task,
     complete_by_id,
@@ -562,6 +563,46 @@ class TestApplyReorder:
         assert "Shared name" in caplog.text
 
 
+# ── _find_duplicate_titles ────────────────────────────────────────────────────
+
+
+class TestFindDuplicateTitles:
+    def _item(self, title: str) -> dict:
+        return {"id": "x", "title": title}
+
+    def test_returns_empty_when_all_unique(self) -> None:
+        items = [self._item("A"), self._item("B"), self._item("C")]
+        assert _find_duplicate_titles(items) == []
+
+    def test_returns_duplicate_title(self) -> None:
+        items = [self._item("Same"), self._item("Other"), self._item("Same")]
+        assert _find_duplicate_titles(items) == ["Same"]
+
+    def test_each_duplicate_listed_once(self) -> None:
+        items = [self._item("X"), self._item("X"), self._item("X")]
+        assert _find_duplicate_titles(items) == ["X"]
+
+    def test_multiple_distinct_duplicates(self) -> None:
+        items = [
+            self._item("A"),
+            self._item("B"),
+            self._item("A"),
+            self._item("B"),
+        ]
+        assert _find_duplicate_titles(items) == ["A", "B"]
+
+    def test_ignores_empty_titles(self) -> None:
+        items = [{"id": "1", "title": ""}, {"id": "2", "title": ""}]
+        assert _find_duplicate_titles(items) == []
+
+    def test_ignores_missing_title_key(self) -> None:
+        items = [{"id": "1"}, {"id": "2"}]
+        assert _find_duplicate_titles(items) == []
+
+    def test_returns_empty_list_when_no_items(self) -> None:
+        assert _find_duplicate_titles([]) == []
+
+
 # ── reorder_tasks ─────────────────────────────────────────────────────────────
 
 
@@ -903,6 +944,117 @@ class TestReorderTasks:
             _on_done=lambda: done_calls.append(1),
         )
         assert done_calls == []
+
+    def test_nudges_when_opus_proposes_duplicate_titles(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        # First response has duplicate titles
+        dup_response = self._response(
+            [
+                {"id": t1["id"], "title": "Shared name", "description": ""},
+                {"id": t2["id"], "title": "Shared name", "description": ""},
+            ]
+        )
+        # Nudge response has unique titles
+        fixed_response = self._response(
+            [
+                {"id": t1["id"], "title": "Fixed Alpha", "description": ""},
+                {"id": t2["id"], "title": "Fixed Beta", "description": ""},
+            ]
+        )
+        client = _client()
+        client.run_turn.side_effect = [dup_response, fixed_response]
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        mock_prompts.rescope_duplicate_nudge.assert_called_once_with(["Shared name"])
+        assert client.run_turn.call_count == 2
+        tasks = list_tasks(tmp_path)
+        assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Fixed Alpha"
+        assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Fixed Beta"
+
+    def test_falls_back_silently_when_nudge_still_has_duplicates(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        dup_response = self._response(
+            [
+                {"id": t1["id"], "title": "Shared name", "description": ""},
+                {"id": t2["id"], "title": "Shared name", "description": ""},
+            ]
+        )
+        client = _client()
+        client.run_turn.side_effect = [dup_response, dup_response]
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        # _apply_reorder's silent fallback: first occurrence wins, second keeps original
+        tasks = list_tasks(tmp_path)
+        assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Shared name"
+        assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
+
+    def test_proceeds_with_original_when_nudge_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        dup_response = self._response(
+            [
+                {"id": t1["id"], "title": "Shared name", "description": ""},
+                {"id": t2["id"], "title": "Shared name", "description": ""},
+            ]
+        )
+        client = _client()
+        client.run_turn.side_effect = [dup_response, ""]
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        # Falls back to original dup_response with silent correction
+        tasks = list_tasks(tmp_path)
+        assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Shared name"
+        assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
+
+    def test_proceeds_with_original_when_nudge_response_unparseable(
+        self, tmp_path: Path
+    ) -> None:
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        dup_response = self._response(
+            [
+                {"id": t1["id"], "title": "Shared name", "description": ""},
+                {"id": t2["id"], "title": "Shared name", "description": ""},
+            ]
+        )
+        client = _client()
+        client.run_turn.side_effect = [dup_response, "not json"]
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        # Falls back to original dup_response with silent correction
+        tasks = list_tasks(tmp_path)
+        assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Shared name"
+        assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
+
+    def test_no_nudge_when_titles_all_unique(self, tmp_path: Path) -> None:
+        t1 = self._add(tmp_path, "Alpha")
+        t2 = self._add(tmp_path, "Beta")
+        raw = self._response(
+            [
+                {"id": t1["id"], "title": "New Alpha", "description": ""},
+                {"id": t2["id"], "title": "New Beta", "description": ""},
+            ]
+        )
+        client = _client(raw)
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "prompt"
+        reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
+        mock_prompts.rescope_duplicate_nudge.assert_not_called()
+        assert client.run_turn.call_count == 1
 
 
 # ── _compute_thread_changes ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #1024.

Adds a duplicate-title guard to `_apply_reorder` so rescope can never collapse unrelated tasks under one title. When Opus proposes a duplicate title, `reorder_tasks` nudges the model up to three times describing what went wrong and how many attempts remain — the silent fallback remains as a final safety net only after all retries are exhausted.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] [Increase rescope duplicate-title nudge retries from one to three](https://github.com/FidoCanCode/home/pull/1025#issuecomment-4321372563) <!-- type:thread -->
- [x] [Include remaining attempt count in the rescope duplicate nudge prompt](https://github.com/FidoCanCode/home/pull/1025#issuecomment-4321367033) <!-- type:thread -->
- [x] [Replace silent duplicate-title fallback with nudge-style retry loop in _apply_reorder](https://github.com/FidoCanCode/home/pull/1025#issuecomment-4321350676) <!-- type:thread -->
- [x] Reject duplicate titles in _apply_reorder <!-- type:spec -->
- [x] Add tests for duplicate-title rejection in _apply_reorder <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->