### PR TITLE
Feature: show (# sent, # received) message counts on the claude-code line in fido status (closes #1018)

### DIFF
--- a/fido
+++ b/fido
@@ -873,7 +873,7 @@ status_fast_path() {
       def repo_header($repo):
         bold("\($repo.repo_name):")
         + " "
-        + (if $repo.fido_running then green("fido running") else dim("fido waiting") end)
+        + (if $repo.fido_running then green("running") else dim("waiting") end)
         + " — "
         + ([provider_status_style($repo.provider_status; ($repo.provider // "unknown")),
             (if ($repo.crash_count // 0) > 0 then red_bold("crashes \($repo.crash_count)") else empty end),

--- a/fido
+++ b/fido
@@ -877,8 +877,6 @@ status_fast_path() {
       def repo_header($repo):
         bold("\($repo.repo_name):")
         + " "
-        + (if $repo.fido_running then green("running") else dim("waiting") end)
-        + " — "
         + ([provider_status_style($repo.provider_status; ($repo.provider // "unknown")),
             (if ($repo.crash_count // 0) > 0 then red_bold("crashes \($repo.crash_count)") else empty end),
             (if $repo.worker_uptime_seconds != null then dim("up " + uptime($repo.worker_uptime_seconds)) else empty end),

--- a/fido
+++ b/fido
@@ -827,6 +827,10 @@ status_fast_path() {
                  (if ($repo.session_dropped_count // 0) > 0
                   then red_bold("dropped " + (if $repo.session_dropped_count == 1 then "session " else "sessions " end) + ($repo.session_dropped_count|tostring))
                   else empty
+                  end),
+                 (if (($repo.session_sent_count // 0) > 0 or ($repo.session_received_count // 0) > 0)
+                  then dim((($repo.session_sent_count // 0)|tostring) + " sent, " + (($repo.session_received_count // 0)|tostring) + " received")
+                  else empty
                   end)]
                 | map(select(. != null and . != ""))
                 | if length > 0 then " " + dim("(") + join(", ") + dim(")") else "" end)

--- a/fido
+++ b/fido
@@ -849,6 +849,10 @@ status_fast_path() {
         else
           "waiting for work"
         end;
+      def should_show_worker($repo):
+        $repo.current_task != null
+        or worker_is_agent_talker($repo)
+        or (($repo.provider_status // {}).paused // false);
       def worker_line($repo):
         (if $repo.current_task != null or worker_is_agent_talker($repo)
          then (if $color then "" else "* " end) + green_bg("Worker:")
@@ -912,7 +916,7 @@ status_fast_path() {
            cache_line(.),
            (if .issue == null then "  no assigned issues" else issue_line(.) end),
            pr_line(.),
-           (if .issue == null then empty else worker_line(.) end)]
+           (if .issue == null or (should_show_worker(.) | not) then empty else worker_line(.) end)]
           + (if .issue == null then [] else webhook_lines(.) end)
         ) | flatten)
       | map(select(. != null and . != ""))

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -923,6 +923,8 @@ class CopilotCLISession(OwnedSession):
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
+        self._sent_count: int = 0
+        self._received_count: int = 0
         # Resume an existing Copilot ACP session when *session_id* is given
         # (fix for #649 — persisted across fido restarts in state.json).
         # When the id is no longer known to Copilot, ensure_session falls
@@ -949,6 +951,24 @@ class CopilotCLISession(OwnedSession):
     @property
     def dropped_session_count(self) -> int:
         return self._runtime.dropped_session_count
+
+    @property
+    def sent_count(self) -> int:
+        """Cumulative number of user turns sent to Copilot since boot.
+
+        Accumulates across session switches and recoveries — model changes and
+        resets do not reset the count.
+        """
+        return self._sent_count
+
+    @property
+    def received_count(self) -> int:
+        """Cumulative number of responses received from Copilot since boot.
+
+        Accumulates across session switches and recoveries — model changes and
+        resets do not reset the count.
+        """
+        return self._received_count
 
     @property
     def last_turn_cancelled(self) -> bool:
@@ -1113,11 +1133,13 @@ class CopilotCLISession(OwnedSession):
             "%s",
             _transcript_block("copilot prompt", prompt),
         )
+        self._sent_count += 1
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
             prompt,
             effective_model,
         )
+        self._received_count += 1
         self._session_id = session_id
         if model is not None:
             self._model = coerce_provider_model(model)

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -255,6 +255,24 @@ class PromptSession(Protocol):
         """Return how many stale persistent session ids were dropped, if tracked."""
         ...
 
+    @property
+    def sent_count(self) -> int:
+        """Return cumulative number of user turns sent to the provider since boot.
+
+        Accumulates across subprocess respawns — model switches and recoveries
+        do not reset the count.
+        """
+        ...
+
+    @property
+    def received_count(self) -> int:
+        """Return cumulative number of responses/events received from the provider since boot.
+
+        Accumulates across subprocess respawns — model switches and recoveries
+        do not reset the count.
+        """
+        ...
+
     def prompt(
         self,
         content: str,

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -86,23 +86,17 @@ class SessionBackedAgent:
 
     @property
     def session_sent_count(self) -> int:
-        """Cumulative number of messages sent to claude since boot."""
+        """Cumulative number of messages sent to the provider since boot."""
         with self._session_lock:
             session = self._session
-        if session is None or not hasattr(session, "sent_count"):
-            return 0
-        count = getattr(session, "sent_count")
-        return count if isinstance(count, int) and count >= 0 else 0
+        return session.sent_count if session is not None else 0
 
     @property
     def session_received_count(self) -> int:
-        """Cumulative number of stream-json events received from claude since boot."""
+        """Cumulative number of responses/events received from the provider since boot."""
         with self._session_lock:
             session = self._session
-        if session is None or not hasattr(session, "received_count"):
-            return 0
-        count = getattr(session, "received_count")
-        return count if isinstance(count, int) and count >= 0 else 0
+        return session.received_count if session is not None else 0
 
     def ensure_session(
         self,

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -1096,12 +1096,32 @@ def _format_repo_body(repo: RepoStatus) -> list[str]:
             pr_line += f" {color(DIM, '—')} {repo.pr_title}"
         body.append(pr_line)
 
-    if repo.worker_what is not None:
+    if _should_show_worker_line(repo):
         body.append(_format_worker_thread_line(repo))
 
     body.extend(_format_webhook_lines(repo))
 
     return body
+
+
+def _should_show_worker_line(repo: RepoStatus) -> bool:
+    """True when the Worker line has meaningful state to display.
+
+    Hides the line when the worker is idle (no task, not the agent talker,
+    not paused for a provider reset).  "waiting for work" is the default
+    state and not worth a line in the output — the interesting states are
+    active task, paused, or actively prompting the session.
+    """
+    if repo.worker_what is None:
+        return False
+    if repo.current_task is not None:
+        return True
+    if _worker_is_agent_talker(repo):
+        return True
+    ps = repo.provider_status
+    if ps is not None and ps.paused:
+        return True
+    return False
 
 
 def _format_worker_thread_line(repo: RepoStatus) -> str:

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -1028,7 +1028,7 @@ def _format_provider_summary_line(statuses: list[ProviderPressureStatus]) -> str
 
 
 def _format_repo_header(repo: RepoStatus) -> str:
-    """Top line per repo: ``<name>: fido <state> — <stats>[ → <claude>]``.
+    """Top line per repo: ``<name>: <state> — <stats>[ → <claude>]``.
 
     Stats list is comma-separated and only shows what matters right now:
     ``crashes N`` (skipped when 0), ``up X`` (worker thread uptime), ``BUSY``
@@ -1049,7 +1049,7 @@ def _format_repo_header(repo: RepoStatus) -> str:
         stats.append(color(RED_BOLD, f"last crash: {repo.last_crash_error}"))
 
     name_styled = color(BOLD, f"{repo.name}:")
-    state_styled = color(state_style, f"fido {state_word}")
+    state_styled = color(state_style, state_word)
     header = f"{name_styled} {state_styled}"
     if stats:
         header += " — " + ", ".join(stats)

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -1028,7 +1028,7 @@ def _format_provider_summary_line(statuses: list[ProviderPressureStatus]) -> str
 
 
 def _format_repo_header(repo: RepoStatus) -> str:
-    """Top line per repo: ``<name>: <state> — <stats>[ → <claude>]``.
+    """Top line per repo: ``<name>: <stats>``.
 
     Stats list is comma-separated and only shows what matters right now:
     ``crashes N`` (skipped when 0), ``up X`` (worker thread uptime), ``BUSY``
@@ -1036,8 +1036,6 @@ def _format_repo_header(repo: RepoStatus) -> str:
     line when crash_count > 0.  If nobody is currently talking to the agent,
     the generic pid/uptime suffix appears on this line.
     """
-    state_word = "running" if repo.fido_running else "waiting"
-    state_style = GREEN if repo.fido_running else DIM
     stats: list[str] = [_styled_repo_provider(repo)]
     if repo.crash_count > 0:
         stats.append(color(RED_BOLD, f"crashes {repo.crash_count}"))
@@ -1049,10 +1047,9 @@ def _format_repo_header(repo: RepoStatus) -> str:
         stats.append(color(RED_BOLD, f"last crash: {repo.last_crash_error}"))
 
     name_styled = color(BOLD, f"{repo.name}:")
-    state_styled = color(state_style, state_word)
-    header = f"{name_styled} {state_styled}"
+    header = name_styled
     if stats:
-        header += " — " + ", ".join(stats)
+        header += " " + ", ".join(stats)
     return header
 
 

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -398,7 +398,7 @@ class TestFidoLauncher:
             " (2026-04-24 14:00:00 UTC)" in result.stdout
         )
         assert (
-            "owner/repo: running — claude-code, crashes 2, up 2m, BUSY,"
+            "owner/repo: claude-code, crashes 2, up 2m, BUSY,"
             " last crash: RuntimeError: boom" in result.stdout
         )
         assert "  claude-code: pid 4242 (dropped session 1)" in result.stdout

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -398,7 +398,7 @@ class TestFidoLauncher:
             " (2026-04-24 14:00:00 UTC)" in result.stdout
         )
         assert (
-            "owner/repo: fido running — claude-code, crashes 2, up 2m, BUSY,"
+            "owner/repo: running — claude-code, crashes 2, up 2m, BUSY,"
             " last crash: RuntimeError: boom" in result.stdout
         )
         assert "  claude-code: pid 4242 (dropped session 1)" in result.stdout

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -416,6 +416,62 @@ class TestFidoLauncher:
         assert "  └─ webhook: triaging comment on PR #9 (12s)" in result.stdout
         assert "host: cpu load " in result.stdout
 
+    def test_status_fast_path_renders_session_message_counts(
+        self, tmp_path: Path
+    ) -> None:
+        result = run_status(
+            {
+                "activities": [
+                    {
+                        "repo_name": "owner/repo",
+                        "what": "Working on: #1",
+                        "busy": True,
+                        "crash_count": 0,
+                        "last_crash_error": None,
+                        "is_stuck": False,
+                        "worker_uptime_seconds": 60,
+                        "webhook_activities": [],
+                        "session_owner": "worker-1",
+                        "session_alive": True,
+                        "session_pid": 5555,
+                        "session_dropped_count": 0,
+                        "session_sent_count": 42,
+                        "session_received_count": 128,
+                        "claude_talker": {
+                            "repo_name": "owner/repo",
+                            "thread_id": 1,
+                            "kind": "worker",
+                            "description": "task turn",
+                            "claude_pid": 5555,
+                            "started_at": "2026-04-24T12:00:00+00:00",
+                        },
+                        "provider": "claude-code",
+                        "provider_status": None,
+                        "rescoping": False,
+                        "issue_cache": None,
+                        "fido_running": True,
+                        "issue": 7,
+                        "issue_title": "Do thing",
+                        "issue_elapsed_seconds": 120,
+                        "pr_number": None,
+                        "pr_title": None,
+                        "pending": 1,
+                        "completed": 0,
+                        "current_task": "Step one",
+                        "task_number": 1,
+                        "task_total": 1,
+                    }
+                ],
+                "rate_limit": None,
+                "fido_uptime_seconds": 300,
+            },
+            tmp_path,
+            env={"NO_COLOR": "1"},
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "42 sent, 128 received" in result.stdout
+
     def test_status_fast_path_renders_with_force_color(self, tmp_path: Path) -> None:
         result = run_status(
             {

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -946,6 +946,30 @@ class TestCopilotCLISession:
         session.stop()
         assert runtime.stop_called is True
 
+    def test_sent_and_received_counts(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+        )
+        assert session.sent_count == 0
+        assert session.received_count == 0
+
+        runtime.next_prompt = ("result-1", "end_turn", "sess-2")
+        session.prompt("first", model=None, system_prompt=None)
+        assert session.sent_count == 1
+        assert session.received_count == 1
+
+        # cancelled turns still count — the send went out and the response came back
+        runtime.next_prompt = ("result-2", "cancelled", "sess-3")
+        session.prompt("second", model=None, system_prompt=None)
+        assert session.sent_count == 2
+        assert session.received_count == 2
+
     def test_prompt_blanks_cancel_sentinel_even_without_cancelled_stop_reason(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1671,8 +1671,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "limits: claude-code 91% (five hour)" in output
-        assert "owner/repo: waiting — claude-code" in output
-        assert "owner/repo: waiting — claude-code 91% (five hour)" not in output
+        assert "owner/repo: claude-code" in output
+        assert "owner/repo: claude-code 91% (five hour)" not in output
 
     def test_includes_provider_reset_time_in_summary(self) -> None:
         provider_status = ProviderPressureStatus(
@@ -1714,8 +1714,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "claude-code limits unknown" in output
-        assert "owner/repo: waiting — claude-code" in output
-        assert "owner/repo: waiting — claude-code limits unknown" not in output
+        assert "owner/repo: claude-code" in output
+        assert "owner/repo: claude-code limits unknown" not in output
 
     def test_includes_copilot_unknown_summary(self) -> None:
         provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
@@ -1731,8 +1731,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "copilot-cli limits unknown" in output
-        assert "owner/repo: waiting — copilot-cli" in output
-        assert "owner/repo: waiting — copilot-cli limits unknown" not in output
+        assert "owner/repo: copilot-cli" in output
+        assert "owner/repo: copilot-cli limits unknown" not in output
 
     def test_fido_up_no_uptime(self) -> None:
         status = FidoStatus(fido_pid=12345, fido_uptime=None, repos=[])
@@ -1751,7 +1751,7 @@ class TestFormatStatus:
             repos=[self._repo(name="owner/myrepo")],
         )
         output = format_status(status)
-        assert "owner/myrepo: waiting" in output
+        assert "owner/myrepo: claude-code" in output
         assert "no assigned issues" in output
 
     def test_repo_fido_running_no_issue(self) -> None:
@@ -1761,7 +1761,7 @@ class TestFormatStatus:
             repos=[self._repo(fido_running=True)],
         )
         output = format_status(status)
-        assert "owner/repo: running" in output
+        assert "owner/repo: claude-code" in output
 
     def test_repo_with_issue_and_task(self) -> None:
         repo = self._repo(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1857,8 +1857,8 @@ class TestFormatStatus:
         status = FidoStatus(fido_pid=None, fido_uptime=None, repos=[repo])
         output = format_status(status)
         assert "Issue: #3" in output
-        # Worker is running but has no task → shows waiting for work
-        assert "Worker: waiting for work" in output
+        # Worker is running but has no task → hidden (idle workers are noise)
+        assert "Worker:" not in output
 
     def test_claude_pid_on_agent_line_when_no_talker(self) -> None:
         """Agent info appears on a dedicated body line, not as a header suffix."""

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1671,8 +1671,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "limits: claude-code 91% (five hour)" in output
-        assert "owner/repo: fido waiting — claude-code" in output
-        assert "owner/repo: fido waiting — claude-code 91% (five hour)" not in output
+        assert "owner/repo: waiting — claude-code" in output
+        assert "owner/repo: waiting — claude-code 91% (five hour)" not in output
 
     def test_includes_provider_reset_time_in_summary(self) -> None:
         provider_status = ProviderPressureStatus(
@@ -1714,8 +1714,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "claude-code limits unknown" in output
-        assert "owner/repo: fido waiting — claude-code" in output
-        assert "owner/repo: fido waiting — claude-code limits unknown" not in output
+        assert "owner/repo: waiting — claude-code" in output
+        assert "owner/repo: waiting — claude-code limits unknown" not in output
 
     def test_includes_copilot_unknown_summary(self) -> None:
         provider_status = ProviderPressureStatus(provider=ProviderID.COPILOT_CLI)
@@ -1731,8 +1731,8 @@ class TestFormatStatus:
         )
         output = format_status(status)
         assert "copilot-cli limits unknown" in output
-        assert "owner/repo: fido waiting — copilot-cli" in output
-        assert "owner/repo: fido waiting — copilot-cli limits unknown" not in output
+        assert "owner/repo: waiting — copilot-cli" in output
+        assert "owner/repo: waiting — copilot-cli limits unknown" not in output
 
     def test_fido_up_no_uptime(self) -> None:
         status = FidoStatus(fido_pid=12345, fido_uptime=None, repos=[])
@@ -1751,7 +1751,7 @@ class TestFormatStatus:
             repos=[self._repo(name="owner/myrepo")],
         )
         output = format_status(status)
-        assert "owner/myrepo: fido waiting" in output
+        assert "owner/myrepo: waiting" in output
         assert "no assigned issues" in output
 
     def test_repo_fido_running_no_issue(self) -> None:
@@ -1761,7 +1761,7 @@ class TestFormatStatus:
             repos=[self._repo(fido_running=True)],
         )
         output = format_status(status)
-        assert "fido running" in output
+        assert "owner/repo: running" in output
 
     def test_repo_with_issue_and_task(self) -> None:
         repo = self._repo(


### PR DESCRIPTION
Fixes #1018.

Fix the incomplete pieces from PR #1021: plumb sent/received counters through the PromptSession protocol and verify they render end-to-end in `./fido status`, remove the running/waiting state from per-repo headers entirely, and hide the Worker line when no worker is active.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] [Remove the running/waiting state word entirely from the per-repo header line](https://github.com/FidoCanCode/home/pull/1029#discussion_r3143097898) <!-- type:thread -->
- [x] Hide Worker line when no worker is active <!-- type:spec -->
- [x] [Verify sent_count/received_count counters render correctly in ./fido status output end-to-end](https://github.com/FidoCanCode/home/pull/1029#issuecomment-4321440138) <!-- type:thread -->
- [x] Add sent_count/received_count to PromptSession protocol and fix counter plumbing <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->