### PR TITLE
Revert #1023 — counter-based _preempt_pending hangs the worker

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -521,16 +521,15 @@ class ClaudeSession(OwnedSession):
         # is dirty.  :meth:`send` drains to the boundary before writing new
         # content so every turn starts on a clean slate.
         self._in_turn = False
-        # Counter of handlers that have signalled pending-preempt but not
-        # yet completed their outermost :meth:`__enter__`.  Workers wait
-        # for this to reach zero before acquiring :attr:`_lock`.  Was a
-        # binary :class:`threading.Event` before #1022 — switched to a
-        # counter so a *second* queued handler doesn't get starved when
-        # the first acquires (the Event would clear after one handler
-        # passed through, letting the worker race ahead of the second).
-        # The counter reflects queue length, so workers keep yielding
-        # while ANY handler is queued.
-        self._preempt_pending: int = 0
+        # Set by :meth:`prompt` right after :attr:`_cancel` and before it
+        # blocks on :attr:`_lock`.  Cleared inside :meth:`__enter__` once the
+        # preempter actually acquires the lock.  Workers check this in their
+        # retry loop to yield fairly: without it, a freshly-released worker
+        # thread can re-acquire :attr:`_lock` before the waiting webhook
+        # gets scheduled, and the next :meth:`iter_events` clears
+        # :attr:`_cancel` — starving the preempter for a full worker turn.
+        # See yield-starvation discussion in #499 comments.
+        self._preempt_pending = threading.Event()
         # Condition that serializes the "set pending → check pending → acquire
         # lock" handshake between webhook (priority) and worker (yields)
         # threads at lock-handoff time.  Webhooks set ``_preempt_pending`` and
@@ -570,7 +569,7 @@ class ClaudeSession(OwnedSession):
         so the worker can otherwise race ahead and starve the preempter for
         a full turn.
         """
-        if not self._preempt_pending > 0:
+        if not self._preempt_pending.is_set():
             return False
         # Wait for the preempter's __enter__ to clear the event, meaning they
         # hold the lock now.  If they don't manage within the deadline, bail.
@@ -584,7 +583,7 @@ class ClaudeSession(OwnedSession):
             "session: worker ceding lock to pending preempter (tid=%d)",
             threading.get_ident(),
         )
-        while self._preempt_pending > 0:
+        while self._preempt_pending.is_set():
             if _time.monotonic() >= deadline:
                 log.warning(
                     "session: preempter still pending after %.2fs — worker "
@@ -829,13 +828,13 @@ class ClaudeSession(OwnedSession):
             if is_worker:
                 with self._preempt_cond:
                     self._preempt_cond.wait_for(
-                        lambda: not self._preempt_pending > 0,
+                        lambda: not self._preempt_pending.is_set(),
                         timeout=30.0,
                     )
             self._lock.acquire()
             if is_worker:
                 with self._preempt_cond:
-                    if self._preempt_pending > 0:
+                    if self._preempt_pending.is_set():
                         # A webhook arrived between our wait and acquire —
                         # let it in.  Release and re-wait.
                         self._lock.release()
@@ -848,15 +847,9 @@ class ClaudeSession(OwnedSession):
         # outer hold_for_handler is still running: clearing it here would
         # let the worker's re-check see False and win the lock over the
         # queued webhook (#1017).
-        # Decrement on the outermost handler entry only — workers don't
-        # decrement (they're not queued).  This is the #1022 fix: a
-        # second queued handler (counter still > 0 after the first
-        # decrements) keeps workers yielding, so the second handler
-        # gets the lock next instead of the worker.
-        if getattr(self._reentry_tls, "depth", 0) == 0 and not is_worker:
+        if getattr(self._reentry_tls, "depth", 0) == 0:
             with self._preempt_cond:
-                if self._preempt_pending > 0:
-                    self._preempt_pending -= 1
+                self._preempt_pending.clear()
                 self._preempt_cond.notify_all()
         # If the entering thread is the same one that fired the most recent
         # cancel, that signal was meant for the previous holder (who has
@@ -1030,7 +1023,7 @@ class ClaudeSession(OwnedSession):
         turn).
         """
         with self._preempt_cond:
-            self._preempt_pending += 1
+            self._preempt_pending.set()
             self._preempt_cond.notify_all()
 
     def _send_control_interrupt(self) -> str:
@@ -1133,15 +1126,15 @@ class ClaudeSession(OwnedSession):
                 )
                 return result
         finally:
-            # Safety net: if __enter__ raised before it could decrement
+            # Safety net: if __enter__ raised before it could clear
             # _preempt_pending, do it here so workers aren't stuck waiting.
             # Skip on normal return (_entered=True) — __enter__ already
-            # decremented.  Decrement by 1 (not zero) so concurrent
-            # other-handler signals aren't over-cleared (#1022).
+            # cleared the flag, and re-clearing would stomp on a pending
+            # signal that a later-arriving webhook set while this prompt()
+            # was running inside hold_for_handler (#1017).
             if not _entered:
                 with self._preempt_cond:
-                    if self._preempt_pending > 0:
-                        self._preempt_pending -= 1
+                    self._preempt_pending.clear()
                     self._preempt_cond.notify_all()
 
     def switch_model(self, model: ProviderModel | str) -> None:
@@ -1248,7 +1241,7 @@ class ClaudeSession(OwnedSession):
         # (fix for #786).  Otherwise the signal fired by the preempter is
         # meant for the current holder — clobbering it here lets the turn
         # run to completion before the preempter ever gets the lock.
-        if not self._preempt_pending > 0:
+        if not self._preempt_pending.is_set():
             self._cancel.clear()
         self._last_turn_cancelled = False
         last_activity = time.monotonic()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1000,7 +1000,7 @@ class TestClaudeSessionDrainToBoundary:
         session._selector = MagicMock(return_value=([], [], []))
         # Set cancel immediately — simulates preempt arriving during drain
         session._cancel.set()
-        session._preempt_pending = 1
+        session._preempt_pending.set()
         with patch.object(session, "recover") as mock_recover:
             session._drain_to_boundary(deadline=5.0)
         # _in_turn stays True so send() knows not to write
@@ -1180,14 +1180,14 @@ class TestClaudeSessionWaitForPendingPreempt:
 
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._preempt_pending = 1
+        session._preempt_pending.set()
 
         # Clear the event from another thread after a brief delay.
         def _clearer() -> None:
             import time as _time
 
             _time.sleep(0.02)
-            session._preempt_pending = 0
+            session._preempt_pending.clear()
 
         t = _t.Thread(target=_clearer)
         t.start()
@@ -1197,7 +1197,7 @@ class TestClaudeSessionWaitForPendingPreempt:
     def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._preempt_pending = 1
+        session._preempt_pending.set()
         # Never cleared → waits out the deadline.
         assert session.wait_for_pending_preempt(timeout=0.05) is False
 
@@ -1333,7 +1333,7 @@ class TestClaudeSessionIterEvents:
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
         session._cancel.set()
-        session._preempt_pending = 1
+        session._preempt_pending.set()
         events = list(session.iter_events())
         # Both events were consumed — pipe is clean for the next holder.
         assert len(events) == 2
@@ -1363,10 +1363,10 @@ class TestClaudeSessionIterEvents:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         assert not session._cancel.is_set()
-        assert not (session._preempt_pending > 0)
+        assert not session._preempt_pending.is_set()
         session._fire_worker_cancel()
         assert session._cancel.is_set()
-        assert session._preempt_pending > 0
+        assert session._preempt_pending.is_set()
         session.stop()
 
     def test_recovers_when_cancel_drain_times_out(self, tmp_path: Path) -> None:
@@ -1897,7 +1897,7 @@ class TestClaudeSessionLock:
                         "— expected 1 (hold_for_handler queueing branch must "
                         "signal pending so workers yield, #983)"
                     )
-                    assert session._preempt_pending > 0, (
+                    assert session._preempt_pending.is_set(), (
                         "_preempt_pending should be set after queueing"
                     )
         finally:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -353,50 +353,6 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     assert result == "triage-reply", f"handler prompt got wrong result — got {result!r}"
 
 
-def test_two_queued_handlers_keep_counter_above_zero_after_first_acquires(
-    tmp_path: Path,
-) -> None:
-    """Regression for #1022: when N handlers signal pending and the first
-    acquires the lock + decrements, the counter must still be > 0 (one
-    remaining queued handler), so a worker waiting on `_preempt_pending == 0`
-    keeps yielding to the second.
-
-    The old code used a binary :class:`threading.Event` for
-    ``_preempt_pending``; once one handler acquired and called ``clear()``,
-    the worker saw ``False`` and won the lock over the second queued
-    handler.  Switching to an int counter fixes the race: each signal
-    increments, each handler acquire decrements, worker waits for == 0."""
-    session = _setup_session(tmp_path)
-    try:
-        # Simulate two handlers signalling pending in arrival order.
-        session._signal_pending_preempt()
-        session._signal_pending_preempt()
-        assert session._preempt_pending == 2, "two pending after two signals"
-
-        # Simulate the first handler acquiring + completing its outermost
-        # __enter__ decrement.
-        provider.set_thread_kind("webhook")
-        try:
-            with session:
-                # Inside the hold, the first handler has decremented once;
-                # the second's signal still keeps the counter at 1, so the
-                # worker would still yield (the bug fix).
-                assert session._preempt_pending == 1, (
-                    "second handler's signal must remain — counter > 0 "
-                    "keeps the worker yielding"
-                )
-        finally:
-            provider.set_thread_kind(None)
-
-        # After the first handler exits, counter is still 1 (second handler
-        # hasn't been through its __enter__ yet).
-        assert session._preempt_pending == 1, (
-            "second handler still queued after first's exit"
-        )
-    finally:
-        session.stop()
-
-
 def test_inner_prompt_preserves_queued_webhook_pending_flag(
     tmp_path: Path,
 ) -> None:
@@ -416,12 +372,12 @@ def test_inner_prompt_preserves_queued_webhook_pending_flag(
         with session.hold_for_handler(preempt_worker=False):
             # Simulate webhook B queuing behind this hold_for_handler.
             session._signal_pending_preempt()
-            assert session._preempt_pending > 0, "sanity: pending set"
+            assert session._preempt_pending.is_set(), "sanity: pending set"
             # Inner prompt() — old code cleared _preempt_pending here.
             session.prompt("triage this issue")
             # After returning, pending must still be set so the worker
             # blocks in __enter__'s wait_for and yields to webhook B.
-            assert session._preempt_pending > 0, (
+            assert session._preempt_pending.is_set(), (
                 "_preempt_pending cleared by inner prompt() inside "
                 "hold_for_handler — worker would win lock over queued "
                 "webhook (bug #1017 regression)"


### PR DESCRIPTION
## Symptom

Home worker hung for 16+ minutes after #1023 (counter-based \`_preempt_pending\`) shipped:

- Last \`[home]\` log line: 06:04:04 (\"webhook handler: EXIT\")
- \`./fido status\` showed \`BUSY\` + \`session idle\`
- No claude turns dispatched, no further log lines, no progress

The claude session itself was idle (last assistant turn ended at 06:04:03 with a one-word reply, then nothing). The hang was purely in fido's worker thread.

## Most likely cause

\`_preempt_pending\` (now an int counter) leaked above 0 and was never decremented. The worker's \`__enter__\` cede loop is:

\`\`\`python
self._cond.wait_for(lambda: not self._preempt_pending > 0, timeout=30.0)
self._lock.acquire()
if self._preempt_pending > 0:
    self._lock.release()
    continue
\`\`\`

If the counter stays at 1 forever, this becomes an infinite spin — wait 30s (timeout), acquire, check, release, repeat — with no log output between iterations. Matches the observed silence.

The decrement only fires in handler outermost \`__enter__\`. There's likely a path where \`_signal_pending_preempt\` increments but the matching handler \`__enter__\` never runs (e.g., the webhook short-circuits or the thread kind isn't \`webhook\` at the right time, or the \`prompt()\` finally-block decrement got mis-conditioned). Diagnosis incomplete; revert first.

## Trade-off

Reverting brings back #1022's intermittent symptom (worker occasionally beats a queued webhook B → comment goes unanswered until the next event). That bug is annoying but not destructive. The counter fix introduced a HANG, which is worse.

#1022 stays open for the proper fix (the FSM rewrite path tracked there).

## Test plan

- [x] \`./fido ci\` green on the revert
- [ ] Live verification: bring fido up, confirm home worker resumes (not hung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)