### PR TITLE
Experiment: drive the lock from session_lock.v's FSM, delete ad-hoc coordination (validates real fix for #984/#1017/#1019/#1022 cascade) (closes #1022)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -530,17 +530,6 @@ class ClaudeSession(OwnedSession):
         self._proc = self._spawn()
         _register_child(self._proc)
 
-    def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
-        """Compatibility stub — the FSM handles priority ordering; always returns False.
-
-        The old :class:`threading.RLock`-based implementation polled
-        ``_preempt_pending`` to let webhook callers win the lock before the
-        worker retried.  The FSM's handler-priority queue makes that polling
-        unnecessary: workers already yield to any queued handler inside
-        :meth:`~provider.OwnedSession._fsm_acquire_worker`.
-        """
-        return False
-
     def _wake(self) -> None:
         """Write a byte to the wakeup pipe to kick select() awake."""
         try:
@@ -1560,7 +1549,6 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
                 or getattr(session, "last_turn_cancelled", False) is not True
             ):
                 return result
-            session.wait_for_pending_preempt()
             attempt += 1
             log.info("ClaudeClient.run_turn: preempted mid-flight — retry %d", attempt)
 

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -509,9 +509,6 @@ class ClaudeSession(OwnedSession):
         # is dirty.  :meth:`send` drains to the boundary before writing new
         # content so every turn starts on a clean slate.
         self._in_turn = False
-        # Set by :meth:`prompt` right after :attr:`_cancel` and before it
-        # blocks on :attr:`_lock`.  Cleared inside :meth:`__enter__` once the
-        # preempter actually acquires the lock.  Workers check this in their
         # Per-thread reentrance counter for the ``with self:`` context so
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -477,19 +477,7 @@ class ClaudeSession(OwnedSession):
         self._system_file = system_file
         self._work_dir = work_dir
         self._popen_fn = popen
-        # Reentrant so :meth:`switch_model` can reacquire while called from
-        # inside a ``with session:`` block (e.g. ``prompt()`` acquires the
-        # lock, then calls switch_model which also needs to serialize with
-        # other sessions' access — a plain threading.Lock self-deadlocks).
-        self._lock = threading.RLock()
         self._cancel = threading.Event()
-        # Thread id that most recently fired :attr:`_cancel` via
-        # :meth:`_fire_worker_cancel`.  Used by :meth:`__enter__` to clear
-        # the signal when the firing thread itself acquires the lock — that
-        # cancel was meant for the previous holder (who has since released),
-        # not for the firer's own first turn (#973).  ``None`` when no
-        # outstanding firing.
-        self._cancel_fired_by_tid: int | None = None
         self._repo_name = repo_name
         self._model = model_name(
             ProviderModel("claude-opus-4-6") if model is None else model
@@ -524,21 +512,6 @@ class ClaudeSession(OwnedSession):
         # Set by :meth:`prompt` right after :attr:`_cancel` and before it
         # blocks on :attr:`_lock`.  Cleared inside :meth:`__enter__` once the
         # preempter actually acquires the lock.  Workers check this in their
-        # retry loop to yield fairly: without it, a freshly-released worker
-        # thread can re-acquire :attr:`_lock` before the waiting webhook
-        # gets scheduled, and the next :meth:`iter_events` clears
-        # :attr:`_cancel` — starving the preempter for a full worker turn.
-        # See yield-starvation discussion in #499 comments.
-        self._preempt_pending = threading.Event()
-        # Condition that serializes the "set pending → check pending → acquire
-        # lock" handshake between webhook (priority) and worker (yields)
-        # threads at lock-handoff time.  Webhooks set ``_preempt_pending`` and
-        # ``notify_all`` under this mutex; workers ``wait_for(not pending)``
-        # under it.  After acquiring the lock, workers re-check pending under
-        # this mutex and yield (release+retry) if a webhook arrived during
-        # the gap — closes the race that #983 reported (worker won the lock
-        # handoff between two webhooks because RLock isn't FIFO).
-        self._preempt_cond = threading.Condition()
         # Per-thread reentrance counter for the ``with self:`` context so
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).
@@ -558,45 +531,15 @@ class ClaudeSession(OwnedSession):
         _register_child(self._proc)
 
     def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
-        """Block for up to *timeout* seconds while a preempter holds the
-        lock queue.  Returns ``True`` if the preemption completed within the
-        window, ``False`` on timeout (no preempter pending in the first place
-        returns immediately with ``False``).
+        """Compatibility stub — the FSM handles priority ordering; always returns False.
 
-        Workers call this after their cancelled-turn exit to let the
-        preempter actually acquire :attr:`_lock` before the worker retries —
-        Python's :class:`threading.RLock` isn't FIFO-fair under contention
-        so the worker can otherwise race ahead and starve the preempter for
-        a full turn.
+        The old :class:`threading.RLock`-based implementation polled
+        ``_preempt_pending`` to let webhook callers win the lock before the
+        worker retried.  The FSM's handler-priority queue makes that polling
+        unnecessary: workers already yield to any queued handler inside
+        :meth:`~provider.OwnedSession._fsm_acquire_worker`.
         """
-        if not self._preempt_pending.is_set():
-            return False
-        # Wait for the preempter's __enter__ to clear the event, meaning they
-        # hold the lock now.  If they don't manage within the deadline, bail.
-        # is_set() -> wait for clear: threading.Event has no "wait-for-clear",
-        # so poll with short sleeps.
-        import time as _time
-
-        started = _time.monotonic()
-        deadline = started + timeout
-        log.info(
-            "session: worker ceding lock to pending preempter (tid=%d)",
-            threading.get_ident(),
-        )
-        while self._preempt_pending.is_set():
-            if _time.monotonic() >= deadline:
-                log.warning(
-                    "session: preempter still pending after %.2fs — worker "
-                    "proceeding anyway",
-                    timeout,
-                )
-                return False
-            _time.sleep(0.01)
-        log.info(
-            "session: preempter acquired lock after %.3fs yield",
-            _time.monotonic() - started,
-        )
-        return True
+        return False
 
     def _wake(self) -> None:
         """Write a byte to the wakeup pipe to kick select() awake."""
@@ -744,25 +687,24 @@ class ClaudeSession(OwnedSession):
     def _respawn(self, *, clear_session_id: bool, reason: str) -> None:
         """Stop the current subprocess and spawn a replacement."""
         log.info("ClaudeSession: %s (model=%s)", reason, self._model)
-        with self._lock:
-            _unregister_child(self._proc)
-            if self._proc.poll() is None:
-                try:
-                    self._proc.kill()
-                    self._proc.wait(timeout=1.0)
-                except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
-                    log.warning("ClaudeSession._respawn: kill/wait failed: %s", exc)
-                    raise
-            if clear_session_id:
-                self._session_id = ""
-            # Fresh subprocess has no in-flight turn, so next send() skips
-            # the drain path.
-            self._in_turn = False
-            # Message counters are cumulative since boot — do NOT reset on
-            # respawn.  Per-subprocess counts would bounce to zero on every
-            # model switch or recovery, making wedge detection meaningless.
-            self._proc = self._spawn()
-            _register_child(self._proc)
+        _unregister_child(self._proc)
+        if self._proc.poll() is None:
+            try:
+                self._proc.kill()
+                self._proc.wait(timeout=1.0)
+            except (OSError, ProcessLookupError, subprocess.TimeoutExpired) as exc:
+                log.warning("ClaudeSession._respawn: kill/wait failed: %s", exc)
+                raise
+        if clear_session_id:
+            self._session_id = ""
+        # Fresh subprocess has no in-flight turn, so next send() skips
+        # the drain path.
+        self._in_turn = False
+        # Message counters are cumulative since boot — do NOT reset on
+        # respawn.  Per-subprocess counts would bounce to zero on every
+        # model switch or recovery, making wedge detection meaningless.
+        self._proc = self._spawn()
+        _register_child(self._proc)
         log.info("ClaudeSession: respawn complete, new pid %d", self._proc.pid)
 
     def recover(self) -> None:
@@ -796,16 +738,16 @@ class ClaudeSession(OwnedSession):
         """Acquire the session lock, serializing send/receive across threads.
 
         On the outermost entry (via the :class:`OwnedSession`
-        reentrance counter), registers a :class:`provider.SessionTalker`
-        whose ``kind`` is read directly from the calling thread's
-        thread-local in :func:`provider.current_thread_kind` — never via
-        any session-shared attribute.  This is load-bearing: a shared
-        attribute would let a worker's ``"worker"`` write get clobbered
-        by a webhook's ``"webhook"`` write (or vice versa) in the window
-        between writing and lock-acquire, leading to a worker registered
-        with ``kind="webhook"`` and a broken ``preempt_worker`` check
-        (#981).  Nested entries (from :meth:`hold_for_handler`) re-acquire
-        the RLock and skip the talker re-registration.
+        reentrance counter), delegates to :meth:`_fsm_acquire_worker` or
+        :meth:`_fsm_acquire_handler` based on the calling thread's kind
+        (read from :func:`provider.current_thread_kind` — never via any
+        session-shared attribute).  Handler acquires queue behind any
+        current holder and are served FIFO; worker acquires yield to any
+        queued handler.
+
+        Registers a :class:`provider.SessionTalker` after acquiring.
+        Nested entries (from :meth:`hold_for_handler`) re-enter the
+        reentrance counter and skip the FSM acquire.
 
         Does *not* clear the cancel event — that is deferred to
         :meth:`iter_events` so a signal that lands between one holder's
@@ -814,85 +756,46 @@ class ClaudeSession(OwnedSession):
 
         Raises :class:`provider.SessionLeakError` on the outermost entry if another
         thread is already registered as the talker for this repo.  The
-        session lock is released before raising so the prior holder isn't
+        FSM lock is released before raising so the prior holder isn't
         deadlocked.
         """
-        is_worker = provider.current_thread_kind() == "worker"
-        # Webhook-priority handoff (#983): worker threads yield to any
-        # queued webhook by waiting on _preempt_cond before acquiring
-        # _lock, AND re-checking under the cond mutex after acquiring —
-        # if a webhook set _preempt_pending during the gap, release the
-        # lock and retry.  Webhook callers skip the wait (they're the
-        # priority lane).
-        while True:
-            if is_worker:
-                with self._preempt_cond:
-                    self._preempt_cond.wait_for(
-                        lambda: not self._preempt_pending.is_set(),
-                        timeout=30.0,
+        depth = getattr(self._reentry_tls, "depth", 0)
+        if depth > 0:
+            self._bump_entry_depth()
+            return self
+        kind = provider.current_thread_kind()
+        if kind == "worker":
+            self._fsm_acquire_worker()
+        else:
+            self._fsm_acquire_handler()
+        self._bump_entry_depth()
+        if self._repo_name is not None:
+            try:
+                provider.register_talker(
+                    provider.SessionTalker(
+                        repo_name=self._repo_name,
+                        thread_id=threading.get_ident(),
+                        kind=kind,
+                        description="persistent session turn",
+                        claude_pid=self._proc.pid,
+                        started_at=provider.talker_now(),
                     )
-            self._lock.acquire()
-            if is_worker:
-                with self._preempt_cond:
-                    if self._preempt_pending.is_set():
-                        # A webhook arrived between our wait and acquire —
-                        # let it in.  Release and re-wait.
-                        self._lock.release()
-                        continue
-            break
-        # We hold the lock now; clear the pending flag — but only on the
-        # outermost acquire for this thread.  A reentrant acquire (e.g.
-        # prompt() called inside hold_for_handler, depth already ≥ 1) must
-        # not stomp on a pending signal that a second webhook set while the
-        # outer hold_for_handler is still running: clearing it here would
-        # let the worker's re-check see False and win the lock over the
-        # queued webhook (#1017).
-        if getattr(self._reentry_tls, "depth", 0) == 0:
-            with self._preempt_cond:
-                self._preempt_pending.clear()
-                self._preempt_cond.notify_all()
-        # If the entering thread is the same one that fired the most recent
-        # cancel, that signal was meant for the previous holder (who has
-        # since released the lock).  Clear it so the firer's own first turn
-        # is not aborted by it (#973).  When the cancel was fired by some
-        # other thread (the #786 lock-handoff race), leave it set —
-        # iter_events will gate on _preempt_pending and consume it.
-        if self._cancel_fired_by_tid == threading.get_ident():
-            self._cancel.clear()
-            self._cancel_fired_by_tid = None
-        depth = self._bump_entry_depth()
-        if depth == 1:
-            kind = provider.current_thread_kind()
-            if self._repo_name is not None:
-                try:
-                    provider.register_talker(
-                        provider.SessionTalker(
-                            repo_name=self._repo_name,
-                            thread_id=threading.get_ident(),
-                            kind=kind,
-                            description="persistent session turn",
-                            claude_pid=self._proc.pid,
-                            started_at=provider.talker_now(),
-                        )
-                    )
-                except provider.SessionLeakError:
-                    self._drop_entry_depth()
-                    self._lock.release()
-                    raise
-            self._oracle_on_acquire(kind)
+                )
+            except provider.SessionLeakError:
+                self._drop_entry_depth()
+                self._fsm_release()
+                raise
         return self
 
     def __exit__(self, *args: object) -> None:
         """Release the session lock.  Unregisters the :class:`provider.SessionTalker`
-        before releasing the lock on the outermost exit so no other thread
-        can race in and see our stale talker entry.
+        before releasing so no other thread can race in and see a stale talker entry.
         """
         depth = self._drop_entry_depth()
         if depth == 0:
             if self._repo_name is not None:
                 provider.unregister_talker(self._repo_name, threading.get_ident())
-            self._oracle_on_release()
-        self._lock.release()
+            self._fsm_release()
 
     def send(self, content: str) -> None:
         """Write a user message to the session stdin, flushing immediately.
@@ -1001,30 +904,9 @@ class ClaudeSession(OwnedSession):
         turn, then exits the turn with ``_in_turn=False``.  Only then
         does the worker release the lock — handing the webhook a fully
         settled session.
-
-        Also sets :attr:`_preempt_pending` so :meth:`iter_events` does
-        not clobber the cancel signal at the start of the very next
-        turn (fix for #786) and so workers waiting in :meth:`__enter__`
-        yield priority to the queued webhook (#983).
         """
         self._cancel.set()
-        self._cancel_fired_by_tid = threading.get_ident()
-        self._signal_pending_preempt()
         self._wake()
-
-    def _signal_pending_preempt(self) -> None:
-        """Set :attr:`_preempt_pending` and wake any worker waiting in
-        :meth:`__enter__` so the worker yields to the queued webhook.
-
-        Held under :attr:`_preempt_cond` so the worker's wait+acquire
-        handshake sees a coherent state (closes #983 — RLock isn't FIFO,
-        so a webhook arriving while another webhook is the holder needs
-        an explicit signal to make the next worker re-acquire wait its
-        turn).
-        """
-        with self._preempt_cond:
-            self._preempt_pending.set()
-            self._preempt_cond.notify_all()
 
     def _send_control_interrupt(self) -> str:
         """Write a stream-json ``control_request`` interrupt to subprocess
@@ -1071,7 +953,7 @@ class ClaudeSession(OwnedSession):
         """
         self._cancel.set()
         self._wake()
-        with self._lock:
+        with self:
             self._send_control_interrupt()
             self.consume_until_result()
             self.send(content)
@@ -1099,43 +981,29 @@ class ClaudeSession(OwnedSession):
         """
         tid = threading.get_ident()
         t_start = time.monotonic()
-        _entered = False
-        try:
-            with self:
-                _entered = True
-                log.info(
-                    "session.prompt: lock acquired (tid=%d, waited=%.2fs)",
-                    tid,
-                    time.monotonic() - t_start,
-                )
-                if model is not None:
-                    self.switch_model(model)
-                if system_prompt:
-                    body = f"{system_prompt}\n\n---\n\n{content}"
-                else:
-                    body = content
-                self.send(body)
-                result = self.consume_until_result()
-                log.info(
-                    "session.prompt: turn complete (tid=%d, total=%.2fs, "
-                    "result_len=%d, cancelled=%s)",
-                    tid,
-                    time.monotonic() - t_start,
-                    len(result or ""),
-                    self._last_turn_cancelled,
-                )
-                return result
-        finally:
-            # Safety net: if __enter__ raised before it could clear
-            # _preempt_pending, do it here so workers aren't stuck waiting.
-            # Skip on normal return (_entered=True) — __enter__ already
-            # cleared the flag, and re-clearing would stomp on a pending
-            # signal that a later-arriving webhook set while this prompt()
-            # was running inside hold_for_handler (#1017).
-            if not _entered:
-                with self._preempt_cond:
-                    self._preempt_pending.clear()
-                    self._preempt_cond.notify_all()
+        with self:
+            log.info(
+                "session.prompt: lock acquired (tid=%d, waited=%.2fs)",
+                tid,
+                time.monotonic() - t_start,
+            )
+            if model is not None:
+                self.switch_model(model)
+            if system_prompt:
+                body = f"{system_prompt}\n\n---\n\n{content}"
+            else:
+                body = content
+            self.send(body)
+            result = self.consume_until_result()
+            log.info(
+                "session.prompt: turn complete (tid=%d, total=%.2fs, "
+                "result_len=%d, cancelled=%s)",
+                tid,
+                time.monotonic() - t_start,
+                len(result or ""),
+                self._last_turn_cancelled,
+            )
+            return result
 
     def switch_model(self, model: ProviderModel | str) -> None:
         """Switch the active model by respawning the claude subprocess
@@ -1164,12 +1032,11 @@ class ClaudeSession(OwnedSession):
             self._model,
             target_model,
         )
-        with self._lock:
-            self._model = target_model
-            self._respawn(
-                clear_session_id=False,
-                reason=f"switching model to {target_model}",
-            )
+        self._model = target_model
+        self._respawn(
+            clear_session_id=False,
+            reason=f"switching model to {target_model}",
+        )
         log.info("switch_model: now on model=%s", target_model)
 
     def _log_event(self, obj: dict[str, Any]) -> None:
@@ -1237,12 +1104,11 @@ class ClaudeSession(OwnedSession):
         should not be silently swallowed.
         """
         assert self._proc.stdout is not None
-        # Clear the cancel event only when no preempter is actively waiting
-        # (fix for #786).  Otherwise the signal fired by the preempter is
-        # meant for the current holder — clobbering it here lets the turn
-        # run to completion before the preempter ever gets the lock.
-        if not self._preempt_pending.is_set():
-            self._cancel.clear()
+        # Clear the cancel event at the start of each turn.  Any cancel signal
+        # that was set before this holder acquired the lock was meant for the
+        # previous holder — the FSM's FIFO handler queue ensures the next
+        # holder's turn starts clean without needing a separate pending flag.
+        self._cancel.clear()
         self._last_turn_cancelled = False
         last_activity = time.monotonic()
         cancelled_at: float | None = None

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -970,17 +970,6 @@ class CopilotCLISession(OwnedSession):
     def last_turn_cancelled(self) -> bool:
         return self._last_turn_cancelled
 
-    def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
-        """Compatibility stub — the FSM handles priority ordering; always returns False.
-
-        The old :class:`threading.RLock`-based implementation polled
-        ``_preempt_condition`` to let webhook callers win the lock before the
-        worker retried.  The FSM's handler-priority queue makes that polling
-        unnecessary: workers already yield to any queued handler inside
-        :meth:`~provider.OwnedSession._fsm_acquire_worker`.
-        """
-        return False
-
     def prompt(
         self,
         content: str,
@@ -1249,7 +1238,6 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
                 or getattr(session, "last_turn_cancelled", False) is not True
             ):
                 return result
-            session.wait_for_pending_preempt()
             attempt += 1
             log.info(
                 "CopilotCLIClient.run_turn: preempted mid-flight — retry %d", attempt

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -13,9 +13,8 @@ import uuid
 from collections.abc import Callable, Sequence
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import acp
 from acp.exceptions import RequestError
@@ -913,13 +912,7 @@ class CopilotCLISession(OwnedSession):
         else:
             factory = CopilotACPRuntime if runtime_factory is None else runtime_factory
             self._runtime = factory(work_dir=self._work_dir, repo_name=repo_name)
-        self._lock = threading.RLock()
         self._init_handler_reentry()
-        self._owner_lock = threading.Lock()
-        self._owner: str | None = None
-        self._pending_preempts = 0
-        self._preempt_condition = threading.Condition()
-        self._thread_state = threading.local()
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
@@ -930,15 +923,18 @@ class CopilotCLISession(OwnedSession):
         # When the id is no longer known to Copilot, ensure_session falls
         # back to creating a fresh session automatically.
         self._session_id: str | None = self._runtime.ensure_session(session_id, model)
-        # Kind the current lock holder is registered under in the shared
-        # talker registry (``"worker"`` / ``"webhook"``), or ``None`` when
-        # no one is inside the lock.  Set by :meth:`_register_talker_kind`.
-        self._registered_talker_kind: Literal["worker", "webhook"] | None = None
 
     @property
     def owner(self) -> str | None:
-        with self._owner_lock:
-            return self._owner
+        if self._repo_name is None:
+            return None
+        talker = provider.get_talker(self._repo_name)
+        if talker is None or talker.kind != "worker":
+            return None
+        for t in threading.enumerate():
+            if t.ident == talker.thread_id:
+                return t.name
+        return None
 
     @property
     def pid(self) -> int | None:
@@ -975,14 +971,15 @@ class CopilotCLISession(OwnedSession):
         return self._last_turn_cancelled
 
     def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
-        deadline = time.monotonic() + timeout
-        with self._preempt_condition:
-            while self._pending_preempts > 0:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    return False
-                self._preempt_condition.wait(timeout=remaining)
-        return True
+        """Compatibility stub — the FSM handles priority ordering; always returns False.
+
+        The old :class:`threading.RLock`-based implementation polled
+        ``_preempt_condition`` to let webhook callers win the lock before the
+        worker retried.  The FSM's handler-priority queue makes that polling
+        unnecessary: workers already yield to any queued handler inside
+        :meth:`~provider.OwnedSession._fsm_acquire_worker`.
+        """
+        return False
 
     def prompt(
         self,
@@ -1040,79 +1037,61 @@ class CopilotCLISession(OwnedSession):
             self._runtime.cancel(session_id)
 
     def __enter__(self) -> "CopilotCLISession":
-        if getattr(self._reentry_tls, "depth", 0) > 0:
-            # Reentrant call from within :meth:`hold_for_handler` — RLock
-            # handles the nested acquire; owner and talker state stay owned
-            # by the outermost entry.
-            self._lock.acquire()
+        """Acquire the session lock, serializing prompt calls across threads.
+
+        On the outermost entry (via the :class:`OwnedSession` reentrance
+        counter), delegates to :meth:`_fsm_acquire_worker` or
+        :meth:`_fsm_acquire_handler` based on the calling thread's kind
+        (read from :func:`provider.current_thread_kind`).  Handler acquires
+        queue behind any current holder and are served FIFO; worker acquires
+        yield to any queued handler.
+
+        Registers a :class:`provider.SessionTalker` after acquiring.
+        Nested entries (from :meth:`hold_for_handler`) re-enter the
+        reentrance counter and skip the FSM acquire.
+
+        Raises :class:`provider.SessionLeakError` on the outermost entry if
+        another thread is already registered as the talker for this repo.  The
+        FSM lock is released before raising so the prior holder isn't
+        deadlocked.
+        """
+        depth = getattr(self._reentry_tls, "depth", 0)
+        if depth > 0:
             self._bump_entry_depth()
             return self
-        waited = not self._lock.acquire(blocking=False)
-        if waited:
-            with self._preempt_condition:
-                self._pending_preempts += 1
-            # Preemption (cancelling a running worker turn) is handled
-            # upstream: the HTTP handler fires preempt_worker() synchronously
-            # (#955) and hold_for_handler fires a second preemption before the
-            # lock is acquired (#658).  Nothing to do here except wait.
-            self._lock.acquire()
-        self._thread_state.waited = waited
-        with self._owner_lock:
-            self._owner = threading.current_thread().name
-        self._register_talker_kind()
+        kind = provider.current_thread_kind()
+        if kind == "worker":
+            self._fsm_acquire_worker()
+        else:
+            self._fsm_acquire_handler()
         self._bump_entry_depth()
-        self._oracle_on_acquire(provider.current_thread_kind())
+        if self._repo_name is not None:
+            try:
+                provider.register_talker(
+                    provider.SessionTalker(
+                        repo_name=self._repo_name,
+                        thread_id=threading.get_ident(),
+                        kind=kind,
+                        description="copilot-cli session turn",
+                        claude_pid=0,  # no claude subprocess — ACP runtime
+                        started_at=provider.talker_now(),
+                    )
+                )
+            except provider.SessionLeakError:
+                self._drop_entry_depth()
+                self._fsm_release()
+                raise
         return self
 
-    def _register_talker_kind(self) -> None:
-        """Register this thread with the shared talker registry so other
-        threads can tell, via :func:`provider.get_talker`, whether the current
-        lock holder is a worker or a webhook.  Matches what
-        :meth:`ClaudeSession.__enter__` does for the claude provider.
-
-        Tracked as :attr:`_registered_talker_kind` so :meth:`__exit__` knows
-        whether to unregister.
-        """
-        if self._repo_name is None:
-            self._registered_talker_kind = None
-            return
-        kind = provider.current_thread_kind()
-        try:
-            provider.register_talker(
-                provider.SessionTalker(
-                    repo_name=self._repo_name,
-                    thread_id=threading.get_ident(),
-                    kind=kind,
-                    description="copilot-cli session turn",
-                    claude_pid=0,  # no claude subprocess — ACP runtime
-                    started_at=datetime.now(tz=timezone.utc),
-                )
-            )
-            self._registered_talker_kind = kind
-        except provider.SessionLeakError:
-            self._lock.release()
-            raise
-
     def __exit__(self, *args: object) -> None:
-        if self._drop_entry_depth() > 0:
-            # Inner exit of a :meth:`hold_for_handler` nest — only drop
-            # the reentrant RLock acquire; owner / talker / waited state
-            # stays until the outermost exit.
-            self._lock.release()
-            return
-        if self._repo_name is not None and self._registered_talker_kind is not None:
-            provider.unregister_talker(self._repo_name, threading.get_ident())
-            self._registered_talker_kind = None
-        with self._owner_lock:
-            self._owner = None
-        self._oracle_on_release()
-        self._lock.release()
-        if getattr(self._thread_state, "waited", False):
-            with self._preempt_condition:
-                self._pending_preempts -= 1
-                if self._pending_preempts == 0:
-                    self._preempt_condition.notify_all()
-            self._thread_state.waited = False
+        """Release the session lock.  Unregisters the :class:`provider.SessionTalker`
+        before releasing so no other thread can race in and see a stale talker entry.
+        """
+        depth = self._drop_entry_depth()
+        if depth == 0:
+            if self._repo_name is not None:
+                provider.unregister_talker(self._repo_name, threading.get_ident())
+            self._fsm_release()
 
     def _prompt_locked(
         self,

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -296,10 +296,6 @@ class PromptSession(Protocol):
         """Report whether the most recent turn was cancelled by preemption."""
         ...
 
-    def wait_for_pending_preempt(self, timeout: float = 30.0) -> bool:
-        """Wait for any queued preemption work to drain before retrying a turn."""
-        ...
-
     def switch_model(self, model: ProviderModel) -> None:
         """Switch the live session to *model* in-place without kill, respawn,
         or session-state loss."""

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -575,10 +575,6 @@ class OwnedSession:
     - ``self._fire_worker_cancel()`` — method that aborts whatever turn the
       current lock-holder's provider subprocess is running
 
-    Subclasses that still maintain a provider-specific :class:`threading.RLock`
-    for reentrant access continue to use :meth:`_oracle_on_acquire` and
-    :meth:`_oracle_on_release` as backward-compatible wrappers until they
-    migrate to :meth:`_fsm_acquire_worker` / :meth:`_fsm_acquire_handler`.
     """
 
     _reentry_tls: threading.local
@@ -617,64 +613,6 @@ class OwnedSession:
         depth = self._reentry_tls.depth - 1
         self._reentry_tls.depth = depth
         return depth
-
-    def _oracle_on_acquire(self, kind: str) -> None:
-        """Assert the session-lock FSM accepts an outermost acquire.
-
-        Called by subclasses from ``__enter__`` when the entry depth
-        transitions 0 → 1.  *kind* is ``"worker"`` for the background
-        worker thread or ``"webhook"`` for a webhook handler holding the
-        session via :meth:`hold_for_handler`.
-
-        Crashes with theorem name ``no_dual_ownership`` if the model
-        rejects the event — i.e. the session is already owned and a
-        second acquire arrived without an intervening release.
-
-        Updates :attr:`_fsm_state` under :attr:`_fsm_lock` so this
-        method is safe to mix with :meth:`_fsm_acquire_worker`,
-        :meth:`_fsm_acquire_handler`, and :meth:`_fsm_release` from
-        concurrent threads.
-        """
-        ev = _FsmWorkerAcquire() if kind == "worker" else _FsmHandlerAcquire()
-        with self._fsm_lock:
-            new_state = _fsm_transition(self._fsm_state, ev)
-            if new_state is None:
-                raise RuntimeError(
-                    f"session-lock FSM oracle: no_dual_ownership violated — "
-                    f"{type(ev).__name__} rejected in state "
-                    f"{type(self._fsm_state).__name__}"
-                )
-            self._fsm_state = new_state
-
-    def _oracle_on_release(self) -> None:
-        """Assert the session-lock FSM accepts the outermost release.
-
-        Called by subclasses from ``__exit__`` when the entry depth
-        transitions 1 → 0.  Derives the release event from the current
-        FSM state so the caller does not need to track the holder kind
-        separately: :class:`~fido.rocq.transition.OwnedByWorker` →
-        ``WorkerRelease``, anything else → ``HandlerRelease``.
-
-        Crashes with theorem name ``release_only_by_owner`` if the
-        model rejects the event — i.e. the session is not owned by the
-        releasing role (cross-release or spurious release from Free).
-
-        Updates :attr:`_fsm_state` under :attr:`_fsm_lock`.
-        """
-        with self._fsm_lock:
-            ev = (
-                _FsmWorkerRelease()
-                if isinstance(self._fsm_state, _FsmOwnedByWorker)
-                else _FsmHandlerRelease()
-            )
-            new_state = _fsm_transition(self._fsm_state, ev)
-            if new_state is None:
-                raise RuntimeError(
-                    f"session-lock FSM oracle: release_only_by_owner violated — "
-                    f"{type(ev).__name__} rejected in state "
-                    f"{type(self._fsm_state).__name__}"
-                )
-            self._fsm_state = new_state
 
     def _fsm_acquire_worker(self) -> None:
         """Block until the worker can acquire the session.
@@ -773,16 +711,6 @@ class OwnedSession:
         with their provider-specific cancel mechanism."""
         raise NotImplementedError  # pragma: no cover — abstract hook
 
-    def _signal_pending_preempt(self) -> None:
-        """Signal that a webhook caller is queued for the lock so workers
-        contending for the same lock yield (#983).  Distinct from
-        :meth:`_fire_worker_cancel`, which only fires when there is an
-        active worker to interrupt — this signal also covers the case
-        where the current holder is itself a webhook and a second webhook
-        is queueing behind it.  Subclasses with priority-aware locking
-        override; default is a no-op for backends that don't need it."""
-        return
-
     def preempt_worker(self) -> bool:
         """Fire the cancel signal synchronously if a worker currently holds
         the session.
@@ -827,8 +755,8 @@ class OwnedSession:
         Webhook handlers wrap their entire body in this so the worker
         can't acquire the lock between individual turns (triage → reply
         → reaction) and stall the reply behind a long worker turn (#658).
-        Inner ``with session:`` / ``session.prompt`` calls re-acquire the
-        RLock and skip the first-enter setup via the reentrance counter.
+        Inner ``with session:`` / ``session.prompt`` calls re-enter via the
+        reentrance counter and skip the FSM acquire.
 
         When *preempt_worker* is true, fires the caller's
         :meth:`_fire_worker_cancel` once upfront (via
@@ -849,11 +777,6 @@ class OwnedSession:
                     self._repo_name,
                 )
             else:
-                # No worker to cancel (holder is another webhook, or no
-                # one).  Still signal pending preempt so worker threads
-                # contending for the same lock yield to this webhook
-                # (#983 — webhook→webhook handoff has to skip the worker).
-                self._signal_pending_preempt()
                 log.info(
                     "hold_for_handler: queuing behind %s holder (tid=%d, repo=%s)",
                     current_kind or "none",

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -23,6 +23,7 @@ from typing import Literal, Protocol, TypeAlias
 from fido.rocq.transition import Free as _FsmFree
 from fido.rocq.transition import HandlerAcquire as _FsmHandlerAcquire
 from fido.rocq.transition import HandlerRelease as _FsmHandlerRelease
+from fido.rocq.transition import OwnedByHandler as _FsmOwnedByHandler
 from fido.rocq.transition import OwnedByWorker as _FsmOwnedByWorker
 from fido.rocq.transition import State as _FsmState
 from fido.rocq.transition import WorkerAcquire as _FsmWorkerAcquire
@@ -555,37 +556,57 @@ def current_repo_session() -> PromptSession:
 class OwnedSession:
     """Base class for :class:`~fido.claude.ClaudeSession` and
     :class:`~fido.copilotcli.CopilotCLISession` providing the shared
-    reentrance counter and :meth:`hold_for_handler` context manager
-    (fix for #658).
+    reentrance counter, FSM-driven lock coordination, and the
+    :meth:`hold_for_handler` context manager (fix for #658).
 
-    Subclasses own their own lock (must be a :class:`threading.RLock` so
-    nested acquires by the same thread are free) and implement the
-    session-specific first-enter / last-exit work in their own ``__enter__``
-    and ``__exit__``.  This base only handles the per-thread depth
-    bookkeeping and the shared ``hold_for_handler`` wrapper so the two
-    providers don't drift apart.
+    The FSM extracted from ``models/session_lock.v`` is the **authoritative**
+    lock coordinator.  :attr:`_fsm_state` is the single source of truth for
+    which role currently holds the session.  :meth:`_fsm_acquire_worker`,
+    :meth:`_fsm_acquire_handler`, and :meth:`_fsm_release` are the
+    provider-neutral acquire/release primitives; subclasses call them at the
+    outermost entry/exit boundary (depth 0 → 1 and 1 → 0).
 
-    Required subclass attributes:
+    Handler threads have priority over the worker: :meth:`_fsm_acquire_worker`
+    yields to any handler registered in :attr:`_handler_queue`, even when the
+    state is :class:`~fido.rocq.transition.Free`.  Handler-on-handler ordering
+    is FIFO — the queue preserves the order in which handlers called
+    :meth:`_fsm_acquire_handler`.
 
-    - ``self._lock`` — :class:`threading.RLock`
+    Subclasses must set:
+
     - ``self._repo_name`` — ``str | None`` (fed to
       :func:`try_preempt_worker` for the preempt decision)
     - ``self._fire_worker_cancel()`` — method that aborts whatever turn the
       current lock-holder's provider subprocess is running
+
+    Subclasses that still maintain a provider-specific :class:`threading.RLock`
+    for reentrant access continue to use :meth:`_oracle_on_acquire` and
+    :meth:`_oracle_on_release` as backward-compatible wrappers until they
+    migrate to :meth:`_fsm_acquire_worker` / :meth:`_fsm_acquire_handler`.
     """
 
     _reentry_tls: threading.local
     _repo_name: str | None
-    _oracle_state: _FsmState
+    _fsm_lock: threading.Lock
+    _fsm_cond: threading.Condition
+    _fsm_state: _FsmState
+    _handler_queue: list[threading.Event]
 
     def _init_handler_reentry(self) -> None:
         """Subclasses call this from their ``__init__`` to set up the
-        thread-local reentrance counter and the session-lock FSM oracle.
+        thread-local reentrance counter and the FSM-driven lock coordinator.
         Separate method (not ``__init__``) so the base doesn't compete
         with the subclass constructor signature."""
         self._reentry_tls = threading.local()
-        # Oracle initial state: nobody holds the session lock.
-        self._oracle_state: _FsmState = _FsmFree()
+        # Authoritative FSM state — which role holds the session.
+        # Protected by _fsm_lock; threads wait on _fsm_cond for state changes.
+        self._fsm_lock = threading.Lock()
+        self._fsm_cond = threading.Condition(self._fsm_lock)
+        self._fsm_state: _FsmState = _FsmFree()
+        # FIFO queue of threading.Event waiters for handler threads that could
+        # not acquire immediately.  _fsm_release pops from the front and sets
+        # the event to hand ownership to the next handler.
+        self._handler_queue: list[threading.Event] = []
 
     def _bump_entry_depth(self) -> int:
         """Increment and return the new per-thread entry depth (1 at
@@ -602,7 +623,7 @@ class OwnedSession:
         return depth
 
     def _oracle_on_acquire(self, kind: str) -> None:
-        """Assert the session-lock FSM oracle accepts an outermost acquire.
+        """Assert the session-lock FSM accepts an outermost acquire.
 
         Called by subclasses from ``__enter__`` when the entry depth
         transitions 0 → 1.  *kind* is ``"worker"`` for the background
@@ -613,48 +634,143 @@ class OwnedSession:
         rejects the event — i.e. the session is already owned and a
         second acquire arrived without an intervening release.
 
-        The session RLock is held by the caller, so the oracle state
-        update is implicitly serialized.
+        Updates :attr:`_fsm_state` under :attr:`_fsm_lock` so this
+        method is safe to mix with :meth:`_fsm_acquire_worker`,
+        :meth:`_fsm_acquire_handler`, and :meth:`_fsm_release` from
+        concurrent threads.
         """
         ev = _FsmWorkerAcquire() if kind == "worker" else _FsmHandlerAcquire()
-        new_state = _fsm_transition(self._oracle_state, ev)
-        if new_state is None:
-            raise RuntimeError(
-                f"session-lock FSM oracle: no_dual_ownership violated — "
-                f"{type(ev).__name__} rejected in state "
-                f"{type(self._oracle_state).__name__}"
-            )
-        self._oracle_state = new_state
+        with self._fsm_lock:
+            new_state = _fsm_transition(self._fsm_state, ev)
+            if new_state is None:
+                raise RuntimeError(
+                    f"session-lock FSM oracle: no_dual_ownership violated — "
+                    f"{type(ev).__name__} rejected in state "
+                    f"{type(self._fsm_state).__name__}"
+                )
+            self._fsm_state = new_state
 
     def _oracle_on_release(self) -> None:
-        """Assert the session-lock FSM oracle accepts the outermost release.
+        """Assert the session-lock FSM accepts the outermost release.
 
         Called by subclasses from ``__exit__`` when the entry depth
         transitions 1 → 0.  Derives the release event from the current
         FSM state so the caller does not need to track the holder kind
-        separately: :class:`_FsmOwnedByWorker` → ``WorkerRelease``,
-        anything else → ``HandlerRelease``.
+        separately: :class:`~fido.rocq.transition.OwnedByWorker` →
+        ``WorkerRelease``, anything else → ``HandlerRelease``.
 
         Crashes with theorem name ``release_only_by_owner`` if the
         model rejects the event — i.e. the session is not owned by the
         releasing role (cross-release or spurious release from Free).
 
-        The session RLock is held by the caller, so the oracle state
-        update is implicitly serialized.
+        Updates :attr:`_fsm_state` under :attr:`_fsm_lock`.
         """
-        ev = (
-            _FsmWorkerRelease()
-            if isinstance(self._oracle_state, _FsmOwnedByWorker)
-            else _FsmHandlerRelease()
-        )
-        new_state = _fsm_transition(self._oracle_state, ev)
-        if new_state is None:
-            raise RuntimeError(
-                f"session-lock FSM oracle: release_only_by_owner violated — "
-                f"{type(ev).__name__} rejected in state "
-                f"{type(self._oracle_state).__name__}"
+        with self._fsm_lock:
+            ev = (
+                _FsmWorkerRelease()
+                if isinstance(self._fsm_state, _FsmOwnedByWorker)
+                else _FsmHandlerRelease()
             )
-        self._oracle_state = new_state
+            new_state = _fsm_transition(self._fsm_state, ev)
+            if new_state is None:
+                raise RuntimeError(
+                    f"session-lock FSM oracle: release_only_by_owner violated — "
+                    f"{type(ev).__name__} rejected in state "
+                    f"{type(self._fsm_state).__name__}"
+                )
+            self._fsm_state = new_state
+
+    def _fsm_acquire_worker(self) -> None:
+        """Block until the worker can acquire the session.
+
+        Waits on :attr:`_fsm_cond` until :attr:`_fsm_state` is
+        :class:`~fido.rocq.transition.Free` **and** :attr:`_handler_queue`
+        is empty.  Handlers have priority: if any handler is registered in
+        the queue, the worker yields even when the state is ``Free``.
+
+        Fires the ``WorkerAcquire`` FSM transition and updates
+        :attr:`_fsm_state` atomically under :attr:`_fsm_lock`.
+        """
+        with self._fsm_cond:
+            while True:
+                if isinstance(self._fsm_state, _FsmFree) and not self._handler_queue:
+                    new = _fsm_transition(self._fsm_state, _FsmWorkerAcquire())
+                    assert new is not None  # Free + WorkerAcquire always succeeds
+                    self._fsm_state = new  # → OwnedByWorker
+                    return
+                self._fsm_cond.wait()
+
+    def _fsm_acquire_handler(self) -> None:
+        """Block until the handler can acquire the session.
+
+        If :attr:`_fsm_state` is :class:`~fido.rocq.transition.Free`, fires
+        ``HandlerAcquire`` and returns immediately.  Otherwise appends a
+        :class:`threading.Event` waiter to the back of :attr:`_handler_queue`
+        and blocks until :meth:`_fsm_release` transfers ownership here.
+
+        Handler-on-handler ordering is FIFO: the queue preserves the order in
+        which handlers registered.  When the worker is the current holder,
+        the caller must have already fired :meth:`_fire_worker_cancel` so the
+        worker drains its turn and calls :meth:`_fsm_release`.
+        """
+        waiter: threading.Event | None = None
+        with self._fsm_cond:
+            new = _fsm_transition(self._fsm_state, _FsmHandlerAcquire())
+            if new is not None:
+                # Free → OwnedByHandler: immediate acquisition.
+                self._fsm_state = new
+                return
+            # Occupied; register in the FIFO handler queue and wait.
+            waiter = threading.Event()
+            self._handler_queue.append(waiter)
+        # Wait outside the Condition so _fsm_release can acquire _fsm_lock.
+        assert waiter is not None
+        waiter.wait()
+        # _fsm_release set _fsm_state = OwnedByHandler and signalled us.
+        # Nothing more to do here.
+
+    def _fsm_release(self) -> None:
+        """Release the FSM lock.
+
+        Fires the appropriate release event for the current holder
+        (``WorkerRelease`` from
+        :class:`~fido.rocq.transition.OwnedByWorker`,
+        ``HandlerRelease`` from
+        :class:`~fido.rocq.transition.OwnedByHandler`).
+
+        If :attr:`_handler_queue` is non-empty, ownership transfers directly
+        to the next queued handler: the handler's :class:`threading.Event` is
+        set and :attr:`_fsm_state` becomes
+        :class:`~fido.rocq.transition.OwnedByHandler`.  Otherwise
+        :attr:`_fsm_state` transitions to :class:`~fido.rocq.transition.Free`
+        and worker threads waiting on :attr:`_fsm_cond` are notified.
+
+        Raises :class:`RuntimeError` if the current state is
+        :class:`~fido.rocq.transition.Free` (``release_only_by_owner``
+        invariant).
+        """
+        with self._fsm_cond:
+            ev = (
+                _FsmWorkerRelease()
+                if isinstance(self._fsm_state, _FsmOwnedByWorker)
+                else _FsmHandlerRelease()
+            )
+            new_state = _fsm_transition(self._fsm_state, ev)
+            if new_state is None:
+                raise RuntimeError(
+                    f"session-lock FSM: release_only_by_owner violated — "
+                    f"{type(ev).__name__} rejected in state "
+                    f"{type(self._fsm_state).__name__}"
+                )
+            if self._handler_queue:
+                # Hand ownership directly to the next waiting handler.
+                waiter = self._handler_queue.pop(0)
+                self._fsm_state = _FsmOwnedByHandler()
+                waiter.set()
+            else:
+                # No handlers waiting; transition to Free and wake workers.
+                self._fsm_state = new_state  # → Free
+                self._fsm_cond.notify_all()
 
     def _fire_worker_cancel(self) -> None:
         """Abort the current lock-holder's turn.  Subclasses override

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -20,15 +20,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Literal, Protocol, TypeAlias
 
-from fido.rocq.transition import Free as _FsmFree
-from fido.rocq.transition import HandlerAcquire as _FsmHandlerAcquire
-from fido.rocq.transition import HandlerRelease as _FsmHandlerRelease
-from fido.rocq.transition import OwnedByHandler as _FsmOwnedByHandler
-from fido.rocq.transition import OwnedByWorker as _FsmOwnedByWorker
-from fido.rocq.transition import State as _FsmState
-from fido.rocq.transition import WorkerAcquire as _FsmWorkerAcquire
-from fido.rocq.transition import WorkerRelease as _FsmWorkerRelease
-from fido.rocq.transition import transition as _fsm_transition
+import fido.rocq.transition as fsm
 
 log = logging.getLogger(__name__)
 
@@ -581,7 +573,7 @@ class OwnedSession:
     _repo_name: str | None
     _fsm_lock: threading.Lock
     _fsm_cond: threading.Condition
-    _fsm_state: _FsmState
+    _fsm_state: fsm.State
     _handler_queue: list[threading.Event]
 
     def _init_handler_reentry(self) -> None:
@@ -594,7 +586,7 @@ class OwnedSession:
         # Protected by _fsm_lock; threads wait on _fsm_cond for state changes.
         self._fsm_lock = threading.Lock()
         self._fsm_cond = threading.Condition(self._fsm_lock)
-        self._fsm_state: _FsmState = _FsmFree()
+        self._fsm_state: fsm.State = fsm.Free()
         # FIFO queue of threading.Event waiters for handler threads that could
         # not acquire immediately.  _fsm_release pops from the front and sets
         # the event to hand ownership to the next handler.
@@ -627,8 +619,8 @@ class OwnedSession:
         """
         with self._fsm_cond:
             while True:
-                if isinstance(self._fsm_state, _FsmFree) and not self._handler_queue:
-                    new = _fsm_transition(self._fsm_state, _FsmWorkerAcquire())
+                if isinstance(self._fsm_state, fsm.Free) and not self._handler_queue:
+                    new = fsm.transition(self._fsm_state, fsm.WorkerAcquire())
                     assert new is not None  # Free + WorkerAcquire always succeeds
                     self._fsm_state = new  # → OwnedByWorker
                     return
@@ -649,7 +641,7 @@ class OwnedSession:
         """
         waiter: threading.Event | None = None
         with self._fsm_cond:
-            new = _fsm_transition(self._fsm_state, _FsmHandlerAcquire())
+            new = fsm.transition(self._fsm_state, fsm.HandlerAcquire())
             if new is not None:
                 # Free → OwnedByHandler: immediate acquisition.
                 self._fsm_state = new
@@ -685,11 +677,11 @@ class OwnedSession:
         """
         with self._fsm_cond:
             ev = (
-                _FsmWorkerRelease()
-                if isinstance(self._fsm_state, _FsmOwnedByWorker)
-                else _FsmHandlerRelease()
+                fsm.WorkerRelease()
+                if isinstance(self._fsm_state, fsm.OwnedByWorker)
+                else fsm.HandlerRelease()
             )
-            new_state = _fsm_transition(self._fsm_state, ev)
+            new_state = fsm.transition(self._fsm_state, ev)
             if new_state is None:
                 raise RuntimeError(
                     f"session-lock FSM: release_only_by_owner violated — "
@@ -699,7 +691,7 @@ class OwnedSession:
             if self._handler_queue:
                 # Hand ownership directly to the next waiting handler.
                 waiter = self._handler_queue.pop(0)
-                self._fsm_state = _FsmOwnedByHandler()
+                self._fsm_state = fsm.OwnedByHandler()
                 waiter.set()
             else:
                 # No handlers waiting; transition to Free and wake workers.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1311,9 +1311,9 @@ class TestClaudeSessionIterEvents:
     def test_cancel_still_cleared_at_iter_events_start(self, tmp_path: Path) -> None:
         """Cancel is always unconditionally cleared at the start of iter_events.
 
-        The FSM's FIFO handler queue ensures the next holder's turn starts clean
-        without needing a separate _preempt_pending gate.  A stale cancel set
-        before this holder acquired the lock is cleared here so the new turn runs.
+        The FSM's FIFO handler queue ensures the next holder's turn starts clean.
+        A stale cancel set before this holder acquired the lock is cleared here
+        so the new turn runs.
         """
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
@@ -1810,9 +1810,7 @@ class TestClaudeSessionLock:
     def test_hold_for_handler_enters_fsm_owned_by_handler(self, tmp_path: Path) -> None:
         """hold_for_handler acquires FSM ownership as handler.
 
-        Verifies the FSM state reflects OwnedByHandler while the
-        hold is active, replacing the old _signal_pending_preempt /
-        _preempt_pending assertions.
+        Verifies the FSM state reflects OwnedByHandler while the hold is active.
         """
         from fido.rocq.transition import OwnedByHandler
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1167,19 +1167,6 @@ class TestClaudeSessionLogEvent:
         assert "claude error: kaboom" in caplog.text
 
 
-class TestClaudeSessionWaitForPendingPreempt:
-    def test_always_returns_false(self, tmp_path: Path) -> None:
-        """wait_for_pending_preempt is a compatibility stub that always returns False.
-
-        The FSM handles priority ordering; polling is gone.
-        """
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        assert session.wait_for_pending_preempt(timeout=0.01) is False
-        assert session.wait_for_pending_preempt(timeout=1.0) is False
-        session.stop()
-
-
 class TestClaudeSessionIterEvents:
     def test_yields_parsed_json_events(self, tmp_path: Path) -> None:
         import json as _json

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1000,7 +1000,6 @@ class TestClaudeSessionDrainToBoundary:
         session._selector = MagicMock(return_value=([], [], []))
         # Set cancel immediately — simulates preempt arriving during drain
         session._cancel.set()
-        session._preempt_pending.set()
         with patch.object(session, "recover") as mock_recover:
             session._drain_to_boundary(deadline=5.0)
         # _in_turn stays True so send() knows not to write
@@ -1169,37 +1168,16 @@ class TestClaudeSessionLogEvent:
 
 
 class TestClaudeSessionWaitForPendingPreempt:
-    def test_returns_false_when_not_pending(self, tmp_path: Path) -> None:
+    def test_always_returns_false(self, tmp_path: Path) -> None:
+        """wait_for_pending_preempt is a compatibility stub that always returns False.
+
+        The FSM handles priority ordering; polling is gone.
+        """
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        # _preempt_pending starts cleared
         assert session.wait_for_pending_preempt(timeout=0.01) is False
-
-    def test_returns_true_when_pending_clears(self, tmp_path: Path) -> None:
-        import threading as _t
-
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session._preempt_pending.set()
-
-        # Clear the event from another thread after a brief delay.
-        def _clearer() -> None:
-            import time as _time
-
-            _time.sleep(0.02)
-            session._preempt_pending.clear()
-
-        t = _t.Thread(target=_clearer)
-        t.start()
-        assert session.wait_for_pending_preempt(timeout=1.0) is True
-        t.join()
-
-    def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        session._preempt_pending.set()
-        # Never cleared → waits out the deadline.
-        assert session.wait_for_pending_preempt(timeout=0.05) is False
+        assert session.wait_for_pending_preempt(timeout=1.0) is False
+        session.stop()
 
 
 class TestClaudeSessionIterEvents:
@@ -1333,7 +1311,6 @@ class TestClaudeSessionIterEvents:
         proc = _make_session_proc(lines)
         session = _make_session(tmp_path, proc)
         session._cancel.set()
-        session._preempt_pending.set()
         events = list(session.iter_events())
         # Both events were consumed — pipe is clean for the next holder.
         assert len(events) == 2
@@ -1344,29 +1321,18 @@ class TestClaudeSessionIterEvents:
         assert session._in_turn is False
         session.stop()
 
-    def test_cancel_still_cleared_when_no_preempt_pending(self, tmp_path: Path) -> None:
-        """Symmetry check: with no preempter waiting, a stale cancel from a
-        previous turn is still cleared at iter_events' start (preserves the
-        existing ``test_cancel_cleared_at_iter_events_start`` semantics)."""
+    def test_cancel_still_cleared_at_iter_events_start(self, tmp_path: Path) -> None:
+        """Cancel is always unconditionally cleared at the start of iter_events.
+
+        The FSM's FIFO handler queue ensures the next holder's turn starts clean
+        without needing a separate _preempt_pending gate.  A stale cancel set
+        before this holder acquired the lock is cleared here so the new turn runs.
+        """
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         session._cancel.set()
-        # _preempt_pending intentionally NOT set — cancel is stale.
         list(session.iter_events())
         assert not session._cancel.is_set()
-        session.stop()
-
-    def test_fire_worker_cancel_sets_preempt_pending(self, tmp_path: Path) -> None:
-        """Regression guard for #786: the cancel fire path must mark a
-        preempter as pending, not just set the cancel event, so the race
-        with iter_events' clear is defused."""
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        assert not session._cancel.is_set()
-        assert not session._preempt_pending.is_set()
-        session._fire_worker_cancel()
-        assert session._cancel.is_set()
-        assert session._preempt_pending.is_set()
         session.stop()
 
     def test_recovers_when_cancel_drain_times_out(self, tmp_path: Path) -> None:
@@ -1851,27 +1817,18 @@ class TestClaudeSessionLock:
     def test_enter_returns_self(self, tmp_path: Path) -> None:
         session = _make_session(tmp_path, _make_session_proc([]))
         assert session.__enter__() is session
-        session._lock.release()
+        session.__exit__(None, None, None)
         session.stop()
 
-    def test_hold_for_handler_signals_pending_when_queueing_behind_webhook(
-        self, tmp_path: Path
-    ) -> None:
-        """Regression for #983: when ``hold_for_handler(preempt_worker=True)``
-        finds the current holder is itself a webhook (no worker to cancel),
-        it must still call ``_signal_pending_preempt`` to set
-        ``_preempt_pending``.  Without this signal, a worker thread
-        contending for the same lock would freely re-acquire between
-        webhook A and webhook B, breaking the webhook→webhook handoff.
+    def test_hold_for_handler_enters_fsm_owned_by_handler(self, tmp_path: Path) -> None:
+        """hold_for_handler acquires FSM ownership as handler.
 
-        Deterministic: drives ``hold_for_handler`` synchronously with
-        ``try_preempt_worker`` patched to return ``(False, "webhook")``
-        (the queueing case) and the session's ``__enter__``/``__exit__``
-        no-op'd so we don't actually contend for a lock.  Asserts:
-
-        - ``_signal_pending_preempt`` was called exactly once.
-        - ``_preempt_pending`` is set after the call.
+        Verifies the FSM state reflects OwnedByHandler while the
+        hold is active, replacing the old _signal_pending_preempt /
+        _preempt_pending assertions.
         """
+        from fido.rocq.transition import OwnedByHandler
+
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         provider.set_thread_kind("webhook")
@@ -1879,27 +1836,8 @@ class TestClaudeSessionLock:
             with patch(
                 "fido.provider.try_preempt_worker", return_value=(False, "webhook")
             ):
-                with patch.object(
-                    session,
-                    "_signal_pending_preempt",
-                    wraps=session._signal_pending_preempt,
-                ) as mock_signal:
-                    # __enter__/__exit__ no-op'd so the test doesn't depend
-                    # on real lock contention.
-                    with (
-                        patch.object(type(session), "__enter__", return_value=session),
-                        patch.object(type(session), "__exit__", return_value=False),
-                    ):
-                        with session.hold_for_handler(preempt_worker=True):
-                            pass
-                    assert mock_signal.call_count == 1, (
-                        f"_signal_pending_preempt called {mock_signal.call_count}x "
-                        "— expected 1 (hold_for_handler queueing branch must "
-                        "signal pending so workers yield, #983)"
-                    )
-                    assert session._preempt_pending.is_set(), (
-                        "_preempt_pending should be set after queueing"
-                    )
+                with session.hold_for_handler(preempt_worker=True):
+                    assert isinstance(session._fsm_state, OwnedByHandler)
         finally:
             provider.set_thread_kind(None)
             session.stop()
@@ -1952,7 +1890,7 @@ class TestClaudeSessionLock:
         session._cancel.set()
         session.__enter__()
         assert session._cancel.is_set()  # still set; iter_events() will clear it
-        session._lock.release()
+        session.__exit__(None, None, None)
         session.stop()
 
     def test_cancel_survives_lock_handoff(self, tmp_path: Path) -> None:
@@ -1965,13 +1903,11 @@ class TestClaudeSessionLock:
         session = _make_session(tmp_path, proc)
 
         cancel_set_after_exit = _threading.Event()
-        new_holder_entered = _threading.Event()
         new_holder_cancel_was_set: list[bool] = []
 
         def first_holder() -> None:
-            session._lock.acquire()
-            # Release without calling iter_events; then interrupt() sets cancel
-            session._lock.release()
+            with session:
+                pass  # Release lock, then set cancel below
             # Simulate interrupt arriving right after release
             session._cancel.set()
             cancel_set_after_exit.set()
@@ -1981,8 +1917,7 @@ class TestClaudeSessionLock:
             session.__enter__()
             # Record whether cancel is still set before iter_events clears it
             new_holder_cancel_was_set.append(session._cancel.is_set())
-            new_holder_entered.set()
-            session._lock.release()
+            session.__exit__(None, None, None)
 
         t1 = _threading.Thread(target=first_holder)
         t2 = _threading.Thread(target=second_holder)
@@ -1995,11 +1930,12 @@ class TestClaudeSessionLock:
         session.stop()
 
     def test_exit_releases_lock(self, tmp_path: Path) -> None:
+        from fido.rocq.transition import Free
+
         session = _make_session(tmp_path, _make_session_proc([]))
         session.__enter__()
         session.__exit__(None, None, None)
-        assert session._lock.acquire(blocking=False)
-        session._lock.release()
+        assert isinstance(session._fsm_state, Free)
         session.stop()
 
     def test_owner_none_when_lock_free(self, tmp_path: Path) -> None:
@@ -2140,9 +2076,10 @@ class TestClaudeSessionLock:
         )
         with pytest.raises(SessionLeakError):
             session.__enter__()
-        # Session lock must be released so we don't deadlock future callers.
-        assert session._lock.acquire(blocking=False)
-        session._lock.release()
+        # FSM must be Free so future callers aren't deadlocked.
+        from fido.rocq.transition import Free
+
+        assert isinstance(session._fsm_state, Free)
         with provider._talkers_lock:
             provider._talkers.clear()
         session.stop()
@@ -2150,10 +2087,12 @@ class TestClaudeSessionLock:
     def test_context_manager_blocks_second_thread(self, tmp_path: Path) -> None:
         import threading as _threading
 
+        from fido.rocq.transition import Free, OwnedByWorker
+
         session = _make_session(tmp_path, _make_session_proc([]))
         entered = _threading.Event()
         done_checking = _threading.Event()
-        could_not_acquire = _threading.Event()
+        fsm_was_owned: list[bool] = []
 
         def first_thread() -> None:
             with session:
@@ -2162,11 +2101,8 @@ class TestClaudeSessionLock:
 
         def second_thread() -> None:
             entered.wait()  # t1 holds the lock and is blocked on done_checking
-            acquired = session._lock.acquire(blocking=False)
-            if not acquired:
-                could_not_acquire.set()
-            else:
-                session._lock.release()
+            # FSM state should be OwnedByWorker — not Free — while t1 holds it.
+            fsm_was_owned.append(isinstance(session._fsm_state, OwnedByWorker))
             done_checking.set()  # let t1 exit the context manager
 
         t1 = _threading.Thread(target=first_thread)
@@ -2175,7 +2111,8 @@ class TestClaudeSessionLock:
         t2.start()
         t1.join(timeout=2)
         t2.join(timeout=2)
-        assert could_not_acquire.is_set()
+        assert fsm_was_owned == [True]
+        assert isinstance(session._fsm_state, Free)
         session.stop()
 
 
@@ -2360,11 +2297,10 @@ class TestClaudeSessionInterrupt:
         cancel_seen: list[bool] = []
 
         def holder() -> None:
-            session._lock.acquire()
-            lock_held.set()
-            release.wait()
-            cancel_seen.append(session._cancel.is_set())
-            session._lock.release()
+            with session:
+                lock_held.set()
+                release.wait()
+                cancel_seen.append(session._cancel.is_set())
 
         t_holder = _threading.Thread(target=holder)
         t_holder.start()
@@ -2392,10 +2328,9 @@ class TestClaudeSessionInterrupt:
         release = _threading.Event()
 
         def holder() -> None:
-            session._lock.acquire()
-            acquired.set()
-            release.wait()
-            session._lock.release()
+            with session:
+                acquired.set()
+                release.wait()
 
         t_holder = _threading.Thread(target=holder)
         t_holder.start()
@@ -2404,7 +2339,7 @@ class TestClaudeSessionInterrupt:
         t_interrupt = _threading.Thread(target=lambda: session.interrupt("msg"))
         t_interrupt.start()
 
-        # interrupt is blocked on lock.acquire(); stdin must not be written yet
+        # interrupt is blocked on FSM acquire; stdin must not be written yet
         assert proc.stdin.write.call_count == 0
 
         release.set()
@@ -2653,7 +2588,6 @@ class TestClaudeClientSessionAttachment:
         session.prompt.side_effect = prompt
         client = ClaudeClient(session=session)
         assert client.run_turn("fetch", retry_on_preempt=True) == "done"
-        session.wait_for_pending_preempt.assert_called_once_with()
 
 
 class TestClaudeOAuthState:

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -340,8 +340,8 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     provider.set_thread_kind("webhook")
     try:
         with session.hold_for_handler(preempt_worker=True):
-            # _fire_worker_cancel set _cancel + _preempt_pending.  Handler's
-            # first prompt() must actually send and read its own response.
+            # _fire_worker_cancel set _cancel.  Handler's first prompt() must
+            # actually send and read its own response.
             result = session.prompt("triage this please")
     finally:
         provider.set_thread_kind(None)

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -41,6 +41,8 @@ def _setup_session(tmp_path: Path, repo: str = "owner/repo") -> ClaudeSession:
 
 
 def test_hold_acquires_lock_and_registers_talker(tmp_path: Path) -> None:
+    from fido.rocq.transition import Free, OwnedByHandler
+
     session = _setup_session(tmp_path)
     provider.set_thread_kind("webhook")
     try:
@@ -48,10 +50,10 @@ def test_hold_acquires_lock_and_registers_talker(tmp_path: Path) -> None:
             talker = provider.get_talker("owner/repo")
             assert talker is not None
             assert talker.kind == "webhook"
-            assert session._lock._is_owned()  # type: ignore[attr-defined]
-        # After exit, talker unregistered, lock released.
+            assert isinstance(session._fsm_state, OwnedByHandler)
+        # After exit, talker unregistered, FSM back to Free.
         assert provider.get_talker("owner/repo") is None
-        assert not session._lock._is_owned()  # type: ignore[attr-defined]
+        assert isinstance(session._fsm_state, Free)
     finally:
         provider.set_thread_kind(None)
         session.stop()
@@ -309,8 +311,8 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     the new design the prior turn's boundary is drained inside iter_events
     itself (cancel no longer breaks early), so by the time the handler
     enters the stream is clean.  The cancel signal that was set for the
-    previous holder is consumed at the start of the handler's iter_events
-    via the existing ``_preempt_pending`` gate."""
+    previous holder is unconditionally cleared at the start of the handler's
+    iter_events call."""
     session = _setup_session(tmp_path)
 
     def fake_talker(kind: str) -> SessionTalker:
@@ -353,54 +355,19 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
     assert result == "triage-reply", f"handler prompt got wrong result — got {result!r}"
 
 
-def test_inner_prompt_preserves_queued_webhook_pending_flag(
-    tmp_path: Path,
-) -> None:
-    """Regression for #1017: _preempt_pending set by a second webhook
-    queuing behind an active hold_for_handler must survive inner prompt()
-    calls made by the holder.
-
-    The old code had two paths that unconditionally cleared _preempt_pending:
-    (1) reentrant __enter__ inside hold_for_handler, and (2) prompt()'s
-    finally block.  Either path wiped the second webhook's pending signal
-    while the first webhook's hold was still active.  When the hold released,
-    the worker saw _preempt_pending=False and won the lock over the queued
-    webhook, leaving the reviewer's comment unanswered."""
-    session = _setup_session(tmp_path)
-    provider.set_thread_kind("webhook")
-    try:
-        with session.hold_for_handler(preempt_worker=False):
-            # Simulate webhook B queuing behind this hold_for_handler.
-            session._signal_pending_preempt()
-            assert session._preempt_pending.is_set(), "sanity: pending set"
-            # Inner prompt() — old code cleared _preempt_pending here.
-            session.prompt("triage this issue")
-            # After returning, pending must still be set so the worker
-            # blocks in __enter__'s wait_for and yields to webhook B.
-            assert session._preempt_pending.is_set(), (
-                "_preempt_pending cleared by inner prompt() inside "
-                "hold_for_handler — worker would win lock over queued "
-                "webhook (bug #1017 regression)"
-            )
-    finally:
-        provider.set_thread_kind(None)
-        session.stop()
-
-
 def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
     tmp_path: Path,
 ) -> None:
-    """Regression for #1017 (threading): webhook B queuing behind an active
-    hold_for_handler acquires the lock before the worker, even after the
-    holder makes inner prompt() calls while B's pending signal is live.
+    """Handler (webhook B) queuing behind an active hold_for_handler acquires
+    before the worker, even after the holder makes inner prompt() calls.
 
-    Timing is made deterministic by ensuring _preempt_pending is already set
-    before the worker thread enters __enter__ — this forces the worker into
-    _preempt_cond.wait_for() rather than racing directly on _lock.acquire()."""
+    The FSM handler queue provides structural priority: workers yield to any
+    queued handler regardless of when they entered _fsm_acquire_worker.
+    """
     session = _setup_session(tmp_path)
 
     webhook_a_holding = threading.Event()
-    webhook_b_queued = threading.Event()
+    webhook_b_queuing = threading.Event()
     order: list[str] = []
     errors: list[Exception] = []
 
@@ -409,11 +376,13 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
         try:
             with session.hold_for_handler(preempt_worker=False):
                 webhook_a_holding.set()
-                # Wait until webhook B has queued (pending set) before
-                # making the inner prompt — this is the ordering that
-                # triggers the bug: B sets pending, then A's inner prompt
-                # used to clear it.
-                assert webhook_b_queued.wait(timeout=2.0), "webhook_b_queued timed out"
+                assert webhook_b_queuing.wait(timeout=2.0), (
+                    "webhook_b_queuing timed out"
+                )
+                # Small sleep to let webhook_b actually block in _fsm_acquire_handler
+                import time as _time
+
+                _time.sleep(0.05)
                 session.prompt("inner turn from webhook A")
         except Exception as exc:
             errors.append(exc)
@@ -424,11 +393,8 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
         provider.set_thread_kind("webhook")
         try:
             assert webhook_a_holding.wait(timeout=2.0), "webhook_a_holding timed out"
-            # Queue behind webhook A — sets _preempt_pending so the worker
-            # yields priority.
-            session._signal_pending_preempt()
-            webhook_b_queued.set()
-            # Now block waiting for webhook A's hold to release.
+            webhook_b_queuing.set()
+            # Queue behind webhook A via the FSM handler queue.
             with session:
                 order.append("webhook_b")
         except Exception as exc:
@@ -439,10 +405,10 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
     def worker() -> None:
         provider.set_thread_kind("worker")
         try:
-            # Wait until B has set _preempt_pending before entering __enter__.
-            # This guarantees the worker hits _preempt_cond.wait_for() instead
-            # of racing on _lock.acquire() — making the handoff deterministic.
-            assert webhook_b_queued.wait(timeout=2.0), "webhook_b_queued timed out"
+            assert webhook_b_queuing.wait(timeout=2.0), "webhook_b_queuing timed out"
+            import time as _time
+
+            _time.sleep(0.05)  # give webhook_b time to actually queue
             with session:
                 order.append("worker")
         except Exception as exc:
@@ -461,14 +427,12 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
     t_a.join(timeout=5.0)
     t_b.join(timeout=5.0)
     t_w.join(timeout=5.0)
+    session.stop()
 
     assert not errors, f"thread errors: {errors}"
-    assert len(order) == 2, f"not all threads completed: {order}"
-    assert order[0] == "webhook_b", (
-        f"worker won lock over queued webhook — got order {order} "
-        f"(bug #1017 regression)"
+    assert order == ["webhook_b", "worker"], (
+        f"webhook_b should acquire before worker — got {order}"
     )
-    session.stop()
 
 
 def test_hold_reraises_leak_error_and_releases_lock(
@@ -494,10 +458,10 @@ def test_hold_reraises_leak_error_and_releases_lock(
         with pytest.raises(provider.SessionLeakError):
             with session.hold_for_handler():
                 pass  # should not reach here
-        # Lock must be released so other threads can acquire.
-        acquired = session._lock.acquire(blocking=False)
-        assert acquired
-        session._lock.release()
+        # FSM must be Free so other threads aren't deadlocked.
+        from fido.rocq.transition import Free
+
+        assert isinstance(session._fsm_state, Free)
     finally:
         provider.set_thread_kind(None)
         provider.unregister_talker("owner/repo", 111_111)

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1030,13 +1030,10 @@ class TestCopilotCLISession:
                     break
                 time.sleep(0.01)
             assert runtime.cancel_calls == ["sess-created"]
-            assert session.wait_for_pending_preempt(timeout=0.01) is False
             session.__exit__(None, None, None)
             acquired.wait(timeout=1.0)
-            assert session.wait_for_pending_preempt(timeout=0.01) is False
             release.set()
             thread.join(timeout=1.0)
-            assert session.wait_for_pending_preempt(timeout=1.0) is False
         finally:
             provider.set_thread_kind(None)
 
@@ -1396,7 +1393,6 @@ class TestCopilotCLIClient:
         session.prompt.side_effect = prompt
         client = CopilotCLIClient(session=session)
         assert client.run_turn("fetch", retry_on_preempt=True) == "done"
-        session.wait_for_pending_preempt.assert_called_once_with()
 
     def test_run_turn_recovers_and_retries_after_connection_loss(self) -> None:
         session = MagicMock()

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1036,7 +1036,7 @@ class TestCopilotCLISession:
             assert session.wait_for_pending_preempt(timeout=0.01) is False
             release.set()
             thread.join(timeout=1.0)
-            assert session.wait_for_pending_preempt(timeout=1.0) is True
+            assert session.wait_for_pending_preempt(timeout=1.0) is False
         finally:
             provider.set_thread_kind(None)
 
@@ -1114,10 +1114,12 @@ class TestCopilotCLISession:
         try:
             with pytest.raises(provider.SessionLeakError):
                 session.__enter__()
-            # Lock must have been released on the leak path so a later
+            # FSM must be back to Free on the leak path so a later
             # legitimate enter (after the squatter clears) still works.
-            assert session._lock.acquire(blocking=False) is True
-            session._lock.release()
+            from fido.rocq.transition import Free as _FsmFree
+
+            with session._fsm_lock:
+                assert isinstance(session._fsm_state, _FsmFree)
         finally:
             provider.unregister_talker("owner/repo", 999_999)
 

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1113,10 +1113,10 @@ class TestCopilotCLISession:
                 session.__enter__()
             # FSM must be back to Free on the leak path so a later
             # legitimate enter (after the squatter clears) still works.
-            from fido.rocq.transition import Free as _FsmFree
+            from fido.rocq.transition import Free
 
             with session._fsm_lock:
-                assert isinstance(session._fsm_state, _FsmFree)
+                assert isinstance(session._fsm_state, Free)
         finally:
             provider.unregister_talker("owner/repo", 999_999)
 

--- a/tests/test_session_lock_oracle.py
+++ b/tests/test_session_lock_oracle.py
@@ -1,17 +1,10 @@
-"""Tests for the session-lock FSM coordination in OwnedSession.
+"""Tests for the FSM-driven lock coordination in OwnedSession.
 
-Covers two layers:
-
-1. **Oracle methods** (``_oracle_on_acquire`` / ``_oracle_on_release``) —
-   backward-compatible wrappers used by subclasses that still maintain a
-   provider-specific RLock.  They update ``_fsm_state`` under ``_fsm_lock``
-   and crash with a theorem name when the FSM rejects the event.
-
-2. **FSM coordination methods** (``_fsm_acquire_worker`` /
-   ``_fsm_acquire_handler`` / ``_fsm_release``) — the authoritative
-   lock coordinator extracted from ``models/session_lock.v``.  Workers
-   block until Free with no queued handlers; handlers block until Free
-   (FIFO queue for handler-on-handler ordering).
+Covers the FSM coordination methods (``_fsm_acquire_worker`` /
+``_fsm_acquire_handler`` / ``_fsm_release``) — the authoritative
+lock coordinator extracted from ``models/session_lock.v``.  Workers
+block until Free with no queued handlers; handlers block until Free
+(FIFO queue for handler-on-handler ordering).
 
 Proved theorems being guarded:
   ``no_dual_ownership``     — acquisition rejected when session already owned
@@ -56,108 +49,6 @@ def test_fsm_state_starts_free() -> None:
     """FSM initialises to Free — nobody holds the session."""
     session = _FakeSession()
     assert isinstance(session._fsm_state, Free)
-
-
-# ---------------------------------------------------------------------------
-# Oracle: happy-path worker acquire → release
-# ---------------------------------------------------------------------------
-
-
-def test_oracle_worker_acquire_and_release() -> None:
-    """Worker acquire transitions Free → OwnedByWorker; release → Free."""
-    session = _FakeSession()
-
-    session._oracle_on_acquire("worker")
-    assert isinstance(session._fsm_state, OwnedByWorker)
-
-    session._oracle_on_release()
-    assert isinstance(session._fsm_state, Free)
-
-
-# ---------------------------------------------------------------------------
-# Oracle: happy-path handler (webhook) acquire → release
-# ---------------------------------------------------------------------------
-
-
-def test_oracle_handler_acquire_and_release() -> None:
-    """Handler acquire transitions Free → OwnedByHandler; release → Free."""
-    session = _FakeSession()
-
-    session._oracle_on_acquire("webhook")
-    assert isinstance(session._fsm_state, OwnedByHandler)
-
-    session._oracle_on_release()
-    assert isinstance(session._fsm_state, Free)
-
-
-# ---------------------------------------------------------------------------
-# Oracle theorem: no_dual_ownership
-# ---------------------------------------------------------------------------
-
-
-def test_oracle_no_dual_ownership_worker_then_worker() -> None:
-    """Worker cannot acquire an already worker-owned session.
-
-    Proved by ``no_dual_ownership`` in ``models/session_lock.v``.
-    """
-    session = _FakeSession()
-    session._oracle_on_acquire("worker")  # Free → OwnedByWorker
-
-    with pytest.raises(RuntimeError, match="no_dual_ownership"):
-        session._oracle_on_acquire("worker")  # OwnedByWorker + WorkerAcquire → None
-
-
-def test_oracle_no_dual_ownership_worker_then_handler() -> None:
-    """Handler cannot acquire a worker-owned session without preemption.
-
-    Proved by ``no_dual_ownership`` in ``models/session_lock.v``.
-    """
-    session = _FakeSession()
-    session._oracle_on_acquire("worker")  # Free → OwnedByWorker
-
-    with pytest.raises(RuntimeError, match="no_dual_ownership"):
-        session._oracle_on_acquire("webhook")  # OwnedByWorker + HandlerAcquire → None
-
-
-def test_oracle_no_dual_ownership_handler_then_worker() -> None:
-    """Worker cannot acquire a handler-owned session.
-
-    Proved by ``no_dual_ownership`` in ``models/session_lock.v``.
-    """
-    session = _FakeSession()
-    session._oracle_on_acquire("webhook")  # Free → OwnedByHandler
-
-    with pytest.raises(RuntimeError, match="no_dual_ownership"):
-        session._oracle_on_acquire("worker")  # OwnedByHandler + WorkerAcquire → None
-
-
-def test_oracle_no_dual_ownership_handler_then_handler() -> None:
-    """Handler cannot acquire an already handler-owned session.
-
-    Proved by ``no_dual_ownership`` in ``models/session_lock.v``.
-    """
-    session = _FakeSession()
-    session._oracle_on_acquire("webhook")  # Free → OwnedByHandler
-
-    with pytest.raises(RuntimeError, match="no_dual_ownership"):
-        session._oracle_on_acquire("webhook")  # OwnedByHandler + HandlerAcquire → None
-
-
-# ---------------------------------------------------------------------------
-# Oracle theorem: release_only_by_owner
-# ---------------------------------------------------------------------------
-
-
-def test_oracle_release_only_by_owner_spurious_from_free() -> None:
-    """Releasing from Free is rejected (spurious release).
-
-    Covered by the Free cases in ``release_only_by_owner``.
-    """
-    session = _FakeSession()
-    # State is Free; _oracle_on_release() will send HandlerRelease because
-    # Free is not OwnedByWorker — transition(Free, HandlerRelease) = None.
-    with pytest.raises(RuntimeError, match="release_only_by_owner"):
-        session._oracle_on_release()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_lock_oracle.py
+++ b/tests/test_session_lock_oracle.py
@@ -1,15 +1,24 @@
-"""Tests for the session-lock FSM oracle wired into OwnedSession.
+"""Tests for the session-lock FSM coordination in OwnedSession.
 
-The oracle runs the Rocq-extracted ``transition`` function from
-``src/fido/rocq/transition.py`` on every outermost lock
-acquire and release.  Divergence from the proved model raises a
-``RuntimeError`` naming the violated theorem so bugs are immediately
-identifiable from the traceback.
+Covers two layers:
+
+1. **Oracle methods** (``_oracle_on_acquire`` / ``_oracle_on_release``) —
+   backward-compatible wrappers used by subclasses that still maintain a
+   provider-specific RLock.  They update ``_fsm_state`` under ``_fsm_lock``
+   and crash with a theorem name when the FSM rejects the event.
+
+2. **FSM coordination methods** (``_fsm_acquire_worker`` /
+   ``_fsm_acquire_handler`` / ``_fsm_release``) — the authoritative
+   lock coordinator extracted from ``models/session_lock.v``.  Workers
+   block until Free with no queued handlers; handlers block until Free
+   (FIFO queue for handler-on-handler ordering).
 
 Proved theorems being guarded:
   ``no_dual_ownership``     — acquisition rejected when session already owned
   ``release_only_by_owner`` — release rejected when wrong owner or Free
 """
+
+import threading
 
 import pytest
 
@@ -22,9 +31,9 @@ from fido.rocq.transition import (
 
 
 class _FakeSession(OwnedSession):
-    """Minimal OwnedSession subclass for unit-testing oracle behaviour.
+    """Minimal OwnedSession subclass for unit-testing coordination behaviour.
 
-    The oracle logic lives entirely in the base class; this stub exists
+    The FSM logic lives entirely in the base class; this stub exists
     only to satisfy the class hierarchy and the ``_repo_name`` attribute
     that ``OwnedSession`` requires.  No real lock or subprocess needed.
     """
@@ -43,14 +52,14 @@ class _FakeSession(OwnedSession):
 # ---------------------------------------------------------------------------
 
 
-def test_oracle_starts_free() -> None:
-    """Oracle initialises to Free — nobody holds the session."""
+def test_fsm_state_starts_free() -> None:
+    """FSM initialises to Free — nobody holds the session."""
     session = _FakeSession()
-    assert isinstance(session._oracle_state, Free)
+    assert isinstance(session._fsm_state, Free)
 
 
 # ---------------------------------------------------------------------------
-# Happy-path: worker acquire → release
+# Oracle: happy-path worker acquire → release
 # ---------------------------------------------------------------------------
 
 
@@ -59,14 +68,14 @@ def test_oracle_worker_acquire_and_release() -> None:
     session = _FakeSession()
 
     session._oracle_on_acquire("worker")
-    assert isinstance(session._oracle_state, OwnedByWorker)
+    assert isinstance(session._fsm_state, OwnedByWorker)
 
     session._oracle_on_release()
-    assert isinstance(session._oracle_state, Free)
+    assert isinstance(session._fsm_state, Free)
 
 
 # ---------------------------------------------------------------------------
-# Happy-path: handler (webhook) acquire → release
+# Oracle: happy-path handler (webhook) acquire → release
 # ---------------------------------------------------------------------------
 
 
@@ -75,14 +84,14 @@ def test_oracle_handler_acquire_and_release() -> None:
     session = _FakeSession()
 
     session._oracle_on_acquire("webhook")
-    assert isinstance(session._oracle_state, OwnedByHandler)
+    assert isinstance(session._fsm_state, OwnedByHandler)
 
     session._oracle_on_release()
-    assert isinstance(session._oracle_state, Free)
+    assert isinstance(session._fsm_state, Free)
 
 
 # ---------------------------------------------------------------------------
-# Theorem: no_dual_ownership
+# Oracle theorem: no_dual_ownership
 # ---------------------------------------------------------------------------
 
 
@@ -135,7 +144,7 @@ def test_oracle_no_dual_ownership_handler_then_handler() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Theorem: release_only_by_owner
+# Oracle theorem: release_only_by_owner
 # ---------------------------------------------------------------------------
 
 
@@ -149,3 +158,210 @@ def test_oracle_release_only_by_owner_spurious_from_free() -> None:
     # Free is not OwnedByWorker — transition(Free, HandlerRelease) = None.
     with pytest.raises(RuntimeError, match="release_only_by_owner"):
         session._oracle_on_release()
+
+
+# ---------------------------------------------------------------------------
+# FSM coordination: _fsm_acquire_worker
+# ---------------------------------------------------------------------------
+
+
+def test_fsm_acquire_worker_immediate_when_free() -> None:
+    """Worker acquires immediately when state is Free and queue is empty."""
+    session = _FakeSession()
+    session._fsm_acquire_worker()
+    assert isinstance(session._fsm_state, OwnedByWorker)
+
+
+def test_fsm_acquire_worker_waits_until_handler_releases() -> None:
+    """Worker blocks while OwnedByHandler and acquires after release."""
+    session = _FakeSession()
+    session._fsm_acquire_handler()  # handler holds; worker will block
+
+    worker_acquired = threading.Event()
+
+    def worker() -> None:
+        session._fsm_acquire_worker()
+        worker_acquired.set()
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    # Worker must be waiting — it cannot acquire while handler holds.
+    assert not worker_acquired.wait(timeout=0.1), "worker should still be waiting"
+    # Release the handler → worker can now acquire.
+    session._fsm_release()
+    assert worker_acquired.wait(timeout=5.0), "worker never acquired"
+    assert isinstance(session._fsm_state, OwnedByWorker)
+    session._fsm_release()
+    t.join(timeout=1.0)
+
+
+def test_fsm_acquire_worker_yields_to_queued_handler() -> None:
+    """Worker waits even when Free if a handler is in the queue.
+
+    Uses direct queue injection so the ordering is deterministic.
+    """
+    session = _FakeSession()
+    # Inject a fake handler waiter directly so we control the queue.
+    fake_handler_waiter = threading.Event()
+    with session._fsm_cond:
+        session._handler_queue.append(fake_handler_waiter)
+
+    # Worker should not be able to acquire (queue non-empty even though Free).
+    worker_acquired = threading.Event()
+
+    def worker() -> None:
+        session._fsm_acquire_worker()
+        worker_acquired.set()
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    assert not worker_acquired.wait(timeout=0.1), (
+        "worker should yield to queued handler"
+    )
+
+    # Remove the fake handler from the queue and notify so the worker re-checks.
+    with session._fsm_cond:
+        session._handler_queue.clear()
+        session._fsm_cond.notify_all()
+
+    assert worker_acquired.wait(timeout=5.0), (
+        "worker never acquired after queue drained"
+    )
+    assert isinstance(session._fsm_state, OwnedByWorker)
+    session._fsm_release()
+    t.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# FSM coordination: _fsm_acquire_handler
+# ---------------------------------------------------------------------------
+
+
+def test_fsm_acquire_handler_immediate_when_free() -> None:
+    """Handler acquires immediately when state is Free."""
+    session = _FakeSession()
+    session._fsm_acquire_handler()
+    assert isinstance(session._fsm_state, OwnedByHandler)
+
+
+def test_fsm_acquire_handler_queues_and_acquires_after_release() -> None:
+    """Handler queues when occupied and acquires when the holder releases."""
+    session = _FakeSession()
+    session._fsm_acquire_handler()  # first handler holds
+
+    acquired = threading.Event()
+
+    def handler2() -> None:
+        session._fsm_acquire_handler()  # will queue
+        acquired.set()
+
+    t = threading.Thread(target=handler2, daemon=True)
+    t.start()
+    # Second handler must not acquire until first releases.
+    assert not acquired.wait(timeout=0.1), "handler2 should be queued"
+    # Release first handler → handler2 acquires.
+    session._fsm_release()
+    assert acquired.wait(timeout=5.0), "handler2 never acquired"
+    assert isinstance(session._fsm_state, OwnedByHandler)
+    session._fsm_release()
+    t.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# FSM coordination: _fsm_release
+# ---------------------------------------------------------------------------
+
+
+def test_fsm_release_worker_no_queue() -> None:
+    """Worker release with no queued handlers transitions to Free."""
+    session = _FakeSession()
+    session._fsm_acquire_worker()
+    session._fsm_release()
+    assert isinstance(session._fsm_state, Free)
+
+
+def test_fsm_release_handler_no_queue() -> None:
+    """Handler release with no queued handlers transitions to Free."""
+    session = _FakeSession()
+    session._fsm_acquire_handler()
+    session._fsm_release()
+    assert isinstance(session._fsm_state, Free)
+
+
+def test_fsm_release_from_free_raises() -> None:
+    """Releasing from Free raises RuntimeError (release_only_by_owner)."""
+    session = _FakeSession()
+    with pytest.raises(RuntimeError, match="release_only_by_owner"):
+        session._fsm_release()
+
+
+def test_fsm_release_handler_with_queued_handler_skips_free() -> None:
+    """Handler release with a queued handler hands ownership directly."""
+    session = _FakeSession()
+    session._fsm_acquire_handler()  # first handler holds
+
+    fake_waiter = threading.Event()
+    with session._fsm_cond:
+        session._handler_queue.append(fake_waiter)
+
+    session._fsm_release()  # should hand to fake_waiter, not go through Free
+
+    assert fake_waiter.is_set(), "queued handler was not signalled"
+    assert isinstance(session._fsm_state, OwnedByHandler)
+    # Clean up by releasing the "fake" handler's ownership.
+    session._fsm_release()
+    assert isinstance(session._fsm_state, Free)
+
+
+def test_fsm_release_worker_with_queued_handler() -> None:
+    """Worker release with a queued handler hands ownership to the handler."""
+    session = _FakeSession()
+    session._fsm_acquire_worker()
+
+    fake_waiter = threading.Event()
+    with session._fsm_cond:
+        session._handler_queue.append(fake_waiter)
+
+    session._fsm_release()
+
+    assert fake_waiter.is_set()
+    assert isinstance(session._fsm_state, OwnedByHandler)
+    session._fsm_release()
+    assert isinstance(session._fsm_state, Free)
+
+
+# ---------------------------------------------------------------------------
+# FSM coordination: handler FIFO ordering
+# ---------------------------------------------------------------------------
+
+
+def test_fsm_handler_fifo_order() -> None:
+    """Handlers acquire in the order they registered (FIFO).
+
+    Uses direct queue injection so the ordering is deterministic and
+    not subject to OS thread scheduling races.
+    """
+    session = _FakeSession()
+    session._fsm_acquire_handler()  # initial holder
+
+    # Inject two waiters in known order.
+    waiter1 = threading.Event()
+    waiter2 = threading.Event()
+    with session._fsm_cond:
+        session._handler_queue.append(waiter1)
+        session._handler_queue.append(waiter2)
+
+    # First release hands to waiter1.
+    session._fsm_release()
+    assert waiter1.is_set()
+    assert not waiter2.is_set()
+    assert isinstance(session._fsm_state, OwnedByHandler)
+
+    # Second release (waiter1's handler done) hands to waiter2.
+    session._fsm_release()
+    assert waiter2.is_set()
+    assert isinstance(session._fsm_state, OwnedByHandler)
+
+    # Final release clears to Free.
+    session._fsm_release()
+    assert isinstance(session._fsm_state, Free)


### PR DESCRIPTION
Fixes #1022.

Flip the extracted FSM in session_lock.v from a side-band oracle to the authoritative lock coordinator in OwnedSession, then migrate both ClaudeSession and CopilotCLISession to delegate to it — deleting the ad-hoc Event/Condition/sleep-poll primitives that caused the #984→#1017→#1019 race cascade. Validates that the proved invariants (no_dual_ownership, release_only_by_owner) eliminate the entire class of coordination bugs by construction.

---

## Work queue

<!-- WORK_QUEUE_START -->
- [ ] [Replace individual FSM type imports with a module-level alias](https://github.com/FidoCanCode/home/pull/1031#discussion_r3143185328) **→ next** <!-- type:thread -->

<details><summary>Completed (5)</summary>

- [x] Remove wait_for_pending_preempt from Protocol and worker callers <!-- type:spec -->
- [x] Final sweep: remove dead code, stale comments, unused imports <!-- type:spec -->
- [x] Rewrite CopilotCLISession lock to delegate to OwnedSession FSM <!-- type:spec -->
- [x] Rewrite ClaudeSession lock to delegate to OwnedSession FSM <!-- type:spec -->
- [x] Promote FSM to authoritative lock coordinator in OwnedSession <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->