### PR TITLE
Instrument FSM lock + register SIGUSR1 thread-dump (relates #1032)

### DIFF
--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -617,13 +617,30 @@ class OwnedSession:
         Fires the ``WorkerAcquire`` FSM transition and updates
         :attr:`_fsm_state` atomically under :attr:`_fsm_lock`.
         """
+        tid = threading.get_ident()
         with self._fsm_cond:
+            waited = False
             while True:
                 if isinstance(self._fsm_state, fsm.Free) and not self._handler_queue:
                     new = fsm.transition(self._fsm_state, fsm.WorkerAcquire())
                     assert new is not None  # Free + WorkerAcquire always succeeds
                     self._fsm_state = new  # → OwnedByWorker
+                    log.info(
+                        "fsm[%s]: WorkerAcquire (tid=%d, waited=%s, queue=%d)",
+                        self._repo_name or "?",
+                        tid,
+                        "yes" if waited else "no",
+                        len(self._handler_queue),
+                    )
                     return
+                log.info(
+                    "fsm[%s]: WorkerAcquire blocked — state=%s, queue=%d (tid=%d)",
+                    self._repo_name or "?",
+                    type(self._fsm_state).__name__,
+                    len(self._handler_queue),
+                    tid,
+                )
+                waited = True
                 self._fsm_cond.wait()
 
     def _fsm_acquire_handler(self) -> None:
@@ -639,21 +656,38 @@ class OwnedSession:
         the caller must have already fired :meth:`_fire_worker_cancel` so the
         worker drains its turn and calls :meth:`_fsm_release`.
         """
+        tid = threading.get_ident()
         waiter: threading.Event | None = None
         with self._fsm_cond:
             new = fsm.transition(self._fsm_state, fsm.HandlerAcquire())
             if new is not None:
                 # Free → OwnedByHandler: immediate acquisition.
                 self._fsm_state = new
+                log.info(
+                    "fsm[%s]: HandlerAcquire immediate (tid=%d)",
+                    self._repo_name or "?",
+                    tid,
+                )
                 return
             # Occupied; register in the FIFO handler queue and wait.
             waiter = threading.Event()
             self._handler_queue.append(waiter)
+            log.info(
+                "fsm[%s]: HandlerAcquire queued — state=%s, position=%d (tid=%d)",
+                self._repo_name or "?",
+                type(self._fsm_state).__name__,
+                len(self._handler_queue),
+                tid,
+            )
         # Wait outside the Condition so _fsm_release can acquire _fsm_lock.
         assert waiter is not None
         waiter.wait()
         # _fsm_release set _fsm_state = OwnedByHandler and signalled us.
-        # Nothing more to do here.
+        log.info(
+            "fsm[%s]: HandlerAcquire dequeued (tid=%d)",
+            self._repo_name or "?",
+            tid,
+        )
 
     def _fsm_release(self) -> None:
         """Release the FSM lock.
@@ -675,6 +709,7 @@ class OwnedSession:
         :class:`~fido.rocq.transition.Free` (``release_only_by_owner``
         invariant).
         """
+        tid = threading.get_ident()
         with self._fsm_cond:
             ev = (
                 fsm.WorkerRelease()
@@ -693,10 +728,23 @@ class OwnedSession:
                 waiter = self._handler_queue.pop(0)
                 self._fsm_state = fsm.OwnedByHandler()
                 waiter.set()
+                log.info(
+                    "fsm[%s]: %s → OwnedByHandler (tid=%d, queue=%d remaining)",
+                    self._repo_name or "?",
+                    type(ev).__name__,
+                    tid,
+                    len(self._handler_queue),
+                )
             else:
                 # No handlers waiting; transition to Free and wake workers.
                 self._fsm_state = new_state  # → Free
                 self._fsm_cond.notify_all()
+                log.info(
+                    "fsm[%s]: %s → Free (tid=%d)",
+                    self._repo_name or "?",
+                    type(ev).__name__,
+                    tid,
+                )
 
     def _fire_worker_cancel(self) -> None:
         """Abort the current lock-holder's turn.  Subclasses override

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1,4 +1,5 @@
 import dataclasses
+import faulthandler
 import fcntl
 import hashlib
 import hmac
@@ -1357,6 +1358,14 @@ def run(
 
     _signal(signal.SIGTERM, _shutdown_handler)
     _signal(signal.SIGINT, _shutdown_handler)
+
+    # Diagnostic hook: ``kill -USR1 <fido-pid>`` (or ``docker kill --signal=
+    # SIGUSR1 fido``) dumps every thread's Python stack to stderr — captured
+    # in fido.log via the launcher's redirect.  Lets us see exactly which
+    # line a hung worker thread is parked on without needing pdb attached.
+    # The :class:`faulthandler` module's signal handler is async-signal-safe
+    # and compatible with the free-threaded (3.14t) runtime.
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
 
     repos_str = ", ".join(f"{name}={rc.work_dir}" for name, rc in config.repos.items())
     log.info("fido listening on :%d — repos: %s", config.port, repos_str)


### PR DESCRIPTION
## Summary

Diagnostic hooks for debugging the FSM-lock hang patterns we hit twice on PR #1031's first restarts (#1032). Production-safe: pure logging + one signal handler. **No FSM behaviour change.**

## What

### 1. \`faulthandler.register(SIGUSR1)\` at server startup

Send SIGUSR1 to fido and every Python thread's current stack dumps to stderr → \`~/log/fido.log\`. Compatible with 3.14t free-threaded runtime.

\`\`\`
docker kill --signal=SIGUSR1 fido
\`\`\`

Then \`tail ~/log/fido.log\` shows tracebacks for every thread, including which line of \`_fsm_acquire_worker\`/\`_fsm_acquire_handler\` a hung worker is parked on. No pdb, no live attach.

### 2. FSM acquire/release/queue log lines in \`OwnedSession\`

Every state transition logs \`(repo, event_name, holder_tid, queue_size)\`:

- \`_fsm_acquire_worker\`: \`WorkerAcquire\` on success; \`WorkerAcquire blocked — state=X, queue=N\` on yield (distinguishes Free-but-queued vs occupied).
- \`_fsm_acquire_handler\`: immediate vs queued (with position).
- \`_fsm_release\`: \`X → OwnedByHandler (queue=N remaining)\` or \`X → Free\`.

All \`log.info\` so the trace is captured at default level. Reading \`fido.log\` linearly will show the exact handoff sequence leading to the hang.

## Why not just revert #1031?

Reverting wholesale loses the architecture win. The hang is reproducible — restart and it hangs again at the same spot. Better to land instrumentation, capture one dump, fix the specific bug, keep the FSM.

## Test plan

- [x] \`./fido ci\` green (no behaviour change; existing FSM tests still pass)
- [ ] After merge: restart fido, wait for home worker to hang, \`docker kill --signal=SIGUSR1 fido\`, capture trace + thread dump, file the specific FSM bug as a follow-up to #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)