### PR TITLE
Bug: PR body work-queue diverged from tasks.json after a DEFER webhook fired (regression — task moved back to pending) (closes #1013)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -858,6 +858,15 @@ def _write_pr_description(
     # Preserve the existing rest section or build the work-queue from scratch.
     if divider in existing_body:
         rest = existing_body.split(divider, 1)[1]
+        # Re-apply the work queue from task_list so a stale PR body snapshot
+        # fetched before the Opus call cannot clobber a sync_tasks update that
+        # landed while Opus was running (fixes #1013).
+        queue = tasks._format_work_queue(  # pyright: ignore[reportPrivateUsage]
+            task_list
+        )
+        rest = tasks._apply_queue_to_body(  # pyright: ignore[reportPrivateUsage]
+            rest, queue
+        )
     else:
         pending = [t for t in task_list if t.get("status") == TaskStatus.PENDING]
         next_task = _pick_next_task(task_list)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4257,11 +4257,48 @@ class TestWritePrDescription:
             "## Work queue\n\n<!-- WORK_QUEUE_START -->\n"
             "- [ ] do a thing\n<!-- WORK_QUEUE_END -->"
         )
-        self._call(gh, existing_body=existing)
+        task_list = [
+            {"id": "1", "title": "do a thing", "status": "pending", "type": "spec"}
+        ]
+        self._call(gh, existing_body=existing, task_list=task_list)
         body = gh.edit_pr_body.call_args[0][2]
         assert "do a thing" in body
         assert "<!-- WORK_QUEUE_START -->" in body
         assert "Old description." not in body
+
+    def test_rewrite_refreshes_work_queue_from_task_list(self) -> None:
+        """Regression: stale pending task in PR body must not survive a rewrite.
+
+        Reproduces the race from #1013: PR body was fetched before the Opus
+        call with a task still showing as pending; sync_tasks then marked it
+        completed in tasks.json; the description rewrite must write the
+        current state from task_list, not the stale body snapshot.
+        """
+        gh = MagicMock()
+        # Existing body has "Rename Wev" as pending — this is the stale snapshot.
+        existing = (
+            "Some description.\n\nFixes #1.\n\n---\n\n"
+            "## Work queue\n\n<!-- WORK_QUEUE_START -->\n"
+            "- [ ] Rename Wev prefix <!-- type:thread -->\n"
+            "<!-- WORK_QUEUE_END -->"
+        )
+        # task_list reflects the true state: task is completed.
+        task_list = [
+            {
+                "id": "1",
+                "title": "Rename Wev prefix",
+                "status": "completed",
+                "type": "thread",
+            }
+        ]
+        self._call(gh, existing_body=existing, task_list=task_list)
+        body = gh.edit_pr_body.call_args[0][2]
+        # The completed task must appear in the completed section, not as pending.
+        assert "- [ ] Rename Wev prefix" not in body
+        assert "- [x] Rename Wev prefix" in body
+        # Structural markers must still be present.
+        assert "<!-- WORK_QUEUE_START -->" in body
+        assert "<!-- WORK_QUEUE_END -->" in body
 
     def test_rewrite_raises_when_no_divider(self) -> None:
         gh = MagicMock()


### PR DESCRIPTION
Fixes #1013.

Fixes a race where `_write_pr_description` preserves a stale work-queue snapshot from the PR body across a slow Opus call, overwriting a correct `sync_tasks` update that landed in between. The fix re-applies the work queue from the authoritative `task_list` parameter after splitting on the divider, so the written body always reflects current task state.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Fix _write_pr_description to re-apply work queue from task_list in preserved rest section <!-- type:spec -->
- [x] Add regression test for stale work-queue overwrite during PR description rewrite <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->