### PR TITLE
Migrate guarddog skill to journald (replaces ~/log/fido.log)

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -24,8 +24,9 @@ checks. Keep it running and sample every 2 minutes:
 ### Collect status
 Run `./fido status` from `/home/rhencke/home-runner`.
 
-Also watch `~/log/fido.log` in the same monitor session so status changes and
-fresh errors are observed together.
+Also watch fido's logs in the same monitor session so status changes and
+fresh errors are observed together. Logs go to user-mode journald, tagged
+`fido`. Live tail: `journalctl --user -t fido -f`.
 
 ### All good — report deltas only
 Compare to the previous check. Report only what changed:
@@ -48,7 +49,7 @@ sampling until the window opens or the user intervenes.
 
 Investigation steps (look, don't touch):
 - `ps aux | grep claude | grep -v grep | grep -v "claude -c"` — any processes alive?
-- inspect recent errors in `~/log/fido.log`
+- inspect recent errors in journald: `journalctl --user -t fido -p warning -S '10 minutes ago'`
 - Check if the Fido session is still producing output
 - Check git status of managed repos for unexpected state
 
@@ -85,7 +86,7 @@ cd /home/rhencke/home-runner
 ```
 
 ### Step 3: Diagnose
-- Read the last 30 lines of `~/log/fido.log` (filter out `{"type` JSON blobs)
+- Read recent fido output: `journalctl --user -t fido -n 30 -S '10 minutes ago' --no-pager` (filter `{"type` JSON blobs separately)
 - Check `tasks.json` state: `cat /home/rhencke/workspace/home/.git/fido/tasks.json`
 - Check `state.json`: `cat /home/rhencke/workspace/home/.git/fido/state.json`
 - Check git status and recent commits of managed repos


### PR DESCRIPTION
## Summary

Local launcher (\`/home/rhencke/start-fido.sh\`, not in this repo) now pipes fido's stdout/stderr through \`systemd-cat --identifier=fido\` instead of appending to \`~/log/fido.log\`. Updates the guarddog skill to read journald.

## Why

\`~/log/fido.log\` was unbounded — grew to 162k lines after a long debug session today and would have eventually filled disk. Journald handles rotation + disk-bounding automatically (~10% of disk, 4GiB cap), and adds queryability:

\`\`\`
journalctl --user -t fido -f                    # live tail
journalctl --user -t fido -p warning -S today   # warnings+errors today
journalctl --user -t fido -S '1 hour ago'       # last hour
\`\`\`

## Changes

- **Skill** (this PR): three references to \`~/log/fido.log\` swapped for the journalctl equivalents
- **Launcher** (separate, lives outside the repo): drops the \`>>\` redirect, drops \`exec\`, pipes through \`systemd-cat\`. Already updated locally; takes effect on next fresh launch of \`start-fido.sh\`.

## Test plan

- [x] systemd-cat available + user journald active on the host
- [ ] Live verification: relaunch fido after this merges, confirm \`journalctl --user -t fido -f\` shows fido output

🤖 Generated with [Claude Code](https://claude.com/claude-code)