### PR TITLE
Logging: redirect to systemd-cat inside ./fido up, drop outer pipe (closes #1036)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ right Docker buildx target, runs the command in the container, and avoids host
 | Command | Purpose |
 |---------|---------|
 | `./fido help` | Print the command list. |
-| `./fido up [args...]` | Run the webhook server in the foreground. The launcher supervises restarts, writes stdout/stderr to `~/log/fido.log`, syncs the runner clone on update exits, rebuilds the runtime image, and starts again. |
+| `./fido up [args...]` | Run the webhook server in the foreground. The launcher supervises restarts, redirects stdout/stderr to journald (`-t fido`), syncs the runner clone on update exits, rebuilds the runtime image, and starts again. |
 | `./fido down` | Gracefully stop the named server container. Normal operation is foreground `docker run --rm`, so Docker removes it after stop. |
 | `./fido ci` | Build the buildx `ci` group: format, lint, typecheck, generated typecheck, tests, and the production runtime image cache. This is what CI and pre-commit use. |
 | `./fido gen-workflows` | Regenerate `.github/workflows/ci.yml` from the buildx bake graph and Dockerfile input graph. Uses host `python3` only for the stdlib generator, not host `uv`. |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Use the root launcher to run project commands inside the buildx uv image:
 buildx bake`, loads it as `fido:local`, then runs it with Docker.
 `./fido help` lists the project commands. `./fido up` runs the Fido server,
 then supervises it in the foreground with `docker run --rm`. `./fido up`
-appends supervisor and container stdout/stderr to `~/log/fido.log`; override
-with `FIDO_LOG=...`. On update exits from the app, `./fido up` syncs the runner
+redirects stdout/stderr to journald (`-t fido`). On update exits from the app, `./fido up` syncs the runner
 clone, rebuilds the image, and starts again. It exits normally on ordinary
 shutdown signals. `./fido down` stops the named container gracefully; `--rm`
 lets Docker remove it after the stop.

--- a/fido
+++ b/fido
@@ -8,7 +8,6 @@ rocq_repl_image=${FIDO_ROCQ_REPL_IMAGE:-fido-rocq-repl:local}
 run_image=$image
 container=${FIDO_CONTAINER:-fido}
 secret=${FIDO_SECRET:-$HOME/.fido-secret}
-fido_log=${FIDO_LOG:-$HOME/log/fido.log}
 auto_update=${FIDO_AUTO_UPDATE:-1}
 prune_on_restart=${FIDO_PRUNE_ON_RESTART:-1}
 prune_keep_storage=${FIDO_BUILDKIT_KEEP_STORAGE:-24gb}
@@ -54,10 +53,8 @@ log() {
 }
 
 redirect_up_logs() {
-  mkdir -p "$(dirname "$fido_log")"
-  log INFO "redirecting up output to $fido_log"
-  exec >>"$fido_log" 2>&1
-  log INFO "up log opened"
+  log INFO "redirecting up output to journald (-t fido)"
+  exec > >(systemd-cat --identifier=fido --priority=info) 2>&1
 }
 
 buildx_driver() {

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -538,9 +538,10 @@ class TestFidoLauncher:
         assert removed_flag not in script
         assert "supervise_up()" in script
         assert "--rm" in script
-        assert "fido_log=${FIDO_LOG:-$HOME/log/fido.log}" in script
+        assert "fido_log=${FIDO_LOG:-$HOME/log/fido.log}" not in script
         assert "redirect_up_logs()" in script
-        assert 'exec >>"$fido_log" 2>&1' in script
+        assert "systemd-cat --identifier=fido --priority=info" in script
+        assert "exec > >(systemd-cat" in script
         assert "prune_on_restart=${FIDO_PRUNE_ON_RESTART:-1}" in script
         assert "prune_keep_storage=${FIDO_BUILDKIT_KEEP_STORAGE:-24gb}" in script
         assert "prune_restart_buildkit_async()" in script


### PR DESCRIPTION
Fixes #1036.

Moves the journald redirect from the outer `start-fido.sh` pipe into `./fido up`'s `redirect_up_logs`, replacing the file-based `exec >>$fido_log` with `exec > >(systemd-cat --identifier=fido)`. Drops the `fido_log` variable and `FIDO_LOG` env, and updates docs and tests to match.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Update CLAUDE.md and README.md to reflect journald logging <!-- type:spec -->
- [x] Replace redirect_up_logs file redirect with systemd-cat process substitution <!-- type:spec -->
- [x] Update test_build_wrapper assertions for systemd-cat logging <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->