### PR TITLE
Lift run_turn into SessionBackedAgent

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -28,7 +28,6 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
-    TurnSessionMode,
     model_name,
 )
 from fido.rocq import claude_session as stream_fsm
@@ -1688,35 +1687,6 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
 
     def _json_parse_candidates(self, raw: str) -> tuple[str, ...]:
         return (raw, *(m.group() for m in re.finditer(r"\{.*?\}", raw, re.DOTALL)))
-
-    def run_turn(
-        self,
-        content: str,
-        *,
-        model: ProviderModel | None = None,
-        system_prompt: str | None = None,
-        retry_on_preempt: bool = False,
-        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
-    ) -> str:
-        session = self._resolve_turn_session(
-            model=model,
-            session_mode=session_mode,
-        )
-        attempt = 0
-        while True:
-            result = self._prompt_with_recovery(
-                session,
-                content,
-                model=model,
-                system_prompt=system_prompt,
-            )
-            if (
-                not retry_on_preempt
-                or getattr(session, "last_turn_cancelled", False) is not True
-            ):
-                return result
-            attempt += 1
-            log.info("ClaudeClient.run_turn: preempted mid-flight — retry %d", attempt)
 
     def generate_status(
         self,

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -41,7 +41,6 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderModel,
     ReasoningEffort,
-    TurnSessionMode,
     coerce_provider_model,
 )
 from fido.session_agent import SessionBackedAgent
@@ -1216,37 +1215,6 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
 
     def _dead_prompt_error_message(self) -> str:
         return "Copilot CLI session died during prompt"
-
-    def run_turn(
-        self,
-        content: str,
-        *,
-        model: ProviderModel | None = None,
-        system_prompt: str | None = None,
-        retry_on_preempt: bool = False,
-        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
-    ) -> str:
-        session = self._resolve_turn_session(
-            model=model,
-            session_mode=session_mode,
-        )
-        attempt = 0
-        while True:
-            result = self._prompt_with_recovery(
-                session,
-                content,
-                model=model,
-                system_prompt=system_prompt,
-            )
-            if (
-                not retry_on_preempt
-                or getattr(session, "last_turn_cancelled", False) is not True
-            ):
-                return result
-            attempt += 1
-            log.info(
-                "CopilotCLIClient.run_turn: preempted mid-flight — retry %d", attempt
-            )
 
     def print_prompt_from_file(
         self,

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -186,8 +186,29 @@ class SessionBackedAgent:
         retry_on_preempt: bool = False,
         session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
-        del content, model, system_prompt, retry_on_preempt, session_mode
-        raise NotImplementedError
+        session = self._resolve_turn_session(
+            model=model,
+            session_mode=session_mode,
+        )
+        attempt = 0
+        while True:
+            result = self._prompt_with_recovery(
+                session,
+                content,
+                model=model,
+                system_prompt=system_prompt,
+            )
+            if (
+                not retry_on_preempt
+                or getattr(session, "last_turn_cancelled", False) is not True
+            ):
+                return result
+            attempt += 1
+            log.info(
+                "%s.run_turn: preempted mid-flight — retry %d",
+                type(self).__name__,
+                attempt,
+            )
 
     def _spawn_owned_session(
         self, model: ProviderModel, *, session_id: str | None = None

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -36,42 +36,9 @@ class _FakeAgent(SessionBackedAgent):
         self._last_session_id = session_id
         return self._session_factory(model)
 
-    def run_turn(
-        self,
-        content: str,
-        *,
-        model: ProviderModel | None = None,
-        system_prompt: str | None = None,
-        retry_on_preempt: bool = False,
-        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
-    ) -> str:
-        del retry_on_preempt
-        session = self._resolve_turn_session(model=model, session_mode=session_mode)
-        return session.prompt(content, model=model, system_prompt=system_prompt)
-
-
-class _RecoveringFakeAgent(_FakeAgent):
-    def run_turn(
-        self,
-        content: str,
-        *,
-        model: ProviderModel | None = None,
-        system_prompt: str | None = None,
-        retry_on_preempt: bool = False,
-        session_mode: TurnSessionMode = TurnSessionMode.REUSE,
-    ) -> str:
-        del retry_on_preempt
-        session = self._resolve_turn_session(model=model, session_mode=session_mode)
-        return self._prompt_with_recovery(
-            session,
-            content,
-            model=model,
-            system_prompt=system_prompt,
-        )
-
 
 class TestSessionBackedAgent:
-    def test_base_abstract_methods_raise(self) -> None:
+    def test_base_spawn_owned_session_raises(self) -> None:
         agent = SessionBackedAgent(
             session_fn=lambda: None,
             session_system_file=None,
@@ -79,8 +46,6 @@ class TestSessionBackedAgent:
             repo_name=None,
             session=None,
         )
-        with pytest.raises(NotImplementedError):
-            agent.run_turn("hi")
         with pytest.raises(NotImplementedError):
             agent._spawn_owned_session(ProviderModel("model"))
 
@@ -250,7 +215,7 @@ class TestSessionBackedAgent:
         session = MagicMock()
         session.prompt.side_effect = [BrokenPipeError("boom"), "done"]
         session.is_alive.return_value = False
-        agent = _RecoveringFakeAgent(session=session)
+        agent = _FakeAgent(session=session)
         assert agent.run_turn("hi", model=agent.voice_model) == "done"
         session.recover.assert_called_once_with()
 
@@ -259,7 +224,22 @@ class TestSessionBackedAgent:
         session.prompt.side_effect = ["", ""]
         session.last_turn_cancelled = False
         session.is_alive.side_effect = [False, False]
-        agent = _RecoveringFakeAgent(session=session)
+        agent = _FakeAgent(session=session)
         with pytest.raises(RuntimeError, match="session died during prompt"):
             agent.run_turn("hi", model=agent.voice_model)
         session.recover.assert_called_once_with()
+
+    def test_run_turn_retries_after_preempt(self) -> None:
+        session = MagicMock()
+        session.last_turn_cancelled = False
+        prompts = iter(["partial", "done"])
+
+        def prompt(*args: object, **kwargs: object) -> str:
+            result = next(prompts)
+            session.last_turn_cancelled = result == "partial"
+            return result
+
+        session.prompt.side_effect = prompt
+        agent = _FakeAgent(session=session)
+        assert agent.run_turn("hi", retry_on_preempt=True) == "done"
+        assert session.prompt.call_count == 2


### PR DESCRIPTION
## Summary

- move the shared session-backed `run_turn` loop into `SessionBackedAgent`
- remove duplicate Claude and Copilot client overrides
- update session-agent tests to cover inherited preempt retry and recovery behavior

Fixes #1055

## Verification

- `./fido tests tests/test_session_agent.py tests/test_claude.py tests/test_copilotcli.py -q`
- `./fido ci`