### PR TITLE
Add Codex provider scaffolding

### DIFF
--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -68,15 +68,18 @@ PROVIDER_PALETTES: dict[ProviderID, ProviderPalette] = {
         dim_bg=(40, 20, 60),  # obvious plum tint, still dark
         bright_fg=(180, 130, 255),  # Copilot-purple, legible on dark terminals
     ),
+    ProviderID.CODEX: ProviderPalette(
+        dim_bg=(8, 54, 43),  # dark teal-green tint, still readable under white
+        bright_fg=(72, 220, 160),  # Codex-green, legible on dark terminals
+    ),
 }
 
 
 def palette_for(provider: ProviderID) -> ProviderPalette | None:
     """Return the :class:`ProviderPalette` for *provider*, or ``None``.
 
-    Returns ``None`` for providers without a registered palette (e.g.
-    ``CODEX`` today).  Callers treat ``None`` as "render without
-    provider-specific color", not as an error.
+    Callers treat ``None`` as "render without provider-specific color", not
+    as an error, so new providers can be wired before their visual identity.
     """
     return PROVIDER_PALETTES.get(provider)
 
@@ -88,7 +91,7 @@ class TurnSessionMode(StrEnum):
     FRESH = "fresh"
 
 
-ReasoningEffort: TypeAlias = Literal["low", "medium", "high"]
+ReasoningEffort: TypeAlias = Literal["low", "medium", "high", "xhigh"]
 ReasoningEffortSpec: TypeAlias = ReasoningEffort | tuple[ReasoningEffort, ...] | None
 
 

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -33,6 +33,8 @@ class DefaultProviderFactory:
                     api = ClaudeAPI()
                 case ProviderID.COPILOT_CLI:
                     api = CopilotCLIAPI()
+                case ProviderID.CODEX:
+                    raise NotImplementedError("codex provider not yet wired")
                 case _:
                     raise ValueError(f"unsupported provider: {repo_cfg.provider}")
             self._apis[repo_cfg.provider] = api
@@ -65,6 +67,8 @@ class DefaultProviderFactory:
                         session=session,
                     )
                 )
+            case ProviderID.CODEX:
+                raise NotImplementedError("codex provider not yet wired")
             case _:
                 raise ValueError(f"unsupported provider: {repo_cfg.provider}")
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -133,6 +133,10 @@ class TestProviderModel:
         assert hash(model) == hash(same)
         assert model != different
 
+    def test_xhigh_effort_supported_for_codex(self) -> None:
+        model = ProviderModel("gpt-5.5", "xhigh")
+        assert model.efforts == ("xhigh",)
+
     def test_comparison_to_unrelated_type_is_false(self) -> None:
         assert ProviderModel("gpt-5.4") != object()
 
@@ -156,12 +160,13 @@ class TestProviderPalette:
         assert palette.dim_bg == (40, 20, 60)
         assert palette.bright_fg == (180, 130, 255)
 
-    def test_palette_for_codex_returns_none(self) -> None:
-        # CODEX has no palette registered today — callers must
-        # handle None as "render without provider color", not as an error.
+    def test_palette_for_codex(self) -> None:
         from fido.provider import ProviderID, palette_for
 
-        assert palette_for(ProviderID.CODEX) is None
+        palette = palette_for(ProviderID.CODEX)
+        assert palette is not None
+        assert palette.dim_bg == (8, 54, 43)
+        assert palette.bright_fg == (72, 220, 160)
 
     @staticmethod
     def _relative_luminance(rgb: tuple[int, int, int]) -> float:

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -37,11 +37,11 @@ class TestDefaultProviderFactory:
         )
         assert api.provider_id == ProviderID.COPILOT_CLI
 
-    def test_create_api_rejects_unknown_provider(self, tmp_path: Path) -> None:
+    def test_create_api_rejects_codex_until_wired(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         factory = DefaultProviderFactory(session_system_file=system_file)
-        with pytest.raises(ValueError, match="unsupported provider"):
+        with pytest.raises(NotImplementedError, match="codex provider not yet wired"):
             factory.create_api(
                 RepoConfig(
                     name="owner/repo",
@@ -98,7 +98,7 @@ class TestDefaultProviderFactory:
         )
         assert agent.provider_id == ProviderID.COPILOT_CLI
 
-    def test_create_provider_rejects_unknown_provider(self, tmp_path: Path) -> None:
+    def test_create_provider_rejects_codex_until_wired(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         factory = DefaultProviderFactory(session_system_file=system_file)
@@ -107,7 +107,7 @@ class TestDefaultProviderFactory:
             work_dir=tmp_path,
             provider=ProviderID.CODEX,
         )
-        with pytest.raises(ValueError, match="unsupported provider"):
+        with pytest.raises(NotImplementedError, match="codex provider not yet wired"):
             factory.create_provider(
                 repo_cfg,
                 work_dir=tmp_path,

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -2678,20 +2678,27 @@ class TestProviderColoredStatus:
         for line in repo_lines:
             assert expected_bg in line, f"bg missing from: {line!r}"
 
-    def test_repo_section_bg_omitted_for_provider_without_palette(self) -> None:
-        # CODEX has no registered palette — section renders without
-        # provider-bg wrap.  This test also guards against crashes when
-        # palette_for returns None.
+    def test_repo_section_lines_get_codex_provider_bg_when_color_enabled(self) -> None:
+        from fido.color import rgb_bg
+        from fido.provider import PROVIDER_PALETTES
+
         with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
             repo = self._repo(provider=ProviderID.CODEX, fido_running=True, issue=7)
             status = FidoStatus(fido_pid=None, fido_uptime=None, repos=[repo])
             output = format_status(status)
-        # No truecolor bg escape (\033[48;2;...m) should appear anywhere.
-        assert "\033[48;2;" not in output
+        palette = PROVIDER_PALETTES[ProviderID.CODEX]
+        expected_bg = rgb_bg(*palette.dim_bg)
+        repo_lines = [
+            ln for ln in output.splitlines() if "owner/repo" in ln or "Issue:" in ln
+        ]
+        assert repo_lines, f"no repo/issue lines:\n{output}"
+        for line in repo_lines:
+            assert expected_bg in line, f"bg missing from: {line!r}"
 
-    def test_limits_line_falls_back_when_provider_has_no_palette(self) -> None:
-        # CODEX has no palette registered; the limits line still renders,
-        # without a truecolor fg prefix for the provider token.
+    def test_limits_line_highlights_codex_token(self) -> None:
+        from fido.color import rgb_fg
+        from fido.provider import PROVIDER_PALETTES
+
         with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
             provider_status = ProviderPressureStatus(
                 provider=ProviderID.CODEX,
@@ -2709,9 +2716,10 @@ class TestProviderColoredStatus:
                 provider_statuses=[provider_status],
             )
             output = format_status(status)
+        palette = PROVIDER_PALETTES[ProviderID.CODEX]
+        expected_prefix = rgb_fg(*palette.bright_fg) + "codex"
         limits_line = next(ln for ln in output.splitlines() if "limits:" in ln)
-        assert "codex 50%" in limits_line
-        assert "\033[38;2;" not in limits_line
+        assert expected_prefix in limits_line
 
     def test_repo_header_colors_provider_name_with_bright_fg(self) -> None:
         # The provider token in the repo header stats line gets the provider's
@@ -2750,16 +2758,18 @@ class TestProviderColoredStatus:
         # DARK_GRAY code (\033[90m) must be present on the header for the paused state.
         assert "\033[90m" in header_line
 
-    def test_repo_header_provider_name_no_color_when_no_palette(self) -> None:
-        # Providers with no palette render the provider name as plain text.
+    def test_repo_header_codex_provider_name_colored(self) -> None:
+        from fido.color import rgb_fg
+        from fido.provider import PROVIDER_PALETTES
+
         with patch.dict("os.environ", {"FORCE_COLOR": "1"}, clear=True):
             repo = self._repo(provider=ProviderID.CODEX)
             status = FidoStatus(fido_pid=None, fido_uptime=None, repos=[repo])
             output = format_status(status)
+        palette = PROVIDER_PALETTES[ProviderID.CODEX]
+        expected = rgb_fg(*palette.bright_fg) + "codex"
         header_line = next(ln for ln in output.splitlines() if "owner/repo" in ln)
-        assert "codex" in header_line
-        # No truecolor fg escape for the provider token.
-        assert "\033[38;2;" not in header_line
+        assert expected in header_line
 
     def test_repo_header_provider_name_colored_when_no_provider_status(self) -> None:
         # Even without a provider_status, the provider name gets bright_fg color


### PR DESCRIPTION
## Summary

- add a Codex provider palette and status-color coverage
- allow `ProviderModel` to carry `xhigh` reasoning effort
- add explicit Codex factory branches that fail closed until the provider is wired

Fixes #1045

## Verification

- `./fido tests tests/test_provider.py tests/test_provider_factory.py tests/test_status.py -q`
- `./fido ci`