### PR TITLE
Add Codex one-shot harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Supported dev-tool commands, `./fido ruff ...`, `./fido pyright ...`, and
 tool binaries under the ephemeral `./pyproject` wrapper; do not use host `uv`
 for normal project checks. The production runtime image installs only production Python
 dependencies, plus pinned Node CLI tools from
-`package-lock.json` (`claude` and
-`copilot`) and the GitHub CLI. Node dependencies are built in their own Docker
+`package-lock.json` (`claude`, `copilot`, and
+`codex`) and the GitHub CLI. Node dependencies are built in their own Docker
 stage with an npm cache mount, so changing application code does not rerun
 `npm ci`.
 

--- a/docs/codex-provider.md
+++ b/docs/codex-provider.md
@@ -1,0 +1,36 @@
+# Codex Provider Notes
+
+Codex provider work is pinned to the stable upstream release
+[`rust-v0.125.0`](https://github.com/openai/codex/releases/tag/rust-v0.125.0)
+and npm package `@openai/codex@0.125.0`.
+
+## One-Shot CLI
+
+The non-persistent harness uses the stable CLI surface:
+
+```bash
+codex exec --json --model <model> --sandbox danger-full-access \
+  --ask-for-approval never --skip-git-repo-check -C <cwd> -
+```
+
+The prompt is passed on stdin. CI tests use fixtures and must not call live
+Codex.
+
+The JSONL event shape is defined by upstream
+`codex-rs/exec/src/exec_events.rs`:
+
+- `thread.started` carries `thread_id`, which is the resume handle for later
+  work.
+- `item.completed` with `item.type == "agent_message"` carries assistant text.
+- `error` and `turn.failed` carry provider/auth/quota failure messages.
+
+## Persistent-Session Fallback Refs
+
+Persistent transport is not implemented in the one-shot harness. If stable CLI
+resume is insufficient for later issues, use these pinned app-server schemas as
+the fallback source of truth:
+
+- `codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json`
+- `codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json`
+- `codex-rs/app-server-protocol/schema/json/v2/TurnInterruptParams.json`
+- `codex-rs/app-server-protocol/schema/json/v2/GetAccountRateLimitsResponse.json`

--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -91,6 +91,7 @@ RUN groupadd --gid "$FIDO_GID" "$FIDO_USER" \
     && mkdir -p "$FIDO_HOME/.config" "$FIDO_HOME/.cache" "$FIDO_HOME/workspace" /tmp/uv-cache \
     && ln -sf /opt/fido-node-tools/node_modules/.bin/claude /usr/local/bin/claude \
     && ln -sf /opt/fido-node-tools/node_modules/.bin/copilot /usr/local/bin/copilot \
+    && ln -sf /opt/fido-node-tools/node_modules/.bin/codex /usr/local/bin/codex \
     && chown -R "$FIDO_UID:$FIDO_GID" "$FIDO_HOME" /tmp/uv-cache
 
 ENV HOME=$FIDO_HOME

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "dependencies": {
         "@anthropic-ai/claude-code": "2.1.114",
-        "@github/copilot": "1.0.32"
+        "@github/copilot": "1.0.32",
+        "@openai/codex": "0.125.0"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -231,6 +232,121 @@
       ],
       "bin": {
         "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.125.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0.tgz",
+      "integrity": "sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.125.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.125.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.125.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.125.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.125.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.125.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-darwin-arm64.tgz",
+      "integrity": "sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-darwin-x64.tgz",
+      "integrity": "sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-linux-arm64.tgz",
+      "integrity": "sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-linux-x64.tgz",
+      "integrity": "sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-win32-arm64.tgz",
+      "integrity": "sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.125.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-win32-x64.tgz",
+      "integrity": "sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Pinned runtime CLI tools for the Fido container image.",
   "dependencies": {
     "@anthropic-ai/claude-code": "2.1.114",
-    "@github/copilot": "1.0.32"
+    "@github/copilot": "1.0.32",
+    "@openai/codex": "0.125.0"
   }
 }

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -1,0 +1,173 @@
+"""Codex CLI helpers.
+
+This module intentionally covers only the non-persistent ``codex exec`` path.
+Persistent session transport and provider factory wiring land in later Codex
+epic issues.
+"""
+
+import json
+import subprocess
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+from fido.provider import ProviderModel, model_name
+
+
+class CodexCLIError(RuntimeError):
+    """Raised when the Codex CLI process exits unsuccessfully."""
+
+    def __init__(self, returncode: int, stderr: str) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        message = stderr.strip() or f"codex exited with code {returncode}"
+        super().__init__(message)
+
+
+class CodexProviderError(RuntimeError):
+    """Raised when Codex reports a provider/auth/quota failure in JSONL output."""
+
+    def __init__(
+        self,
+        *,
+        message: str,
+        kind: str = "provider",
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.kind = kind
+        self.payload = payload or {}
+        super().__init__(message)
+
+
+def _codex(
+    *args: str,
+    prompt: str | None = None,
+    timeout: int = 30,
+    cwd: Path | str | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    """Run the Codex CLI with *args*, optionally piping *prompt* to stdin."""
+    return runner(
+        ["codex", *args],
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
+    )
+
+
+def _iter_jsonl(output: str) -> Iterable[dict[str, Any]]:
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def extract_session_id(output: str) -> str:
+    """Extract the final Codex thread id from ``codex exec --json`` output."""
+    result = ""
+    for obj in _iter_jsonl(output):
+        if obj.get("type") != "thread.started":
+            continue
+        thread_id = obj.get("thread_id")
+        if isinstance(thread_id, str) and thread_id:
+            result = thread_id
+    return result
+
+
+def extract_result_text(output: str) -> str:
+    """Extract the last completed agent message from Codex exec JSONL."""
+    result = ""
+    for obj in _iter_jsonl(output):
+        if obj.get("type") != "item.completed":
+            continue
+        item = obj.get("item")
+        if not isinstance(item, dict) or item.get("type") != "agent_message":
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            result = text
+    return result
+
+
+def _classify_provider_error(message: str) -> str:
+    lowered = message.lower()
+    if "rate limit" in lowered or "rate_limit" in lowered or "quota" in lowered:
+        return "rate_limit"
+    if "auth" in lowered or "login" in lowered or "unauthorized" in lowered:
+        return "auth"
+    if "cancel" in lowered or "interrupt" in lowered:
+        return "cancelled"
+    return "provider"
+
+
+def _provider_error_from_event(obj: dict[str, Any]) -> CodexProviderError | None:
+    event_type = obj.get("type")
+    message: str | None = None
+    payload: dict[str, Any] = obj
+    if event_type == "error":
+        raw = obj.get("message")
+        message = raw if isinstance(raw, str) else str(obj)
+    elif event_type == "turn.failed":
+        error = obj.get("error")
+        if isinstance(error, dict):
+            raw = error.get("message")
+            message = raw if isinstance(raw, str) else str(error)
+        else:
+            message = str(error or obj)
+    if message is None:
+        return None
+    return CodexProviderError(
+        message=message,
+        kind=_classify_provider_error(message),
+        payload=payload,
+    )
+
+
+def raise_for_provider_error_output(output: str) -> None:
+    """Raise the first provider failure encoded in Codex exec JSONL output."""
+    for obj in _iter_jsonl(output):
+        provider_error = _provider_error_from_event(obj)
+        if provider_error is not None:
+            raise provider_error
+
+
+def run_codex_exec(
+    prompt: str,
+    *,
+    model: ProviderModel | str,
+    timeout: int = 30,
+    cwd: Path | str = ".",
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str:
+    """Run one non-persistent Codex exec turn and return raw JSONL output."""
+    work_dir = Path(cwd).resolve()
+    completed = _codex(
+        "exec",
+        "--json",
+        "--model",
+        model_name(model),
+        "--sandbox",
+        "danger-full-access",
+        "--ask-for-approval",
+        "never",
+        "--skip-git-repo-check",
+        "-C",
+        str(work_dir),
+        "-",
+        prompt=prompt,
+        timeout=timeout,
+        cwd=work_dir,
+        runner=runner,
+    )
+    if completed.returncode != 0:
+        raise CodexCLIError(completed.returncode, completed.stderr)
+    raise_for_provider_error_output(completed.stdout)
+    return completed.stdout

--- a/tests/fixtures/codex/auth-fail.jsonl
+++ b/tests/fixtures/codex/auth-fail.jsonl
@@ -1,0 +1,2 @@
+{"type":"thread.started","thread_id":"auth-thread"}
+{"type":"error","message":"authentication failed: please login to Codex"}

--- a/tests/fixtures/codex/cancelled.jsonl
+++ b/tests/fixtures/codex/cancelled.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"cancel-thread"}
+{"type":"turn.started"}
+{"type":"turn.failed","error":{"message":"turn cancelled by user interrupt"}}

--- a/tests/fixtures/codex/normal.jsonl
+++ b/tests/fixtures/codex/normal.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"67e55044-10b1-426f-9247-bb680e5fe0c8"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"first reply"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"final reply"}}
+{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":1}}

--- a/tests/fixtures/codex/rate-limit.jsonl
+++ b/tests/fixtures/codex/rate-limit.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"rate-limit-thread"}
+{"type":"turn.started"}
+{"type":"turn.failed","error":{"message":"rate_limit_exceeded: rate limit reached for codex"}}

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -754,6 +754,7 @@ class TestModelDockerfile:
         assert "gh_${GH_VERSION}_linux_amd64.deb" in dockerfile
         assert "ln -sf /opt/fido-node-tools/node_modules/.bin/claude" in dockerfile
         assert "ln -sf /opt/fido-node-tools/node_modules/.bin/copilot" in dockerfile
+        assert "ln -sf /opt/fido-node-tools/node_modules/.bin/codex" in dockerfile
         assert (
             "./pyproject uv sync --frozen --no-dev --no-install-project" in dockerfile
         )

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,164 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from fido.codex import (
+    CodexCLIError,
+    CodexProviderError,
+    _codex,
+    extract_result_text,
+    extract_session_id,
+    raise_for_provider_error_output,
+    run_codex_exec,
+)
+from fido.provider import ProviderModel
+
+FIXTURES = Path(__file__).parent / "fixtures" / "codex"
+
+
+def _completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+class TestCodexHelper:
+    def test_calls_subprocess_run_with_prompt_and_cwd(self, tmp_path: Path) -> None:
+        mock_run = MagicMock(return_value=_completed("out"))
+        result = _codex(
+            "exec",
+            "--json",
+            prompt="input",
+            timeout=5,
+            cwd=tmp_path,
+            runner=mock_run,
+        )
+        mock_run.assert_called_once_with(
+            ["codex", "exec", "--json"],
+            input="input",
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=tmp_path,
+        )
+        assert result.stdout == "out"
+
+
+class TestCodexJsonlParsing:
+    def test_extract_session_id_from_thread_started(self) -> None:
+        assert (
+            extract_session_id(_fixture("normal.jsonl"))
+            == "67e55044-10b1-426f-9247-bb680e5fe0c8"
+        )
+
+    def test_extract_session_id_returns_last_thread_started(self) -> None:
+        output = (
+            '{"type":"thread.started","thread_id":"one"}\n'
+            '{"type":"thread.started","thread_id":"two"}\n'
+        )
+        assert extract_session_id(output) == "two"
+
+    def test_extract_session_id_tolerates_malformed_lines(self) -> None:
+        output = 'not-json\n{"type":"thread.started","thread_id":"ok"}\n[]'
+        assert extract_session_id(output) == "ok"
+
+    def test_extract_result_text_from_last_agent_message(self) -> None:
+        assert extract_result_text(_fixture("normal.jsonl")) == "final reply"
+
+    def test_extract_result_text_ignores_non_agent_items(self) -> None:
+        output = "\n".join(
+            [
+                "not-json",
+                '{"type":"item.completed","item":{"id":"x","type":"reasoning","text":"ignore"}}',
+                '{"type":"item.completed","item":{"id":"y","type":"agent_message","text":"ok"}}',
+            ]
+        )
+        assert extract_result_text(output) == "ok"
+
+
+class TestCodexProviderErrors:
+    def test_rate_limit_fixture_classified(self) -> None:
+        with pytest.raises(CodexProviderError) as exc_info:
+            raise_for_provider_error_output(_fixture("rate-limit.jsonl"))
+        assert exc_info.value.kind == "rate_limit"
+        assert "rate limit" in str(exc_info.value)
+
+    def test_auth_fixture_classified(self) -> None:
+        with pytest.raises(CodexProviderError) as exc_info:
+            raise_for_provider_error_output(_fixture("auth-fail.jsonl"))
+        assert exc_info.value.kind == "auth"
+        assert "login" in str(exc_info.value)
+
+    def test_cancelled_fixture_classified(self) -> None:
+        with pytest.raises(CodexProviderError) as exc_info:
+            raise_for_provider_error_output(_fixture("cancelled.jsonl"))
+        assert exc_info.value.kind == "cancelled"
+        assert "cancelled" in str(exc_info.value)
+
+    def test_ignores_successful_fixture(self) -> None:
+        raise_for_provider_error_output(_fixture("normal.jsonl"))
+
+
+class TestRunCodexExec:
+    def test_builds_stable_json_exec_command(self, tmp_path: Path) -> None:
+        mock_run = MagicMock(return_value=_completed(_fixture("normal.jsonl")))
+        output = run_codex_exec(
+            "hello",
+            model=ProviderModel("gpt-5.5", "xhigh"),
+            timeout=17,
+            cwd=tmp_path,
+            runner=mock_run,
+        )
+        assert extract_result_text(output) == "final reply"
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args.args[0]
+        assert cmd == [
+            "codex",
+            "exec",
+            "--json",
+            "--model",
+            "gpt-5.5",
+            "--sandbox",
+            "danger-full-access",
+            "--ask-for-approval",
+            "never",
+            "--skip-git-repo-check",
+            "-C",
+            str(tmp_path),
+            "-",
+        ]
+        assert mock_run.call_args.kwargs["input"] == "hello"
+        assert mock_run.call_args.kwargs["timeout"] == 17
+        assert mock_run.call_args.kwargs["cwd"] == tmp_path.resolve()
+
+    def test_normalizes_relative_work_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+        mock_run = MagicMock(return_value=_completed(_fixture("normal.jsonl")))
+        run_codex_exec("hello", model="gpt-5.5", cwd="work", runner=mock_run)
+        assert mock_run.call_args.args[0][-2] == str(work_dir)
+        assert mock_run.call_args.kwargs["cwd"] == work_dir
+
+    def test_raises_cli_error_on_nonzero_exit(self) -> None:
+        mock_run = MagicMock(return_value=_completed(returncode=2, stderr="bad flags"))
+        with pytest.raises(CodexCLIError) as exc_info:
+            run_codex_exec("hello", model="gpt-5.5", runner=mock_run)
+        assert exc_info.value.returncode == 2
+        assert exc_info.value.stderr == "bad flags"
+
+    def test_raises_provider_error_from_successful_process_output(self) -> None:
+        mock_run = MagicMock(return_value=_completed(_fixture("rate-limit.jsonl")))
+        with pytest.raises(CodexProviderError) as exc_info:
+            run_codex_exec("hello", model="gpt-5.5", runner=mock_run)
+        assert exc_info.value.kind == "rate_limit"


### PR DESCRIPTION
## Summary
- pin @openai/codex@0.125.0 in the runtime image and expose the codex binary
- add fixture-backed codex exec JSONL parsing and provider-error classification
- document pinned Codex CLI/protocol refs for later persistent-session work

Fixes #1046

## Verification
- `./fido tests tests/test_codex.py tests/test_build_wrapper.py -q`
- `./fido ci`