### PR TITLE
Add Codex app-server session transport

### DIFF
--- a/docs/codex-provider.md
+++ b/docs/codex-provider.md
@@ -48,14 +48,22 @@ Codex epic issue wires Codex into `CodexClient`/provider selection.
 For bootstrap validation against the local Codex install, run:
 
 ```bash
-PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --turn
 PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py \
-  --interrupt --prompt 'Run `sleep 20` in the shell, then reply done.'
+  --turn --resume --interrupt --preempt \
+  --prompt 'Run `sleep 20` in the shell, then reply done.'
+docker run --rm --interactive --user "$(id -u):$(id -g)" \
+  --env "HOME=$HOME" --env "PYTHONPATH=/workspace/src" --network host \
+  --volume "$PWD:/workspace" --volume "$HOME/workspace:$HOME/workspace" \
+  --volume "$HOME/.codex:$HOME/.codex" --workdir /workspace \
+  --entrypoint /opt/fido-venv/bin/python3 fido-test:local \
+  tools/codex_appserver_smoke.py --turn --resume --interrupt --preempt \
+  --prompt 'Run `sleep 20` in the shell, then reply done.'
 ```
 
 The smoke driver is intentionally outside CI. It is for reconciling Fido's
 fixtures with live app-server behavior before codifying that behavior in unit
-tests.
+tests. The Docker form validates the same image, Codex binary, and `~/.codex`
+mount shape Fido uses at runtime.
 
 Pinned app-server schemas:
 

--- a/docs/codex-provider.md
+++ b/docs/codex-provider.md
@@ -45,6 +45,18 @@ sandbox policy because container and branch isolation happen outside Codex.
 The live worker-provider factory is still intentionally gated until the final
 Codex epic issue wires Codex into `CodexClient`/provider selection.
 
+For bootstrap validation against the local Codex install, run:
+
+```bash
+PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --turn
+PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py \
+  --interrupt --prompt 'Run `sleep 20` in the shell, then reply done.'
+```
+
+The smoke driver is intentionally outside CI. It is for reconciling Fido's
+fixtures with live app-server behavior before codifying that behavior in unit
+tests.
+
 Pinned app-server schemas:
 
 - `codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json`

--- a/docs/codex-provider.md
+++ b/docs/codex-provider.md
@@ -24,11 +24,28 @@ The JSONL event shape is defined by upstream
 - `item.completed` with `item.type == "agent_message"` carries assistant text.
 - `error` and `turn.failed` carry provider/auth/quota failure messages.
 
-## Persistent-Session Fallback Refs
+## Persistent App-Server Transport
 
-Persistent transport is not implemented in the one-shot harness. If stable CLI
-resume is insufficient for later issues, use these pinned app-server schemas as
-the fallback source of truth:
+Persistent transport uses the pinned app-server protocol over stdio:
+
+```bash
+codex app-server --listen stdio://
+```
+
+The wire format is newline-delimited JSON without a `jsonrpc` version field.
+Fido sends `initialize`, then the `initialized` notification, then uses:
+
+- `account/rateLimits/read` for quota/status snapshots.
+- `thread/start` and `thread/resume` for persistent Codex thread ids.
+- `turn/start` for prompt turns.
+- `turn/interrupt` for worker preemption/cancel.
+
+Fido always sends `approvalPolicy: "never"` and a `danger-full-access`
+sandbox policy because container and branch isolation happen outside Codex.
+The live worker-provider factory is still intentionally gated until the final
+Codex epic issue wires Codex into `CodexClient`/provider selection.
+
+Pinned app-server schemas:
 
 - `codex-rs/app-server-protocol/schema/json/v2/ThreadStartParams.json`
 - `codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json`

--- a/fido
+++ b/fido
@@ -506,6 +506,7 @@ run_container() {
   add_mount_if_exists "$HOME/.claude.json"
   add_mount_if_exists "$HOME/.config/gh"
   add_mount_if_exists "$HOME/.cache/copilot"
+  add_mount_if_exists "$HOME/.codex"
   # SSH keys are needed for git push/fetch on SSH-origin workspace clones.
   # Mounted read-only so the container can use them without mutating.
   if [ -d "$HOME/.ssh" ]; then

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -183,7 +183,11 @@ class CodexAppServerClient:
         )
         self._reader.start()
         self._stderr_reader.start()
-        self._initialize()
+        try:
+            self._initialize()
+        except Exception:
+            self.stop()
+            raise
 
     @property
     def pid(self) -> int | None:
@@ -587,8 +591,9 @@ class CodexAPI(ProviderAPI):
                 < _CODEX_RATE_LIMIT_CACHE_SECONDS
             ):
                 return self._limit_snapshot_cache
-            client = self._client_factory()
+            client: CodexAppServer | None = None
             try:
+                client = self._client_factory()
                 payload = client.request(
                     "account/rateLimits/read", timeout=_CODEX_APP_SERVER_TIMEOUT
                 )
@@ -610,7 +615,8 @@ class CodexAPI(ProviderAPI):
                     unavailable_reason=f"Codex usage unavailable: {exc}",
                 )
             finally:
-                client.stop()
+                if client is not None:
+                    client.stop()
             self._limit_snapshot_cache = snapshot
             self._limit_snapshot_cached_at = self._monotonic()
             return snapshot
@@ -850,7 +856,7 @@ class CodexSession(OwnedSession):
                 )
                 self._session_id = _thread_id_from_result(result)
                 return
-            except Exception:
+            except CodexProviderError:
                 log.exception("CodexSession: failed to resume session %s", session_id)
                 self._dropped_session_count += 1
         result = self._client.request("thread/start", self._thread_params(None))

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -497,8 +497,10 @@ def _rate_limit_window(
     )
 
 
-def _credits_depleted(payload: object) -> bool:
-    if not isinstance(payload, dict):
+def _credits_depleted(payload: object, reached_type: object) -> bool:
+    if not isinstance(payload, dict) or not isinstance(reached_type, str):
+        return False
+    if "credits_depleted" not in reached_type:
         return False
     has_credits = payload.get("hasCredits")
     unlimited = payload.get("unlimited")
@@ -524,9 +526,12 @@ def _codex_limit_windows(payload: dict[str, Any]) -> tuple[ProviderLimitWindow, 
         raw_limits = [rate_limits_by_id[key] for key in sorted(rate_limits_by_id)]
     else:
         rate_limits = payload["rateLimits"]
-        if not isinstance(rate_limits, list):
-            raise ValueError("Codex rateLimits must be a list")
-        raw_limits = list(rate_limits)
+        if isinstance(rate_limits, list):
+            raw_limits = list(rate_limits)
+        elif isinstance(rate_limits, dict):
+            raw_limits = [rate_limits]
+        else:
+            raise ValueError("Codex rateLimits must be an object or list")
 
     windows: list[ProviderLimitWindow] = []
     for index, raw_limit in enumerate(raw_limits):
@@ -540,11 +545,12 @@ def _codex_limit_windows(payload: dict[str, Any]) -> tuple[ProviderLimitWindow, 
                 windows.append(window)
                 if window.pressure is not None and window.pressure >= 1.0:
                     reached_names.add(window.name)
-        if _credits_depleted(raw_limit.get("credits")):
+        reached_type = raw_limit.get("rateLimitReachedType")
+        if _credits_depleted(raw_limit.get("credits"), reached_type):
             credit_name = f"{limit_id}_credits"
             windows.append(ProviderLimitWindow(name=credit_name, used=100, limit=100))
             reached_names.add(credit_name)
-        reached_name = _reached_window_name(raw_limit.get("rateLimitReachedType"))
+        reached_name = _reached_window_name(reached_type)
         full_reached_name = f"{limit_id}_{reached_name}" if reached_name else None
         if full_reached_name is not None and full_reached_name not in reached_names:
             windows.append(
@@ -700,12 +706,14 @@ class CodexSession(OwnedSession):
             "turn/start",
             {
                 "threadId": thread_id,
-                "input": {"type": "text", "text": content, "text_elements": []},
+                "input": [
+                    {"type": "text", "text": content, "text_elements": []},
+                ],
                 "model": self._model.model,
                 "effort": self._model.efforts[0] if self._model.efforts else None,
                 "cwd": str(self._work_dir),
                 "approvalPolicy": "never",
-                "sandboxPolicy": {"mode": "danger-full-access"},
+                "sandboxPolicy": {"type": "dangerFullAccess"},
             },
         )
         turn = result.get("turn") if isinstance(result, dict) else None
@@ -744,13 +752,15 @@ class CodexSession(OwnedSession):
             if (
                 method == "item/completed"
                 and isinstance(item, dict)
-                and item.get("type") == "agent_message"
+                and item.get("type") in {"agent_message", "agentMessage"}
             ):
                 text = item.get("text")
                 if isinstance(text, str):
                     final_text = text
                     self._received_count += 1
-            completed = _extract_completed_turn(params)
+            completed = (
+                _extract_completed_turn(params) if method == "turn/completed" else None
+            )
             if completed is None and method == "item/completed":
                 completed = self._poll_completed_turn(thread_id, active_turn_id)
             if completed is not None:
@@ -781,6 +791,10 @@ class CodexSession(OwnedSession):
 
     def stop(self) -> None:
         self._client.stop()
+
+    def interrupt_active_turn(self) -> None:
+        """Interrupt the currently active turn, if one is in flight."""
+        self._fire_worker_cancel()
 
     def _fire_worker_cancel(self) -> None:
         with self._turn_lock:
@@ -847,7 +861,7 @@ class CodexSession(OwnedSession):
             "model": self._model.model,
             "cwd": str(self._work_dir),
             "approvalPolicy": "never",
-            "sandbox": {"mode": "danger-full-access"},
+            "sandbox": "danger-full-access",
             "developerInstructions": self._base_system_prompt,
         }
         if session_id is not None:

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -1,17 +1,39 @@
-"""Codex CLI helpers.
-
-This module intentionally covers only the non-persistent ``codex exec`` path.
-Persistent session transport and provider factory wiring land in later Codex
-epic issues.
-"""
+"""Codex CLI and app-server helpers."""
 
 import json
+import logging
+import queue
 import subprocess
+import threading
+import time
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import IO, Any, Protocol
 
-from fido.provider import ProviderModel, model_name
+import fido.provider as provider
+from fido.provider import (
+    OwnedSession,
+    ProviderAPI,
+    ProviderID,
+    ProviderLimitSnapshot,
+    ProviderLimitWindow,
+    ProviderModel,
+    coerce_provider_model,
+    model_name,
+)
+
+log = logging.getLogger(__name__)
+
+_CODEX_RATE_LIMIT_CACHE_SECONDS = 300.0
+_CODEX_APP_SERVER_TIMEOUT = 30.0
+_CODEX_APP_SERVER_MAX_LINE_BYTES = 8 * 1024 * 1024
+_CODEX_CLIENT_INFO = {
+    "name": "fido",
+    "title": "Fido",
+    "version": "0.1.0",
+}
 
 
 class CodexCLIError(RuntimeError):
@@ -39,6 +61,58 @@ class CodexProviderError(RuntimeError):
         super().__init__(message)
 
 
+class CodexProtocolError(RuntimeError):
+    """Raised when the Codex app-server stream violates the protocol."""
+
+
+class CodexAppServerProcess(Protocol):
+    """Small protocol for a text-mode ``codex app-server`` subprocess."""
+
+    stdin: IO[str] | None
+    stdout: IO[str] | None
+    stderr: IO[str] | None
+    pid: int
+
+    def poll(self) -> int | None: ...
+
+    def terminate(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+    def kill(self) -> None: ...
+
+
+class CodexAppServer(Protocol):
+    """JSON-RPC-ish app-server boundary used by Codex API/session code."""
+
+    @property
+    def pid(self) -> int | None: ...
+
+    def request(
+        self, method: str, params: dict[str, Any] | None = None, *, timeout: float = ...
+    ) -> Any: ...
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None: ...
+
+    def wait_notification(
+        self,
+        method: str,
+        *,
+        predicate: Callable[[dict[str, Any]], bool] | None = None,
+        timeout: float = ...,
+    ) -> dict[str, Any]: ...
+
+    def is_alive(self) -> bool: ...
+
+    def stop(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class _Response:
+    result: Any = None
+    error: dict[str, Any] | None = None
+
+
 def _codex(
     *args: str,
     prompt: str | None = None,
@@ -55,6 +129,253 @@ def _codex(
         timeout=timeout,
         cwd=cwd,
     )
+
+
+def _spawn_app_server(
+    *,
+    cwd: Path | str | None = None,
+) -> CodexAppServerProcess:
+    return subprocess.Popen(  # noqa: S603 - command is fixed, args are not shell-expanded.
+        ["codex", "app-server", "--listen", "stdio://"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        bufsize=1,
+    )
+
+
+class CodexAppServerClient:
+    """Thread-safe owner for one ``codex app-server`` stdio connection."""
+
+    def __init__(
+        self,
+        *,
+        process_factory: Callable[..., CodexAppServerProcess] = _spawn_app_server,
+        cwd: Path | str | None = None,
+        timeout: float = _CODEX_APP_SERVER_TIMEOUT,
+        max_line_bytes: int = _CODEX_APP_SERVER_MAX_LINE_BYTES,
+    ) -> None:
+        self._process_factory = process_factory
+        self._cwd = cwd
+        self._timeout = timeout
+        self._max_line_bytes = max_line_bytes
+        self._send_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._response_cond = threading.Condition(self._state_lock)
+        self._next_id = 1
+        self._responses: dict[int, _Response] = {}
+        self._notifications: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr_lines: queue.Queue[str] = queue.Queue()
+        self._stopped = False
+        self._protocol_error: BaseException | None = None
+        self._process = self._process_factory(cwd=self._cwd)
+        self._reader = threading.Thread(
+            target=self._read_stdout,
+            name="codex-app-server-stdout",
+            daemon=True,
+        )
+        self._stderr_reader = threading.Thread(
+            target=self._read_stderr,
+            name="codex-app-server-stderr",
+            daemon=True,
+        )
+        self._reader.start()
+        self._stderr_reader.start()
+        self._initialize()
+
+    @property
+    def pid(self) -> int | None:
+        return self._process.pid
+
+    def _initialize(self) -> None:
+        self.request(
+            "initialize",
+            {
+                "clientInfo": _CODEX_CLIENT_INFO,
+                "capabilities": {
+                    "experimentalApi": True,
+                    "optOutNotificationMethods": [],
+                },
+            },
+            timeout=self._timeout,
+        )
+        self.notify("initialized")
+
+    def request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float = _CODEX_APP_SERVER_TIMEOUT,
+    ) -> Any:
+        request_id = self._next_request_id()
+        self._write({"id": request_id, "method": method, "params": params or {}})
+        deadline = time.monotonic() + timeout
+        with self._response_cond:
+            while request_id not in self._responses:
+                self._raise_if_unavailable_locked()
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"Codex app-server request timed out: {method}")
+                self._response_cond.wait(min(remaining, 0.25))
+            response = self._responses.pop(request_id)
+        if response.error is not None:
+            message = response.error.get("message")
+            raise CodexProviderError(
+                message=message if isinstance(message, str) else str(response.error),
+                kind=_classify_provider_error(str(message or response.error)),
+                payload=response.error,
+            )
+        return response.result
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        self._write({"method": method, "params": params or {}})
+
+    def wait_notification(
+        self,
+        method: str,
+        *,
+        predicate: Callable[[dict[str, Any]], bool] | None = None,
+        timeout: float = _CODEX_APP_SERVER_TIMEOUT,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        deferred: list[dict[str, Any]] = []
+        try:
+            while True:
+                with self._state_lock:
+                    self._raise_if_unavailable_locked()
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out waiting for Codex notification: {method}"
+                    )
+                try:
+                    notification = self._notifications.get(timeout=min(remaining, 0.25))
+                except queue.Empty:
+                    continue
+                if method != "*" and notification.get("method") != method:
+                    deferred.append(notification)
+                    continue
+                params = notification.get("params")
+                if not isinstance(params, dict):
+                    raise CodexProtocolError(
+                        f"Codex notification {method} params must be an object"
+                    )
+                if predicate is None or predicate(params):
+                    return notification
+                deferred.append(notification)
+        finally:
+            for notification in deferred:
+                self._notifications.put(notification)
+
+    def is_alive(self) -> bool:
+        with self._state_lock:
+            return (
+                not self._stopped
+                and self._protocol_error is None
+                and self._process.poll() is None
+            )
+
+    def stop(self) -> None:
+        with self._response_cond:
+            self._stopped = True
+            self._response_cond.notify_all()
+        if self._process.poll() is not None:
+            return
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=5)
+
+    def _next_request_id(self) -> int:
+        with self._state_lock:
+            request_id = self._next_id
+            self._next_id += 1
+            return request_id
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")) + "\n"
+        with self._send_lock:
+            stdin = self._process.stdin
+            if stdin is None:
+                raise CodexProtocolError("Codex app-server stdin is unavailable")
+            stdin.write(encoded)
+            stdin.flush()
+
+    def _read_stdout(self) -> None:
+        stdout = self._process.stdout
+        if stdout is None:
+            self._fail_protocol(CodexProtocolError("Codex app-server stdout missing"))
+            return
+        try:
+            while True:
+                line = stdout.readline()
+                if line == "":
+                    self._fail_protocol(
+                        CodexProtocolError("Codex app-server closed stdout")
+                    )
+                    return
+                if len(line.encode()) > self._max_line_bytes:
+                    self._fail_protocol(
+                        CodexProtocolError("Codex app-server line too large")
+                    )
+                    return
+                self._handle_line(line)
+        except BaseException as exc:
+            self._fail_protocol(exc)
+
+    def _read_stderr(self) -> None:
+        stderr = self._process.stderr
+        if stderr is None:
+            return
+        for line in stderr:
+            self._stderr_lines.put(line.rstrip())
+
+    def _handle_line(self, line: str) -> None:
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CodexProtocolError(
+                f"Codex app-server emitted invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(message, dict):
+            raise CodexProtocolError("Codex app-server message must be a JSON object")
+        raw_id = message.get("id")
+        if isinstance(raw_id, int) and ("result" in message or "error" in message):
+            error = message.get("error")
+            if error is not None and not isinstance(error, dict):
+                raise CodexProtocolError(
+                    "Codex app-server response error must be an object"
+                )
+            with self._response_cond:
+                self._responses[raw_id] = _Response(
+                    result=message.get("result"), error=error
+                )
+                self._response_cond.notify_all()
+            return
+        method = message.get("method")
+        if isinstance(method, str) and "params" in message:
+            self._notifications.put(message)
+            return
+        raise CodexProtocolError(f"Unsupported Codex app-server message: {message!r}")
+
+    def _fail_protocol(self, exc: BaseException) -> None:
+        with self._response_cond:
+            if not self._stopped and self._protocol_error is None:
+                self._protocol_error = exc
+            self._response_cond.notify_all()
+
+    def _raise_if_unavailable_locked(self) -> None:
+        if self._protocol_error is not None:
+            raise self._protocol_error
+        if self._stopped:
+            raise CodexProtocolError("Codex app-server connection is stopped")
+        if self._process.poll() is not None:
+            raise CodexProtocolError("Codex app-server process exited")
 
 
 def _iter_jsonl(output: str) -> Iterable[dict[str, Any]]:
@@ -137,6 +458,480 @@ def raise_for_provider_error_output(output: str) -> None:
         provider_error = _provider_error_from_event(obj)
         if provider_error is not None:
             raise provider_error
+
+
+def _normalize_limit_name(value: object, fallback: str) -> str:
+    if not isinstance(value, str) or not value:
+        return fallback
+    return "_".join(value.lower().replace("-", "_").split())
+
+
+def _parse_rate_limit_reset(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, int | float):
+        raise ValueError(f"Codex rate limit resetsAt must be numeric, got {value!r}")
+    return datetime.fromtimestamp(float(value), tz=UTC)
+
+
+def _rate_limit_window(
+    limit_id: str, suffix: str, payload: object
+) -> ProviderLimitWindow | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise ValueError(f"Codex rate limit {limit_id}.{suffix} must be an object")
+    used_percent = payload.get("usedPercent")
+    if used_percent is None:
+        return None
+    if not isinstance(used_percent, int | float):
+        raise ValueError(
+            f"Codex rate limit {limit_id}.{suffix}.usedPercent must be numeric"
+        )
+    return ProviderLimitWindow(
+        name=f"{limit_id}_{suffix}",
+        used=round(float(used_percent)),
+        limit=100,
+        resets_at=_parse_rate_limit_reset(payload.get("resetsAt")),
+        unit="%",
+    )
+
+
+def _credits_depleted(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    has_credits = payload.get("hasCredits")
+    unlimited = payload.get("unlimited")
+    return has_credits is False and unlimited is False
+
+
+def _reached_window_name(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    if "credits_depleted" in value:
+        return "credits"
+    if "usage_limit_reached" in value:
+        return "workspace_usage"
+    if "rate_limit_reached" in value:
+        return "rate_limit_reached"
+    return _normalize_limit_name(value, "codex_limit_reached")
+
+
+def _codex_limit_windows(payload: dict[str, Any]) -> tuple[ProviderLimitWindow, ...]:
+    rate_limits_by_id = payload.get("rateLimitsByLimitId")
+    raw_limits: list[object]
+    if isinstance(rate_limits_by_id, dict) and rate_limits_by_id:
+        raw_limits = [rate_limits_by_id[key] for key in sorted(rate_limits_by_id)]
+    else:
+        rate_limits = payload["rateLimits"]
+        if not isinstance(rate_limits, list):
+            raise ValueError("Codex rateLimits must be a list")
+        raw_limits = list(rate_limits)
+
+    windows: list[ProviderLimitWindow] = []
+    for index, raw_limit in enumerate(raw_limits):
+        if not isinstance(raw_limit, dict):
+            raise ValueError("Codex rate limit snapshots must be objects")
+        limit_id = _normalize_limit_name(raw_limit.get("limitId"), f"codex_{index}")
+        reached_names: set[str] = set()
+        for suffix in ("primary", "secondary"):
+            window = _rate_limit_window(limit_id, suffix, raw_limit.get(suffix))
+            if window is not None:
+                windows.append(window)
+                if window.pressure is not None and window.pressure >= 1.0:
+                    reached_names.add(window.name)
+        if _credits_depleted(raw_limit.get("credits")):
+            credit_name = f"{limit_id}_credits"
+            windows.append(ProviderLimitWindow(name=credit_name, used=100, limit=100))
+            reached_names.add(credit_name)
+        reached_name = _reached_window_name(raw_limit.get("rateLimitReachedType"))
+        full_reached_name = f"{limit_id}_{reached_name}" if reached_name else None
+        if full_reached_name is not None and full_reached_name not in reached_names:
+            windows.append(
+                ProviderLimitWindow(name=full_reached_name, used=100, limit=100)
+            )
+    return tuple(windows)
+
+
+class CodexAPI(ProviderAPI):
+    """Read-only account API for Codex quota and limits."""
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], CodexAppServer] = CodexAppServerClient,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._client_factory = client_factory
+        self._monotonic = monotonic
+        self._limit_snapshot_lock = threading.Lock()
+        self._limit_snapshot_cached_at: float | None = None
+        self._limit_snapshot_cache: ProviderLimitSnapshot | None = None
+
+    @property
+    def provider_id(self) -> ProviderID:
+        return ProviderID.CODEX
+
+    def get_limit_snapshot(self) -> ProviderLimitSnapshot:
+        with self._limit_snapshot_lock:
+            if (
+                self._limit_snapshot_cache is not None
+                and self._limit_snapshot_cached_at is not None
+                and self._monotonic() - self._limit_snapshot_cached_at
+                < _CODEX_RATE_LIMIT_CACHE_SECONDS
+            ):
+                return self._limit_snapshot_cache
+            client = self._client_factory()
+            try:
+                payload = client.request(
+                    "account/rateLimits/read", timeout=_CODEX_APP_SERVER_TIMEOUT
+                )
+                if not isinstance(payload, dict):
+                    raise ValueError("Codex rate limit response must be a JSON object")
+                windows = _codex_limit_windows(payload)
+                snapshot = (
+                    ProviderLimitSnapshot(provider=self.provider_id, windows=windows)
+                    if windows
+                    else ProviderLimitSnapshot(
+                        provider=self.provider_id,
+                        unavailable_reason="Codex rate limits did not include usable windows.",
+                    )
+                )
+            except Exception as exc:
+                log.exception("CodexAPI: failed to fetch rate limit snapshot")
+                snapshot = ProviderLimitSnapshot(
+                    provider=self.provider_id,
+                    unavailable_reason=f"Codex usage unavailable: {exc}",
+                )
+            finally:
+                client.stop()
+            self._limit_snapshot_cache = snapshot
+            self._limit_snapshot_cached_at = self._monotonic()
+            return snapshot
+
+
+class CodexSession(OwnedSession):
+    """Persistent Codex app-server thread/session implementation."""
+
+    voice_model = ProviderModel("gpt-5.5", "xhigh")
+    work_model = ProviderModel("gpt-5.5", "medium")
+    brief_model = ProviderModel("gpt-5.5", "low")
+
+    def __init__(
+        self,
+        system_file: Path,
+        *,
+        work_dir: Path | str,
+        model: ProviderModel | str,
+        repo_name: str | None = None,
+        client_factory: Callable[..., CodexAppServer] = CodexAppServerClient,
+        session_id: str | None = None,
+    ) -> None:
+        self._work_dir = Path(work_dir).resolve()
+        self._repo_name = repo_name
+        self._base_system_prompt = (
+            system_file.read_text() if system_file.exists() else ""
+        )
+        self._client_factory = client_factory
+        self._client = self._client_factory(cwd=self._work_dir)
+        self._model = coerce_provider_model(model)
+        self._session_id: str | None = None
+        self._turn_lock = threading.Lock()
+        self._active_turn_id: str | None = None
+        self._last_turn_cancelled = False
+        self._sent_count = 0
+        self._received_count = 0
+        self._dropped_session_count = 0
+        self._init_handler_reentry()
+        self._ensure_thread(session_id=session_id)
+
+    @property
+    def owner(self) -> str | None:
+        if self._repo_name is None:
+            return None
+        talker = provider.get_talker(self._repo_name)
+        if talker is None or talker.kind != "worker":
+            return None
+        for thread in threading.enumerate():
+            if thread.ident == talker.thread_id:
+                return thread.name
+        return None
+
+    @property
+    def pid(self) -> int | None:
+        return self._client.pid
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def dropped_session_count(self) -> int:
+        return self._dropped_session_count
+
+    @property
+    def sent_count(self) -> int:
+        return self._sent_count
+
+    @property
+    def received_count(self) -> int:
+        return self._received_count
+
+    @property
+    def last_turn_cancelled(self) -> bool:
+        return self._last_turn_cancelled
+
+    def prompt(
+        self,
+        content: str,
+        model: ProviderModel | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        with self:
+            if model is not None:
+                self.switch_model(model)
+            self.send(_combine_prompt(content, self._base_system_prompt, system_prompt))
+            return self.consume_until_result()
+
+    def send(self, content: str) -> None:
+        thread_id = self._require_thread_id()
+        self._last_turn_cancelled = False
+        result = self._client.request(
+            "turn/start",
+            {
+                "threadId": thread_id,
+                "input": {"type": "text", "text": content, "text_elements": []},
+                "model": self._model.model,
+                "effort": self._model.efforts[0] if self._model.efforts else None,
+                "cwd": str(self._work_dir),
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"mode": "danger-full-access"},
+            },
+        )
+        turn = result.get("turn") if isinstance(result, dict) else None
+        turn_id = turn.get("id") if isinstance(turn, dict) else None
+        if not isinstance(turn_id, str) or not turn_id:
+            raise CodexProtocolError("Codex turn/start response missing turn.id")
+        with self._turn_lock:
+            self._active_turn_id = turn_id
+        self._sent_count += 1
+
+    def consume_until_result(self) -> str:
+        with self._turn_lock:
+            active_turn_id = self._active_turn_id
+        if active_turn_id is None:
+            return ""
+        final_text = ""
+        thread_id = self._require_thread_id()
+        while True:
+            notification = self._client.wait_notification(
+                "*",
+                predicate=lambda params: _notification_matches(
+                    params, thread_id=thread_id, turn_id=active_turn_id
+                ),
+                timeout=_CODEX_APP_SERVER_TIMEOUT,
+            )
+            method = notification.get("method")
+            params = notification["params"]
+            if method == "error":
+                message = params.get("message")
+                raise CodexProviderError(
+                    message=message if isinstance(message, str) else str(params),
+                    kind=_classify_provider_error(str(message or params)),
+                    payload=params,
+                )
+            item = params.get("item")
+            if (
+                method == "item/completed"
+                and isinstance(item, dict)
+                and item.get("type") == "agent_message"
+            ):
+                text = item.get("text")
+                if isinstance(text, str):
+                    final_text = text
+                    self._received_count += 1
+            completed = _extract_completed_turn(params)
+            if completed is None and method == "item/completed":
+                completed = self._poll_completed_turn(thread_id, active_turn_id)
+            if completed is not None:
+                return self._finish_turn(completed, final_text)
+
+    def switch_model(self, model: ProviderModel | str) -> None:
+        self._model = coerce_provider_model(model)
+
+    def switch_tools(self, tools: str | None) -> None:
+        del tools
+
+    def recover(self) -> None:
+        old_session_id = self._session_id
+        self._client.stop()
+        self._client = self._client_factory(cwd=self._work_dir)
+        self._ensure_thread(session_id=old_session_id)
+
+    def reset(self, model: ProviderModel | None = None) -> None:
+        if model is not None:
+            self._model = coerce_provider_model(model)
+        self._session_id = None
+        self._active_turn_id = None
+        self._last_turn_cancelled = False
+        self._ensure_thread(session_id=None)
+
+    def is_alive(self) -> bool:
+        return self._client.is_alive()
+
+    def stop(self) -> None:
+        self._client.stop()
+
+    def _fire_worker_cancel(self) -> None:
+        with self._turn_lock:
+            turn_id = self._active_turn_id
+        thread_id = self._session_id
+        if thread_id is None or turn_id is None or not self._client.is_alive():
+            return
+        self._client.request(
+            "turn/interrupt", {"threadId": thread_id, "turnId": turn_id}, timeout=5
+        )
+
+    def __enter__(self) -> "CodexSession":
+        depth = getattr(self._reentry_tls, "depth", 0)
+        if depth > 0:
+            self._bump_entry_depth()
+            return self
+        kind = provider.current_thread_kind()
+        if kind == "worker":
+            self._fsm_acquire_worker()
+        else:
+            self._fsm_acquire_handler()
+        self._bump_entry_depth()
+        if self._repo_name is not None:
+            try:
+                provider.register_talker(
+                    provider.SessionTalker(
+                        repo_name=self._repo_name,
+                        thread_id=threading.get_ident(),
+                        kind=kind,
+                        description="codex session turn",
+                        claude_pid=self.pid or 0,
+                        started_at=provider.talker_now(),
+                    )
+                )
+            except provider.SessionLeakError:
+                self._drop_entry_depth()
+                self._fsm_release()
+                raise
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        depth = self._drop_entry_depth()
+        if depth == 0:
+            if self._repo_name is not None:
+                provider.unregister_talker(self._repo_name, threading.get_ident())
+            self._fsm_release()
+
+    def _ensure_thread(self, *, session_id: str | None) -> None:
+        if session_id:
+            try:
+                result = self._client.request(
+                    "thread/resume", self._thread_params(session_id)
+                )
+                self._session_id = _thread_id_from_result(result)
+                return
+            except Exception:
+                log.exception("CodexSession: failed to resume session %s", session_id)
+                self._dropped_session_count += 1
+        result = self._client.request("thread/start", self._thread_params(None))
+        self._session_id = _thread_id_from_result(result)
+
+    def _thread_params(self, session_id: str | None) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "model": self._model.model,
+            "cwd": str(self._work_dir),
+            "approvalPolicy": "never",
+            "sandbox": {"mode": "danger-full-access"},
+            "developerInstructions": self._base_system_prompt,
+        }
+        if session_id is not None:
+            params["threadId"] = session_id
+            params["excludeTurns"] = True
+        return params
+
+    def _require_thread_id(self) -> str:
+        if self._session_id is None:
+            raise CodexProtocolError("Codex session has no thread id")
+        return self._session_id
+
+    def _poll_completed_turn(
+        self, thread_id: str, turn_id: str
+    ) -> dict[str, Any] | None:
+        try:
+            notification = self._client.wait_notification(
+                "turn/completed",
+                predicate=lambda params: _notification_matches(
+                    params, thread_id=thread_id, turn_id=turn_id
+                ),
+                timeout=0.01,
+            )
+        except TimeoutError:
+            return None
+        return notification["params"]
+
+    def _finish_turn(self, params: dict[str, Any], final_text: str) -> str:
+        with self._turn_lock:
+            self._active_turn_id = None
+        turn = params.get("turn")
+        status = turn.get("status") if isinstance(turn, dict) else params.get("status")
+        if isinstance(status, str) and status.lower() in {"interrupted", "cancelled"}:
+            self._last_turn_cancelled = True
+            return ""
+        if isinstance(status, str) and status.lower() in {"failed", "error"}:
+            error = params.get("error")
+            message = error.get("message") if isinstance(error, dict) else str(params)
+            raise CodexProviderError(
+                message=message if isinstance(message, str) else str(error),
+                kind=_classify_provider_error(str(message)),
+                payload=params,
+            )
+        self._last_turn_cancelled = False
+        return final_text
+
+
+def _thread_id_from_result(result: Any) -> str:
+    thread = result.get("thread") if isinstance(result, dict) else None
+    thread_id = thread.get("id") if isinstance(thread, dict) else None
+    if not isinstance(thread_id, str) or not thread_id:
+        raise CodexProtocolError("Codex thread response missing thread.id")
+    return thread_id
+
+
+def _combine_prompt(
+    content: str, base_system_prompt: str, system_prompt: str | None
+) -> str:
+    pieces = [piece for piece in (base_system_prompt, system_prompt, content) if piece]
+    return "\n\n".join(pieces)
+
+
+def _notification_matches(
+    params: dict[str, Any], *, thread_id: str, turn_id: str
+) -> bool:
+    raw_thread_id = params.get("threadId")
+    if isinstance(raw_thread_id, str) and raw_thread_id != thread_id:
+        return False
+    raw_turn_id = params.get("turnId")
+    if isinstance(raw_turn_id, str) and raw_turn_id != turn_id:
+        return False
+    turn = params.get("turn")
+    if isinstance(turn, dict):
+        nested_turn_id = turn.get("id")
+        if isinstance(nested_turn_id, str) and nested_turn_id != turn_id:
+            return False
+    return True
+
+
+def _extract_completed_turn(params: dict[str, Any]) -> dict[str, Any] | None:
+    turn = params.get("turn")
+    if isinstance(turn, dict) and isinstance(turn.get("status"), str):
+        return params
+    return None
 
 
 def run_codex_exec(

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -4,6 +4,7 @@ import threading
 from pathlib import Path
 
 from fido.claude import ClaudeAPI, ClaudeClient, ClaudeCode
+from fido.codex import CodexAPI
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLI, CopilotCLIAPI, CopilotCLIClient
 from fido.provider import (
@@ -34,7 +35,7 @@ class DefaultProviderFactory:
                 case ProviderID.COPILOT_CLI:
                     api = CopilotCLIAPI()
                 case ProviderID.CODEX:
-                    raise NotImplementedError("codex provider not yet wired")
+                    api = CodexAPI()
                 case _:
                     raise ValueError(f"unsupported provider: {repo_cfg.provider}")
             self._apis[repo_cfg.provider] = api

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -457,7 +457,7 @@ def preflight_repo_identity(
         log.info("preflight: %s: work_dir identity confirmed", name)
 
 
-_REQUIRED_TOOLS = ("git", "gh", "claude", "copilot")
+_REQUIRED_TOOLS = ("git", "gh", "claude", "copilot", "codex")
 
 
 def preflight_tools(fs: Filesystem) -> None:

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -641,6 +641,7 @@ class TestFidoLauncher:
         assert 'add_mount_if_exists "$HOME/.claude.json"' in script
         assert 'add_mount_if_exists "$HOME/.config/gh"' in script
         assert 'add_mount_if_exists "$HOME/.cache/copilot"' in script
+        assert 'add_mount_if_exists "$HOME/.codex"' in script
         assert 'chmod 600 "$secret"' in script
 
     def test_only_up_requires_webhook_secret(self) -> None:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -270,6 +270,7 @@ class TestCodexAppServerClient:
         process = _FakeProcess("not-json\n")
         with pytest.raises(CodexProtocolError, match="invalid JSON"):
             CodexAppServerClient(process_factory=lambda **_: process)
+        assert process.terminated
 
     def test_oversized_line_fails_loudly(self) -> None:
         process = _FakeProcess('{"id":1,"result":{}}\n')
@@ -278,6 +279,7 @@ class TestCodexAppServerClient:
                 process_factory=lambda **_: process,
                 max_line_bytes=1,
             )
+        assert process.terminated
 
 
 class TestCodexAPI:
@@ -344,6 +346,15 @@ class TestCodexAPI:
         snapshot = CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
         assert snapshot.provider == ProviderID.CODEX
         assert snapshot.unavailable_reason is not None
+
+    def test_client_factory_failure_is_unavailable_snapshot(self) -> None:
+        def fail() -> _FakeAppServer:
+            raise RuntimeError("codex unavailable")
+
+        snapshot = CodexAPI(client_factory=fail).get_limit_snapshot()
+        assert snapshot.provider == ProviderID.CODEX
+        assert snapshot.unavailable_reason is not None
+        assert "codex unavailable" in snapshot.unavailable_reason
 
     def test_caches_snapshot(self) -> None:
         fake = _FakeAppServer()

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -319,6 +319,25 @@ class TestCodexAPI:
         assert [window.name for window in snapshot.windows] == ["workspace_credits"]
         assert snapshot.closest_to_exhaustion().pressure == 1.0
 
+    def test_does_not_mark_zero_credit_balance_depleted_without_reached_type(
+        self,
+    ) -> None:
+        fake = _FakeAppServer()
+        fake.responses["account/rateLimits/read"] = {
+            "rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 1},
+                "secondary": {"usedPercent": 0},
+                "credits": {"balance": "0", "hasCredits": False, "unlimited": False},
+                "rateLimitReachedType": None,
+            }
+        }
+        snapshot = CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
+        assert [window.name for window in snapshot.windows] == [
+            "codex_primary",
+            "codex_secondary",
+        ]
+
     def test_malformed_response_is_unavailable_snapshot(self) -> None:
         fake = _FakeAppServer()
         fake.responses["account/rateLimits/read"] = {"rateLimits": "bad"}
@@ -349,11 +368,18 @@ class TestCodexSession:
         fake.notifications.extend(
             [
                 {
+                    "method": "turn/started",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "inProgress"},
+                    },
+                },
+                {
                     "method": "item/completed",
                     "params": {
                         "threadId": "thread-new",
                         "turnId": "turn-1",
-                        "item": {"type": "agent_message", "text": "reply"},
+                        "item": {"type": "agentMessage", "text": "reply"},
                     },
                 },
                 {
@@ -378,7 +404,10 @@ class TestCodexSession:
         turn_params = fake.requests[1][1]
         assert turn_params["model"] == "gpt-5.5"
         assert turn_params["effort"] == "medium"
-        assert "base\n\nhello" == turn_params["input"]["text"]
+        assert turn_params["sandboxPolicy"] == {"type": "dangerFullAccess"}
+        assert turn_params["input"] == [
+            {"type": "text", "text": "base\n\nhello", "text_elements": []}
+        ]
         assert session.sent_count == 1
         assert session.received_count == 1
 
@@ -400,7 +429,7 @@ class TestCodexSession:
                 "model": "gpt-5.5",
                 "cwd": str(tmp_path.resolve()),
                 "approvalPolicy": "never",
-                "sandbox": {"mode": "danger-full-access"},
+                "sandbox": "danger-full-access",
                 "developerInstructions": "",
                 "threadId": "persisted",
                 "excludeTurns": True,

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,3 +1,4 @@
+import io
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -5,15 +6,19 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.codex import (
+    CodexAPI,
+    CodexAppServerClient,
     CodexCLIError,
+    CodexProtocolError,
     CodexProviderError,
+    CodexSession,
     _codex,
     extract_result_text,
     extract_session_id,
     raise_for_provider_error_output,
     run_codex_exec,
 )
-from fido.provider import ProviderModel
+from fido.provider import ProviderID, ProviderModel
 
 FIXTURES = Path(__file__).parent / "fixtures" / "codex"
 
@@ -28,6 +33,89 @@ def _completed(
 
 def _fixture(name: str) -> str:
     return (FIXTURES / name).read_text()
+
+
+class _FakeProcess:
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO(stderr)
+        self.pid = 1234
+        self._returncode: int | None = None
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self._returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._returncode = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        self._returncode = 0
+        return 0
+
+    def kill(self) -> None:
+        self._returncode = -9
+
+
+class _FakeAppServer:
+    def __init__(self, *, cwd: Path | str | None = None) -> None:
+        self.cwd = cwd
+        self.pid = 456
+        self.requests: list[tuple[str, dict]] = []
+        self.notifications: list[dict] = []
+        self.responses: dict[str, object | Exception] = {}
+        self.stopped = False
+        self.alive = True
+
+    def request(
+        self, method: str, params: dict | None = None, *, timeout: float = 30.0
+    ) -> object:
+        del timeout
+        payload = params or {}
+        self.requests.append((method, payload))
+        response = self.responses.get(method)
+        if isinstance(response, Exception):
+            raise response
+        if response is not None:
+            return response
+        if method == "thread/start":
+            return {"thread": {"id": "thread-new"}}
+        if method == "thread/resume":
+            return {"thread": {"id": payload["threadId"]}}
+        if method == "turn/start":
+            return {"turn": {"id": "turn-1"}}
+        if method == "turn/interrupt":
+            return {}
+        return {}
+
+    def notify(self, method: str, params: dict | None = None) -> None:
+        self.requests.append((method, params or {}))
+
+    def wait_notification(
+        self,
+        method: str,
+        *,
+        predicate=None,
+        timeout: float = 30.0,
+    ) -> dict:
+        del timeout
+        for index, notification in enumerate(self.notifications):
+            if method != "*" and notification["method"] != method:
+                continue
+            params = notification["params"]
+            if predicate is None or predicate(params):
+                return self.notifications.pop(index)
+        raise TimeoutError(method)
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def stop(self) -> None:
+        self.stopped = True
+        self.alive = False
 
 
 class TestCodexHelper:
@@ -161,4 +249,236 @@ class TestRunCodexExec:
         mock_run = MagicMock(return_value=_completed(_fixture("rate-limit.jsonl")))
         with pytest.raises(CodexProviderError) as exc_info:
             run_codex_exec("hello", model="gpt-5.5", runner=mock_run)
+        assert exc_info.value.kind == "rate_limit"
+
+
+class TestCodexAppServerClient:
+    def test_initializes_and_routes_response_by_id(self) -> None:
+        process = _FakeProcess(
+            '{"id":1,"result":{"serverInfo":{"name":"codex"}}}\n'
+            '{"id":2,"result":{"ok":true}}\n'
+        )
+        client = CodexAppServerClient(process_factory=lambda **_: process)
+        assert client.request("example/method") == {"ok": True}
+        written = process.stdin.getvalue().splitlines()
+        assert '"method":"initialize"' in written[0]
+        assert '"method":"initialized"' in written[1]
+        assert '"method":"example/method"' in written[2]
+        client.stop()
+
+    def test_invalid_json_fails_loudly(self) -> None:
+        process = _FakeProcess("not-json\n")
+        with pytest.raises(CodexProtocolError, match="invalid JSON"):
+            CodexAppServerClient(process_factory=lambda **_: process)
+
+    def test_oversized_line_fails_loudly(self) -> None:
+        process = _FakeProcess('{"id":1,"result":{}}\n')
+        with pytest.raises(CodexProtocolError, match="line too large"):
+            CodexAppServerClient(
+                process_factory=lambda **_: process,
+                max_line_bytes=1,
+            )
+
+
+class TestCodexAPI:
+    def test_maps_primary_secondary_and_reset_windows(self) -> None:
+        fake = _FakeAppServer()
+        fake.responses["account/rateLimits/read"] = {
+            "rateLimits": [
+                {
+                    "limitId": "Main Limit",
+                    "primary": {"usedPercent": 43, "resetsAt": 1_700_000_000},
+                    "secondary": {"usedPercent": 91.2},
+                }
+            ]
+        }
+        api = CodexAPI(client_factory=lambda: fake, monotonic=lambda: 1.0)
+        snapshot = api.get_limit_snapshot()
+        assert snapshot.provider == ProviderID.CODEX
+        assert [window.name for window in snapshot.windows] == [
+            "main_limit_primary",
+            "main_limit_secondary",
+        ]
+        assert snapshot.windows[0].used == 43
+        assert snapshot.windows[0].unit == "%"
+        assert snapshot.windows[0].resets_at is not None
+        assert fake.stopped
+
+    def test_maps_credit_depletion_to_paused_window(self) -> None:
+        fake = _FakeAppServer()
+        fake.responses["account/rateLimits/read"] = {
+            "rateLimits": [
+                {
+                    "limitId": "workspace",
+                    "credits": {"hasCredits": False, "unlimited": False},
+                    "rateLimitReachedType": "workspace_owner_credits_depleted",
+                }
+            ]
+        }
+        snapshot = CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
+        assert [window.name for window in snapshot.windows] == ["workspace_credits"]
+        assert snapshot.closest_to_exhaustion().pressure == 1.0
+
+    def test_malformed_response_is_unavailable_snapshot(self) -> None:
+        fake = _FakeAppServer()
+        fake.responses["account/rateLimits/read"] = {"rateLimits": "bad"}
+        snapshot = CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
+        assert snapshot.provider == ProviderID.CODEX
+        assert snapshot.unavailable_reason is not None
+
+    def test_caches_snapshot(self) -> None:
+        fake = _FakeAppServer()
+        fake.responses["account/rateLimits/read"] = {
+            "rateLimits": [{"limitId": "main", "primary": {"usedPercent": 1}}]
+        }
+        now = 1.0
+        api = CodexAPI(client_factory=lambda: fake, monotonic=lambda: now)
+        first = api.get_limit_snapshot()
+        second = api.get_limit_snapshot()
+        assert first is second
+        assert [method for method, _ in fake.requests].count(
+            "account/rateLimits/read"
+        ) == 1
+
+
+class TestCodexSession:
+    def test_starts_thread_and_runs_prompt_turn(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agent_message", "text": "reply"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model=ProviderModel("gpt-5.5", "medium"),
+            client_factory=lambda **_: fake,
+        )
+        assert session.session_id == "thread-new"
+        assert session.prompt("hello") == "reply"
+        methods = [method for method, _ in fake.requests]
+        assert methods == ["thread/start", "turn/start"]
+        turn_params = fake.requests[1][1]
+        assert turn_params["model"] == "gpt-5.5"
+        assert turn_params["effort"] == "medium"
+        assert "base\n\nhello" == turn_params["input"]["text"]
+        assert session.sent_count == 1
+        assert session.received_count == 1
+
+    def test_resumes_persisted_thread_id(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            session_id="persisted",
+            client_factory=lambda **_: fake,
+        )
+        assert session.session_id == "persisted"
+        assert fake.requests[0] == (
+            "thread/resume",
+            {
+                "model": "gpt-5.5",
+                "cwd": str(tmp_path.resolve()),
+                "approvalPolicy": "never",
+                "sandbox": {"mode": "danger-full-access"},
+                "developerInstructions": "",
+                "threadId": "persisted",
+                "excludeTurns": True,
+            },
+        )
+
+    def test_stale_resume_starts_new_thread_and_counts_drop(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        fake.responses["thread/resume"] = CodexProviderError(message="missing")
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            session_id="stale",
+            client_factory=lambda **_: fake,
+        )
+        assert session.session_id == "thread-new"
+        assert session.dropped_session_count == 1
+        assert [method for method, _ in fake.requests] == [
+            "thread/resume",
+            "thread/start",
+        ]
+
+    def test_cancel_interrupts_active_turn_and_next_turn_is_clean(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        fake.notifications.append(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-new",
+                    "turn": {"id": "turn-1", "status": "interrupted"},
+                },
+            }
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: fake,
+        )
+        session.send("work")
+        session._fire_worker_cancel()
+        assert session.consume_until_result() == ""
+        assert session.last_turn_cancelled
+        assert fake.requests[-1] == (
+            "turn/interrupt",
+            {"threadId": "thread-new", "turnId": "turn-1"},
+        )
+
+    def test_failed_turn_raises_provider_error(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        fake.notifications.append(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-new",
+                    "turn": {"id": "turn-1", "status": "failed"},
+                    "error": {"message": "rate limit reached"},
+                },
+            }
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: fake,
+        )
+        session.send("work")
+        with pytest.raises(CodexProviderError) as exc_info:
+            session.consume_until_result()
         assert exc_info.value.kind == "rate_limit"

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -37,18 +37,18 @@ class TestDefaultProviderFactory:
         )
         assert api.provider_id == ProviderID.COPILOT_CLI
 
-    def test_create_api_rejects_codex_until_wired(self, tmp_path: Path) -> None:
+    def test_create_api_builds_codex(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         factory = DefaultProviderFactory(session_system_file=system_file)
-        with pytest.raises(NotImplementedError, match="codex provider not yet wired"):
-            factory.create_api(
-                RepoConfig(
-                    name="owner/repo",
-                    work_dir=tmp_path,
-                    provider=ProviderID.CODEX,
-                )
+        api = factory.create_api(
+            RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                provider=ProviderID.CODEX,
             )
+        )
+        assert api.provider_id == ProviderID.CODEX
 
     def test_create_provider_builds_claude(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4434,7 +4434,7 @@ class TestPreflightTools:
     def test_required_tools_constant(self) -> None:
         from fido.server import _REQUIRED_TOOLS
 
-        assert set(_REQUIRED_TOOLS) == {"git", "gh", "claude", "copilot"}
+        assert set(_REQUIRED_TOOLS) == {"git", "gh", "claude", "copilot", "codex"}
 
 
 class TestPreflightSubDir:

--- a/tools/codex_appserver_smoke.py
+++ b/tools/codex_appserver_smoke.py
@@ -4,21 +4,23 @@
 This is intentionally not part of CI: it talks to the local Codex install and
 account. Run it when changing Codex app-server integration code:
 
-    ./pyproject python tools/codex_appserver_smoke.py --turn
-    ./pyproject python tools/codex_appserver_smoke.py --turn --interrupt
+    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --turn
+    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --resume
+    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --interrupt
 """
 
 import argparse
 import json
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
 from fido.codex import CodexAPI, CodexSession
-from fido.provider import ProviderLimitSnapshot, ProviderModel
+from fido.provider import ProviderLimitSnapshot, ProviderModel, set_thread_kind
 
 
 def _json_default(value: object) -> object:
@@ -106,6 +108,124 @@ def _run_turn(args: argparse.Namespace) -> None:
             session.stop()
 
 
+def _run_resume(args: argparse.Namespace) -> None:
+    with tempfile.TemporaryDirectory(prefix="fido-codex-smoke-") as tmp:
+        system_file = Path(tmp) / "system.md"
+        system_file.write_text(
+            "You are validating Fido's Codex app-server resume integration. "
+            "Be concise.\n"
+        )
+        first = CodexSession(
+            system_file,
+            work_dir=args.work_dir,
+            model=ProviderModel(args.model, args.effort),
+            repo_name=None,
+        )
+        session_id = first.session_id
+        try:
+            first_result = first.prompt("Reply with exactly: resume first ok")
+            if not first_result:
+                raise RuntimeError("first resume-smoke turn returned no assistant text")
+        finally:
+            first.stop()
+
+        if session_id is None:
+            raise RuntimeError("first session did not expose a session id")
+
+        second = CodexSession(
+            system_file,
+            work_dir=args.work_dir,
+            model=ProviderModel(args.model, args.effort),
+            repo_name=None,
+            session_id=session_id,
+        )
+        try:
+            second_result = second.prompt("Reply with exactly: resume second ok")
+            _print_json(
+                "resume",
+                {
+                    "session_id": session_id,
+                    "resumed_session_id": second.session_id,
+                    "dropped_session_count": second.dropped_session_count,
+                    "first_result": first_result,
+                    "second_result": second_result,
+                },
+            )
+            if second.session_id != session_id:
+                raise RuntimeError("resume returned a different session id")
+            if second.dropped_session_count != 0:
+                raise RuntimeError("resume dropped the persisted session id")
+            if not second_result:
+                raise RuntimeError("resumed turn returned no assistant text")
+        finally:
+            second.stop()
+
+
+def _run_preempt(args: argparse.Namespace) -> None:
+    with tempfile.TemporaryDirectory(prefix="fido-codex-smoke-") as tmp:
+        system_file = Path(tmp) / "system.md"
+        system_file.write_text(
+            "You are validating Fido's Codex worker preemption path. Be concise.\n"
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=args.work_dir,
+            model=ProviderModel(args.model, args.effort),
+            repo_name="smoke/preempt",
+        )
+        worker_started = threading.Event()
+        worker_done = threading.Event()
+        worker_result: dict[str, object] = {}
+
+        def worker_turn() -> None:
+            set_thread_kind("worker")
+            try:
+                with session:
+                    session.send(args.prompt)
+                    worker_started.set()
+                    result = session.consume_until_result()
+                    worker_result["result"] = result
+                    worker_result["last_turn_cancelled"] = session.last_turn_cancelled
+            except Exception as exc:
+                worker_result["error"] = str(exc)
+            finally:
+                set_thread_kind(None)
+                worker_done.set()
+
+        worker = threading.Thread(
+            target=worker_turn,
+            name="codex-smoke-worker",
+            daemon=True,
+        )
+        worker.start()
+        try:
+            if not worker_started.wait(timeout=20):
+                raise RuntimeError("worker turn did not start")
+            time.sleep(args.interrupt_delay)
+            preempted = session.preempt_worker()
+            if not worker_done.wait(timeout=30):
+                raise RuntimeError("preempted worker did not drain")
+            worker.join(timeout=1)
+            _print_json(
+                "preempt",
+                {
+                    "preempted": preempted,
+                    "worker_result": worker_result,
+                    "session_id": session.session_id,
+                },
+            )
+            if not preempted:
+                raise RuntimeError("preempt_worker returned false")
+            if worker_result.get("error") is not None:
+                raise RuntimeError(str(worker_result["error"]))
+            if worker_result.get("last_turn_cancelled") is not True:
+                raise RuntimeError("worker did not observe a cancelled turn")
+            if worker_result.get("result") != "":
+                raise RuntimeError("preempted worker returned assistant text")
+        finally:
+            session.stop()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--work-dir", type=Path, default=Path.cwd())
@@ -126,6 +246,16 @@ def main() -> int:
         action="store_true",
         help="Interrupt the turn after --interrupt-delay seconds.",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Start a thread, stop the app server, resume the thread, and run another turn.",
+    )
+    parser.add_argument(
+        "--preempt",
+        action="store_true",
+        help="Run a worker-held turn and cancel it through OwnedSession.preempt_worker().",
+    )
     parser.add_argument("--interrupt-delay", type=float, default=1.0)
     args = parser.parse_args()
 
@@ -133,6 +263,10 @@ def main() -> int:
         _run_rate_limits()
         if args.turn or args.interrupt:
             _run_turn(args)
+        if args.resume:
+            _run_resume(args)
+        if args.preempt:
+            _run_preempt(args)
     except Exception as exc:
         print(f"codex app-server smoke failed: {exc}", file=sys.stderr)
         return 1

--- a/tools/codex_appserver_smoke.py
+++ b/tools/codex_appserver_smoke.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Exercise the real Codex app-server transport outside Fido runtime.
+
+This is intentionally not part of CI: it talks to the local Codex install and
+account. Run it when changing Codex app-server integration code:
+
+    ./pyproject python tools/codex_appserver_smoke.py --turn
+    ./pyproject python tools/codex_appserver_smoke.py --turn --interrupt
+"""
+
+import argparse
+import json
+import sys
+import tempfile
+import time
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from fido.codex import CodexAPI, CodexSession
+from fido.provider import ProviderLimitSnapshot, ProviderModel
+
+
+def _json_default(value: object) -> object:
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[no-any-return]
+    return str(value)
+
+
+def _print_json(label: str, value: object) -> None:
+    print(f"\n== {label} ==")
+    print(json.dumps(value, default=_json_default, indent=2, sort_keys=True))
+
+
+def _snapshot_summary(snapshot: ProviderLimitSnapshot) -> dict[str, Any]:
+    closest = snapshot.closest_to_exhaustion()
+    return {
+        "provider": snapshot.provider,
+        "unavailable_reason": snapshot.unavailable_reason,
+        "closest": closest,
+        "windows": snapshot.windows,
+    }
+
+
+def _run_rate_limits() -> None:
+    snapshot = CodexAPI().get_limit_snapshot()
+    _print_json("rate limits", _snapshot_summary(snapshot))
+    if snapshot.unavailable_reason is not None:
+        raise RuntimeError(snapshot.unavailable_reason)
+
+
+def _run_turn(args: argparse.Namespace) -> None:
+    with tempfile.TemporaryDirectory(prefix="fido-codex-smoke-") as tmp:
+        system_file = Path(tmp) / "system.md"
+        system_file.write_text(
+            "You are validating Fido's Codex app-server integration. Be concise.\n"
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=args.work_dir,
+            model=ProviderModel(args.model, args.effort),
+            repo_name=None,
+        )
+        try:
+            _print_json(
+                "thread",
+                {
+                    "pid": session.pid,
+                    "session_id": session.session_id,
+                    "alive": session.is_alive(),
+                },
+            )
+            if args.interrupt:
+                with session:
+                    session.send(args.prompt)
+                    time.sleep(args.interrupt_delay)
+                    session.interrupt_active_turn()
+                    result = session.consume_until_result()
+                _print_json(
+                    "interrupted turn",
+                    {
+                        "result": result,
+                        "last_turn_cancelled": session.last_turn_cancelled,
+                        "sent_count": session.sent_count,
+                        "received_count": session.received_count,
+                    },
+                )
+                if not session.last_turn_cancelled:
+                    raise RuntimeError("turn was not reported as cancelled")
+            else:
+                result = session.prompt(args.prompt)
+                _print_json(
+                    "turn",
+                    {
+                        "result": result,
+                        "last_turn_cancelled": session.last_turn_cancelled,
+                        "sent_count": session.sent_count,
+                        "received_count": session.received_count,
+                    },
+                )
+                if not result:
+                    raise RuntimeError("turn returned no assistant text")
+        finally:
+            session.stop()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--work-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--effort", default="medium")
+    parser.add_argument(
+        "--prompt",
+        default="Reply with exactly: fido codex smoke ok",
+        help="Prompt used for the optional turn check.",
+    )
+    parser.add_argument(
+        "--turn",
+        action="store_true",
+        help="Also start a thread and run a prompt turn.",
+    )
+    parser.add_argument(
+        "--interrupt",
+        action="store_true",
+        help="Interrupt the turn after --interrupt-delay seconds.",
+    )
+    parser.add_argument("--interrupt-delay", type=float, default=1.0)
+    args = parser.parse_args()
+
+    try:
+        _run_rate_limits()
+        if args.turn or args.interrupt:
+            _run_turn(args)
+    except Exception as exc:
+        print(f"codex app-server smoke failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a thread-safe Codex app-server stdio client with request routing, notifications, protocol failures, and lifecycle shutdown
- add Codex quota/status API mapping from upstream rate-limit payloads and wire `create_api()` for status
- add persistent `CodexSession` thread/turn/resume/cancel primitives while leaving live provider selection gated for the final Codex epic issue
- mount Codex auth state in the launcher and require `codex` in server preflight

Fixes #1047
Fixes #1048
Fixes #1049

## Verification
- `./fido tests tests/test_codex.py tests/test_provider_factory.py tests/test_server.py::TestStartupPreflight tests/test_build_wrapper.py::TestDockerRunCommand`
- `./fido ruff check src/fido/codex.py tests/test_codex.py src/fido/provider_factory.py tests/test_provider_factory.py tests/test_server.py tests/test_build_wrapper.py`
- `./fido pyright src/fido/codex.py`
- `./fido ci`