### PR TITLE
Wire Codex provider into factory

### DIFF
--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -15,6 +15,9 @@ from typing import IO, Any, Protocol
 import fido.provider as provider
 from fido.provider import (
     OwnedSession,
+    PromptSession,
+    Provider,
+    ProviderAgent,
     ProviderAPI,
     ProviderID,
     ProviderLimitSnapshot,
@@ -23,6 +26,7 @@ from fido.provider import (
     coerce_provider_model,
     model_name,
 )
+from fido.session_agent import SessionBackedAgent
 
 log = logging.getLogger(__name__)
 
@@ -647,6 +651,7 @@ class CodexSession(OwnedSession):
         self._client_factory = client_factory
         self._client = self._client_factory(cwd=self._work_dir)
         self._model = coerce_provider_model(model)
+        self._state_lock = threading.Lock()
         self._session_id: str | None = None
         self._turn_lock = threading.Lock()
         self._active_turn_id: str | None = None
@@ -671,27 +676,33 @@ class CodexSession(OwnedSession):
 
     @property
     def pid(self) -> int | None:
-        return self._client.pid
+        with self._state_lock:
+            return self._client.pid
 
     @property
     def session_id(self) -> str | None:
-        return self._session_id
+        with self._state_lock:
+            return self._session_id
 
     @property
     def dropped_session_count(self) -> int:
-        return self._dropped_session_count
+        with self._state_lock:
+            return self._dropped_session_count
 
     @property
     def sent_count(self) -> int:
-        return self._sent_count
+        with self._state_lock:
+            return self._sent_count
 
     @property
     def received_count(self) -> int:
-        return self._received_count
+        with self._state_lock:
+            return self._received_count
 
     @property
     def last_turn_cancelled(self) -> bool:
-        return self._last_turn_cancelled
+        with self._state_lock:
+            return self._last_turn_cancelled
 
     def prompt(
         self,
@@ -707,7 +718,8 @@ class CodexSession(OwnedSession):
 
     def send(self, content: str) -> None:
         thread_id = self._require_thread_id()
-        self._last_turn_cancelled = False
+        with self._state_lock:
+            self._last_turn_cancelled = False
         result = self._client.request(
             "turn/start",
             {
@@ -728,7 +740,8 @@ class CodexSession(OwnedSession):
             raise CodexProtocolError("Codex turn/start response missing turn.id")
         with self._turn_lock:
             self._active_turn_id = turn_id
-        self._sent_count += 1
+        with self._state_lock:
+            self._sent_count += 1
 
     def consume_until_result(self) -> str:
         with self._turn_lock:
@@ -763,7 +776,8 @@ class CodexSession(OwnedSession):
                 text = item.get("text")
                 if isinstance(text, str):
                     final_text = text
-                    self._received_count += 1
+                    with self._state_lock:
+                        self._received_count += 1
             completed = (
                 _extract_completed_turn(params) if method == "turn/completed" else None
             )
@@ -779,24 +793,33 @@ class CodexSession(OwnedSession):
         del tools
 
     def recover(self) -> None:
-        old_session_id = self._session_id
-        self._client.stop()
-        self._client = self._client_factory(cwd=self._work_dir)
+        with self._state_lock:
+            old_session_id = self._session_id
+            old_client = self._client
+        old_client.stop()
+        new_client = self._client_factory(cwd=self._work_dir)
+        with self._state_lock:
+            self._client = new_client
         self._ensure_thread(session_id=old_session_id)
 
     def reset(self, model: ProviderModel | None = None) -> None:
         if model is not None:
             self._model = coerce_provider_model(model)
-        self._session_id = None
-        self._active_turn_id = None
-        self._last_turn_cancelled = False
+        with self._state_lock:
+            self._session_id = None
+            self._last_turn_cancelled = False
+        with self._turn_lock:
+            self._active_turn_id = None
         self._ensure_thread(session_id=None)
 
     def is_alive(self) -> bool:
-        return self._client.is_alive()
+        with self._state_lock:
+            return self._client.is_alive()
 
     def stop(self) -> None:
-        self._client.stop()
+        with self._state_lock:
+            client = self._client
+        client.stop()
 
     def interrupt_active_turn(self) -> None:
         """Interrupt the currently active turn, if one is in flight."""
@@ -805,10 +828,12 @@ class CodexSession(OwnedSession):
     def _fire_worker_cancel(self) -> None:
         with self._turn_lock:
             turn_id = self._active_turn_id
-        thread_id = self._session_id
-        if thread_id is None or turn_id is None or not self._client.is_alive():
+        with self._state_lock:
+            thread_id = self._session_id
+            client = self._client
+        if thread_id is None or turn_id is None or not client.is_alive():
             return
-        self._client.request(
+        client.request(
             "turn/interrupt", {"threadId": thread_id, "turnId": turn_id}, timeout=5
         )
 
@@ -854,13 +879,16 @@ class CodexSession(OwnedSession):
                 result = self._client.request(
                     "thread/resume", self._thread_params(session_id)
                 )
-                self._session_id = _thread_id_from_result(result)
+                with self._state_lock:
+                    self._session_id = _thread_id_from_result(result)
                 return
             except CodexProviderError:
                 log.exception("CodexSession: failed to resume session %s", session_id)
-                self._dropped_session_count += 1
+                with self._state_lock:
+                    self._dropped_session_count += 1
         result = self._client.request("thread/start", self._thread_params(None))
-        self._session_id = _thread_id_from_result(result)
+        with self._state_lock:
+            self._session_id = _thread_id_from_result(result)
 
     def _thread_params(self, session_id: str | None) -> dict[str, Any]:
         params: dict[str, Any] = {
@@ -876,9 +904,11 @@ class CodexSession(OwnedSession):
         return params
 
     def _require_thread_id(self) -> str:
-        if self._session_id is None:
+        with self._state_lock:
+            session_id = self._session_id
+        if session_id is None:
             raise CodexProtocolError("Codex session has no thread id")
-        return self._session_id
+        return session_id
 
     def _poll_completed_turn(
         self, thread_id: str, turn_id: str
@@ -901,7 +931,8 @@ class CodexSession(OwnedSession):
         turn = params.get("turn")
         status = turn.get("status") if isinstance(turn, dict) else params.get("status")
         if isinstance(status, str) and status.lower() in {"interrupted", "cancelled"}:
-            self._last_turn_cancelled = True
+            with self._state_lock:
+                self._last_turn_cancelled = True
             return ""
         if isinstance(status, str) and status.lower() in {"failed", "error"}:
             error = params.get("error")
@@ -911,7 +942,8 @@ class CodexSession(OwnedSession):
                 kind=_classify_provider_error(str(message)),
                 payload=params,
             )
-        self._last_turn_cancelled = False
+        with self._state_lock:
+            self._last_turn_cancelled = False
         return final_text
 
 
@@ -986,3 +1018,164 @@ def run_codex_exec(
         raise CodexCLIError(completed.returncode, completed.stderr)
     raise_for_provider_error_output(completed.stdout)
     return completed.stdout
+
+
+def run_codex_exec_resume(
+    session_id: str,
+    prompt: str,
+    *,
+    model: ProviderModel | str,
+    timeout: int = 300,
+    cwd: Path | str = ".",
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str:
+    """Run one non-persistent Codex exec resume turn and return raw JSONL output."""
+    work_dir = Path(cwd).resolve()
+    completed = _codex(
+        "exec",
+        "--json",
+        "--model",
+        model_name(model),
+        "--sandbox",
+        "danger-full-access",
+        "--ask-for-approval",
+        "never",
+        "--skip-git-repo-check",
+        "resume",
+        session_id,
+        "-",
+        prompt=prompt,
+        timeout=timeout,
+        cwd=work_dir,
+        runner=runner,
+    )
+    if completed.returncode != 0:
+        raise CodexCLIError(completed.returncode, completed.stderr)
+    raise_for_provider_error_output(completed.stdout)
+    return completed.stdout
+
+
+class CodexClient(SessionBackedAgent, ProviderAgent):
+    """Injectable collaborator for Codex CLI and app-server interactions."""
+
+    voice_model = ProviderModel("gpt-5.5", "xhigh")
+    work_model = ProviderModel("gpt-5.5", "medium")
+    brief_model = ProviderModel("gpt-5.5", "low")
+
+    def __init__(
+        self,
+        runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+        session_fn: Callable[[], PromptSession] = provider.current_repo_session,
+        session_factory: Callable[..., PromptSession] | None = None,
+        session_system_file: Path | None = None,
+        work_dir: Path | str | None = None,
+        repo_name: str | None = None,
+        session: PromptSession | None = None,
+    ) -> None:
+        self._runner = runner
+        self._session_factory = (
+            CodexSession if session_factory is None else session_factory
+        )
+        super().__init__(
+            session_fn=session_fn,
+            session_system_file=session_system_file,
+            work_dir=work_dir,
+            repo_name=repo_name,
+            session=session,
+        )
+
+    @property
+    def provider_id(self) -> ProviderID:
+        return ProviderID.CODEX
+
+    def _spawn_owned_session(
+        self, model: ProviderModel, *, session_id: str | None = None
+    ) -> PromptSession:
+        system_file = self._session_system_file
+        work_dir = self._work_dir
+        assert system_file is not None
+        assert work_dir is not None
+        return self._session_factory(
+            system_file,
+            work_dir=work_dir,
+            model=model,
+            repo_name=self._repo_name,
+            session_id=session_id,
+        )
+
+    def _prompt_failure_is_passthrough(self, exc: Exception) -> bool:
+        return isinstance(exc, CodexProviderError)
+
+    def _dead_prompt_error_message(self) -> str:
+        return "Codex session died during prompt"
+
+    def print_prompt_from_file(
+        self,
+        system_file: Path,
+        prompt_file: Path,
+        model: ProviderModel,
+        timeout: int = 30,
+        idle_timeout: float = 1800.0,
+        cwd: Path | str = ".",
+    ) -> str:
+        del idle_timeout
+        prompt = _combine_prompt(prompt_file.read_text(), system_file.read_text(), None)
+        return run_codex_exec(
+            prompt,
+            model=model,
+            timeout=timeout,
+            cwd=cwd,
+            runner=self._runner,
+        )
+
+    def resume_session(
+        self,
+        session_id: str,
+        prompt_file: Path,
+        model: ProviderModel,
+        timeout: int = 300,
+        idle_timeout: float = 1800.0,
+        cwd: Path | str = ".",
+    ) -> str:
+        del idle_timeout
+        return run_codex_exec_resume(
+            session_id,
+            prompt_file.read_text(),
+            model=model,
+            timeout=timeout,
+            cwd=cwd,
+            runner=self._runner,
+        )
+
+    def extract_session_id(self, output: str) -> str:
+        return extract_session_id(output)
+
+
+class Codex(Provider):
+    """Composite Codex provider with separate account API and runtime agent."""
+
+    def __init__(
+        self,
+        *,
+        api: ProviderAPI | None = None,
+        agent: ProviderAgent | None = None,
+        session: PromptSession | None = None,
+    ) -> None:
+        if agent is None:
+            agent = CodexClient(session=session)
+        elif session is not None:
+            agent.attach_session(session)
+        self._api = CodexAPI() if api is None else api
+        self._agent = agent
+
+    @property
+    def provider_id(self) -> ProviderID:
+        return ProviderID.CODEX
+
+    @property
+    def api(self) -> ProviderAPI:
+        return self._api
+
+    @property
+    def agent(self) -> ProviderAgent:
+        return self._agent

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -4,7 +4,7 @@ import threading
 from pathlib import Path
 
 from fido.claude import ClaudeAPI, ClaudeClient, ClaudeCode
-from fido.codex import CodexAPI
+from fido.codex import Codex, CodexAPI, CodexClient
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLI, CopilotCLIAPI, CopilotCLIClient
 from fido.provider import (
@@ -69,7 +69,14 @@ class DefaultProviderFactory:
                     )
                 )
             case ProviderID.CODEX:
-                raise NotImplementedError("codex provider not yet wired")
+                return Codex(
+                    agent=CodexClient(
+                        session_system_file=self._session_system_file,
+                        work_dir=work_dir,
+                        repo_name=repo_name,
+                        session=session,
+                    )
+                )
             case _:
                 raise ValueError(f"unsupported provider: {repo_cfg.provider}")
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.codex import (
+    Codex,
     CodexAPI,
     CodexAppServerClient,
+    CodexClient,
     CodexCLIError,
     CodexProtocolError,
     CodexProviderError,
@@ -17,6 +19,7 @@ from fido.codex import (
     extract_session_id,
     raise_for_provider_error_output,
     run_codex_exec,
+    run_codex_exec_resume,
 )
 from fido.provider import ProviderID, ProviderModel
 
@@ -250,6 +253,41 @@ class TestRunCodexExec:
         with pytest.raises(CodexProviderError) as exc_info:
             run_codex_exec("hello", model="gpt-5.5", runner=mock_run)
         assert exc_info.value.kind == "rate_limit"
+
+    def test_resume_builds_stable_json_exec_resume_command(
+        self, tmp_path: Path
+    ) -> None:
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("continue")
+        mock_run = MagicMock(return_value=_completed(_fixture("normal.jsonl")))
+        output = run_codex_exec_resume(
+            "sess-1",
+            prompt_file.read_text(),
+            model=ProviderModel("gpt-5.5", "medium"),
+            timeout=19,
+            cwd=tmp_path,
+            runner=mock_run,
+        )
+        assert extract_result_text(output) == "final reply"
+        cmd = mock_run.call_args.args[0]
+        assert cmd == [
+            "codex",
+            "exec",
+            "--json",
+            "--model",
+            "gpt-5.5",
+            "--sandbox",
+            "danger-full-access",
+            "--ask-for-approval",
+            "never",
+            "--skip-git-repo-check",
+            "resume",
+            "sess-1",
+            "-",
+        ]
+        assert mock_run.call_args.kwargs["input"] == "continue"
+        assert mock_run.call_args.kwargs["timeout"] == 19
+        assert mock_run.call_args.kwargs["cwd"] == tmp_path.resolve()
 
 
 class TestCodexAppServerClient:
@@ -522,3 +560,122 @@ class TestCodexSession:
         with pytest.raises(CodexProviderError) as exc_info:
             session.consume_until_result()
         assert exc_info.value.kind == "rate_limit"
+
+
+class TestCodexClient:
+    def test_model_slots_and_provider_id(self) -> None:
+        client = CodexClient(session=MagicMock())
+        assert client.provider_id == ProviderID.CODEX
+        assert client.voice_model == ProviderModel("gpt-5.5", "xhigh")
+        assert client.work_model == ProviderModel("gpt-5.5", "medium")
+        assert client.brief_model == ProviderModel("gpt-5.5", "low")
+
+    def test_spawns_owned_session_with_resume_id(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("persona")
+        session = MagicMock()
+        factory = MagicMock(return_value=session)
+        client = CodexClient(
+            session_system_file=system_file,
+            work_dir=tmp_path,
+            repo_name="owner/repo",
+            session_factory=factory,
+        )
+        client.ensure_session(client.voice_model, session_id="thread-1")
+        factory.assert_called_once_with(
+            system_file,
+            work_dir=tmp_path,
+            model=client.voice_model,
+            repo_name="owner/repo",
+            session_id="thread-1",
+        )
+        assert client.session is session
+
+    def test_run_turn_through_fake_codex_session(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "reply"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        client = CodexClient(
+            session_system_file=system_file,
+            work_dir=tmp_path,
+            session_factory=lambda *args, **kwargs: CodexSession(
+                *args,
+                **kwargs,
+                client_factory=lambda **_: fake,
+            ),
+        )
+        assert client.run_turn("hello", model=client.work_model) == "reply"
+        assert [method for method, _ in fake.requests] == ["thread/start", "turn/start"]
+        assert fake.requests[1][1]["effort"] == "medium"
+
+    def test_provider_errors_pass_through(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = CodexProviderError(message="rate limit")
+        client = CodexClient(session=session)
+        with pytest.raises(CodexProviderError, match="rate limit"):
+            client.run_turn("hello", model=client.work_model)
+
+    def test_file_helpers_use_exec_paths(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        prompt_file = tmp_path / "prompt.md"
+        system_file.write_text("system")
+        prompt_file.write_text("prompt")
+        runner = MagicMock(return_value=_completed(_fixture("normal.jsonl")))
+        client = CodexClient(runner=runner)
+
+        assert client.print_prompt_from_file(
+            system_file, prompt_file, client.work_model, cwd=tmp_path
+        )
+        assert runner.call_args.kwargs["input"] == "system\n\nprompt"
+
+        client.resume_session("sess-1", prompt_file, client.brief_model, cwd=tmp_path)
+        assert runner.call_args.args[0][-3:] == ["resume", "sess-1", "-"]
+
+    def test_extract_session_id(self) -> None:
+        client = CodexClient(session=MagicMock())
+        assert (
+            client.extract_session_id(
+                '{"type":"thread.started","thread_id":"codex-sess"}'
+            )
+            == "codex-sess"
+        )
+
+
+class TestCodex:
+    def test_default_provider_id_and_injected_components(self) -> None:
+        api = MagicMock()
+        agent = MagicMock()
+        provider = Codex(api=api, agent=agent)
+        assert provider.provider_id == ProviderID.CODEX
+        assert provider.api is api
+        assert provider.agent is agent
+
+    def test_default_agent_receives_session(self) -> None:
+        session = MagicMock()
+        provider = Codex(session=session)
+        assert provider.agent.session is session
+
+    def test_injected_agent_receives_session(self) -> None:
+        agent = MagicMock()
+        session = MagicMock()
+        Codex(agent=agent, session=session)
+        agent.attach_session.assert_called_once_with(session)

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from fido.config import RepoConfig
 from fido.provider import ProviderID
 from fido.provider_factory import DefaultProviderFactory
@@ -98,22 +96,22 @@ class TestDefaultProviderFactory:
         )
         assert agent.provider_id == ProviderID.COPILOT_CLI
 
-    def test_create_provider_rejects_codex_until_wired(self, tmp_path: Path) -> None:
+    def test_create_provider_builds_codex(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         factory = DefaultProviderFactory(session_system_file=system_file)
-        repo_cfg = RepoConfig(
-            name="owner/repo",
-            work_dir=tmp_path,
-            provider=ProviderID.CODEX,
-        )
-        with pytest.raises(NotImplementedError, match="codex provider not yet wired"):
-            factory.create_provider(
-                repo_cfg,
+        provider = factory.create_provider(
+            RepoConfig(
+                name="owner/repo",
                 work_dir=tmp_path,
-                repo_name="owner/repo",
-                session=None,
-            )
+                provider=ProviderID.CODEX,
+            ),
+            work_dir=tmp_path,
+            repo_name="owner/repo",
+            session=None,
+        )
+        assert provider.provider_id == ProviderID.CODEX
+        assert provider.agent.provider_id == ProviderID.CODEX
 
 
 class TestProviderSessionIdExtraction:
@@ -151,4 +149,24 @@ class TestProviderSessionIdExtraction:
         assert (
             agent.extract_session_id('{"type":"result","sessionId":"copilot-sess"}')
             == "copilot-sess"
+        )
+
+    def test_codex_agent_extracts_session_id(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        agent = factory.create_agent(
+            RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                provider=ProviderID.CODEX,
+            ),
+            work_dir=tmp_path,
+            repo_name="owner/repo",
+        )
+        assert (
+            agent.extract_session_id(
+                '{"type":"thread.started","thread_id":"codex-sess"}'
+            )
+            == "codex-sess"
         )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -15,6 +15,7 @@ from fido.config import RepoConfig as _RepoConfig
 from fido.provider import (
     ProviderID,
     ProviderLimitSnapshot,
+    ProviderLimitWindow,
     ProviderPressureStatus,
 )
 from fido.status import (
@@ -202,6 +203,24 @@ class TestProviderStatusesForRepoConfigs:
         with patch("fido.status.DefaultProviderFactory", return_value=factory):
             statuses = provider_statuses_for_repo_configs([repo])
         assert list(statuses) == [ProviderID.CLAUDE_CODE]
+
+    def test_collects_codex_provider_status(self, tmp_path: Path) -> None:
+        repo = RepoConfig(
+            name="owner/repo", work_dir=tmp_path, provider=ProviderID.CODEX
+        )
+        factory = MagicMock()
+        api = MagicMock()
+        api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
+            provider=ProviderID.CODEX,
+            windows=(ProviderLimitWindow(name="codex_primary", used=25, limit=100),),
+        )
+        factory.create_api.return_value = api
+
+        statuses = provider_statuses_for_repo_configs([repo], _provider_factory=factory)
+
+        assert statuses[ProviderID.CODEX].provider == ProviderID.CODEX
+        assert statuses[ProviderID.CODEX].percent_used == 25
+        factory.create_api.assert_called_once_with(repo)
 
 
 class TestProcessUptimeSeconds:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -438,6 +438,21 @@ class TestWorker:
         )
         assert worker._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
 
+    def test_repo_cfg_provider_selects_codex_provider(self, tmp_path: Path) -> None:
+        from fido.config import RepoConfig
+
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                provider=ProviderID.CODEX,
+            ),
+            issue_cache=MagicMock(),
+        )
+        assert worker._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
+
     def test_config_defaults_to_none(self, tmp_path: Path) -> None:
         worker = Worker(tmp_path, MagicMock())
         assert worker._config is None
@@ -12943,6 +12958,23 @@ class TestWorkerThread:
         )
         assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert wt._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
+
+    def test_repo_cfg_provider_selects_codex_provider(self, tmp_path: Path) -> None:
+        from fido.config import RepoConfig
+
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            repo_cfg=RepoConfig(
+                name="owner/repo",
+                work_dir=tmp_path,
+                provider=ProviderID.CODEX,
+            ),
+            issue_cache=MagicMock(),
+        )
+        assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
+        assert wt._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
 
     def test_config_defaults_to_none(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)


### PR DESCRIPTION
## Summary

- add CodexClient as a SessionBackedAgent and Codex as the composite provider
- wire :codex provider construction through DefaultProviderFactory
- cover Codex run_turn, provider-error propagation, status collection, worker selection, and session-id extraction
- tighten CodexSession shared state reads for status/worker access under Python 3.14t

Fixes #1050.

## Verification

- ./fido tests tests/test_codex.py tests/test_provider_factory.py tests/test_status.py::TestProviderStatusesForRepoConfigs::test_collects_codex_provider_status tests/test_worker.py::TestWorker::test_repo_cfg_provider_selects_codex_provider tests/test_worker.py::TestWorkerThread::test_repo_cfg_provider_selects_codex_provider
- ./fido pyright src/fido/codex.py src/fido/provider_factory.py
- ./fido ci

## Note

Also updated #710 with the explicit TODO to make the repo-local command queue / single-worker executor the primary Rocq target.