### PR TITLE
Codex live smoke: provider parity branch cycle (closes #1080)

### DIFF
--- a/docs/codex-live-smoke.md
+++ b/docs/codex-live-smoke.md
@@ -1,0 +1,6 @@
+# Codex Live Smoke
+
+## 2026-04-28
+
+The Codex provider created and updated the `provider-parity-smoke` branch for
+the live provider parity smoke.


### PR DESCRIPTION
Adds a concise docs-only smoke note for the Codex provider parity branch cycle. The note records that the Codex provider created and updated this smoke branch on 2026-04-28.

Fixes #1080.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add Codex live smoke docs note <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->