### PR TITLE
Fix Codex turn idle timeout handling

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -18,6 +18,7 @@ from typing import Any
 import requests as _requests
 
 from fido import provider
+from fido.idle_timeout import IdleDeadline
 from fido.provider import (
     OwnedSession,
     PromptSession,
@@ -417,24 +418,29 @@ def _run_streaming(
         talker_registered = True
 
     try:
-        last_activity = clock()
+        idle_deadline = IdleDeadline(
+            idle_timeout,
+            poll_interval=_SELECT_POLL_INTERVAL,
+            clock=clock,
+        )
 
         while True:
-            ready, _, _ = selector([proc.stdout], [], [], _SELECT_POLL_INTERVAL)
+            poll_timeout = idle_deadline.poll_timeout_or_expired()
+            if poll_timeout is None:
+                log.warning("claude idle for %.0fs — killing", idle_timeout)
+                proc.kill()
+                proc.wait()
+                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
+            ready, _, _ = selector([proc.stdout], [], [], poll_timeout)
             if ready:
                 line = proc.stdout.readline()
                 if not line:
                     break  # EOF
                 yield line
                 log.debug(line.rstrip())
-                last_activity = clock()
+                idle_deadline.reset()
             elif proc.poll() is not None:
                 break  # process exited
-            elif clock() - last_activity > idle_timeout:
-                log.warning("claude idle for %.0fs — killing", idle_timeout)
-                proc.kill()
-                proc.wait()
-                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
 
         proc.wait()
         # Drain any remaining output
@@ -1222,7 +1228,10 @@ class ClaudeSession(OwnedSession):
         # previous holder — the FSM's FIFO handler queue ensures the next
         # holder's turn starts clean without needing a separate pending flag.
         self._cancel.clear()
-        last_activity = time.monotonic()
+        idle_deadline = IdleDeadline(
+            self._idle_timeout,
+            poll_interval=_SELECT_POLL_INTERVAL,
+        )
         cancelled_at: float | None = None
         cancel_request_id: str | None = None
         cancel_ack_seen = False
@@ -1283,8 +1292,17 @@ class ClaudeSession(OwnedSession):
                 self._stream_reset()
                 self.recover()
                 raise ClaudeStreamError(_RETURNCODE_CANCEL_DRAIN_TIMEOUT)
+            poll_timeout = idle_deadline.poll_timeout_or_expired()
+            if poll_timeout is None:
+                log.warning(
+                    "ClaudeSession: idle for %.0fs — killing", self._idle_timeout
+                )
+                self._proc.kill()
+                self._proc.wait()
+                self.recover()
+                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
             ready, _, _ = self._selector(
-                [self._proc.stdout, self._wakeup_r], [], [], _SELECT_POLL_INTERVAL
+                [self._proc.stdout, self._wakeup_r], [], [], poll_timeout
             )
             self._drain_wakeup()
             if self._proc.stdout in ready:
@@ -1294,12 +1312,12 @@ class ClaudeSession(OwnedSession):
                     break  # EOF
                 line = line.strip()
                 if not line:
-                    last_activity = time.monotonic()
+                    idle_deadline.reset()
                     continue
                 obj = json.loads(line)
                 self._log_event(obj)
                 self._received_count += 1
-                last_activity = time.monotonic()
+                idle_deadline.reset()
                 # First non-empty event after Send transitions Sending →
                 # AwaitingReply.  Other states (AwaitingReply, Draining,
                 # Idle scaffolding) leave the FSM untouched.
@@ -1369,14 +1387,6 @@ class ClaudeSession(OwnedSession):
             elif self._proc.poll() is not None:
                 self._stream_reset()
                 break  # process exited
-            elif time.monotonic() - last_activity > self._idle_timeout:
-                log.warning(
-                    "ClaudeSession: idle for %.0fs — killing", self._idle_timeout
-                )
-                self._proc.kill()
-                self._proc.wait()
-                self.recover()
-                raise ClaudeStreamError(_RETURNCODE_IDLE_TIMEOUT)
 
     def consume_until_result(self) -> str:
         """Drain events for the current turn and return the result text.

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import IO, Any, Protocol
 
 import fido.provider as provider
+from fido.idle_timeout import IdleDeadline
 from fido.provider import (
     OwnedSession,
     PromptSession,
@@ -32,6 +33,8 @@ log = logging.getLogger(__name__)
 
 _CODEX_RATE_LIMIT_CACHE_SECONDS = 300.0
 _CODEX_APP_SERVER_TIMEOUT = 30.0
+_CODEX_TURN_IDLE_TIMEOUT = 1800.0
+_CODEX_TURN_POLL_INTERVAL = 1.0
 _CODEX_APP_SERVER_MAX_LINE_BYTES = 8 * 1024 * 1024
 _CODEX_CLIENT_INFO = {
     "name": "fido",
@@ -642,6 +645,8 @@ class CodexSession(OwnedSession):
         repo_name: str | None = None,
         client_factory: Callable[..., CodexAppServer] = CodexAppServerClient,
         session_id: str | None = None,
+        turn_idle_timeout: float = _CODEX_TURN_IDLE_TIMEOUT,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._work_dir = Path(work_dir).resolve()
         self._repo_name = repo_name
@@ -651,6 +656,8 @@ class CodexSession(OwnedSession):
         self._client_factory = client_factory
         self._client = self._client_factory(cwd=self._work_dir)
         self._model = coerce_provider_model(model)
+        self._turn_idle_timeout = turn_idle_timeout
+        self._clock = clock
         self._state_lock = threading.Lock()
         self._session_id: str | None = None
         self._turn_lock = threading.Lock()
@@ -750,14 +757,25 @@ class CodexSession(OwnedSession):
             return ""
         final_text = ""
         thread_id = self._require_thread_id()
+        idle_deadline = IdleDeadline(
+            self._turn_idle_timeout,
+            clock=self._clock,
+        )
         while True:
-            notification = self._client.wait_notification(
-                "*",
-                predicate=lambda params: _notification_matches(
-                    params, thread_id=thread_id, turn_id=active_turn_id
-                ),
-                timeout=_CODEX_APP_SERVER_TIMEOUT,
-            )
+            timeout = min(idle_deadline.remaining(), _CODEX_TURN_POLL_INTERVAL)
+            if timeout <= 0:
+                self._recover_after_turn_idle_timeout(active_turn_id)
+            try:
+                notification = self._client.wait_notification(
+                    "*",
+                    predicate=lambda params: _notification_matches(
+                        params, thread_id=thread_id, turn_id=active_turn_id
+                    ),
+                    timeout=timeout,
+                )
+            except TimeoutError:
+                continue
+            idle_deadline.reset()
             method = notification.get("method")
             params = notification["params"]
             if method == "error":
@@ -785,6 +803,18 @@ class CodexSession(OwnedSession):
                 completed = self._poll_completed_turn(thread_id, active_turn_id)
             if completed is not None:
                 return self._finish_turn(completed, final_text)
+
+    def _recover_after_turn_idle_timeout(self, turn_id: str) -> None:
+        log.warning(
+            "CodexSession: turn %s idle for %.0fs — restarting app-server",
+            turn_id,
+            self._turn_idle_timeout,
+        )
+        with self._turn_lock:
+            if self._active_turn_id == turn_id:
+                self._active_turn_id = None
+        self.recover()
+        raise TimeoutError(f"Timed out waiting for Codex turn activity: {turn_id}")
 
     def switch_model(self, model: ProviderModel | str) -> None:
         self._model = coerce_provider_model(model)

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import IO, Any, Protocol
+from typing import IO, Any, NoReturn, Protocol
 
 import fido.provider as provider
 from fido.idle_timeout import IdleDeadline
@@ -759,11 +759,12 @@ class CodexSession(OwnedSession):
         thread_id = self._require_thread_id()
         idle_deadline = IdleDeadline(
             self._turn_idle_timeout,
+            poll_interval=_CODEX_TURN_POLL_INTERVAL,
             clock=self._clock,
         )
         while True:
-            timeout = min(idle_deadline.remaining(), _CODEX_TURN_POLL_INTERVAL)
-            if timeout <= 0:
+            timeout = idle_deadline.poll_timeout_or_expired()
+            if timeout is None:
                 self._recover_after_turn_idle_timeout(active_turn_id)
             try:
                 notification = self._client.wait_notification(
@@ -804,7 +805,7 @@ class CodexSession(OwnedSession):
             if completed is not None:
                 return self._finish_turn(completed, final_text)
 
-    def _recover_after_turn_idle_timeout(self, turn_id: str) -> None:
+    def _recover_after_turn_idle_timeout(self, turn_id: str) -> NoReturn:
         log.warning(
             "CodexSession: turn %s idle for %.0fs — restarting app-server",
             turn_id,

--- a/src/fido/idle_timeout.py
+++ b/src/fido/idle_timeout.py
@@ -1,0 +1,24 @@
+"""Shared idle-timeout bookkeeping for streaming provider turns."""
+
+import time
+from collections.abc import Callable
+
+
+class IdleDeadline:
+    """Track a timeout that resets whenever provider activity arrives."""
+
+    def __init__(
+        self,
+        timeout: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._timeout = timeout
+        self._clock = clock
+        self._last_activity = self._clock()
+
+    def reset(self) -> None:
+        self._last_activity = self._clock()
+
+    def remaining(self) -> float:
+        return self._timeout - (self._clock() - self._last_activity)

--- a/src/fido/idle_timeout.py
+++ b/src/fido/idle_timeout.py
@@ -5,15 +5,23 @@ from collections.abc import Callable
 
 
 class IdleDeadline:
-    """Track a timeout that resets whenever provider activity arrives."""
+    """Track provider turn idleness using bounded poll slices.
+
+    Provider loops should call :meth:`poll_timeout` before each blocking read and
+    :meth:`reset` whenever real provider activity arrives.  This keeps
+    preemption responsive while allowing long model turns that emit occasional
+    activity.
+    """
 
     def __init__(
         self,
         timeout: float,
         *,
+        poll_interval: float,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._timeout = timeout
+        self._poll_interval = poll_interval
         self._clock = clock
         self._last_activity = self._clock()
 
@@ -22,3 +30,15 @@ class IdleDeadline:
 
     def remaining(self) -> float:
         return self._timeout - (self._clock() - self._last_activity)
+
+    def poll_timeout(self) -> float:
+        return min(self.remaining(), self._poll_interval)
+
+    def poll_timeout_or_expired(self) -> float | None:
+        remaining = self.remaining()
+        if remaining <= 0:
+            return None
+        return min(remaining, self._poll_interval)
+
+    def expired(self) -> bool:
+        return self.remaining() <= 0

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -68,6 +68,9 @@ class _FakeAppServer:
         self.cwd = cwd
         self.pid = 456
         self.requests: list[tuple[str, dict]] = []
+        self.notification_timeouts: list[float] = []
+        self.notification_timeouts_before_match = 0
+        self.on_notification_wait = lambda _timeout: None
         self.notifications: list[dict] = []
         self.responses: dict[str, object | Exception] = {}
         self.stopped = False
@@ -104,7 +107,11 @@ class _FakeAppServer:
         predicate=None,
         timeout: float = 30.0,
     ) -> dict:
-        del timeout
+        self.notification_timeouts.append(timeout)
+        self.on_notification_wait(timeout)
+        if self.notification_timeouts_before_match > 0:
+            self.notification_timeouts_before_match -= 1
+            raise TimeoutError(method)
         for index, notification in enumerate(self.notifications):
             if method != "*" and notification["method"] != method:
                 continue
@@ -560,6 +567,87 @@ class TestCodexSession:
         with pytest.raises(CodexProviderError) as exc_info:
             session.consume_until_result()
         assert exc_info.value.kind == "rate_limit"
+
+    def test_turn_consumption_tolerates_quiet_notification_polls(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        now = 0.0
+
+        def clock() -> float:
+            return now
+
+        def advance(timeout: float) -> None:
+            nonlocal now
+            now += timeout
+
+        fake.notification_timeouts_before_match = 2
+        fake.on_notification_wait = advance
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "reply"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: fake,
+            turn_idle_timeout=10.0,
+            clock=clock,
+        )
+        session.send("work")
+        assert session.consume_until_result() == "reply"
+        assert fake.notification_timeouts[:3] == [1.0, 1.0, 1.0]
+
+    def test_turn_consumption_times_out_after_idle_budget(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        replacement = _FakeAppServer()
+        clients = [fake, replacement]
+        now = 0.0
+
+        def clock() -> float:
+            return now
+
+        def advance(timeout: float) -> None:
+            nonlocal now
+            now += timeout
+
+        fake.notification_timeouts_before_match = 100
+        fake.on_notification_wait = advance
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: clients.pop(0),
+            turn_idle_timeout=2.5,
+            clock=clock,
+        )
+        session.send("work")
+        with pytest.raises(TimeoutError, match="Codex turn activity"):
+            session.consume_until_result()
+        assert fake.notification_timeouts == [1.0, 1.0, 0.5]
+        assert fake.stopped
+        assert replacement.requests[0][0] == "thread/resume"
+        assert replacement.requests[0][1]["threadId"] == "thread-new"
 
 
 class TestCodexClient:

--- a/tests/test_idle_timeout.py
+++ b/tests/test_idle_timeout.py
@@ -1,0 +1,68 @@
+from fido.idle_timeout import IdleDeadline
+
+
+def test_poll_timeout_is_capped_by_poll_interval() -> None:
+    now = 0.0
+
+    def clock() -> float:
+        return now
+
+    deadline = IdleDeadline(30.0, poll_interval=1.0, clock=clock)
+
+    assert deadline.poll_timeout() == 1.0
+
+
+def test_poll_timeout_shrinks_to_remaining_idle_budget() -> None:
+    now = 9.75
+
+    def clock() -> float:
+        return now
+
+    deadline = IdleDeadline(10.0, poll_interval=1.0, clock=clock)
+    now = 19.5
+
+    assert deadline.poll_timeout() == 0.25
+    assert not deadline.expired()
+
+
+def test_reset_extends_deadline_from_current_activity() -> None:
+    now = 0.0
+
+    def clock() -> float:
+        return now
+
+    deadline = IdleDeadline(10.0, poll_interval=1.0, clock=clock)
+    now = 9.0
+    deadline.reset()
+    now = 18.0
+
+    assert deadline.poll_timeout() == 1.0
+    assert not deadline.expired()
+
+
+def test_expired_after_full_idle_budget() -> None:
+    now = 0.0
+
+    def clock() -> float:
+        return now
+
+    deadline = IdleDeadline(10.0, poll_interval=1.0, clock=clock)
+    now = 10.0
+
+    assert deadline.expired()
+
+
+def test_poll_timeout_or_expired_samples_clock_once() -> None:
+    calls = 0
+    now = 0.0
+
+    def clock() -> float:
+        nonlocal calls
+        calls += 1
+        return now
+
+    deadline = IdleDeadline(10.0, poll_interval=1.0, clock=clock)
+    now = 11.0
+
+    assert deadline.poll_timeout_or_expired() is None
+    assert calls == 2


### PR DESCRIPTION
Fixes #1083.

## Summary

- Add shared idle-deadline bookkeeping for provider turn consumption.
- Keep Codex app-server control RPCs on the existing short timeout.
- Change Codex model-turn notification consumption to poll in short slices while allowing Claude-style long idle turns.
- Restart the Codex app-server on true turn-idle timeout before surfacing the failure for watchdog recovery.
- Cover quiet-but-valid turns and true idle timeout recovery in Codex session tests.

## Verification

- `./fido pytest tests/test_codex.py`
- `./fido ruff check src/fido/codex.py src/fido/idle_timeout.py tests/test_codex.py`
- `./fido ruff format --check src/fido/codex.py src/fido/idle_timeout.py tests/test_codex.py`
- pre-commit `./fido ci` during commit
