### PR TITLE
P1: Rocq extraction expression precedence coverage (closes #1086)

### DIFF
--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -1278,6 +1278,8 @@ let rec pp_expr state env expr =
                  py_prec_not
              | MLglob r, [_; _] when is_std_bool_ref r "andb" ->
                  py_prec_and
+             | MLglob r, [_; _] when is_std_bool_ref r "orb" ->
+                 py_prec_or
              | MLglob r, [_; _] when is_std_bool_ref r "eqb" ->
                  py_prec_compare
              | MLglob r, [_; _] when is_std_primitive_compare_ref r ->
@@ -1451,6 +1453,12 @@ let rec pp_expr state env expr =
                  py_prec_and
                  (rendered_expr left)
                  (rendered_expr right))
+        | [left; right] when is_std_bool_ref r "orb" ->
+            Some
+              (py_infix "or"
+                 py_prec_or
+                 (rendered_expr left)
+                 (rendered_expr right))
         | [left; right] when is_std_bool_ref r "eqb" ->
             Some
               (py_infix ~associativity:PyAssocNone "=="
@@ -1491,8 +1499,8 @@ let rec pp_expr state env expr =
       in
       let pp_collection_expr =
         match head with
-        | MLglob r when is_std_bool_ref r "andb" || is_std_bool_ref r "negb" ||
-                        is_std_bool_ref r "eqb" ->
+        | MLglob r when is_std_bool_ref r "andb" || is_std_bool_ref r "orb" ||
+                        is_std_bool_ref r "negb" || is_std_bool_ref r "eqb" ->
             pp_std_bool_app r
         | MLglob r when is_std_primitive_compare_ref r ->
             pp_std_primitive_compare r
@@ -3922,8 +3930,8 @@ type type_decl_action =
   | TypeDeclUnsupported
 
 let is_std_bool_term_ref r =
-  is_std_bool_ref r "andb" || is_std_bool_ref r "negb" ||
-  is_std_bool_ref r "eqb"
+  is_std_bool_ref r "andb" || is_std_bool_ref r "orb" ||
+  is_std_bool_ref r "negb" || is_std_bool_ref r "eqb"
 
 let classify_term_decl state r typ =
   if is_prop_type typ then TermDeclSuppress

--- a/rocq-python-extraction/test/finite_collections.v
+++ b/rocq-python-extraction/test/finite_collections.v
@@ -101,6 +101,27 @@ Definition positive_claim_nested_expr : PositiveSet.t :=
     (PositiveSet.union positive_claim_set positive_claim_diff)
     positive_claim_union.
 
+(** [positive_claim_union_inter_expr] keeps higher-precedence intersection as
+    the right child of lowered set union without extra parentheses. *)
+Definition positive_claim_union_inter_expr : PositiveSet.t :=
+  PositiveSet.union
+    positive_claim_diff
+    (PositiveSet.inter positive_claim_set positive_claim_union).
+
+(** [positive_claim_diff_union_expr] parenthesizes a lowered union expression
+    used as the right operand of set difference. *)
+Definition positive_claim_diff_union_expr : PositiveSet.t :=
+  PositiveSet.diff
+    positive_claim_union
+    (PositiveSet.union positive_claim_diff positive_claim_inter).
+
+(** [positive_claim_inter_diff_expr] parenthesizes lowered set difference when
+    it feeds set intersection. *)
+Definition positive_claim_inter_diff_expr : PositiveSet.t :=
+  PositiveSet.inter
+    (PositiveSet.diff positive_claim_union positive_claim_diff)
+    positive_claim_set.
+
 (** [positive_claim_removed] removes [p2] from the base set, directly
     covering [PositiveSet.remove]. *)
 Definition positive_claim_removed : PositiveSet.t :=

--- a/rocq-python-extraction/test/generated_pytest_targets.txt
+++ b/rocq-python-extraction/test/generated_pytest_targets.txt
@@ -22,6 +22,10 @@ nat_pred_or_zero.py
 nat_roundtrip.py
 positive_five.py
 positive_case.py
+nat_compare_and.py
+nat_compare_or.py
+nat_compare_neg.py
+nat_compare_bool_eq.py
 n_seven.py
 n_case.py
 z_neg_three.py

--- a/rocq-python-extraction/test/generated_pytest_targets.txt
+++ b/rocq-python-extraction/test/generated_pytest_targets.txt
@@ -14,6 +14,7 @@ eq_dec_bool.py
 proof_pair_zero.py
 tick.py
 option_chain.py
+option_chain_twice.py
 ModuleLookupFixture.py
 source_map_runtime_error.py
 source_map_runtime_error.pymap

--- a/rocq-python-extraction/test/monads.v
+++ b/rocq-python-extraction/test/monads.v
@@ -57,6 +57,13 @@ Definition option_bind {A B : Type}
 Definition option_chain (o : option nat) : option nat :=
   option_bind o (fun n => Some (S n)).
 
+(** [option_chain_twice] nests one lowered option-bind expression inside
+    another, covering bind-as-child precedence. *)
+Definition option_chain_twice (o : option nat) : option nat :=
+  option_bind
+    (option_bind o (fun n => Some (S n)))
+    (fun n => Some (S n)).
+
 Extract Constant StateT "'s" "'a" => "StateT".
 Extract Constant state_pure => "__PYMONAD_STATE_PURE__".
 Extract Constant state_bind => "__PYMONAD_STATE_BIND__".
@@ -66,3 +73,4 @@ Extract Constant option_bind => "__PYMONAD_OPTION_BIND__".
 
 Python Extraction tick.
 Python Extraction option_chain.
+Python Extraction option_chain_twice.

--- a/rocq-python-extraction/test/numbers.v
+++ b/rocq-python-extraction/test/numbers.v
@@ -8,6 +8,7 @@ Declare ML Module "rocq-python-extraction".
 Declare ML Module "rocq-runtime.plugins.extraction".
 
 From Stdlib Require Import
+  Bool.Bool
   Numbers.BinNums
   NArith.BinNat
   ZArith.BinInt
@@ -47,6 +48,26 @@ Definition positive_case (p : positive) : nat :=
     a generated [Pos] protocol module. *)
 Definition positive_eq (left right : positive) : bool :=
   Pos.eqb left right.
+
+(** [nat_compare_and] keeps primitive comparisons as high-precedence children
+    of a lowered boolean conjunction. *)
+Definition nat_compare_and (left middle right : nat) : bool :=
+  andb (Nat.ltb left middle) (Nat.leb middle right).
+
+(** [nat_compare_or] keeps primitive comparisons as high-precedence children
+    of a lowered boolean disjunction. *)
+Definition nat_compare_or (left middle right : nat) : bool :=
+  orb (Nat.eqb left middle) (Nat.ltb middle right).
+
+(** [nat_compare_neg] parenthesizes a primitive comparison under lowered
+    boolean negation. *)
+Definition nat_compare_neg (left right : nat) : bool :=
+  negb (Nat.leb left right).
+
+(** [nat_compare_bool_eq] parenthesizes a primitive comparison when it becomes
+    the left operand of another lowered equality expression. *)
+Definition nat_compare_bool_eq (left right : nat) (expected : bool) : bool :=
+  Bool.eqb (Nat.ltb left right) expected.
 
 (** [n_seven] checks [N] literals become Python non-negative ints. *)
 Definition n_seven : N := Npos (xI (xI xH)).
@@ -90,6 +111,10 @@ Python Extraction nat_roundtrip.
 Python Extraction positive_five.
 Python Extraction positive_case.
 Python Extraction positive_eq.
+Python Extraction nat_compare_and.
+Python Extraction nat_compare_or.
+Python Extraction nat_compare_neg.
+Python Extraction nat_compare_bool_eq.
 Python Extraction n_seven.
 Python Extraction n_case.
 Python Extraction z_neg_three.

--- a/rocq-python-extraction/test/primitives.v
+++ b/rocq-python-extraction/test/primitives.v
@@ -41,6 +41,10 @@ Definition bool_not (b : bool) : bool := if b then false else true.
     expression instead of retaining the Rocq helper call. *)
 Definition bool_and (b1 b2 : bool) : bool := andb b1 b2.
 
+(** [bool_or]: standard bool disjunction lowers to a native Python [or]
+    expression instead of retaining the Rocq helper call. *)
+Definition bool_or (b1 b2 : bool) : bool := orb b1 b2.
+
 (** [bool_neg]: standard bool negation lowers to a native Python [not]
     expression instead of retaining the Rocq helper call. *)
 Definition bool_neg (b : bool) : bool := negb b.
@@ -48,6 +52,18 @@ Definition bool_neg (b : bool) : bool := negb b.
 (** [bool_neg_and]: nested lowered bool operations must preserve Python
     precedence with parentheses around the lowered [and] expression. *)
 Definition bool_neg_and (b1 b2 : bool) : bool := negb (andb b1 b2).
+
+(** [bool_neg_or]: nested lowered bool operations must preserve Python
+    precedence with parentheses around the lowered [or] expression. *)
+Definition bool_neg_or (b1 b2 : bool) : bool := negb (orb b1 b2).
+
+(** [bool_or_and]: conjunction binds more tightly than disjunction, so a
+    lowered [and] expression can feed [or] without extra parentheses. *)
+Definition bool_or_and (b1 b2 b3 : bool) : bool := orb b1 (andb b2 b3).
+
+(** [bool_and_or]: a lowered disjunction used as a conjunction operand must
+    stay parenthesized so Python does not parse the result as [(b1 and b2) or b3]. *)
+Definition bool_and_or (b1 b2 b3 : bool) : bool := andb b1 (orb b2 b3).
 
 (** [bool_eq]: standard bool equality lowers to native Python equality instead
     of retaining the Rocq helper call. *)
@@ -175,4 +191,4 @@ Definition lambda_call_head (n : nat) : nat :=
   (fun f => f n) (fun x => S x).
 
 Python File Extraction primitives
-  "bool_not bool_and bool_neg bool_neg_and bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append lambda_call_head".
+  "bool_not bool_and bool_or bool_neg bool_neg_and bool_neg_or bool_or_and bool_and_or bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append lambda_call_head".

--- a/rocq-python-extraction/test/primitives.v
+++ b/rocq-python-extraction/test/primitives.v
@@ -197,10 +197,22 @@ Definition list_append_right_nested
     (left middle right : list nat) : list nat :=
   left ++ (middle ++ right).
 
+(** [list_append_let_child]: a lambda-lifted let expression can feed lowered
+    list append as its left child. *)
+Definition list_append_let_child
+    (h : nat) (right : list nat) : list nat :=
+  (let prefix := h :: nil in prefix) ++ right.
+
+(** [list_append_match_child]: a lowered boolean match expression must be
+    parenthesized when it feeds lowered list append. *)
+Definition list_append_match_child
+    (flag : bool) (right : list nat) : list nat :=
+  (if flag then O :: nil else S O :: nil) ++ right.
+
 (** [lambda_call_head]: application of an inline lambda must parenthesize the
     call head because Python lambda has lower precedence than calls. *)
 Definition lambda_call_head (n : nat) : nat :=
   (fun f => f n) (fun x => S x).
 
 Python File Extraction primitives
-  "bool_not bool_and bool_or bool_neg bool_neg_and bool_neg_or bool_or_and bool_and_or bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append list_append_left_nested list_append_right_nested lambda_call_head".
+  "bool_not bool_and bool_or bool_neg bool_neg_and bool_neg_or bool_or_and bool_and_or bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append list_append_left_nested list_append_right_nested list_append_let_child list_append_match_child lambda_call_head".

--- a/rocq-python-extraction/test/primitives.v
+++ b/rocq-python-extraction/test/primitives.v
@@ -185,10 +185,22 @@ Fixpoint list_add_one (l : list nat) : list nat :=
 Definition list_cons_append (h : nat) (left right : list nat) : list nat :=
   h :: (left ++ right).
 
+(** [list_append_left_nested]: nested list append lowers to left-associative
+    Python [+] without redundant parentheses. *)
+Definition list_append_left_nested
+    (left middle right : list nat) : list nat :=
+  (left ++ middle) ++ right.
+
+(** [list_append_right_nested]: nested list append on the right keeps the
+    generated Python expression flat, relying on list-append associativity. *)
+Definition list_append_right_nested
+    (left middle right : list nat) : list nat :=
+  left ++ (middle ++ right).
+
 (** [lambda_call_head]: application of an inline lambda must parenthesize the
     call head because Python lambda has lower precedence than calls. *)
 Definition lambda_call_head (n : nat) : nat :=
   (fun f => f n) (fun x => S x).
 
 Python File Extraction primitives
-  "bool_not bool_and bool_or bool_neg bool_neg_and bool_neg_or bool_or_and bool_and_or bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append lambda_call_head".
+  "bool_not bool_and bool_or bool_neg bool_neg_and bool_neg_or bool_or_and bool_and_or bool_eq bool_eq_and bool_and_eq nat_double option_inc pair_swap list_add_one list_cons_append list_append_left_nested list_append_right_nested lambda_call_head".

--- a/rocq-python-extraction/test/test_bool_not.py
+++ b/rocq-python-extraction/test/test_bool_not.py
@@ -1,11 +1,15 @@
 from primitives import (
     bool_and,
     bool_and_eq,
+    bool_and_or,
     bool_eq,
     bool_eq_and,
     bool_neg,
     bool_neg_and,
+    bool_neg_or,
     bool_not,
+    bool_or,
+    bool_or_and,
     lambda_call_head,
     list_cons_append,
 )
@@ -23,6 +27,13 @@ def test_bool_and_round_trip() -> None:
     assert bool_and(False, False) is False
 
 
+def test_bool_or_round_trip() -> None:
+    assert bool_or(True, True) is True
+    assert bool_or(True, False) is True
+    assert bool_or(False, True) is True
+    assert bool_or(False, False) is False
+
+
 def test_bool_neg_round_trip() -> None:
     assert bool_neg(True) is False
     assert bool_neg(False) is True
@@ -33,6 +44,25 @@ def test_bool_neg_and_round_trip() -> None:
     assert bool_neg_and(True, False) is True
     assert bool_neg_and(False, True) is True
     assert bool_neg_and(False, False) is True
+
+
+def test_bool_neg_or_round_trip() -> None:
+    assert bool_neg_or(True, True) is False
+    assert bool_neg_or(True, False) is False
+    assert bool_neg_or(False, True) is False
+    assert bool_neg_or(False, False) is True
+
+
+def test_bool_or_and_round_trip() -> None:
+    assert bool_or_and(False, True, True) is True
+    assert bool_or_and(False, True, False) is False
+    assert bool_or_and(True, False, False) is True
+
+
+def test_bool_and_or_round_trip() -> None:
+    assert bool_and_or(True, False, True) is True
+    assert bool_and_or(True, False, False) is False
+    assert bool_and_or(False, True, True) is False
 
 
 def test_bool_eq_round_trip() -> None:
@@ -68,6 +98,13 @@ def test_bool_and_lowers_to_native_and(build_default) -> None:
     assert "return b1 and b2" in source
 
 
+def test_bool_or_lowers_to_native_or(build_default) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "def orb(" not in source
+    assert "return b1 or b2" in source
+
+
 def test_bool_neg_lowers_to_native_not(build_default) -> None:
     source = (build_default / "primitives.py").read_text()
 
@@ -80,6 +117,27 @@ def test_bool_neg_and_preserves_precedence(build_default) -> None:
 
     assert "return not (b1 and b2)" in source
     assert "return not b1 and b2" not in source
+
+
+def test_bool_neg_or_preserves_precedence(build_default) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "return not (b1 or b2)" in source
+    assert "return not b1 or b2" not in source
+
+
+def test_bool_or_and_keeps_python_precedence(build_default) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "return b1 or b2 and b3" in source
+    assert "return b1 or (b2 and b3)" not in source
+
+
+def test_bool_and_or_parenthesizes_or_operand(build_default) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "return b1 and (b2 or b3)" in source
+    assert "return b1 and b2 or b3" not in source
 
 
 def test_bool_eq_lowers_to_native_equality(build_default) -> None:

--- a/rocq-python-extraction/test/test_bool_not.py
+++ b/rocq-python-extraction/test/test_bool_not.py
@@ -11,6 +11,8 @@ from primitives import (
     bool_or,
     bool_or_and,
     lambda_call_head,
+    list_append_left_nested,
+    list_append_right_nested,
     list_cons_append,
 )
 
@@ -86,6 +88,11 @@ def test_bool_and_eq_round_trip() -> None:
 
 def test_list_cons_append_round_trip() -> None:
     assert list_cons_append(1, [2], [3, 4]) == [1, 2, 3, 4]
+
+
+def test_nested_list_append_round_trip() -> None:
+    assert list_append_left_nested([1], [2], [3]) == [1, 2, 3]
+    assert list_append_right_nested([1], [2], [3]) == [1, 2, 3]
 
 
 def test_lambda_call_head_round_trip() -> None:
@@ -164,6 +171,14 @@ def test_list_append_preserves_left_associative_grouping(build_default) -> None:
     source = (build_default / "primitives.py").read_text()
 
     assert "return [h] + left + right" in source
+
+
+def test_nested_list_append_expressions_stay_flat(build_default) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "return left + middle + right" in source
+    assert "return (left + middle) + right" not in source
+    assert "return left + (middle + right)" not in source
 
 
 def test_lambda_call_head_is_parenthesized(build_default) -> None:

--- a/rocq-python-extraction/test/test_bool_not.py
+++ b/rocq-python-extraction/test/test_bool_not.py
@@ -12,6 +12,8 @@ from primitives import (
     bool_or_and,
     lambda_call_head,
     list_append_left_nested,
+    list_append_let_child,
+    list_append_match_child,
     list_append_right_nested,
     list_cons_append,
 )
@@ -93,6 +95,12 @@ def test_list_cons_append_round_trip() -> None:
 def test_nested_list_append_round_trip() -> None:
     assert list_append_left_nested([1], [2], [3]) == [1, 2, 3]
     assert list_append_right_nested([1], [2], [3]) == [1, 2, 3]
+
+
+def test_low_precedence_list_append_children_round_trip() -> None:
+    assert list_append_let_child(1, [2, 3]) == [1, 2, 3]
+    assert list_append_match_child(True, [2, 3]) == [0, 2, 3]
+    assert list_append_match_child(False, [2, 3]) == [1, 2, 3]
 
 
 def test_lambda_call_head_round_trip() -> None:
@@ -179,6 +187,16 @@ def test_nested_list_append_expressions_stay_flat(build_default) -> None:
     assert "return left + middle + right" in source
     assert "return (left + middle) + right" not in source
     assert "return left + (middle + right)" not in source
+
+
+def test_list_append_low_precedence_children_are_parenthesized(
+    build_default,
+) -> None:
+    source = (build_default / "primitives.py").read_text()
+
+    assert "return (lambda prefix: prefix)([h] + []) + right" in source
+    assert "return [0] + [] if flag else [0 + 1] + [] + right" not in source
+    assert "return ([0] + [] if flag else [0 + 1] + []) + right" in source
 
 
 def test_lambda_call_head_is_parenthesized(build_default) -> None:

--- a/rocq-python-extraction/test/test_finite_collections.py
+++ b/rocq-python-extraction/test/test_finite_collections.py
@@ -23,6 +23,9 @@ def test_positive_sets_are_native_persistent_frozensets() -> None:
     assert fixtures.positive_claim_inter_expr == frozenset({2, 5})
     assert fixtures.positive_claim_diff_expr == frozenset({7})
     assert fixtures.positive_claim_nested_expr == frozenset({2, 5})
+    assert fixtures.positive_claim_union_inter_expr == frozenset({2, 5, 7})
+    assert fixtures.positive_claim_diff_union_expr == frozenset({2})
+    assert fixtures.positive_claim_inter_diff_expr == frozenset({2, 5})
     assert fixtures.positive_claim_removed == frozenset({5})
     assert fixtures.positive_claim_has_2 is True
     assert fixtures.positive_claim_count == 2
@@ -56,4 +59,16 @@ def test_set_infix_lowerings_preserve_precedence(build_default) -> None:
     assert (
         "positive_claim_nested_expr = "
         "((positive_claim_set | positive_claim_diff) & positive_claim_union)"
+    ) in source
+    assert (
+        "positive_claim_union_inter_expr = "
+        "(positive_claim_diff | positive_claim_set & positive_claim_union)"
+    ) in source
+    assert (
+        "positive_claim_diff_union_expr = "
+        "(positive_claim_union - (positive_claim_diff | positive_claim_inter))"
+    ) in source
+    assert (
+        "positive_claim_inter_diff_expr = "
+        "((positive_claim_union - positive_claim_diff) & positive_claim_set)"
     ) in source

--- a/rocq-python-extraction/test/test_numbers.py
+++ b/rocq-python-extraction/test/test_numbers.py
@@ -3,6 +3,10 @@ from fractions import Fraction
 import pytest
 from n_case import n_case
 from n_seven import n_seven
+from nat_compare_and import nat_compare_and
+from nat_compare_bool_eq import nat_compare_bool_eq
+from nat_compare_neg import nat_compare_neg
+from nat_compare_or import nat_compare_or
 from nat_pred_or_zero import nat_pred_or_zero
 from nat_roundtrip import nat_roundtrip
 from nat_three import nat_three
@@ -27,6 +31,15 @@ def test_nat_positive_n_and_z_are_native_ints() -> None:
     assert positive_case(5) == 1
     assert positive_eq(1, 1) is True
     assert positive_eq(1, 5) is False
+    assert nat_compare_and(1, 2, 2) is True
+    assert nat_compare_and(2, 1, 3) is False
+    assert nat_compare_or(3, 3, 2) is True
+    assert nat_compare_or(3, 2, 4) is True
+    assert nat_compare_or(3, 2, 1) is False
+    assert nat_compare_neg(3, 2) is True
+    assert nat_compare_neg(2, 3) is False
+    assert nat_compare_bool_eq(1, 2, True) is True
+    assert nat_compare_bool_eq(1, 2, False) is False
     assert n_seven == 7
     assert n_case(0) == 0
     assert n_case(9) == 1
@@ -57,3 +70,25 @@ def test_positive_equality_lowers_without_pos_protocol(build_default) -> None:
     assert "class Pos_Module" not in source
     assert "Pos:" not in source
     assert "return left == right" in source
+
+
+def test_primitive_comparisons_compose_with_bool_ops(build_default) -> None:
+    compare_and = (build_default / "nat_compare_and.py").read_text()
+    compare_or = (build_default / "nat_compare_or.py").read_text()
+    compare_neg = (build_default / "nat_compare_neg.py").read_text()
+
+    assert "return left < middle and middle <= right" in compare_and
+    assert "return (left < middle) and (middle <= right)" not in compare_and
+    assert "return left == middle or middle < right" in compare_or
+    assert "return (left == middle) or (middle < right)" not in compare_or
+    assert "return not (left <= right)" in compare_neg
+    assert "return not left <= right" not in compare_neg
+
+
+def test_primitive_comparison_as_equality_operand_is_parenthesized(
+    build_default,
+) -> None:
+    source = (build_default / "nat_compare_bool_eq.py").read_text()
+
+    assert "return (left < right) == expected" in source
+    assert "return left < right == expected" not in source

--- a/rocq-python-extraction/test/test_option_chain.py
+++ b/rocq-python-extraction/test/test_option_chain.py
@@ -1,4 +1,5 @@
 from option_chain import option_chain
+from option_chain_twice import option_chain_twice
 
 
 def test_option_chain_uses_none_short_circuit(build_default) -> None:
@@ -7,3 +8,12 @@ def test_option_chain_uses_none_short_circuit(build_default) -> None:
 
     source = (build_default / "option_chain.py").read_text()
     assert "None if __option_value is None else" in source
+
+
+def test_nested_option_bind_child_preserves_precedence(build_default) -> None:
+    assert option_chain_twice(None) is None
+    assert option_chain_twice(4) == 6
+
+    source = (build_default / "option_chain_twice.py").read_text()
+    assert "None if __option_value is None else" in source
+    assert ")(__option_value))((lambda __option_value:" in source


### PR DESCRIPTION
Adds focused Rocq-to-Python extraction coverage for expression precedence across collection infix operators and low-precedence child expressions. The tests lock in parenthesization behavior before the printer abstraction changes.

Fixes #1086.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Cover list and set infix precedence <!-- type:spec -->
- [x] Cover low-precedence child expressions <!-- type:spec -->
- [x] Cover primitive comparison composition <!-- type:spec -->
- [x] Cover nested boolean precedence <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->