### PR TITLE
Fix task queuing for resolved thread followups

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -29,6 +29,8 @@ from fido.types import TaskType
 
 log = logging.getLogger(__name__)
 
+_FIDO_LOGINS = {"fidocancode", "fido-can-code"}
+
 # Per-work_dir coalescing state for _reorder_tasks_background.
 # Ensures at most one Opus call in-flight + one pending per repo.
 _reorder_coalesce: dict[str, dict[str, Any]] = {}
@@ -375,8 +377,9 @@ def queue_reply_tasks(
     if not reply_outcome_creates_tasks(category, thread=thread):
         return 0
     task_fn = create_task if create_task_fn is None else create_task_fn
+    created = 0
     for title in titles:
-        task_fn(
+        task = task_fn(
             title,
             config,
             repo_cfg,
@@ -384,7 +387,9 @@ def queue_reply_tasks(
             thread=thread,
             registry=registry,
         )
-    return len(titles)
+        if not (isinstance(task, dict) and task.get("status") == "skipped_resolved"):
+            created += 1
+    return created
 
 
 def _apply_reply_result(
@@ -929,14 +934,11 @@ def reply_to_comment(
                 "fetched %d comment(s) in thread for context", len(thread_comments)
             )
 
-    # Fido login set — used for initial snapshot and post-re-fetch comparison.
-    _fido_logins = {"fidocancode", "fido-can-code"}
-
     # Capture Fido reply IDs from the initial snapshot so we can detect new
     # replies posted by concurrent handlers during the triage + generation
     # window (compared against the re-fetched thread below).
     initial_fido_ids: set[int] = {
-        c["id"] for c in thread_comments if c.get("author", "").lower() in _fido_logins
+        c["id"] for c in thread_comments if c.get("author", "").lower() in _FIDO_LOGINS
     }
 
     # Root comment body — used for task title generation.
@@ -1031,7 +1033,7 @@ def reply_to_comment(
     current_fido_target_ids: set[int] = {
         c["id"]
         for c in thread_comments
-        if c.get("author", "").lower() in _fido_logins
+        if c.get("author", "").lower() in _FIDO_LOGINS
         and c.get("in_reply_to_id") == target_id
     }
     if current_fido_target_ids - initial_fido_ids:
@@ -1854,6 +1856,29 @@ def _reorder_tasks_background(
         raise
 
 
+def _thread_task_is_stale_resolved(gh: GitHub, thread: dict[str, Any]) -> bool:
+    """Return whether a resolved-thread task request is stale duplicate work.
+
+    Resolved-thread suppression exists for late handlers racing with Fido's
+    auto-resolve path. A new human reply on that same resolved thread is not
+    stale: it is fresh input that should queue work without requiring the human
+    to manually unresolve the GitHub thread.
+    """
+    comment_id = thread.get("comment_id")
+    if comment_id is None:
+        return True
+    comments = gh.fetch_comment_thread(thread["repo"], thread["pr"], int(comment_id))
+    if not comments:
+        return True
+    latest_human_id: int | None = None
+    for comment in comments:
+        author = str(comment.get("author", "")).lower()
+        if author in _FIDO_LOGINS:
+            continue
+        latest_human_id = int(comment["id"])
+    return latest_human_id != int(comment_id)
+
+
 def create_task(
     prompt: str,
     config: Config,
@@ -1906,7 +1931,7 @@ def create_task(
         # return another MagicMock — truthy by default) don't cause this
         # guard to swallow every test-level task creation.  Real GitHub
         # always returns a real bool from ``is_thread_resolved_for_comment``.
-        if already is True:
+        if already is True and _thread_task_is_stale_resolved(gh, thread):
             log.info(
                 "create_task: thread for comment %s already resolved on GitHub — "
                 "skipping queue (closes #520)",
@@ -1920,6 +1945,12 @@ def create_task(
                 "status": "skipped_resolved",
                 "thread": thread,
             }
+        if already is True:
+            log.info(
+                "create_task: thread for comment %s is resolved, but comment is "
+                "fresh human input — queueing task",
+                thread["comment_id"],
+            )
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -960,6 +960,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             handled = False
             category: str | None = None
             titles: list[str] = []
+            queued_tasks = 0
 
             if action.reply_to:
                 promise = self._prepare_reply(repo_cfg, action)
@@ -987,7 +988,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                             if len(titles or []) != 1
                             else "queuing review comment task"
                         )
-                    queue_reply_tasks(
+                    queued_tasks += queue_reply_tasks(
                         category,
                         titles or [],
                         self.config,
@@ -1026,7 +1027,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         if len(titles) != 1
                         else "queuing PR comment task"
                     )
-                queue_reply_tasks(
+                queued_tasks += queue_reply_tasks(
                     category or "",
                     titles,
                     self.config,
@@ -1041,7 +1042,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 "action outcome: handled=%s category=%s tasks=%d",
                 handled,
                 category,
-                len(titles),
+                queued_tasks,
             )
             # When a human comments on a PR, transition any BLOCKED tasks back
             # to PENDING so the worker can re-evaluate and resume.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -28,6 +28,7 @@ from fido.events import (
     launch_worker,
     maybe_react,
     needs_more_context,
+    queue_reply_tasks,
     recover_reply_promises,
     reply_to_comment,
     reply_to_issue_comment,
@@ -2876,6 +2877,37 @@ class TestCreateTask:
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
 
+    def test_queues_resolved_thread_when_comment_is_fresh_human_reply(
+        self, tmp_path: Path
+    ) -> None:
+        """A new human reply on a resolved thread is fresh work, not stale triage."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 5, "comment_id": 1002}
+        mock_tasks = self._mock_tasks()
+        mock_gh = MagicMock()
+        mock_gh.is_thread_resolved_for_comment.return_value = True
+        mock_gh.fetch_comment_thread.return_value = [
+            {"id": 1000, "author": "owner", "body": "original"},
+            {"id": 1001, "author": "FidoCanCode", "body": "fixed"},
+            {"id": 1002, "author": "owner", "body": "actually queue it"},
+            {"id": 1003, "author": "FidoCanCode", "body": "will do"},
+        ]
+        with patch("fido.events.launch_sync"):
+            result = create_task(
+                "do something",
+                cfg,
+                repo_cfg,
+                mock_gh,
+                thread=thread,
+                _tasks=mock_tasks,
+                _reorder_background_fn=MagicMock(),
+            )
+        mock_tasks.add.assert_called_once_with(
+            title="do something", task_type=ANY, thread=thread
+        )
+        assert result["status"] == "pending"
+
     def test_queues_when_thread_resolved_check_raises(self, tmp_path: Path) -> None:
         """If the GitHub thread-resolved check fails, fail open and queue
         the task — better to dedup later than drop work."""
@@ -2912,6 +2944,29 @@ class TestCreateTask:
                 "do something", cfg, repo_cfg, MagicMock(), _tasks=mock_tasks
             )
         assert result == fake_task
+
+    def test_queue_reply_tasks_counts_only_created_tasks(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        thread = {"repo": "owner/repo", "pr": 1, "comment_id": 42}
+
+        def fake_create(title: str, *args: object, **kwargs: object) -> dict[str, str]:
+            if title == "skip":
+                return {"title": title, "status": "skipped_resolved"}
+            return {"title": title, "status": "pending"}
+
+        assert (
+            queue_reply_tasks(
+                "ACT",
+                ["create", "skip"],
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                thread=thread,
+                create_task_fn=fake_create,
+            )
+            == 1
+        )
 
     def test_no_abort_without_registry(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)


### PR DESCRIPTION
## Summary
- queue fresh human followups on resolved review threads instead of treating them as stale duplicate triage
- count only actually-created ACT tasks in webhook outcome logging
- cover the resolved-thread followup and skipped-task-count cases in tests

## Verification
- ./fido ruff check src/fido/events.py src/fido/server.py tests/test_events.py
- ./fido pyright src/fido/events.py src/fido/server.py
- ./fido tests tests/test_events.py::TestCreateTask tests/test_server.py::TestWebhookHandler
- git diff --check
- git commit pre-commit: full buildx CI checks and runtime image cache, model mirrors, generated workflow files

## Notes
This is the tactical fix for the observed bug where Fido promised to queue followup work on an already-resolved review thread, then skipped task creation. The broader durable intent/reducer/outbox model remains tracked under the Rocq epic issues.