### PR TITLE
P1: Rocq extraction declaration and export classification (closes #1095)

### DIFF
--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -5156,18 +5156,29 @@ type classified_decl =
   | ClassifiedFix of classified_term_decl list
 
 let classify_term_decl_base state r typ =
-  match () with
-  | _ when is_prop_type typ -> TermDeclSuppressErasedProp
-  | _ when is_runtime_marker_ref r -> TermDeclSuppressRuntimeMarker
-  | _ when is_native_equality_marker_ref r ->
+  match
+    ( is_prop_type typ,
+      is_runtime_marker_ref r,
+      is_native_equality_marker_ref r,
+      is_inline_custom r,
+      rewrite_lowering_rule_of_ref state r,
+      is_custom r )
+  with
+  | true, _, _, _, _, _ -> TermDeclSuppressErasedProp
+  | false, true, _, _, _, _ -> TermDeclSuppressRuntimeMarker
+  | false, false, true, _, _, _ ->
       TermDeclSuppressNativeEqualityMarker
-  | _ when is_inline_custom r -> TermDeclSuppressInlineCustom
-  | _ -> (
-      match rewrite_lowering_rule_of_ref state r, is_custom r with
-      | Some rule, _ when rule.lowering_suppress_declaration ->
-          TermDeclSuppressInlinePrimitive
-      | (Some _ | None), true -> TermDeclEmitCustomAlias (find_custom r)
-      | (Some _ | None), false -> TermDeclEmit)
+  | false, false, false, true, _, _ -> TermDeclSuppressInlineCustom
+  | ( false,
+      false,
+      false,
+      false,
+      Some { lowering_suppress_declaration = true; _ },
+      _ ) ->
+      TermDeclSuppressInlinePrimitive
+  | false, false, false, false, (Some _ | None), true ->
+      TermDeclEmitCustomAlias (find_custom r)
+  | false, false, false, false, (Some _ | None), false -> TermDeclEmit
 
 let classify_term_decl state r a typ =
   match classify_term_decl_base state r typ with
@@ -5212,9 +5223,11 @@ let classify_type_decl r =
   match classify_stdlib_type_ref r, is_custom r with
   | _, true -> TypeDeclSuppressCustomAlias
   | Some StdlibRealType, false -> TypeDeclEmitDiagnostic "PYEX041"
-  | Some type_ref, false when stdlib_type_ref_is_remapped type_ref ->
-      TypeDeclSuppressRemappedStdlib
-  | (Some _ | None), false -> TypeDeclUnsupported
+  | Some type_ref, false -> (
+      match stdlib_type_ref_is_remapped type_ref with
+      | true -> TypeDeclSuppressRemappedStdlib
+      | false -> TypeDeclUnsupported)
+  | None, false -> TypeDeclUnsupported
 
 let classify_term_decl_record state r a typ =
   { term_decl_ref = r;

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -5156,29 +5156,17 @@ type classified_decl =
   | ClassifiedFix of classified_term_decl list
 
 let classify_term_decl_base state r typ =
-  match
-    ( is_prop_type typ,
-      is_runtime_marker_ref r,
-      is_native_equality_marker_ref r,
-      is_inline_custom r,
-      rewrite_lowering_rule_of_ref state r,
-      is_custom r )
-  with
-  | true, _, _, _, _, _ -> TermDeclSuppressErasedProp
-  | false, true, _, _, _, _ -> TermDeclSuppressRuntimeMarker
-  | false, false, true, _, _, _ ->
-      TermDeclSuppressNativeEqualityMarker
-  | false, false, false, true, _, _ -> TermDeclSuppressInlineCustom
-  | ( false,
-      false,
-      false,
-      false,
-      Some { lowering_suppress_declaration = true; _ },
-      _ ) ->
-      TermDeclSuppressInlinePrimitive
-  | false, false, false, false, (Some _ | None), true ->
-      TermDeclEmitCustomAlias (find_custom r)
-  | false, false, false, false, (Some _ | None), false -> TermDeclEmit
+  if is_prop_type typ then TermDeclSuppressErasedProp
+  else if is_runtime_marker_ref r then TermDeclSuppressRuntimeMarker
+  else if is_native_equality_marker_ref r then
+    TermDeclSuppressNativeEqualityMarker
+  else if is_inline_custom r then TermDeclSuppressInlineCustom
+  else
+    match rewrite_lowering_rule_of_ref state r, is_custom r with
+    | Some { lowering_suppress_declaration = true; _ }, _ ->
+        TermDeclSuppressInlinePrimitive
+    | (Some _ | None), true -> TermDeclEmitCustomAlias (find_custom r)
+    | (Some _ | None), false -> TermDeclEmit
 
 let classify_term_decl state r a typ =
   match classify_term_decl_base state r typ with

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -5156,17 +5156,18 @@ type classified_decl =
   | ClassifiedFix of classified_term_decl list
 
 let classify_term_decl_base state r typ =
-  if is_prop_type typ then TermDeclSuppressErasedProp
-  else if is_runtime_marker_ref r then TermDeclSuppressRuntimeMarker
-  else if is_native_equality_marker_ref r then TermDeclSuppressNativeEqualityMarker
-  else if is_inline_custom r then TermDeclSuppressInlineCustom
-  else
-    match rewrite_lowering_rule_of_ref state r with
-    | Some rule when rule.lowering_suppress_declaration ->
-        TermDeclSuppressInlinePrimitive
-    | Some _ | None ->
-        if is_custom r then TermDeclEmitCustomAlias (find_custom r)
-        else TermDeclEmit
+  match () with
+  | _ when is_prop_type typ -> TermDeclSuppressErasedProp
+  | _ when is_runtime_marker_ref r -> TermDeclSuppressRuntimeMarker
+  | _ when is_native_equality_marker_ref r ->
+      TermDeclSuppressNativeEqualityMarker
+  | _ when is_inline_custom r -> TermDeclSuppressInlineCustom
+  | _ -> (
+      match rewrite_lowering_rule_of_ref state r, is_custom r with
+      | Some rule, _ when rule.lowering_suppress_declaration ->
+          TermDeclSuppressInlinePrimitive
+      | (Some _ | None), true -> TermDeclEmitCustomAlias (find_custom r)
+      | (Some _ | None), false -> TermDeclEmit)
 
 let classify_term_decl state r a typ =
   match classify_term_decl_base state r typ with
@@ -5208,13 +5209,12 @@ let term_decl_is_emitted = function
       false
 
 let classify_type_decl r =
-  if is_custom r then TypeDeclSuppressCustomAlias
-  else
-    match classify_stdlib_type_ref r with
-    | Some StdlibRealType -> TypeDeclEmitDiagnostic "PYEX041"
-    | Some type_ref when stdlib_type_ref_is_remapped type_ref ->
-        TypeDeclSuppressRemappedStdlib
-    | Some _ | None -> TypeDeclUnsupported
+  match classify_stdlib_type_ref r, is_custom r with
+  | _, true -> TypeDeclSuppressCustomAlias
+  | Some StdlibRealType, false -> TypeDeclEmitDiagnostic "PYEX041"
+  | Some type_ref, false when stdlib_type_ref_is_remapped type_ref ->
+      TypeDeclSuppressRemappedStdlib
+  | (Some _ | None), false -> TypeDeclUnsupported
 
 let classify_term_decl_record state r a typ =
   { term_decl_ref = r;
@@ -5264,10 +5264,11 @@ let pp_classified_term_decl state env term_decl =
   | TermDeclSuppressRuntimeMarker ->
       mt ()
 
-let term_decl_export_names state r a typ =
-  match classify_term_decl state r a typ with
+let classified_term_decl_export_names state term_decl =
+  match term_decl.term_decl_classification with
   | action when not (term_decl_is_emitted action) -> []
-  | TermDeclEmitCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
+  | TermDeclEmitCustomAlias _ | TermDeclEmit ->
+      [pp_global state Term term_decl.term_decl_ref]
   | TermDeclSuppressConstructorTagPredicate _
   | TermDeclSuppressErasedProp
   | TermDeclSuppressInlineCustom
@@ -5277,18 +5278,30 @@ let term_decl_export_names state r a typ =
   | TermDeclSuppressRuntimeMarker ->
       []
 
-let fixed_term_decl_export_names state r typ =
-  match classify_term_decl_base state r typ with
-  | action when not (term_decl_is_emitted action) -> []
-  | TermDeclEmitCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
-  | TermDeclSuppressConstructorTagPredicate _
-  | TermDeclSuppressErasedProp
-  | TermDeclSuppressInlineCustom
-  | TermDeclSuppressInlinePrimitive
-  | TermDeclSuppressListMembershipPredicate _
-  | TermDeclSuppressNativeEqualityMarker
-  | TermDeclSuppressRuntimeMarker ->
-      []
+let classified_ind_export_names state ind =
+  let packet_names packet =
+    if is_std_remapped_type_ref packet.ip_typename_ref then []
+    else
+      let tname = capitalize_first (pp_global state Term packet.ip_typename_ref) in
+      let cnames =
+        Array.to_list packet.ip_consnames_ref |> List.map (pp_global state Cons)
+      in
+      tname :: cnames
+  in
+  Array.to_list ind.ind_packets |> List.concat_map packet_names
+
+let classified_decl_export_names state = function
+  | ClassifiedTerm term_decl -> classified_term_decl_export_names state term_decl
+  | ClassifiedFix term_decls ->
+      List.concat_map (classified_term_decl_export_names state) term_decls
+  | ClassifiedType (r, classification) -> (
+      match classification with
+      | TypeDeclEmitDiagnostic _
+      | TypeDeclSuppressCustomAlias
+      | TypeDeclSuppressRemappedStdlib ->
+          []
+      | TypeDeclUnsupported -> [pp_global state Type r])
+  | ClassifiedInd ind -> classified_ind_export_names state ind
 
 let pp_classified_decl state = function
   | ClassifiedInd ind -> pp_ind_decl state ind
@@ -5328,32 +5341,6 @@ let rec module_type_annotation state = function
       str "], " ++
       module_type_annotation state ret_mt ++
       str "]"
-
-let decl_export_names state = function
-  | Dterm (r, a, typ) ->
-      term_decl_export_names state r a typ
-  | Dfix (rv, _, typs) ->
-      List.init (Array.length rv) Fun.id
-      |> List.concat_map (fun i -> fixed_term_decl_export_names state rv.(i) typs.(i))
-  | Dtype (r, _, _) ->
-      (match classify_type_decl r with
-       | TypeDeclEmitDiagnostic _
-       | TypeDeclSuppressCustomAlias
-       | TypeDeclSuppressRemappedStdlib ->
-           []
-       | TypeDeclUnsupported -> [pp_global state Type r])
-  | Dind ind ->
-      let packet_names packet =
-        if is_std_remapped_type_ref packet.ip_typename_ref then []
-        else
-          let tname = capitalize_first (pp_global state Term packet.ip_typename_ref) in
-          let cnames =
-            Array.to_list packet.ip_consnames_ref
-            |> List.map (pp_global state Cons)
-          in
-          tname :: cnames
-      in
-      Array.to_list ind.ind_packets |> List.concat_map packet_names
 
 let pp_decl_exports target names indent =
   prlist
@@ -5484,8 +5471,12 @@ and pp_module_expr_return state indent local_name = function
 
 and pp_module_structure_elem_into state indent target = function
   | (_, SEdecl d) ->
-      indent_pp indent (pp_decl state d) ++
-      pp_decl_exports target (decl_export_names state d) indent
+      let classified_decl = classify_decl state d in
+      indent_pp indent (pp_classified_decl state classified_decl) ++
+      pp_decl_exports
+        target
+        (classified_decl_export_names state classified_decl)
+        indent
   | (l, SEmodule m) ->
       let name = module_binding_name state l in
       if is_std_remapped_module_name name then mt ()

--- a/rocq-python-extraction/python.ml
+++ b/rocq-python-extraction/python.ml
@@ -5126,87 +5126,187 @@ let pp_ind_decl state (ind : ml_ind) =
 
 (*s Declaration printer. *)
 
-type term_decl_action =
-  | TermDeclSuppress
-  | TermDeclCustomAlias of string
+type term_decl_classification =
   | TermDeclEmit
+  | TermDeclEmitCustomAlias of string
+  | TermDeclSuppressConstructorTagPredicate of string * global
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressListMembershipPredicate of string
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker
 
-type type_decl_action =
-  | TypeDeclError of string
-  | TypeDeclSuppress
+type type_decl_classification =
+  | TypeDeclEmitDiagnostic of string
+  | TypeDeclSuppressCustomAlias
+  | TypeDeclSuppressRemappedStdlib
   | TypeDeclUnsupported
 
-let classify_term_decl state r typ =
-  if is_prop_type typ then TermDeclSuppress
-  else if is_runtime_marker_ref r then TermDeclSuppress
-  else if is_native_equality_marker_ref r then TermDeclSuppress
-  else if is_inline_custom r then TermDeclSuppress
+type classified_term_decl =
+  { term_decl_ref : global;
+    term_decl_body : ml_ast;
+    term_decl_type : ml_type;
+    term_decl_classification : term_decl_classification }
+
+type classified_decl =
+  | ClassifiedInd of ml_ind
+  | ClassifiedType of global * type_decl_classification
+  | ClassifiedTerm of classified_term_decl
+  | ClassifiedFix of classified_term_decl list
+
+let classify_term_decl_base state r typ =
+  if is_prop_type typ then TermDeclSuppressErasedProp
+  else if is_runtime_marker_ref r then TermDeclSuppressRuntimeMarker
+  else if is_native_equality_marker_ref r then TermDeclSuppressNativeEqualityMarker
+  else if is_inline_custom r then TermDeclSuppressInlineCustom
   else
     match rewrite_lowering_rule_of_ref state r with
-    | Some rule when rule.lowering_suppress_declaration -> TermDeclSuppress
+    | Some rule when rule.lowering_suppress_declaration ->
+        TermDeclSuppressInlinePrimitive
     | Some _ | None ->
-        if is_custom r then TermDeclCustomAlias (find_custom r)
+        if is_custom r then TermDeclEmitCustomAlias (find_custom r)
         else TermDeclEmit
 
-let register_inline_term_decl state r a action =
-  let source_name = pp_global state Term r in
-  match action, constructor_tag_predicate_target a with
-  | TermDeclEmit, Some constructor_ref ->
+let classify_term_decl state r a typ =
+  match classify_term_decl_base state r typ with
+  | TermDeclEmit ->
+      let source_name = pp_global state Term r in
+      (match constructor_tag_predicate_target a with
+       | Some constructor_ref ->
+           TermDeclSuppressConstructorTagPredicate (source_name, constructor_ref)
+       | None when String.equal (source_name_tail source_name) "positive_mem" ->
+           TermDeclSuppressListMembershipPredicate source_name
+       | None -> TermDeclEmit)
+  | action -> action
+
+let apply_term_decl_classification_effects = function
+  | TermDeclSuppressConstructorTagPredicate (source_name, constructor_ref) ->
       active_constructor_tag_predicates :=
-        (source_name, constructor_ref) :: !active_constructor_tag_predicates;
-      TermDeclSuppress
-  | TermDeclEmit, _ when String.equal (source_name_tail source_name) "positive_mem" ->
+        (source_name, constructor_ref) :: !active_constructor_tag_predicates
+  | TermDeclSuppressListMembershipPredicate source_name ->
       active_list_membership_predicates :=
-        source_name :: !active_list_membership_predicates;
-      TermDeclSuppress
-  | _, _ ->
-      action
+        source_name :: !active_list_membership_predicates
+  | TermDeclEmit
+  | TermDeclEmitCustomAlias _
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker ->
+      ()
+
+let term_decl_is_emitted = function
+  | TermDeclEmit | TermDeclEmitCustomAlias _ -> true
+  | TermDeclSuppressConstructorTagPredicate _
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressListMembershipPredicate _
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker ->
+      false
 
 let classify_type_decl r =
-  if is_custom r then TypeDeclSuppress
+  if is_custom r then TypeDeclSuppressCustomAlias
   else
     match classify_stdlib_type_ref r with
-    | Some StdlibRealType -> TypeDeclError "PYEX041"
-    | Some type_ref when stdlib_type_ref_is_remapped type_ref -> TypeDeclSuppress
+    | Some StdlibRealType -> TypeDeclEmitDiagnostic "PYEX041"
+    | Some type_ref when stdlib_type_ref_is_remapped type_ref ->
+        TypeDeclSuppressRemappedStdlib
     | Some _ | None -> TypeDeclUnsupported
 
-let pp_classified_term_decl state env r a typ =
-  match register_inline_term_decl state r a (classify_term_decl state r typ) with
-  | TermDeclSuppress -> mt ()
-  | TermDeclCustomAlias alias ->
+let classify_term_decl_record state r a typ =
+  { term_decl_ref = r;
+    term_decl_body = a;
+    term_decl_type = typ;
+    term_decl_classification = classify_term_decl state r a typ }
+
+let classify_decl state = function
+  | Dind ind -> ClassifiedInd ind
+  | Dtype (r, _, _) -> ClassifiedType (r, classify_type_decl r)
+  | Dterm (r, a, typ) -> ClassifiedTerm (classify_term_decl_record state r a typ)
+  | Dfix (rv, defs, typs) ->
+      let classify_one i =
+        classify_term_decl_record state rv.(i) defs.(i) typs.(i)
+      in
+      ClassifiedFix (List.init (Array.length rv) classify_one)
+
+let pp_classified_term_decl state env term_decl =
+  apply_term_decl_classification_effects term_decl.term_decl_classification;
+  match term_decl.term_decl_classification with
+  | action when not (term_decl_is_emitted action) -> mt ()
+  | TermDeclEmitCustomAlias alias ->
       fnl () ++ fnl () ++
-      str (pp_global state Term r) ++ str " = " ++ str alias ++ fnl ()
+      str (pp_global state Term term_decl.term_decl_ref) ++
+      str " = " ++ str alias ++ fnl ()
   | TermDeclEmit ->
-      let () = validate_prop_discipline_decl (Dterm (r, a, typ)) in
-      fnl () ++ fnl () ++ pp_term_decl state env (pp_global state Term r) a typ
+      let () =
+        validate_prop_discipline_decl
+          (Dterm
+             ( term_decl.term_decl_ref,
+               term_decl.term_decl_body,
+               term_decl.term_decl_type ))
+      in
+      fnl () ++ fnl () ++
+      pp_term_decl
+        state
+        env
+        (pp_global state Term term_decl.term_decl_ref)
+        term_decl.term_decl_body
+        term_decl.term_decl_type
+  | TermDeclSuppressConstructorTagPredicate _
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressListMembershipPredicate _
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker ->
+      mt ()
 
 let term_decl_export_names state r a typ =
-  match register_inline_term_decl state r a (classify_term_decl state r typ) with
-  | TermDeclSuppress -> []
-  | TermDeclCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
+  match classify_term_decl state r a typ with
+  | action when not (term_decl_is_emitted action) -> []
+  | TermDeclEmitCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
+  | TermDeclSuppressConstructorTagPredicate _
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressListMembershipPredicate _
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker ->
+      []
 
 let fixed_term_decl_export_names state r typ =
-  match classify_term_decl state r typ with
-  | TermDeclSuppress -> []
-  | TermDeclCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
+  match classify_term_decl_base state r typ with
+  | action when not (term_decl_is_emitted action) -> []
+  | TermDeclEmitCustomAlias _ | TermDeclEmit -> [pp_global state Term r]
+  | TermDeclSuppressConstructorTagPredicate _
+  | TermDeclSuppressErasedProp
+  | TermDeclSuppressInlineCustom
+  | TermDeclSuppressInlinePrimitive
+  | TermDeclSuppressListMembershipPredicate _
+  | TermDeclSuppressNativeEqualityMarker
+  | TermDeclSuppressRuntimeMarker ->
+      []
 
-let pp_decl state = function
-  | Dind  ind   -> pp_ind_decl state ind
-  | Dtype (r, _, _) -> (
-      match classify_type_decl r with
-      | TypeDeclError code -> extraction_diagnostic_error code
-      | TypeDeclSuppress -> mt ()
+let pp_classified_decl state = function
+  | ClassifiedInd ind -> pp_ind_decl state ind
+  | ClassifiedType (_r, classification) -> (
+      match classification with
+      | TypeDeclEmitDiagnostic code -> extraction_diagnostic_error code
+      | TypeDeclSuppressCustomAlias | TypeDeclSuppressRemappedStdlib -> mt ()
       | TypeDeclUnsupported -> fnl () ++ fnl () ++ diagnostic_comment "PYEX003")
-  | Dterm (r, a, typ) ->
-      pp_classified_term_decl state (empty_env state ()) r a typ
-  | Dfix (rv, defs, typs) ->
+  | ClassifiedTerm term_decl ->
+      pp_classified_term_decl state (empty_env state ()) term_decl
+  | ClassifiedFix term_decls ->
       (* Each function in the fix block is named globally; the bodies use
          [MLglob] references for mutual recursion, so [empty_env] suffices. *)
       let env = empty_env state () in
-      let pp_one i =
-        pp_classified_term_decl state env rv.(i) defs.(i) typs.(i)
-      in
-      prlist_with_sep mt pp_one (List.init (Array.length rv) (fun i -> i))
+      prlist_with_sep mt (pp_classified_term_decl state env) term_decls
+
+let pp_decl state decl =
+  pp_classified_decl state (classify_decl state decl)
 
 (*s Module structure walker.
     [State.with_visibility] must be called around each module so that
@@ -5237,7 +5337,10 @@ let decl_export_names state = function
       |> List.concat_map (fun i -> fixed_term_decl_export_names state rv.(i) typs.(i))
   | Dtype (r, _, _) ->
       (match classify_type_decl r with
-       | TypeDeclError _ | TypeDeclSuppress -> []
+       | TypeDeclEmitDiagnostic _
+       | TypeDeclSuppressCustomAlias
+       | TypeDeclSuppressRemappedStdlib ->
+           []
        | TypeDeclUnsupported -> [pp_global state Type r])
   | Dind ind ->
       let packet_names packet =

--- a/rocq-python-extraction/test/test_declaration_exports.py
+++ b/rocq-python-extraction/test/test_declaration_exports.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+
+def assert_module_exports(source: str, target: str, names: tuple[str, ...]) -> None:
+    for name in names:
+        assert f"{target}.{name} = {name}" in source
+
+
+def assert_module_does_not_export(
+    source: str,
+    target: str,
+    names: tuple[str, ...],
+) -> None:
+    for name in names:
+        assert f"{target}.{name} = {name}" not in source
+
+
+def test_finite_collection_fixture_exports_stay_stable(build_default: Path) -> None:
+    source = (build_default / "FiniteCollectionFixtures.py").read_text()
+
+    assert_module_exports(
+        source,
+        "FiniteCollectionFixtures",
+        (
+            "p1",
+            "p2",
+            "p3",
+            "p5",
+            "p7",
+            "positive_task_map",
+            "positive_task_hit",
+            "positive_task_missing",
+            "positive_task_removed",
+            "positive_task_find_expr",
+            "positive_task_mem_expr",
+            "positive_task_cardinal_expr",
+            "positive_task_elements_expr",
+            "positive_task_fold_count",
+            "positive_task_has_3",
+            "positive_task_count",
+            "positive_task_elements",
+            "positive_claim_set",
+            "positive_claim_union",
+            "positive_claim_inter",
+            "positive_claim_diff",
+            "positive_claim_union_expr",
+            "positive_claim_inter_expr",
+            "positive_claim_diff_expr",
+            "positive_claim_nested_expr",
+            "positive_claim_union_inter_expr",
+            "positive_claim_diff_union_expr",
+            "positive_claim_inter_diff_expr",
+            "positive_claim_removed",
+            "positive_claim_mem_expr",
+            "positive_claim_cardinal_expr",
+            "positive_claim_elements_expr",
+            "positive_claim_fold_count",
+            "positive_claim_has_2",
+            "positive_claim_count",
+            "positive_claim_elements",
+            "string_label_map",
+            "string_label_hit",
+            "string_label_elements",
+            "string_label_set",
+            "string_label_set_elements",
+        ),
+    )
+
+
+def test_finite_collection_stdlib_declarations_stay_out_of_exports(
+    build_default: Path,
+) -> None:
+    source = (build_default / "FiniteCollectionFixtures.py").read_text()
+
+    assert_module_does_not_export(
+        source,
+        "FiniteCollectionFixtures",
+        (
+            "PositiveMap",
+            "PositiveSet",
+            "add",
+            "remove",
+            "find",
+            "mem",
+            "cardinal",
+            "elements",
+            "fold",
+        ),
+    )
+    assert "class PositiveMap" not in source
+    assert "class PositiveSet" not in source
+
+
+def test_runtime_marker_declarations_stay_suppressed(build_default: Path) -> None:
+    source = (build_default / "concurrency_primitives.py").read_text()
+
+    for marker_name in (
+        "new_mutex",
+        "new_channel",
+        "new_future",
+        "mutex_acquire",
+        "mutex_release",
+        "channel_send",
+        "channel_receive",
+        "future_set",
+        "future_result",
+        "future_done",
+    ):
+        assert f"def {marker_name}(" not in source
+        assert f"{marker_name} =" not in source
+
+    assert "__PYCONC_" not in source
+    assert "__PYMONAD_IO_" not in source
+
+
+def test_custom_aliases_and_record_accessors_stay_classified(
+    build_default: Path,
+) -> None:
+    records_source = (build_default / "records.py").read_text()
+    proof_source = (build_default / "proof_pair_zero.py").read_text()
+
+    assert "def pair_r_same(" in records_source
+    assert "pair_r_eq =" not in records_source
+    assert "__PY_NATIVE_EQ__" not in records_source
+
+    assert "def pfst_r(" not in records_source
+    assert "def psnd_r(" not in records_source
+    assert "return p.pfst_r" in records_source
+    assert "return p.psnd_r" in records_source
+
+    assert "def proof_pair_zero(" in proof_source
+    assert "eq_refl" not in proof_source


### PR DESCRIPTION
Adds focused extraction coverage for declaration/export stability and centralizes Rocq declaration classification so declaration printing and export collection share one path.

Fixes #1095.

The remaining work restores the term classifier to the clearer `if`/`else` shape requested in review.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Restore term classifier to if else chain](https://github.com/FidoCanCode/home/pull/1110#discussion_r3164964792) <!-- type:thread -->
- [x] Regenerate Rocq outputs and verify CI <!-- type:spec -->
- [x] [Rewrite classifier branches with match](https://github.com/FidoCanCode/home/pull/1110#discussion_r3164933946) <!-- type:thread -->
- [x] Introduce shared declaration classifier <!-- type:spec -->
- [x] Add declaration export stability tests <!-- type:spec -->
- [x] [Rewrite declaration classification branches with match](https://github.com/FidoCanCode/home/pull/1110#discussion_r3164921256) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->