### PR TITLE
Prevent slow HTTP clients from blocking Fido ingress

### DIFF
--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -12,7 +12,7 @@ import sys
 import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -65,6 +65,7 @@ log = logging.getLogger(__name__)
 _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
 _RESTART_EXIT_CODE = 75
+_REQUEST_TIMEOUT_SECONDS = 10.0
 
 # XML namespace URIs for the /status endpoint structural XML.
 _NS_FIDO = "https://fidocancode.dog/fido"
@@ -82,6 +83,26 @@ class PreflightError(RuntimeError):
     Caught by :func:`run` and converted to :exc:`SystemExit` so individual
     preflight functions remain testable without triggering process exit.
     """
+
+
+class FidoHTTPServer(ThreadingHTTPServer):
+    """Threaded webhook server with bounded per-connection reads.
+
+    The standard ``HTTPServer`` handles one request at a time. A client that
+    connects and stalls before sending a full HTTP request can otherwise block
+    every webhook and status request behind it.
+    """
+
+    allow_reuse_address = True
+    block_on_close = False
+    daemon_threads = True
+    request_queue_size = 64
+    request_timeout_seconds = _REQUEST_TIMEOUT_SECONDS
+
+    def get_request(self) -> tuple[Any, Any]:
+        request, client_address = super().get_request()
+        request.settimeout(self.request_timeout_seconds)
+        return request, client_address
 
 
 def _runner_dir() -> Path:
@@ -1346,7 +1367,7 @@ def bootstrap_issue_caches(
 def run(
     *,
     _from_args: Callable[..., Config] = Config.from_args,
-    _HTTPServer: Callable[..., HTTPServer] = HTTPServer,
+    _HTTPServer: Callable[..., HTTPServer] = FidoHTTPServer,
     _make_registry: Callable[..., WorkerRegistry] = make_registry,
     _path_home: Callable[[], Path] = Path.home,
     _basic_config: Callable[..., None] = logging.basicConfig,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import socket
 import subprocess
 import threading
 import urllib.error
@@ -26,7 +27,7 @@ from fido.events import (
 )
 from fido.infra import Infra
 from fido.provider import ProviderID
-from fido.server import PreflightError, WebhookHandler, _repo_status
+from fido.server import FidoHTTPServer, PreflightError, WebhookHandler, _repo_status
 from fido.store import FidoStore
 
 
@@ -3564,6 +3565,26 @@ class TestRun:
 
         mock_server.serve_forever.assert_called_once()
         mock_server.server_close.assert_called_once()
+
+    def test_default_server_does_not_block_behind_slow_client(self) -> None:
+        srv = FidoHTTPServer(("127.0.0.1", 0), WebhookHandler)
+        srv.request_timeout_seconds = 0.2
+        port = srv.server_address[1]
+        thread = threading.Thread(
+            target=srv.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True
+        )
+        thread.start()
+        slow = socket.create_connection(("127.0.0.1", port), timeout=1)
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/", timeout=1
+            ) as response:
+                assert response.read() == b"fido is running"
+        finally:
+            slow.close()
+            srv.shutdown()
+            srv.server_close()
+            thread.join(timeout=1)
 
     def test_run_keyboard_interrupt_kills_children(self, tmp_path: Path) -> None:
         from fido.server import run


### PR DESCRIPTION
## Summary
- replace the production single-threaded HTTPServer with a threaded FidoHTTPServer
- set a bounded per-connection read timeout so stalled clients cannot monopolize ingress
- add a regression test that keeps one socket idle while a second request still succeeds

## Why
A live Fido instance was still running workers/watchdogs, but `/status.json` and likely webhooks hung. A SIGUSR1 stack dump showed the main HTTP thread blocked in `http.server.handle_one_request()` reading from a client socket. Since HTTPServer is single-threaded, that one stalled connection blocked all ingress.

## Verification
- ./fido tests tests/test_server.py::TestRun::test_default_server_does_not_block_behind_slow_client tests/test_server.py::TestRun::test_run_starts_server
- ./fido tests tests/test_server.py
- ./fido ruff check src/fido/server.py tests/test_server.py
- ./fido pyright src/fido/server.py
- git diff --check
- git commit pre-commit: full buildx CI checks and runtime image cache, model mirrors, generated workflow files