### PR TITLE
Fix no-commit task completion loop

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -248,6 +248,27 @@ class Prompts:
             f"{plain}"
         )
 
+    def task_completed_without_commit_comment_prompt(self, task_title: str) -> str:
+        """Prompt for a Fido-voiced PR note when a task completes with no commit."""
+        plain = (
+            "I marked a task complete, but it did not produce a git commit. "
+            "Explain why no commit was needed using the context you already "
+            "have from this PR and task. I am marking the task done, advancing "
+            "to the next task, and preserving this PR branch instead of running "
+            "branch cleanup or replacing the PR. "
+            f"Task: {task_title}"
+        )
+        return (
+            f"{self.persona}\n\n"
+            "Rewrite the following GitHub pull request comment in character as "
+            "Fido. Keep it to 2-3 sentences. Explain why the task completed "
+            "without a commit, using your existing context from this PR and "
+            "task. Also say that the work queue will advance while the PR is "
+            "preserved. "
+            "Output only the comment text, no quotes, no explanation.\n\n"
+            f"{plain}"
+        )
+
     def status_prompt(self, activities: list[tuple[str, str, bool]]) -> str:
         """Build the combined status-text + emoji prompt for a session nudge.
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2378,6 +2378,29 @@ class Worker:
             for t in current_task_list
         )
 
+    def _report_task_completed_without_commit(
+        self,
+        repo: str,
+        pr_number: int,
+        task_id: str,
+        task_title: str,
+    ) -> None:
+        """Explain a completed task that did not produce git progress."""
+        log.warning(
+            "task %s was marked completed but HEAD did not change; "
+            "advancing without branch cleanup",
+            task_id,
+        )
+        prompts = self._get_prompts()
+        prompt = prompts.task_completed_without_commit_comment_prompt(task_title)
+        msg = self._provider_agent.generate_reply(
+            prompt, self._provider_agent.voice_model
+        )
+        if not msg:
+            raise ValueError("task completed without commit comment was empty")
+        body = f"{msg}\n\n<!-- fido:task-complete-no-commit -->"
+        self.gh.comment_issue(repo, pr_number, body)
+
     def execute_task(
         self,
         fido_dir: Path,
@@ -2476,18 +2499,20 @@ class Worker:
         # Resume loop: let the provider agent cook until commits appear
         attempt = 0
         fresh_session_retry_used = False
+        completed_without_commit = False
         while head_before == head_after:
-            # If the task was completed externally (e.g. via `fido task
-            # complete`) while we were waiting, stop retrying — the work is
-            # already recorded as done and no commits will ever appear.
             current_task_list = self._tasks.list()
             if any(
                 t["id"] == task["id"] and t.get("status") == TaskStatus.COMPLETED
                 for t in current_task_list
             ):
-                log.info(
-                    "task externally completed — stopping retry (id=%s)", task["id"]
+                self._report_task_completed_without_commit(
+                    repo_ctx.repo,
+                    pr_number,
+                    task["id"],
+                    task_title,
                 )
+                completed_without_commit = True
                 break
             attempt += 1
             use_fresh_session = (
@@ -2561,6 +2586,16 @@ class Worker:
             # Yield at the retry boundary so untriaged handlers get their turn
             # before we loop back for another provider run (#1067).
             self._yield_for_untriaged()
+
+        if completed_without_commit:
+            self._tasks.complete_with_resolve(task["id"], self.gh)
+            with State(fido_dir).modify() as state:
+                state.pop("current_task_id", None)
+            tasks.sync_tasks(self.work_dir, self.gh, blocking=True)
+            self._delete_leaked_task_comments(
+                repo_ctx.repo, pr_number, repo_ctx.gh_user, leak_before_ids
+            )
+            return True
 
         self._squash_wip_commit("origin", slug, repo_ctx.default_branch)
         pushed = self.ensure_pushed("origin", slug)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8862,25 +8862,34 @@ class TestExecuteTask:
         assert mock_run.call_count == 4
         mock_complete.assert_called_once()
 
-    def test_breaks_retry_loop_when_task_externally_completed(
+    def test_advances_completed_task_without_commit_and_explains_on_pr(
         self, tmp_path: Path
     ) -> None:
-        # Task is pending on first list_tasks call (execute_task picks it up),
-        # then externally completed before the retry loop re-checks — loop
-        # should break without calling provider_run a second time.
-        worker, _ = self._make_worker(tmp_path)
-        fido_dir = self._fido_dir(tmp_path)
-        task = self._pending_task("Already done task")
-        completed_task = {**task, "status": "completed"}
-        # HEAD never changes — no commits will ever appear.
-        git_mock = MagicMock(
-            side_effect=lambda args, **kw: MagicMock(
-                returncode=0,
-                stdout="aaa" if args == ["rev-parse", "HEAD"] else "",
-                stderr="",
-            )
+        # Some tasks are legitimately planning/no-op tasks. If such a task is
+        # completed without a commit, the worker should advance the queue, but
+        # must not run the normal push/sentinel-cleanup path because that can
+        # make GitHub close an otherwise valid empty-sentinel PR.
+        mock_agent = _client()
+        mock_agent.generate_reply.return_value = (
+            "Woof — this task finished without a code change because it was "
+            "planning-only, so I am marking it done and keeping this PR intact."
         )
-        list_tasks_calls = iter([[task], [completed_task]])
+        gh = MagicMock()
+        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 1, "current_task_id": "t1"})
+        task = self._pending_task("Already done task")
+        in_progress_task = {**task, "status": "in_progress"}
+        completed_task = {**task, "status": "completed"}
+
+        def fake_git(args, **kw):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "aaa" if args == ["rev-parse", "HEAD"] else ""
+            result.stderr = ""
+            return result
+
+        list_tasks_calls = iter([[task], [in_progress_task], [completed_task]])
         with (
             patch(
                 "fido.tasks.Tasks.list",
@@ -8889,18 +8898,36 @@ class TestExecuteTask:
             patch.object(worker, "set_status"),
             patch("fido.worker.build_prompt"),
             patch(
-                "fido.worker.provider_run", return_value=("sess-1", "output")
+                "fido.worker.provider_run",
+                return_value=("sess-1", "output"),
             ) as mock_run,
-            patch.object(worker, "_git", git_mock),
-            patch.object(worker, "ensure_pushed", return_value=True),
+            patch.object(worker, "_git", MagicMock(side_effect=fake_git)),
+            patch.object(worker, "_squash_wip_commit") as mock_squash,
+            patch.object(worker, "ensure_pushed") as mock_push,
             patch("fido.tasks.Tasks.complete_with_resolve") as mock_complete,
-            patch("fido.tasks.sync_tasks"),
+            patch("fido.tasks.sync_tasks") as mock_sync,
         ):
             worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
-        # provider_run called exactly once (initial dispatch), not again after break
         mock_run.assert_called_once()
-        # complete_with_resolve still called (idempotent — task already completed externally)
+        gh.comment_issue.assert_called_once()
+        comment_args = gh.comment_issue.call_args.args
+        assert comment_args[0] == "owner/repo"
+        assert comment_args[1] == 1
+        assert "Woof" in comment_args[2]
+        assert "<!-- fido:task-complete-no-commit -->" in comment_args[2]
+        mock_agent.generate_reply.assert_called_once()
+        assert mock_agent.generate_reply.call_args.args[1] == mock_agent.voice_model
+        prompt = mock_agent.generate_reply.call_args.args[0]
+        assert "Already done task" in prompt
+        assert (
+            "Explain why no commit was needed using the context you already have"
+            in prompt
+        )
+        mock_squash.assert_not_called()
+        mock_push.assert_not_called()
         mock_complete.assert_called_once_with(task["id"], worker.gh)
+        assert "current_task_id" not in State(fido_dir).load()
+        mock_sync.assert_any_call(tmp_path, gh, blocking=True)
 
     def test_does_not_treat_in_progress_task_as_externally_completed(
         self, tmp_path: Path
@@ -8926,7 +8953,9 @@ class TestExecuteTask:
             )
         )
         # Picker sees PENDING; resume loop's re-check sees IN_PROGRESS.
-        list_tasks_calls = iter([[task], [in_progress_task]])
+        list_tasks_calls = iter(
+            [[task], [in_progress_task], [in_progress_task], [in_progress_task]]
+        )
         with (
             patch(
                 "fido.tasks.Tasks.list",


### PR DESCRIPTION
## Summary

Fixes the worker path where a task marked completed without a new commit flowed into normal branch cleanup/push handling. That path could remove the empty start sentinel, make the PR disappear/close, and force fresh-retry to wipe the planned task queue.

This now treats no-commit completion as a real task completion, posts an explanatory PR comment, preserves the PR branch, syncs the task queue, and lets the worker move to the next task.

## Verification

- ./fido pytest tests/test_worker.py::TestExecuteTask -q
- ./fido ruff format src/fido/worker.py tests/test_worker.py --check
- ./fido ruff check src/fido/worker.py tests/test_worker.py
- pre-commit ./fido ci during commit