### PR TITLE
Fix ACT task titles from review comment chains

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -923,7 +923,6 @@ def reply_to_comment(
         context["reply_promise_id"] = direct_promise.promise_id
 
     # Always fetch the full thread for this comment.
-    # Normalize to list so root_body extraction below is type-safe.
     thread_comments: list[dict[str, Any]] = []
     if info.get("repo") and info.get("pr") and info.get("comment_id"):
         fetched = gh.fetch_comment_thread(info["repo"], info["pr"], info["comment_id"])
@@ -941,10 +940,7 @@ def reply_to_comment(
         c["id"] for c in thread_comments if c.get("author", "").lower() in _FIDO_LOGINS
     }
 
-    # Root comment body — used for task title generation.
-    # When the webhook fires on a reply (e.g. "Yes" or "Woof, you're right!"),
-    # the task title should describe the reviewer's original feedback, not the reply.
-    root_body = thread_comments[0].get("body", comment) if thread_comments else comment
+    final_comment_id = info.get("comment_id")
 
     # Enrich context with sibling threads when the comment needs more context
     if needs_more_context(comment, agent=agent) and info.get("repo") and info.get("pr"):
@@ -962,14 +958,20 @@ def reply_to_comment(
     )
     log.info("triage: %s — %s", category, titles)
 
-    # Step 1b: Always derive task titles from the root comment body for action
-    # categories.  The originating PR comment is the source of truth for what
-    # was requested; triage may have run on a short reply body ("Yes", "Done")
-    # that produces a poor title.  Using root_body here ensures the task always
-    # reflects what the reviewer originally asked.
+    # Step 1b: Derive task titles from the full comment chain for action
+    # categories.  The final triggering comment is the ACT source, while prior
+    # comments provide the context needed for terse follow-ups.
     if category in ("ACT", "DO"):
-        log.info("deriving task title from root comment")
-        titles = [_summarize_as_action_item(root_body, agent=agent)]
+        log.info("deriving task title from comment chain")
+        titles = [
+            _comment_chain_action_title(
+                thread_comments,
+                final_comment_id if isinstance(final_comment_id, int) else None,
+                comment,
+                titles,
+                agent=agent,
+            )
+        ]
 
     # Step 2: For DEFER, open a tracking issue before crafting the reply.
     # Raises on failure so we don't craft a reply referencing a missing issue.
@@ -1177,6 +1179,37 @@ def needs_more_context(
 _MAX_TITLE_LEN = 80
 
 
+def _shorten_title_if_needed(
+    title: str, *, agent: ProviderAgent, log_prefix: str
+) -> str:
+    """Shorten an overlong task title while preserving imperative wording."""
+    result = title
+    for _ in range(3):
+        if len(result) <= _MAX_TITLE_LEN:
+            break
+        log.info(
+            "%s: title too long (%d chars), requesting shorten",
+            log_prefix,
+            len(result),
+        )
+        shortened = safe_voice_turn(
+            agent,
+            f"{NO_TOOLS_CLAUSE}\n\n"
+            f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
+            f"Reply with ONLY the shortened title.\n\nTitle: {result}",
+            model=agent.voice_model,
+            log_prefix=f"{log_prefix}/shorten",
+        )
+        result = shortened.strip()
+        log.info(
+            "%s: shorten returned %d chars (preview=%r)",
+            log_prefix,
+            len(result),
+            result[:60],
+        )
+    return result[:_MAX_TITLE_LEN]
+
+
 def _summarize_as_action_item(
     comment_body: str, *, agent: ProviderAgent | None = None
 ) -> str:
@@ -1203,28 +1236,73 @@ def _summarize_as_action_item(
         len(result),
         result[:60],
     )
-    for _ in range(3):
-        if len(result) <= _MAX_TITLE_LEN:
-            break
-        log.info(
-            "summarize-action-item: title too long (%d chars), requesting shorten",
-            len(result),
+    return _shorten_title_if_needed(
+        result, agent=agent, log_prefix="_summarize_as_action_item"
+    )
+
+
+def _comment_chain_action_title(
+    thread_comments: list[dict[str, Any]],
+    final_comment_id: int | None,
+    final_comment_body: str,
+    triage_titles: list[str],
+    *,
+    agent: ProviderAgent | None = None,
+) -> str:
+    """Ask Opus for a task title using the whole comment chain."""
+    if agent is None:
+        raise ValueError("_comment_chain_action_title requires agent")
+    chain = list(thread_comments)
+    if final_comment_id is not None and not any(
+        c.get("id") == final_comment_id for c in chain
+    ):
+        chain.append(
+            {
+                "id": final_comment_id,
+                "author": "commenter",
+                "body": final_comment_body,
+            }
         )
-        shortened = safe_voice_turn(
-            agent,
-            f"{NO_TOOLS_CLAUSE}\n\n"
-            f"Shorten this task title to under {_MAX_TITLE_LEN} characters while keeping it imperative. "
-            f"Reply with ONLY the shortened title.\n\nTitle: {result}",
-            model=agent.voice_model,
-            log_prefix="_summarize_as_action_item/shorten",
+    if not chain:
+        chain.append(
+            {
+                "id": final_comment_id,
+                "author": "commenter",
+                "body": final_comment_body,
+            }
         )
-        result = shortened.strip()
-        log.info(
-            "summarize-action-item: shorten returned %d chars (preview=%r)",
-            len(result),
-            result[:60],
-        )
-    return result[:_MAX_TITLE_LEN]
+    lines: list[str] = []
+    for index, item in enumerate(chain, start=1):
+        marker = " (FINAL ACT COMMENT)" if item.get("id") == final_comment_id else ""
+        user = item.get("user")
+        user_login = user.get("login") if isinstance(user, dict) else None
+        author = item.get("author") or user_login or "unknown"
+        body = str(item.get("body", "") or "")
+        lines.append(f"{index}. {author}{marker}: {body}")
+    suggested = "\n".join(f"- {title}" for title in triage_titles if title.strip())
+    prompt = (
+        f"{NO_TOOLS_CLAUSE}\n\n"
+        "Convert this PR review comment chain into a short, imperative task title "
+        "starting with a verb. The comment marked FINAL ACT COMMENT is the comment "
+        "that produced the ACT decision; use the earlier comments only as context. "
+        "Preserve the concrete action from the final comment. Reply with ONLY the "
+        "title — no category prefix, no punctuation at the end.\n\n"
+        f"Suggested ACT title(s) from triage:\n{suggested or '- none'}\n\n"
+        "Comment chain:\n" + "\n".join(lines)
+    )
+    log.info("comment-chain-action-title: requesting title from opus")
+    raw = safe_voice_turn(
+        agent, prompt, model=agent.voice_model, log_prefix="_comment_chain_action_title"
+    )
+    result = raw.strip()
+    log.info(
+        "comment-chain-action-title: returned %d chars (preview=%r)",
+        len(result),
+        result[:60],
+    )
+    return _shorten_title_if_needed(
+        result, agent=agent, log_prefix="_comment_chain_action_title"
+    )
 
 
 def _triage(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1241,6 +1241,8 @@ class TestDispatchReviewComment:
         assert result is not None
         assert result.reply_to is not None
         assert result.comment_body == "fix this"
+        assert result.reply_to["comment_id"] == 123
+        assert result.reply_to["url"] == "https://example.com"
 
     def test_reply_to_includes_author(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
@@ -1899,6 +1901,38 @@ class TestReplyToComment:
             )
         mock_create_task.assert_not_called()
 
+    def test_apply_reply_result_preserves_triggering_comment_link(
+        self, tmp_path: Path
+    ) -> None:
+        """Task metadata links to the comment that requested work."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = self._repo_cfg(tmp_path)
+        thread = {
+            "repo": "owner/repo",
+            "pr": 1,
+            "comment_id": 102,
+            "url": "https://github.com/owner/repo/pull/1#discussion_r102",
+            "author": "rhencke",
+            "comment_type": "pulls",
+        }
+        with patch("fido.events.create_task") as mock_create_task:
+            _apply_reply_result(
+                "ACT",
+                ["Remove redundant empty-list concatenation"],
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                thread=thread,
+                registry=None,
+            )
+        mock_create_task.assert_called_once()
+        _, kwargs = mock_create_task.call_args
+        assert kwargs["thread"]["comment_id"] == 102
+        assert (
+            kwargs["thread"]["url"]
+            == "https://github.com/owner/repo/pull/1#discussion_r102"
+        )
+
     def test_full_flow_answer(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(
@@ -2118,8 +2152,8 @@ class TestReplyToComment:
         )
         assert cat == "ACT"
 
-    def test_act_title_from_summarize_not_triage(self, tmp_path: Path) -> None:
-        """ACT task title always comes from _summarize_as_action_item, not triage output."""
+    def test_act_title_from_comment_chain_not_raw_triage(self, tmp_path: Path) -> None:
+        """ACT task title uses the chain-aware title pass, not raw triage output."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -2128,12 +2162,15 @@ class TestReplyToComment:
             is_bot=False,
         )
 
+        calls: list[str] = []
+
         def fake_pp(prompt, model, **kwargs):
+            calls.append(prompt)
             if model == "claude-haiku-4-5":
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: add unit tests\nACT: update documentation"
-            if "Convert this PR review comment" in prompt:
+            if "Convert this PR review comment chain" in prompt:
                 return "Add tests and update docs"
             return "On it!"
 
@@ -2145,16 +2182,25 @@ class TestReplyToComment:
             agent=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
-        # Title comes from _summarize_as_action_item(root_body), not multi-item triage
         assert titles == ["Add tests and update docs"]
+        chain_prompts = [
+            p for p in calls if "Convert this PR review comment chain" in p
+        ]
+        assert len(chain_prompts) == 1
+        assert "Suggested ACT title(s) from triage:" in chain_prompts[0]
+        assert "- add unit tests" in chain_prompts[0]
+        assert "- update documentation" in chain_prompts[0]
+        assert "FINAL ACT COMMENT" in chain_prompts[0]
 
-    def test_act_title_uses_root_comment_when_reply(self, tmp_path: Path) -> None:
-        """When the triggering comment is a reply, ACT title comes from the root."""
+    def test_act_title_uses_thread_context_and_final_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """When the triggering comment is a reply, ACT title sees the whole chain."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
             reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 42},
-            comment_body="Woof, you're right!",
+            comment_body="But what about ] + []?",
             is_bot=False,
         )
 
@@ -2165,20 +2211,22 @@ class TestReplyToComment:
             if model == "claude-haiku-4-5":
                 return "NO"
             if "Triage" in prompt:
-                return "ACT: do it"
-            if "Convert this PR review comment" in prompt:
-                return "Add null input validation"
+                return "ACT: remove redundant empty-list concatenation"
+            if "Convert this PR review comment chain" in prompt:
+                return "Remove redundant empty-list concatenation"
             return "Done!"
 
         mock_gh = MagicMock()
-        # Thread: root is reviewer feedback, second is fido's reply
+        # The root explains the surrounding concern; the final human reply
+        # supplies the concrete ACT request.
         mock_gh.fetch_comment_thread.return_value = [
             {
                 "id": 100,
-                "author": "reviewer",
-                "body": "Please add null input validation",
+                "author": "rhencke",
+                "body": "Why did generated fields get renamed?",
             },
-            {"id": 101, "author": "fidocancode", "body": "Woof, you're right!"},
+            {"id": 101, "author": "fidocancode", "body": "Woof, because..."},
+            {"id": 42, "author": "rhencke", "body": "But what about ] + []?"},
         ]
         cat, titles = reply_to_comment(
             action,
@@ -2188,12 +2236,16 @@ class TestReplyToComment:
             agent=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
-        # Title derived from root comment, not the "Woof" reply
-        assert titles == ["Add null input validation"]
-        # _summarize_as_action_item was called with the root body
-        summarize_calls = [p for p in calls if "Convert this PR review comment" in p]
-        assert len(summarize_calls) == 1
-        assert "Please add null input validation" in summarize_calls[0]
+        assert titles == ["Remove redundant empty-list concatenation"]
+        chain_prompts = [
+            p for p in calls if "Convert this PR review comment chain" in p
+        ]
+        assert len(chain_prompts) == 1
+        assert "1. rhencke: Why did generated fields get renamed?" in chain_prompts[0]
+        assert "2. fidocancode: Woof, because..." in chain_prompts[0]
+        assert (
+            "3. rhencke (FINAL ACT COMMENT): But what about ] + []?" in chain_prompts[0]
+        )
         # Posted replies are immutable; even with a prior Fido reply we post a new one.
         reply_args = mock_gh.reply_to_review_comment.call_args.args
         assert reply_args[:2] == ("owner/repo", 1)
@@ -2201,8 +2253,10 @@ class TestReplyToComment:
         assert "fido:reply-promise:" in reply_args[2]
         mock_gh.edit_review_comment.assert_not_called()
 
-    def test_act_title_always_from_root_comment(self, tmp_path: Path) -> None:
-        """ACT title is always derived from the root comment via _summarize_as_action_item."""
+    def test_act_title_marks_single_comment_thread_as_final(
+        self, tmp_path: Path
+    ) -> None:
+        """A single-comment thread is still explicitly marked as the ACT source."""
         cfg = self._cfg(tmp_path)
         action = Action(
             prompt="comment",
@@ -2211,12 +2265,15 @@ class TestReplyToComment:
             is_bot=False,
         )
 
+        calls: list[str] = []
+
         def fake_pp(prompt, model, **kwargs):
+            calls.append(prompt)
             if model == "claude-haiku-4-5":
                 return "NO"
             if "Triage" in prompt:
                 return "ACT: add error handling"
-            if "Convert this PR review comment" in prompt:
+            if "Convert this PR review comment chain" in prompt:
                 return "Add error handling for null inputs"
             return "Will do!"
 
@@ -2237,9 +2294,15 @@ class TestReplyToComment:
             agent=_client(side_effect=fake_pp),
         )
         assert cat == "ACT"
-        # Title always comes from _summarize_as_action_item(root_body), even when
-        # the triggering comment is the root itself
         assert titles == ["Add error handling for null inputs"]
+        chain_prompts = [
+            p for p in calls if "Convert this PR review comment chain" in p
+        ]
+        assert len(chain_prompts) == 1
+        assert (
+            "1. reviewer (FINAL ACT COMMENT): Add error handling for null inputs"
+            in chain_prompts[0]
+        )
         # No prior Fido reply in thread — a new reply is posted
         mock_gh.reply_to_review_comment.assert_called_once()
         mock_gh.edit_review_comment.assert_not_called()


### PR DESCRIPTION
Fixes #1115

## Summary
- derive ACT/DO task titles from the full review comment chain
- mark the triggering comment as the final ACT source in the title prompt
- keep task metadata linked to the triggering comment URL

## Verification
- ./fido pytest tests/test_events.py::TestSummarizeAsActionItem tests/test_events.py::TestDispatchReviewComment::test_owner_comment tests/test_events.py::TestReplyToComment::test_act_title_from_comment_chain_not_raw_triage tests/test_events.py::TestReplyToComment::test_act_title_uses_thread_context_and_final_comment tests/test_events.py::TestReplyToComment::test_act_title_marks_single_comment_thread_as_final tests/test_events.py::TestReplyToComment::test_apply_reply_result_preserves_triggering_comment_link -q
- ./fido ruff check src/fido/events.py tests/test_events.py
- ./fido ruff format --check src/fido/events.py tests/test_events.py
- pre-commit hook: ./fido ci, model mirror check, generated workflow check