### PR TITLE
Bug: kill provider and resume when interrupt timeout blocks webhook preemption (closes #1128)

### DIFF
--- a/models/handler_preemption.v
+++ b/models/handler_preemption.v
@@ -125,8 +125,11 @@ Inductive Event : Type :=
 
     [HandlerDone] from [NonEmpty] stays [NonEmpty] in the FSM; the
     runtime uses the actual counter to decide when to flip to [Empty].
-    This is safe because the invariant ([WorkerTurnStart] rejected
-    from [NonEmpty]) holds regardless of count. *)
+    [HandlerDone] is also accepted from durable-demand states because the
+    legacy untriaged inbox and durable queue can overlap: finishing the
+    handler must not clear the durable blocker.  This is safe because the
+    invariant ([WorkerTurnStart] rejected from all demand states) holds
+    regardless of count. *)
 Definition transition (current : State) (event : Event) : option State :=
   match current, event with
   | Empty,           WebhookArrives        => Some NonEmpty
@@ -136,16 +139,18 @@ Definition transition (current : State) (event : Event) : option State :=
   | NonEmpty,        WebhookArrives        => Some NonEmpty
   | NonEmpty,        DurableDemandRecorded => Some DurableDemand
   | NonEmpty,        HandlerDone           => Some NonEmpty
-  | NonEmpty,        DurableDemandDrained  => Some Empty
+  | NonEmpty,        DurableDemandDrained  => Some NonEmpty
 
   | DurableDemand,   WebhookArrives        => Some DurableDemand
   | DurableDemand,   DurableDemandRecorded => Some DurableDemand
   | DurableDemand,   InterruptRequested    => Some PreemptedDemand
+  | DurableDemand,   HandlerDone           => Some DurableDemand
   | DurableDemand,   DurableDemandDrained  => Some Empty
 
   | PreemptedDemand, WebhookArrives        => Some PreemptedDemand
   | PreemptedDemand, DurableDemandRecorded => Some PreemptedDemand
   | PreemptedDemand, InterruptRequested    => Some PreemptedDemand
+  | PreemptedDemand, HandlerDone           => Some PreemptedDemand
   | PreemptedDemand, DurableDemandDrained  => Some Empty
 
   | _,               _                     => None
@@ -208,6 +213,25 @@ Qed.
     check is correct: the FSM also rejects it. *)
 Lemma handler_done_rejected_from_empty :
   transition Empty HandlerDone = None.
+Proof.
+  reflexivity.
+Qed.
+
+(** [handler_done_preserves_durable_gate]: a handler may finish while durable
+    demand remains pending.  The legacy untriaged counter is count-aware at
+    runtime, but [HandlerDone] must not clear durable scheduler priority. *)
+Lemma handler_done_preserves_durable_gate :
+  transition DurableDemand   HandlerDone = Some DurableDemand /\
+  transition PreemptedDemand HandlerDone = Some PreemptedDemand.
+Proof.
+  split; reflexivity.
+Qed.
+
+(** [durable_drain_preserves_legacy_gate]: durable demand can drain while the
+    legacy untriaged inbox still has handlers in flight.  The durable drain
+    event must not unblock worker turns while legacy demand remains. *)
+Lemma durable_drain_preserves_legacy_gate :
+  transition NonEmpty DurableDemandDrained = Some NonEmpty.
 Proof.
   reflexivity.
 Qed.

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -21,6 +21,7 @@ from fido.provider import (
     ProviderAgent,
     ProviderAPI,
     ProviderID,
+    ProviderInterruptTimeout,
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
@@ -864,9 +865,16 @@ class CodexSession(OwnedSession):
             client = self._client
         if thread_id is None or turn_id is None or not client.is_alive():
             return
-        client.request(
-            "turn/interrupt", {"threadId": thread_id, "turnId": turn_id}, timeout=5
-        )
+        try:
+            client.request(
+                "turn/interrupt",
+                {"threadId": thread_id, "turnId": turn_id},
+                timeout=5,
+            )
+        except TimeoutError as exc:
+            raise ProviderInterruptTimeout(
+                f"Codex turn/interrupt timed out for thread {thread_id} turn {turn_id}"
+            ) from exc
 
     def __enter__(self) -> "CodexSession":
         depth = getattr(self._reentry_tls, "depth", 0)

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -825,9 +825,12 @@ class CodexSession(OwnedSession):
         del tools
 
     def recover(self) -> None:
+        with self._turn_lock:
+            self._active_turn_id = None
         with self._state_lock:
             old_session_id = self._session_id
             old_client = self._client
+            self._last_turn_cancelled = False
         old_client.stop()
         new_client = self._client_factory(cwd=self._work_dir)
         with self._state_lock:

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -25,6 +25,19 @@ import fido.rocq.transition as fsm
 log = logging.getLogger(__name__)
 
 
+class RecoverableProviderWedgeError(RuntimeError):
+    """A provider transport wedged but can be killed and resumed from state."""
+
+
+class ProviderInterruptTimeout(RecoverableProviderWedgeError):
+    """Provider did not acknowledge a worker interrupt within the deadline."""
+
+
+def is_recoverable_provider_wedge(exc: BaseException) -> bool:
+    """Return true when *exc* means the provider should be killed and resumed."""
+    return isinstance(exc, RecoverableProviderWedgeError)
+
+
 class ProviderID(StrEnum):
     """Supported LLM providers for fido."""
 

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -962,6 +962,10 @@ class ProviderAgent(Protocol):
         """Stop and detach any currently attached persistent session."""
         ...
 
+    def recover_session(self) -> bool:
+        """Recover the currently attached persistent session, if any."""
+        ...
+
     def run_turn(
         self,
         content: str,

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -528,16 +528,20 @@ class WorkerRegistry:
                 return
             new = old - 1
             self._untriaged[repo_name] = new
-            # The FSM models {Empty, NonEmpty} — HandlerDone stays NonEmpty.
-            # When the count reaches 0, reset the FSM to Empty directly so
-            # WorkerTurnStart is accepted on the next worker turn.
+            # HandlerDone preserves the active demand state.  When legacy
+            # untriaged demand is the only blocker and the count reaches 0,
+            # reset to Empty; durable demand must remain until its store drains.
             self._preemption_fsm_transition(repo_name, preemption_fsm.HandlerDone())
             if new == 0:
-                self._preemption_fsm_states[repo_name] = preemption_fsm.Empty()
-                log.debug(
-                    "preemption[%s]: FSM NonEmpty →Empty (count reached 0)",
-                    repo_name,
+                current = self._preemption_fsm_states.get(
+                    repo_name, preemption_fsm.Empty()
                 )
+                if isinstance(current, preemption_fsm.NonEmpty):
+                    self._preemption_fsm_states[repo_name] = preemption_fsm.Empty()
+                    log.debug(
+                        "preemption[%s]: FSM NonEmpty →Empty (count reached 0)",
+                        repo_name,
+                    )
                 ev = self._untriaged_drained.get(repo_name)
                 if ev is not None:
                     ev.set()
@@ -571,9 +575,19 @@ class WorkerRegistry:
             current = self._preemption_fsm_states.get(repo_name, preemption_fsm.Empty())
             if isinstance(current, preemption_fsm.Empty):
                 return
-            self._preemption_fsm_transition(
+            new_state = self._preemption_fsm_transition(
                 repo_name, preemption_fsm.DurableDemandDrained()
             )
+            if self._untriaged.get(repo_name, 0) > 0 and not isinstance(
+                new_state, preemption_fsm.NonEmpty
+            ):
+                self._preemption_fsm_states[repo_name] = preemption_fsm.NonEmpty()
+                log.debug(
+                    "preemption[%s]: FSM %s →NonEmpty (durable drained; "
+                    "untriaged count remains)",
+                    repo_name,
+                    type(new_state).__name__,
+                )
 
     def wait_for_inbox_drain(
         self, repo_name: str, timeout: float | None = None

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -234,6 +234,13 @@ class WorkerRegistry:
         if thread:
             thread.abort_task()
 
+    def recover_provider(self, repo_name: str) -> bool:
+        """Recover the attached provider session for *repo_name*, if present."""
+        thread = self._threads.get(repo_name)
+        if thread is None:
+            return False
+        return thread.recover_provider()
+
     def report_activity(
         self,
         repo_name: str,

--- a/src/fido/rocq/handler_preemption.py
+++ b/src/fido/rocq/handler_preemption.py
@@ -128,7 +128,7 @@ def transition(
                 case HandlerDone():
                     return NonEmpty()
                 case DurableDemandDrained():
-                    return Empty()
+                    return NonEmpty()
                 case WorkerTurnStart():
                     return None
                 case __impossible:
@@ -142,7 +142,7 @@ def transition(
                 case InterruptRequested():
                     return PreemptedDemand()
                 case HandlerDone():
-                    return None
+                    return DurableDemand()
                 case DurableDemandDrained():
                     return Empty()
                 case WorkerTurnStart():
@@ -158,7 +158,7 @@ def transition(
                 case InterruptRequested():
                     return PreemptedDemand()
                 case HandlerDone():
-                    return None
+                    return PreemptedDemand()
                 case DurableDemandDrained():
                     return Empty()
                 case WorkerTurnStart():

--- a/src/fido/rocq/handler_preemption.pymap
+++ b/src/fido/rocq/handler_preemption.pymap
@@ -11,4 +11,4 @@ open,67,0,68,8,handler_preemption.v,107,2,107,20,extraction,InterruptRequested,I
 open,73,0,74,8,handler_preemption.v,108,2,108,13,extraction,HandlerDone,HandlerDone
 open,79,0,80,8,handler_preemption.v,109,2,109,22,extraction,DurableDemandDrained,DurableDemandDrained
 open,85,0,86,8,handler_preemption.v,110,2,110,17,extraction,WorkerTurnStart,WorkerTurnStart
-open,99,0,101,18,handler_preemption.v,130,11,130,21,extraction,transition,transition
+open,99,0,101,18,handler_preemption.v,133,11,133,21,extraction,transition,transition

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -799,6 +799,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
     def _preempt_worker_best_effort(self, repo_name: str) -> None:
         """Try to interrupt the current worker after durable demand is recorded."""
+        self.registry.note_durable_demand(repo_name)
         session = self.registry.get_session(repo_name)
         if session is None:
             return

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -804,7 +804,25 @@ class WebhookHandler(BaseHTTPRequestHandler):
             return
         try:
             session.preempt_worker()
-        except Exception:
+        except Exception as exc:
+            if provider.is_recoverable_provider_wedge(exc):
+                log.exception(
+                    "provider preempt wedged for %s after durable webhook enqueue "
+                    "— recovering provider",
+                    repo_name,
+                )
+                recovered = self.registry.recover_provider(repo_name)
+                if recovered:
+                    log.warning(
+                        "provider recovery requested for %s after preempt wedge",
+                        repo_name,
+                    )
+                else:
+                    log.error(
+                        "provider recovery unavailable for %s after preempt wedge",
+                        repo_name,
+                    )
+                return
             log.exception(
                 "provider preempt failed for %s after durable webhook enqueue",
                 repo_name,

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -135,6 +135,15 @@ class SessionBackedAgent:
         if session is not None:
             session.stop()
 
+    def recover_session(self) -> bool:
+        """Recover the attached persistent session if one exists."""
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return False
+        session.recover()
+        return True
+
     def _can_spawn_owned_session(self) -> bool:
         return self._session_system_file is not None and self._work_dir is not None
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -398,6 +398,7 @@ def provider_run(
     timeout: int = 300,
     cwd: Path | str = ".",
     session_mode: TurnSessionMode = TurnSessionMode.REUSE,
+    retry_on_preempt: bool = True,
 ) -> tuple[str, str]:
     """Continue or start a provider session, streaming progress as raw text.
 
@@ -416,7 +417,7 @@ def provider_run(
         agent.run_turn(
             _session_turn_prompt(fido_dir),
             model=model,
-            retry_on_preempt=True,
+            retry_on_preempt=retry_on_preempt,
             session_mode=session_mode,
         )
         return "", ""
@@ -2620,6 +2621,10 @@ class Worker:
         )
         self._registry.wait_for_inbox_drain(self._repo_name, timeout=30.0)
 
+    def _provider_turn_was_preempted(self) -> bool:
+        session = self._provider_agent.session
+        return bool(session is not None and session.last_turn_cancelled)
+
     def _has_durable_webhook_demand(self) -> bool:
         """Return whether durable PR-comment demand should run before work."""
         return FidoStore(self.work_dir).has_pending_pr_comments(self._repo_name)
@@ -2800,8 +2805,15 @@ class Worker:
             cwd=self.work_dir,
             session=None,
             session_mode=self._consume_turn_session_mode(),
+            retry_on_preempt=False,
         )
         log.info("task done (session=%s)", session_id)
+        if self._provider_turn_was_preempted():
+            log.info(
+                "task provider turn preempted for %s — yielding to worker loop",
+                repo_ctx.repo,
+            )
+            return True
         head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
         if self._abort_task.is_set():
@@ -2892,8 +2904,15 @@ class Worker:
                 cwd=self.work_dir,
                 session=session_id or None,
                 session_mode=session_mode,
+                retry_on_preempt=False,
             )
             log.info("task resume done (session=%s)", session_id)
+            if self._provider_turn_was_preempted():
+                log.info(
+                    "task provider resume preempted for %s — yielding to worker loop",
+                    repo_ctx.repo,
+                )
+                return True
             head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
             if self._abort_task.is_set():

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3659,6 +3659,14 @@ class WorkerThread(threading.Thread):
         with self._provider_lock:
             return self._provider
 
+    def recover_provider(self) -> bool:
+        """Recover the attached provider session, if any."""
+        with self._provider_lock:
+            provider = self._provider
+        if provider is None:
+            return False
+        return provider.agent.recover_session()
+
     @property
     def session_owner(self) -> str | None:
         """Name of the thread currently holding the provider session lock, or ``None``.

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -21,7 +21,7 @@ from fido.codex import (
     run_codex_exec,
     run_codex_exec_resume,
 )
-from fido.provider import ProviderID, ProviderModel
+from fido.provider import ProviderID, ProviderInterruptTimeout, ProviderModel
 
 FIXTURES = Path(__file__).parent / "fixtures" / "codex"
 
@@ -68,6 +68,7 @@ class _FakeAppServer:
         self.cwd = cwd
         self.pid = 456
         self.requests: list[tuple[str, dict]] = []
+        self.request_timeouts: list[float] = []
         self.notification_timeouts: list[float] = []
         self.notification_timeouts_before_match = 0
         self.on_notification_wait = lambda _timeout: None
@@ -79,7 +80,7 @@ class _FakeAppServer:
     def request(
         self, method: str, params: dict | None = None, *, timeout: float = 30.0
     ) -> object:
-        del timeout
+        self.request_timeouts.append(timeout)
         payload = params or {}
         self.requests.append((method, payload))
         response = self.responses.get(method)
@@ -542,6 +543,30 @@ class TestCodexSession:
             "turn/interrupt",
             {"threadId": "thread-new", "turnId": "turn-1"},
         )
+        assert fake.request_timeouts[-1] == 5
+
+    def test_interrupt_timeout_is_recoverable_provider_wedge(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        fake.responses["turn/interrupt"] = TimeoutError("turn/interrupt")
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: fake,
+        )
+        session.send("work")
+
+        with pytest.raises(ProviderInterruptTimeout) as exc_info:
+            session._fire_worker_cancel()
+
+        assert isinstance(exc_info.value.__cause__, TimeoutError)
+        assert "thread-new" in str(exc_info.value)
+        assert "turn-1" in str(exc_info.value)
+        assert fake.request_timeouts[-1] == 5
 
     def test_failed_turn_raises_provider_error(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -674,6 +674,30 @@ class TestCodexSession:
         assert replacement.requests[0][0] == "thread/resume"
         assert replacement.requests[0][1]["threadId"] == "thread-new"
 
+    def test_recover_clears_stale_cancelled_turn_state(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        fake = _FakeAppServer()
+        replacement = _FakeAppServer()
+        clients = [fake, replacement]
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model="gpt-5.5",
+            client_factory=lambda **_: clients.pop(0),
+        )
+
+        session.send("work")
+        with session._state_lock:
+            session._last_turn_cancelled = True
+
+        session.recover()
+        session._fire_worker_cancel()
+
+        assert fake.stopped
+        assert session.last_turn_cancelled is False
+        assert replacement.requests == [("thread/resume", {"threadId": "thread-new"})]
+
 
 class TestCodexClient:
     def test_model_slots_and_provider_id(self) -> None:

--- a/tests/test_handler_preemption_oracle.py
+++ b/tests/test_handler_preemption_oracle.py
@@ -267,6 +267,30 @@ def test_handler_done_from_nonempty_stays_nonempty() -> None:
     )
 
 
+def test_handler_done_from_durable_demand_preserves_durable_gate() -> None:
+    """HandlerDone from DurableDemand keeps durable scheduler priority."""
+    result = transition(DurableDemand(), HandlerDone())
+    assert isinstance(result, DurableDemand), (
+        f"HandlerDone from DurableDemand yielded {result!r}, expected DurableDemand"
+    )
+
+
+def test_handler_done_from_preempted_demand_preserves_preempted_gate() -> None:
+    """HandlerDone from PreemptedDemand keeps the preempted gate."""
+    result = transition(PreemptedDemand(), HandlerDone())
+    assert isinstance(result, PreemptedDemand), (
+        f"HandlerDone from PreemptedDemand yielded {result!r}, expected PreemptedDemand"
+    )
+
+
+def test_durable_demand_drain_from_nonempty_preserves_nonempty_gate() -> None:
+    """DurableDemandDrained from NonEmpty keeps legacy handler demand."""
+    result = transition(NonEmpty(), DurableDemandDrained())
+    assert isinstance(result, NonEmpty), (
+        f"DurableDemandDrained from NonEmpty yielded {result!r}, expected NonEmpty"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Full lifecycle sequences
 # ---------------------------------------------------------------------------

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,10 +5,12 @@ import pytest
 
 from fido.provider import (
     ProviderID,
+    ProviderInterruptTimeout,
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
     ProviderPressureStatus,
+    is_recoverable_provider_wedge,
     safe_voice_turn,
 )
 
@@ -29,6 +31,15 @@ class TestProviderLimitWindow:
     def test_pressure_returns_none_when_limit_not_positive(self) -> None:
         window = ProviderLimitWindow(name="requests", used=9, limit=0)
         assert window.pressure is None
+
+
+class TestRecoverableProviderWedge:
+    def test_interrupt_timeout_is_recoverable_wedge(self) -> None:
+        exc = ProviderInterruptTimeout("interrupt timed out")
+        assert is_recoverable_provider_wedge(exc) is True
+
+    def test_unrelated_exception_is_not_recoverable_wedge(self) -> None:
+        assert is_recoverable_provider_wedge(RuntimeError("boom")) is False
 
 
 class TestProviderLimitSnapshot:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1057,6 +1057,30 @@ class TestPreemptionFsmOracle:
         reg.note_durable_demand_drained("foo/bar")
         reg.assert_worker_turn_ok("foo/bar")
 
+    def test_durable_demand_before_untriaged_handler_exits_cleanly(self) -> None:
+        reg = self._reg()
+        reg.note_durable_demand("foo/bar")
+        reg.enter_untriaged("foo/bar")
+
+        reg.exit_untriaged("foo/bar")
+
+        with pytest.raises(AssertionError, match="WorkerTurnStart rejected"):
+            reg.assert_worker_turn_ok("foo/bar")
+        reg.note_durable_demand_drained("foo/bar")
+        reg.assert_worker_turn_ok("foo/bar")
+
+    def test_durable_demand_drain_preserves_untriaged_blocker(self) -> None:
+        reg = self._reg()
+        reg.note_durable_demand("foo/bar")
+        reg.enter_untriaged("foo/bar")
+
+        reg.note_durable_demand_drained("foo/bar")
+
+        with pytest.raises(AssertionError, match="WorkerTurnStart rejected"):
+            reg.assert_worker_turn_ok("foo/bar")
+        reg.exit_untriaged("foo/bar")
+        reg.assert_worker_turn_ok("foo/bar")
+
     # ── worker_turn_proceeds_when_empty ──────────────────────────────────
 
     def test_assert_worker_turn_ok_succeeds_when_empty(self) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -159,6 +159,20 @@ class TestWorkerRegistry:
         reg.abort_task("unknown/repo")  # must not raise
         factory.return_value.abort_task.assert_not_called()
 
+    def test_recover_provider_calls_thread_recover_provider(
+        self, tmp_path: Path
+    ) -> None:
+        reg, factory = self._make_registry()
+        factory.return_value.recover_provider.return_value = True
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.recover_provider("foo/bar") is True
+        factory.return_value.recover_provider.assert_called_once_with()
+
+    def test_recover_provider_unknown_repo_returns_false(self) -> None:
+        reg, factory = self._make_registry()
+        assert reg.recover_provider("unknown/repo") is False
+        factory.return_value.recover_provider.assert_not_called()
+
     def test_stop_and_join_default_timeout(self, tmp_path: Path) -> None:
         reg, factory = self._make_registry()
         reg.start(_repo("foo/bar", tmp_path))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3146,10 +3146,54 @@ class TestSynchronousPreemption:
         assert status == 200
         assert call_order == ["preempt", "spawn"]
         WebhookHandler.registry.enter_untriaged.assert_called_with("owner/repo")
+        WebhookHandler.registry.recover_provider.assert_not_called()
         queued = FidoStore(cfg.repos["owner/repo"].work_dir).pending_pr_comments(
             repo="owner/repo"
         )
         assert [entry.comment_id for entry in queued] == [901]
+
+    def test_preempt_wedge_recovers_provider_and_spawns(self, server: tuple) -> None:
+        """Recoverable provider wedges trigger provider recovery after enqueue."""
+        url, cfg = server
+
+        call_order: list[str] = []
+
+        mock_session = MagicMock()
+        WebhookHandler.registry.get_session.return_value = mock_session
+        WebhookHandler.registry.recover_provider.side_effect = lambda repo: (
+            call_order.append(f"recover:{repo}") or True
+        )
+
+        original_spawn = _capturing_spawn_bg
+
+        def tracking_spawn(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
+            call_order.append("spawn")
+            original_spawn(fn, args)
+
+        def wedged_preempt() -> None:
+            call_order.append("preempt")
+            raise provider.ProviderInterruptTimeout("interrupt timed out")
+
+        mock_session.preempt_worker.side_effect = wedged_preempt
+        WebhookHandler._fn_spawn_bg = staticmethod(tracking_spawn)  # type: ignore[assignment]
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            return_value=("ANSWER", [])
+        )
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+
+        status = _post_webhook(
+            url, cfg, "issue_comment", self._issue_comment_payload(902)
+        )
+
+        assert status == 200
+        assert call_order == ["preempt", "recover:owner/repo", "spawn"]
+        WebhookHandler.registry.recover_provider.assert_called_once_with("owner/repo")
+        WebhookHandler.registry.enter_untriaged.assert_called_with("owner/repo")
+        queued = FidoStore(cfg.repos["owner/repo"].work_dir).pending_pr_comments(
+            repo="owner/repo"
+        )
+        assert [entry.comment_id for entry in queued] == [902]
 
     def test_no_preempt_for_non_model_action(self, server: tuple) -> None:
         """A PR-merge webhook does not use the model — ``preempt_worker`` must

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3082,6 +3082,11 @@ class TestSynchronousPreemption:
             },
         }
 
+    def _record_durable_demand_order(self, call_order: list[str]) -> None:
+        WebhookHandler.registry.note_durable_demand.side_effect = lambda repo: (
+            call_order.append(f"durable:{repo}")
+        )
+
     def test_preempt_fires_before_background_spawn(self, server: tuple) -> None:
         """``session.preempt_worker()`` must be called before ``_fn_spawn_bg``
         for a webhook action that reports durable demand."""
@@ -3090,6 +3095,7 @@ class TestSynchronousPreemption:
         call_order: list[str] = []
 
         mock_session = MagicMock()
+        self._record_durable_demand_order(call_order)
         mock_session.preempt_worker.side_effect = lambda: call_order.append("preempt")
         WebhookHandler.registry.get_session.return_value = mock_session
 
@@ -3108,7 +3114,10 @@ class TestSynchronousPreemption:
 
         status = _post_webhook(url, cfg, "issue_comment", self._issue_comment_payload())
         assert status == 200
-        assert call_order == ["preempt", "spawn"]
+        assert call_order == ["durable:owner/repo", "preempt", "spawn"]
+        WebhookHandler.registry.note_durable_demand.assert_called_once_with(
+            "owner/repo"
+        )
 
     def test_preempt_failure_keeps_enqueued_comment_and_spawns(
         self, server: tuple
@@ -3119,6 +3128,7 @@ class TestSynchronousPreemption:
         call_order: list[str] = []
 
         mock_session = MagicMock()
+        self._record_durable_demand_order(call_order)
         WebhookHandler.registry.get_session.return_value = mock_session
 
         original_spawn = _capturing_spawn_bg
@@ -3144,7 +3154,10 @@ class TestSynchronousPreemption:
         )
 
         assert status == 200
-        assert call_order == ["preempt", "spawn"]
+        assert call_order == ["durable:owner/repo", "preempt", "spawn"]
+        WebhookHandler.registry.note_durable_demand.assert_called_once_with(
+            "owner/repo"
+        )
         WebhookHandler.registry.enter_untriaged.assert_called_with("owner/repo")
         WebhookHandler.registry.recover_provider.assert_not_called()
         queued = FidoStore(cfg.repos["owner/repo"].work_dir).pending_pr_comments(
@@ -3159,6 +3172,7 @@ class TestSynchronousPreemption:
         call_order: list[str] = []
 
         mock_session = MagicMock()
+        self._record_durable_demand_order(call_order)
         WebhookHandler.registry.get_session.return_value = mock_session
         WebhookHandler.registry.recover_provider.side_effect = lambda repo: (
             call_order.append(f"recover:{repo}") or True
@@ -3187,7 +3201,15 @@ class TestSynchronousPreemption:
         )
 
         assert status == 200
-        assert call_order == ["preempt", "recover:owner/repo", "spawn"]
+        assert call_order == [
+            "durable:owner/repo",
+            "preempt",
+            "recover:owner/repo",
+            "spawn",
+        ]
+        WebhookHandler.registry.note_durable_demand.assert_called_once_with(
+            "owner/repo"
+        )
         WebhookHandler.registry.recover_provider.assert_called_once_with("owner/repo")
         WebhookHandler.registry.enter_untriaged.assert_called_with("owner/repo")
         queued = FidoStore(cfg.repos["owner/repo"].work_dir).pending_pr_comments(
@@ -3212,6 +3234,7 @@ class TestSynchronousPreemption:
         }
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
+        WebhookHandler.registry.note_durable_demand.assert_not_called()
         mock_session.preempt_worker.assert_not_called()
 
     def test_no_preempt_when_session_is_none(self, server: tuple) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import logging
 import socket
 import subprocess
 import threading
@@ -3087,6 +3088,15 @@ class TestSynchronousPreemption:
             call_order.append(f"durable:{repo}")
         )
 
+    def _record_background_spawn_order(self, call_order: list[str]) -> None:
+        original_spawn = _capturing_spawn_bg
+
+        def tracking_spawn(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
+            call_order.append("spawn")
+            original_spawn(fn, args)
+
+        WebhookHandler._fn_spawn_bg = staticmethod(tracking_spawn)  # type: ignore[assignment]
+
     def test_preempt_fires_before_background_spawn(self, server: tuple) -> None:
         """``session.preempt_worker()`` must be called before ``_fn_spawn_bg``
         for a webhook action that reports durable demand."""
@@ -3099,13 +3109,7 @@ class TestSynchronousPreemption:
         mock_session.preempt_worker.side_effect = lambda: call_order.append("preempt")
         WebhookHandler.registry.get_session.return_value = mock_session
 
-        original_spawn = _capturing_spawn_bg
-
-        def tracking_spawn(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
-            call_order.append("spawn")
-            original_spawn(fn, args)
-
-        WebhookHandler._fn_spawn_bg = staticmethod(tracking_spawn)  # type: ignore[assignment]
+        self._record_background_spawn_order(call_order)
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             return_value=("ANSWER", [])
         )
@@ -3120,7 +3124,7 @@ class TestSynchronousPreemption:
         )
 
     def test_preempt_failure_keeps_enqueued_comment_and_spawns(
-        self, server: tuple
+        self, server: tuple, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A provider interrupt failure must not discard durable webhook demand."""
         url, cfg = server
@@ -3131,27 +3135,22 @@ class TestSynchronousPreemption:
         self._record_durable_demand_order(call_order)
         WebhookHandler.registry.get_session.return_value = mock_session
 
-        original_spawn = _capturing_spawn_bg
-
-        def tracking_spawn(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
-            call_order.append("spawn")
-            original_spawn(fn, args)
-
         def failing_preempt() -> None:
             call_order.append("preempt")
             raise RuntimeError("interrupt failed")
 
         mock_session.preempt_worker.side_effect = failing_preempt
-        WebhookHandler._fn_spawn_bg = staticmethod(tracking_spawn)  # type: ignore[assignment]
+        self._record_background_spawn_order(call_order)
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             return_value=("ANSWER", [])
         )
         WebhookHandler._fn_create_task = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
 
-        status = _post_webhook(
-            url, cfg, "issue_comment", self._issue_comment_payload(901)
-        )
+        with caplog.at_level(logging.ERROR, logger="fido.server"):
+            status = _post_webhook(
+                url, cfg, "issue_comment", self._issue_comment_payload(901)
+            )
 
         assert status == 200
         assert call_order == ["durable:owner/repo", "preempt", "spawn"]
@@ -3164,8 +3163,16 @@ class TestSynchronousPreemption:
             repo="owner/repo"
         )
         assert [entry.comment_id for entry in queued] == [901]
+        assert (
+            "provider preempt failed for owner/repo after durable webhook enqueue"
+            in caplog.text
+        )
+        assert "provider preempt wedged" not in caplog.text
+        assert "provider recovery requested" not in caplog.text
 
-    def test_preempt_wedge_recovers_provider_and_spawns(self, server: tuple) -> None:
+    def test_preempt_wedge_recovers_provider_and_spawns(
+        self, server: tuple, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Recoverable provider wedges trigger provider recovery after enqueue."""
         url, cfg = server
 
@@ -3178,27 +3185,22 @@ class TestSynchronousPreemption:
             call_order.append(f"recover:{repo}") or True
         )
 
-        original_spawn = _capturing_spawn_bg
-
-        def tracking_spawn(fn: Callable[..., Any], args: tuple[Any, ...]) -> None:
-            call_order.append("spawn")
-            original_spawn(fn, args)
-
         def wedged_preempt() -> None:
             call_order.append("preempt")
             raise provider.ProviderInterruptTimeout("interrupt timed out")
 
         mock_session.preempt_worker.side_effect = wedged_preempt
-        WebhookHandler._fn_spawn_bg = staticmethod(tracking_spawn)  # type: ignore[assignment]
+        self._record_background_spawn_order(call_order)
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             return_value=("ANSWER", [])
         )
         WebhookHandler._fn_create_task = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
 
-        status = _post_webhook(
-            url, cfg, "issue_comment", self._issue_comment_payload(902)
-        )
+        with caplog.at_level(logging.WARNING, logger="fido.server"):
+            status = _post_webhook(
+                url, cfg, "issue_comment", self._issue_comment_payload(902)
+            )
 
         assert status == 200
         assert call_order == [
@@ -3216,6 +3218,61 @@ class TestSynchronousPreemption:
             repo="owner/repo"
         )
         assert [entry.comment_id for entry in queued] == [902]
+        assert (
+            "provider preempt wedged for owner/repo after durable webhook enqueue "
+            "— recovering provider"
+        ) in caplog.text
+        assert (
+            "provider recovery requested for owner/repo after preempt wedge"
+            in caplog.text
+        )
+        assert "provider preempt failed" not in caplog.text
+
+    def test_preempt_wedge_logs_unavailable_recovery(
+        self, server: tuple, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Recoverable wedges log loudly when no provider recovery is available."""
+        url, cfg = server
+
+        call_order: list[str] = []
+
+        mock_session = MagicMock()
+        self._record_durable_demand_order(call_order)
+        WebhookHandler.registry.get_session.return_value = mock_session
+        WebhookHandler.registry.recover_provider.side_effect = lambda repo: (
+            call_order.append(f"recover:{repo}") or False
+        )
+
+        def wedged_preempt() -> None:
+            call_order.append("preempt")
+            raise provider.ProviderInterruptTimeout("interrupt timed out")
+
+        mock_session.preempt_worker.side_effect = wedged_preempt
+        self._record_background_spawn_order(call_order)
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            return_value=("ANSWER", [])
+        )
+        WebhookHandler._fn_create_task = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="fido.server"):
+            status = _post_webhook(
+                url, cfg, "issue_comment", self._issue_comment_payload(903)
+            )
+
+        assert status == 200
+        assert call_order == [
+            "durable:owner/repo",
+            "preempt",
+            "recover:owner/repo",
+            "spawn",
+        ]
+        WebhookHandler.registry.recover_provider.assert_called_once_with("owner/repo")
+        assert (
+            "provider recovery unavailable for owner/repo after preempt wedge"
+            in caplog.text
+        )
+        assert "provider recovery requested" not in caplog.text
 
     def test_no_preempt_for_non_model_action(self, server: tuple) -> None:
         """A PR-merge webhook does not use the model — ``preempt_worker`` must

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -117,6 +117,15 @@ class TestSessionBackedAgent:
         agent.ensure_session(agent.brief_model)
         attached.switch_model.assert_called_once_with(agent.brief_model)
 
+    def test_recover_session_returns_false_without_session(self) -> None:
+        assert _FakeAgent().recover_session() is False
+
+    def test_recover_session_delegates_to_attached_session(self) -> None:
+        session = MagicMock()
+        agent = _FakeAgent(session=session)
+        assert agent.recover_session() is True
+        session.recover.assert_called_once_with()
+
     def test_resolve_turn_prefers_live_session_over_owned_spawn(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3605,6 +3605,24 @@ class TestProviderRun:
             session_mode=TurnSessionMode.REUSE,
         )
 
+    def test_session_path_can_disable_preempt_retry(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = self._mock_session()
+        client = _client()
+        client.session = session
+        provider_run(
+            fido_dir,
+            agent=client,
+            model=client.work_model,
+            retry_on_preempt=False,
+        )
+        client.run_turn.assert_called_once_with(
+            "skill text\n\n---\n\nprompt text",
+            model=client.work_model,
+            retry_on_preempt=False,
+            session_mode=TurnSessionMode.REUSE,
+        )
+
     def test_session_path_calls_agent_once(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         session = self._mock_session()
@@ -8699,6 +8717,43 @@ class TestExecuteTask:
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
         assert result is True
+
+    def test_preempted_task_turn_yields_before_commit_or_retry(
+        self, tmp_path: Path
+    ) -> None:
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Implement feature")
+        session = MagicMock()
+        session.last_turn_cancelled = False
+        worker._provider_agent.session = session
+
+        def preempt_provider_turn(*_args: object, **_kwargs: object) -> tuple[str, str]:
+            session.last_turn_cancelled = True
+            return "sid", ""
+
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch(
+                "fido.worker.provider_run", side_effect=preempt_provider_turn
+            ) as mock_provider_run,
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(
+                worker, "_commit_provider_leftovers_if_any"
+            ) as mock_commit_leftovers,
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve") as mock_complete,
+            patch("fido.tasks.sync_tasks"),
+        ):
+            result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        assert result is True
+        mock_provider_run.assert_called_once()
+        assert mock_provider_run.call_args.kwargs["retry_on_preempt"] is False
+        mock_commit_leftovers.assert_not_called()
+        mock_complete.assert_not_called()
 
     def test_calls_set_status_with_task_title(self, tmp_path: Path) -> None:
         worker, _ = self._make_worker(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13187,6 +13187,20 @@ class TestWorkerThread:
         assert wt.detach_provider() is provider
         assert wt.current_provider() is None
 
+    def test_recover_provider_returns_false_without_provider(
+        self, tmp_path: Path
+    ) -> None:
+        wt = self._make_thread(tmp_path)
+        wt.detach_provider()
+        assert wt.recover_provider() is False
+
+    def test_recover_provider_delegates_to_provider_agent(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        provider.agent.recover_session.return_value = True
+        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        assert wt.recover_provider() is True
+        provider.agent.recover_session.assert_called_once_with()
+
     def test_session_setter_recreates_provider_when_detached(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Provider interrupt timeouts now recover through webhook preemption after durable comment demand is queued, with tests covering the recovery ordering and log distinctions. The remaining fix teaches the handler-preemption state machine to represent durable demand and untriaged preemption together so the normal comment path can still exit cleanly.

Fixes #1128.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [support durable demand before untriaged preemption](https://github.com/FidoCanCode/home/pull/1130#issuecomment-4356776878) <!-- type:thread -->
- [x] Preserve durable demand before resumed worker turns <!-- type:spec -->
- [x] Cover timeout recovery logs and ordering in tests <!-- type:spec -->
- [x] Recover wedged providers during webhook preemption <!-- type:spec -->
- [x] Expose provider recovery through WorkerRegistry <!-- type:spec -->
- [x] Classify interrupt timeouts as recoverable provider wedges <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->