### PR TITLE
Bug: retry pickup ack after issue resume

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1386,11 +1386,33 @@ class Worker:
                 "issue_started_at": datetime.now(tz=timezone.utc).isoformat(),
             }
         )
-        self.set_status(f"Picking up issue #{choice.number}: {choice.title}")
-        self.post_pickup_comment(
-            repo_ctx.repo, choice.number, choice.title, repo_ctx.gh_user
+        self._ensure_pickup_comment(
+            fido_dir, repo_ctx.repo, choice.number, choice.title, repo_ctx.gh_user
         )
+        self.set_status(f"Picking up issue #{choice.number}: {choice.title}")
         return choice.number
+
+    def _ensure_pickup_comment(
+        self,
+        fido_dir: Path,
+        repo: str,
+        issue: int,
+        issue_title: str,
+        gh_user: str,
+    ) -> None:
+        """Ensure the issue has its pickup acknowledgement after restart.
+
+        Fido writes the current issue to durable state before provider-backed
+        status/comment generation. If he crashes in that gap, the next run
+        resumes the issue instead of re-entering ``find_next_issue()``. A
+        separate durable bit lets resume retry this idempotent check.
+        """
+        state = State(fido_dir)
+        if state.load().get("pickup_comment_ensured") is True:
+            return
+        self.post_pickup_comment(repo, issue, issue_title, gh_user)
+        with state.modify() as data:
+            data["pickup_comment_ensured"] = True
 
     def _pick_from_cache(self, repo_ctx: RepoContext) -> PickerChoice | None:
         """Cache-driven picker (closes #812).
@@ -3464,6 +3486,9 @@ class Worker:
             issue_data = self.gh.view_issue(repo_ctx.repo, issue)
             issue_title = issue_data["title"]
             issue_body = issue_data.get("body", "") or ""
+            self._ensure_pickup_comment(
+                ctx.fido_dir, repo_ctx.repo, issue, issue_title, repo_ctx.gh_user
+            )
             pr_number, slug, pr_is_fresh = self.find_or_create_pr(
                 ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
             )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1329,9 +1329,41 @@ class TestWorker:
         ):
             assert worker.run() == 0
 
-    def test_run_does_not_call_post_pickup_comment(self, tmp_path: Path) -> None:
-        """post_pickup_comment is now called from find_next_issue, not run()."""
+    def test_run_ensures_pickup_comment_when_resuming_issue(
+        self, tmp_path: Path
+    ) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
+        gh = self._make_gh()
+        gh.view_issue.return_value = {
+            "title": "Test issue",
+            "body": "",
+            "state": "OPEN",
+        }
+        worker = Worker(tmp_path, gh)
+        mock_pickup = MagicMock()
+        repo_ctx = self._make_mock_repo_ctx()
+        with (
+            patch.object(worker, "create_context", return_value=mock_ctx),
+            patch.object(worker, "discover_repo_context", return_value=repo_ctx),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "get_current_issue", return_value=5),
+            patch.object(worker, "post_pickup_comment", mock_pickup),
+            patch.object(
+                worker, "find_or_create_pr", return_value=(1, "my-branch", False)
+            ),
+            patch.object(worker, "handle_ci", return_value=False),
+            patch.object(worker, "handle_threads", return_value=False),
+        ):
+            worker.run()
+        mock_pickup.assert_called_once_with("owner/repo", 5, "Test issue", "fido-bot")
+        assert State(mock_ctx.fido_dir).load()["pickup_comment_ensured"] is True
+
+    def test_run_skips_pickup_comment_when_already_ensured(
+        self, tmp_path: Path
+    ) -> None:
+        mock_ctx = self._make_mock_ctx(tmp_path)
+        State(mock_ctx.fido_dir).save({"issue": 5, "pickup_comment_ensured": True})
         gh = self._make_gh()
         gh.view_issue.return_value = {
             "title": "Test issue",


### PR DESCRIPTION
## Summary

- add a durable `pickup_comment_ensured` state bit separate from the current issue number
- retry the idempotent pickup-comment check when resuming an issue without that bit
- move initial pickup ack before provider-backed status generation so a status nudge crash cannot skip the ack

Closes #1135.

## Tests

- `./fido tests tests/test_worker.py::TestWorkerRun::test_run_ensures_pickup_comment_when_resuming_issue tests/test_worker.py::TestWorkerRun::test_run_skips_pickup_comment_when_already_ensured tests/test_worker.py::TestFindNextIssue::test_calls_post_pickup_comment_when_issue_found tests/test_worker.py::TestFindNextIssue::test_calls_post_pickup_comment_immediately_when_issue_found`
- `./fido tests tests/test_worker.py`
- `./fido ruff check src/fido/worker.py tests/test_worker.py && ./fido ruff format --check src/fido/worker.py tests/test_worker.py`
- pre-commit: `./fido ci` path via git commit hook
