### PR TITLE
Bug: shared-turn must recover from BrokenPipe; watchdog must heal stuck FSM (closes #1142)

### DIFF
--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -195,6 +195,15 @@ class WorkerRegistry:
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Rescue())
             provider = old_thread.detach_provider()
             session_issue, old_thread._session_issue = old_thread._session_issue, None  # pyright: ignore[reportPrivateUsage]
+            # Heal the rescued session before the new worker runs.  A worker
+            # crash mid-turn can leave the ClaudeSession FSM in a non-Idle state
+            # (e.g. Sending after BrokenPipe on stdin write); without this
+            # respawn the next worker's first send() hits "Send rejected in
+            # state Sending" and the watchdog rescues into a permanent crash
+            # loop.  recover() respawns the subprocess with --resume so
+            # conversation context is preserved.
+            if provider is not None:
+                provider.agent.recover_session()
         elif not old_thread.is_alive():
             # Orderly-stopped predecessor (_stop is True):
             # Active → Stopped (ThreadStops) → Active (Launch).

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -330,11 +330,16 @@ class SessionBackedAgent:
         model: ProviderModel,
         system_prompt: str | None = None,
     ) -> tuple[str, str]:
+        # Route through _prompt_with_recovery so a stale subprocess (BrokenPipe
+        # on stdin write) recovers and retries instead of killing the worker
+        # and leaving the persistent ClaudeSession FSM stuck in Sending.
         session = self._resolve_turn_session(
             model=model,
             session_mode=TurnSessionMode.REUSE,
         )
-        text = session.prompt(content, model=model, system_prompt=system_prompt)
+        text = self._prompt_with_recovery(
+            session, content, model=model, system_prompt=system_prompt
+        )
         session_id = getattr(session, "session_id", None)
         return text, session_id if isinstance(session_id, str) else ""
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -59,6 +59,28 @@ class TestWorkerRegistry:
         assert kwargs["session_issue"] == 42
         threads[0].detach_provider.assert_called_once_with()
 
+    def test_start_recovers_rescued_session_to_clear_stuck_fsm(
+        self, tmp_path: Path
+    ) -> None:
+        """Rescued provider's session is recovered before the new worker runs.
+
+        Without this, a worker that crashed mid-turn leaves the persistent
+        ClaudeSession FSM in a non-Idle state (e.g. Sending after BrokenPipe),
+        and the replacement worker's first send() hits "Send rejected in
+        state Sending" — turning a single crash into a permanent loop.
+        """
+        mock_provider = MagicMock()
+        threads = [MagicMock(), MagicMock()]
+        factory = MagicMock(side_effect=threads)
+        reg = WorkerRegistry(factory)
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        threads[0].is_alive.return_value = False
+        threads[0]._stop = False
+        threads[0].detach_provider.return_value = mock_provider
+        reg.start(cfg)
+        mock_provider.agent.recover_session.assert_called_once_with()
+
     def test_start_does_not_rescue_session_from_orderly_shutdown_thread(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -238,6 +238,18 @@ class TestSessionBackedAgent:
             agent.run_turn("hi", model=agent.voice_model)
         session.recover.assert_called_once_with()
 
+    def test_generate_reply_recovers_after_dead_prompt_failure(self) -> None:
+        # Regression: _run_shared_turn used to call session.prompt directly
+        # without recovery, so a BrokenPipe from a stale subprocess killed
+        # the worker thread and left the persistent ClaudeSession FSM stuck
+        # in Sending forever.
+        session = MagicMock()
+        session.prompt.side_effect = [BrokenPipeError("boom"), "ok"]
+        session.is_alive.return_value = False
+        agent = _FakeAgent(session=session)
+        assert agent.generate_reply("hi") == "ok"
+        session.recover.assert_called_once_with()
+
     def test_run_turn_retries_after_preempt(self) -> None:
         session = MagicMock()
         session.last_turn_cancelled = False


### PR DESCRIPTION
## Summary

Fixes a tight crash loop on FidoCanCode/home worker — diagnosed live during a guarddog vet cycle. Two cooperating bugs (root-cause analysis in #1142):

- `session_agent._run_shared_turn` called `session.prompt()` directly, skipping the `_prompt_with_recovery` wrapper that `run_turn` uses. A stale `BrokenPipeError` from the persistent claude subprocess therefore killed the worker thread instead of triggering one recover-and-retry. Affects `generate_reply`, `generate_branch_name`, `generate_status_with_session`.
- `send()` flips the stream FSM Idle→Sending *before* writing to stdin. When the write/flush raised, the FSM was left in Sending. The persistent `ClaudeSession` survives worker crashes, so every restart hit `Send rejected in state Sending` — a permanent loop.

Fix routes `_run_shared_turn` through `_prompt_with_recovery` and adds a watchdog-side heal: when the registry rescues a provider from a crashed thread, it now also `recover()`s the session before the replacement worker runs.

## Test plan
- [x] `tests/test_session_agent.py::test_generate_reply_recovers_after_dead_prompt_failure`
- [x] `tests/test_registry.py::test_start_recovers_rescued_session_to_clear_stuck_fsm`
- [x] full \`./fido ci\` green via pre-commit hook