### PR TITLE
Bug: PR #1191 dropped-work trio — preempt-skips-push, abort-leaks, empty-PR-promote (closes #1192, #1193, #1194)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2210,7 +2210,7 @@ def _maybe_abort_for_new_task(
             current_task.get("type", "?"),
             current_task.get("title", "")[:60],
         )
-        registry.abort_task(repo_cfg.name)
+        registry.abort_task(repo_cfg.name, task_id=current_task_id)
 
 
 def _get_commit_summary(work_dir: Path) -> str:
@@ -2458,12 +2458,12 @@ def _make_reorder_kwargs(
     }
     if registry is not None and repo_cfg is not None:
 
-        def on_inprogress_affected() -> None:
+        def on_inprogress_affected(task_id: str) -> None:
             log.info(
                 "reorder_tasks_background: in-progress task affected — aborting %s",
                 repo_cfg.name,
             )
-            registry.abort_task(repo_cfg.name)
+            registry.abort_task(repo_cfg.name, task_id=task_id)
 
         kwargs["_on_inprogress_affected"] = on_inprogress_affected
     return kwargs

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -234,14 +234,19 @@ class WorkerRegistry:
         if thread:
             thread.wake()
 
-    def abort_task(self, repo_name: str) -> None:
-        """Signal the worker for *repo_name* to abort its current task.
+    def abort_task(self, repo_name: str, *, task_id: str | None = None) -> None:
+        """Signal the worker for *repo_name* to abort *task_id*.
+
+        ``task_id=None`` is the legacy untargeted form (matches whichever
+        task is running).  Real callers should pass the id of the task
+        they intend to abort so a leaked signal cannot clobber a
+        different task on the next loop iteration (closes #1193).
 
         No-op if no thread is registered for that repo.
         """
         thread = self._threads.get(repo_name)
         if thread:
-            thread.abort_task()
+            thread.abort_task(task_id=task_id)
 
     def recover_provider(self, repo_name: str) -> bool:
         """Recover the attached provider session for *repo_name*, if present."""

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -837,7 +837,7 @@ def reorder_tasks(
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
-    _on_inprogress_affected: Callable[[], None] | None = None,
+    _on_inprogress_affected: Callable[[str], None] | None = None,
     _on_done: Callable[[], None] | None = None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
@@ -857,10 +857,11 @@ def reorder_tasks(
     it is called with a list of change records (see :func:`_compute_thread_changes`).
 
     If *_on_inprogress_affected* is provided and the currently in-progress task
-    is marked completed or modified by Opus, it is called with no arguments so
-    the caller can abort the running worker and restart on the new next task.
-    When the in-progress task is modified its status is reset to ``pending`` so
-    the worker loop picks it up again with the updated description.
+    is marked completed or modified by Opus, it is called with the affected
+    task's id so the caller can abort the running worker (targeted at that
+    task) and restart on the new next task.  When the in-progress task is
+    modified its status is reset to ``pending`` so the worker loop picks it
+    up again with the updated description.
 
     If *_on_done* is provided, it is called after a successful reorder write so
     callers can trigger follow-up work (e.g. rewriting the PR description).
@@ -966,7 +967,8 @@ def reorder_tasks(
             _on_changes(changes)
 
     if inprogress_affected and _on_inprogress_affected is not None:
-        _on_inprogress_affected()
+        assert inprogress is not None  # inprogress_affected is True
+        _on_inprogress_affected(str(inprogress["id"]))
 
     log.info("reorder_tasks: applied reorder — %d tasks", len(result))
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1019,6 +1019,71 @@ def _write_pr_description(
     log.info("_write_pr_description: PR #%s description written", pr_number)
 
 
+class AbortHandle:
+    """Per-task abort signal.
+
+    Replaces a per-worker :class:`threading.Event` that previously leaked
+    across task boundaries (closes #1193): when a rescope marked an
+    in-progress task ``completed`` instead of letting :meth:`Worker._cleanup_aborted_task`
+    consume the abort signal, the still-set ``Event`` would clobber the
+    very next task to enter :meth:`Worker.execute_task`.
+
+    The handle binds an abort request to a specific ``task_id``.  Only
+    the cleanup path for the *targeted* task consumes it.  An untargeted
+    request (``task_id=None``) is the legacy "abort whatever is running"
+    semantic, kept available for the external
+    :meth:`WorkerThread.abort_task` entry point that fires before any
+    task is in flight.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._target_task_id: str | None = None
+        self._event = threading.Event()
+
+    def request(self, task_id: str | None) -> None:
+        """Request abort of *task_id*.
+
+        ``task_id=None`` is an untargeted request that matches whichever
+        task happens to be running.  Real callers (preempt, rescope)
+        always know the task they're aborting and should pass it.
+        """
+        with self._lock:
+            self._target_task_id = task_id
+            self._event.set()
+
+    def is_active_for(self, task_id: str) -> bool:
+        """Return ``True`` when an abort request matches *task_id*.
+
+        An untargeted (legacy) request matches any task.  A targeted
+        request matches only its named task — a leaked abort from a
+        prior, since-removed task no longer fires here.
+        """
+        with self._lock:
+            if not self._event.is_set():
+                return False
+            return self._target_task_id is None or self._target_task_id == task_id
+
+    def is_set(self) -> bool:
+        """Return whether *any* abort request is pending."""
+        return self._event.is_set()
+
+    def set(self) -> None:
+        """Untargeted shorthand for ``request(None)``.
+
+        Kept for back-compat with code that fired an abort signal
+        without a specific task in mind.  Real callers should prefer
+        :meth:`request` so the abort cannot leak to a different task.
+        """
+        self.request(None)
+
+    def clear(self) -> None:
+        """Consume the abort request (cleanup path)."""
+        with self._lock:
+            self._target_task_id = None
+            self._event.clear()
+
+
 class Worker:
     """Fido worker for a single repository.
 
@@ -1031,7 +1096,7 @@ class Worker:
         self,
         work_dir: Path,
         gh: GitHub,
-        abort_task: threading.Event | None = None,
+        abort_task: AbortHandle | None = None,
         repo_name: str = "",
         registry: ActivityReporter | None = None,
         membership: RepoMembership | None = None,
@@ -1050,7 +1115,7 @@ class Worker:
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
-        self._abort_task = abort_task if abort_task is not None else threading.Event()
+        self._abort_task = abort_task if abort_task is not None else AbortHandle()
         self._repo_name = repo_name
         # Replay missed issue_comment webhooks exactly once per WorkerThread
         # lifetime (at startup).  Fix for #794 — without this, top-level PR
@@ -2845,7 +2910,7 @@ class Worker:
             with State(fido_dir).modify() as state:
                 state.pop("current_task_id", None)
             return True
-        if self._abort_task.is_set():
+        if self._abort_task.is_active_for(task["id"]):
             self._cleanup_aborted_task(fido_dir, task["id"], task_title)
             return True
         if not self._task_still_current(fido_dir, task["id"]):
@@ -2872,7 +2937,7 @@ class Worker:
             return True
         head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
-        if self._abort_task.is_set():
+        if self._abort_task.is_active_for(task["id"]):
             self._cleanup_aborted_task(fido_dir, task["id"], task_title)
             return True
 
@@ -2944,7 +3009,7 @@ class Worker:
             )
             if not self._admit_worker_turn(pr_number):
                 return True
-            if self._abort_task.is_set():
+            if self._abort_task.is_active_for(task["id"]):
                 self._cleanup_aborted_task(fido_dir, task["id"], task_title)
                 return True
             if not self._task_still_current(fido_dir, task["id"]):
@@ -2972,7 +3037,7 @@ class Worker:
                 return True
             head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
-            if self._abort_task.is_set():
+            if self._abort_task.is_active_for(task["id"]):
                 self._cleanup_aborted_task(fido_dir, task["id"], task_title)
                 return True
 
@@ -3664,7 +3729,7 @@ class WorkerThread(threading.Thread):
         self._registry = registry
         self._membership = membership if membership is not None else RepoMembership()
         self._wake = threading.Event()
-        self._abort_task = threading.Event()
+        self._abort_task = AbortHandle()
         self._stop = False
         self.crash_error: str | None = None
         self._provider_lock = threading.Lock()
@@ -3809,9 +3874,16 @@ class WorkerThread(threading.Thread):
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()
 
-    def abort_task(self) -> None:
-        """Signal the worker to abort the current task after provider_run returns."""
-        self._abort_task.set()
+    def abort_task(self, task_id: str | None = None) -> None:
+        """Signal the worker to abort *task_id* after provider_run returns.
+
+        ``task_id=None`` is the legacy untargeted form, used by external
+        entry points that want to abort whichever task is running.  Real
+        callers (preempt, rescope) always know the task they're aborting
+        and should pass it so a leaked abort cannot clobber a different,
+        unrelated task on the next loop iteration.
+        """
+        self._abort_task.request(task_id)
         self._wake.set()
 
     def stop(self) -> None:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2447,6 +2447,29 @@ class Worker:
             return False
         return True
 
+    def _push_committed_work_before_yield(
+        self, task_title: str, head_before: str, slug: str
+    ) -> None:
+        """Push any commits that landed during the turn before yielding.
+
+        On a preempt early-return the worker would otherwise leave a
+        committed-but-unpushed branch behind: bash command N committed,
+        bash command N+1 (``git push``) never ran because the webhook cut
+        in.  The next worker iteration may rescope, abort, or otherwise
+        forget about the in-flight task and the local commit becomes a
+        permanent orphan in the workspace clone (closes #1192).
+
+        Uses ``_commit_provider_leftovers_if_any`` first to absorb any
+        uncommitted worktree changes (so the wip-commit safety net still
+        runs on a preempt path), then ``ensure_pushed`` to send anything
+        new to ``origin``.  Both helpers are idempotent and safe to call
+        when nothing changed during the turn.
+        """
+        head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
+        if head_after == head_before:
+            return
+        self.ensure_pushed("origin", slug)
+
     def _commit_provider_leftovers_if_any(
         self, task_title: str, head_before: str
     ) -> str:
@@ -2845,6 +2868,7 @@ class Worker:
                 "task provider turn preempted for %s — yielding to worker loop",
                 repo_ctx.repo,
             )
+            self._push_committed_work_before_yield(task_title, head_before, slug)
             return True
         head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 
@@ -2944,6 +2968,7 @@ class Worker:
                     "task provider resume preempted for %s — yielding to worker loop",
                     repo_ctx.repo,
                 )
+                self._push_committed_work_before_yield(task_title, head_before, slug)
                 return True
             head_after = self._commit_provider_leftovers_if_any(task_title, head_before)
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2739,10 +2739,12 @@ class Worker:
     ) -> None:
         """Discard uncommitted changes and remove task after an abort signal.
 
-        Called when ``self._abort_task`` is set mid-execution.  Runs
-        ``git_clean`` to restore the working tree, removes the task from the
-        queue, clears ``current_task_id`` from state, resets the abort event,
-        and syncs the PR work queue.
+        Called when ``self._abort_task`` is *active for* this task —
+        i.e. an abort was requested with this ``task_id`` (or untargeted)
+        and ``execute_task`` observed it mid-execution.  Runs
+        ``git_clean`` to restore the working tree, removes the task from
+        the queue, clears ``current_task_id`` from state, clears the
+        abort handle, and syncs the PR work queue.
         """
         log.info("task aborted: %s", task_title)
         self.git_clean()

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -66,6 +66,14 @@ _PICKUP_COMMENT_MARKER = "<!-- fido:pickup -->"
 # Allows the retry path to dedup across crash-replay cycles (fix for #802).
 _RETRY_COMMENT_MARKER = "<!-- fido:retry-ack -->"
 
+# Invisible HTML marker on the one-time comment fido posts when its
+# promote-merge guard refuses to mark a PR ready_for_review because
+# the branch has no diff vs base (closes #1194).  The PR is left open
+# so the human can decide whether more work is needed; the marker
+# prevents the worker loop from posting the same comment on every
+# subsequent iteration.
+_EMPTY_PR_COMMENT_MARKER = "<!-- fido:empty-pr-blocked -->"
+
 log = logging.getLogger(__name__)
 
 _thread_repo: threading.local = threading.local()
@@ -1067,15 +1075,6 @@ class AbortHandle:
     def is_set(self) -> bool:
         """Return whether *any* abort request is pending."""
         return self._event.is_set()
-
-    def set(self) -> None:
-        """Untargeted shorthand for ``request(None)``.
-
-        Kept for back-compat with code that fired an abort signal
-        without a specific task in mind.  Real callers should prefer
-        :meth:`request` so the abort cannot leak to a different task.
-        """
-        self.request(None)
 
     def clear(self) -> None:
         """Consume the abort request (cleanup path)."""
@@ -2647,6 +2646,47 @@ class Worker:
                     pr_number,
                 )
 
+    def _post_empty_pr_comment_once(self, repo: str, pr_number: int) -> None:
+        """Post a one-time BLOCKED comment when the empty-diff guard refuses
+        to promote a PR (closes #1194).
+
+        The PR is left open so a human can decide whether more work is
+        needed via review comments — fido cannot meaningfully act on an
+        empty PR from inside the worker loop.  Idempotent on
+        :data:`_EMPTY_PR_COMMENT_MARKER`: if the marker is already
+        present in any existing comment on the PR, this is a no-op,
+        which prevents the worker loop from re-posting the same comment
+        on every iteration.
+        """
+        try:
+            existing = self.gh.get_issue_comments(repo, pr_number)
+        except _requests.RequestException:
+            log.exception(
+                "_post_empty_pr_comment_once: failed to fetch comments on %s#%d",
+                repo,
+                pr_number,
+            )
+            return
+        if any(_EMPTY_PR_COMMENT_MARKER in (c.get("body") or "") for c in existing):
+            return
+        body = (
+            "BLOCKED: I finished my task list and CI is green, but the branch "
+            "has no diff against the base — there's nothing here for a "
+            "reviewer to look at. Leaving the PR open so you can decide what "
+            "to do: comment with more guidance and I'll pick it up, or close "
+            "the PR if there's nothing further.\n\n"
+            f"{_EMPTY_PR_COMMENT_MARKER}"
+        )
+        try:
+            self.gh.comment_issue(repo, pr_number, body)
+            log.info("posted empty-PR BLOCKED comment on %s#%d", repo, pr_number)
+        except _requests.RequestException:
+            log.exception(
+                "_post_empty_pr_comment_once: failed to post comment on %s#%d",
+                repo,
+                pr_number,
+            )
+
     def _pr_has_real_diff(self, remote: str, slug: str, default_branch: str) -> bool:
         """Return True iff the branch has any file diff vs the default branch.
 
@@ -3335,6 +3375,7 @@ class Worker:
                         pr_number,
                         repo_ctx.default_branch,
                     )
+                    self._post_empty_pr_comment_once(repo_ctx.repo, pr_number)
                     return 0
                 log.info(
                     "PR #%s: changes requested — all addressed, CI passing — marking ready",
@@ -3395,6 +3436,7 @@ class Worker:
                     pr_number,
                     repo_ctx.default_branch,
                 )
+                self._post_empty_pr_comment_once(repo_ctx.repo, pr_number)
                 return 0
             log.info("PR #%s: work complete, CI green — marking ready", pr_number)
             self.gh.pr_ready(repo_ctx.repo, pr_number)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2647,6 +2647,39 @@ class Worker:
                     pr_number,
                 )
 
+    def _pr_has_real_diff(self, remote: str, slug: str, default_branch: str) -> bool:
+        """Return True iff the branch has any file diff vs the default branch.
+
+        Used as a guard before promoting a draft PR to ready-for-review
+        (closes #1194).  A PR whose only commit is the ``wip: start``
+        placeholder, or whose branch has no commits ahead of base, has
+        nothing to review — promoting it advertises broken state to
+        reviewers.
+
+        Compares ``remote/default_branch`` to ``remote/slug`` because
+        that's what reviewers actually see; a local commit not yet pushed
+        does not count.
+
+        Fails closed: any git error returns ``False`` (treat as no diff,
+        do not promote).
+        """
+        diff = self._git(
+            ["diff", "--quiet", f"{remote}/{default_branch}", f"{remote}/{slug}"],
+            check=False,
+        )
+        # `git diff --quiet`: exit 0 = no diff, 1 = diff present.
+        if diff.returncode == 0:
+            return False
+        if diff.returncode == 1:
+            return True
+        log.warning(
+            "_pr_has_real_diff: git diff %s..%s returned %s — treating as no diff",
+            default_branch,
+            slug,
+            diff.returncode,
+        )
+        return False
+
     def _squash_wip_commit(self, remote: str, slug: str, default_branch: str) -> bool:
         """Drop the empty 'wip: start' sentinel if it is the branch root.
 
@@ -3293,6 +3326,14 @@ class Worker:
                 return 0
             promoted_from_draft = False
             if is_draft:
+                if not self._pr_has_real_diff("origin", slug, repo_ctx.default_branch):
+                    log.warning(
+                        "PR #%s: refusing ready_for_review — branch has no diff "
+                        "vs %s (#1194)",
+                        pr_number,
+                        repo_ctx.default_branch,
+                    )
+                    return 0
                 log.info(
                     "PR #%s: changes requested — all addressed, CI passing — marking ready",
                     pr_number,
@@ -3343,6 +3384,14 @@ class Worker:
                 log.info(
                     "PR #%s: work complete but unresolved review threads remain — deferring promote",
                     pr_number,
+                )
+                return 0
+            if not self._pr_has_real_diff("origin", slug, repo_ctx.default_branch):
+                log.warning(
+                    "PR #%s: refusing ready_for_review — branch has no diff "
+                    "vs %s (#1194)",
+                    pr_number,
+                    repo_ctx.default_branch,
                 )
                 return 0
             log.info("PR #%s: work complete, CI green — marking ready", pr_number)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4220,7 +4220,7 @@ class TestCreateTask:
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
             )
-        registry.abort_task.assert_called_once_with("owner/repo")
+        registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # ABORT_KEEP: current task stays in tasks.json
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -4251,7 +4251,7 @@ class TestCreateTask:
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
             )
-        registry.abort_task.assert_called_once_with("owner/repo")
+        registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # task should still be in tasks.json (ABORT_KEEP)
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -4300,7 +4300,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
             )
-        registry.abort_task.assert_called_once_with("owner/repo")
+        registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
 
@@ -4321,7 +4321,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
             )
-        registry.abort_task.assert_called_once_with("owner/repo")
+        registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
 
@@ -4655,8 +4655,8 @@ class TestReorderTasksBackground:
         )
         self._run_thread(started)
         on_inprogress_affected = calls[0][2]["_on_inprogress_affected"]
-        on_inprogress_affected()
-        registry.abort_task.assert_called_once_with("owner/repo")
+        on_inprogress_affected("t-current")
+        registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
 
     def test_releases_untriaged_hold_after_reorder_finishes(
         self, tmp_path: Path

--- a/tests/test_task_queue_rescope.py
+++ b/tests/test_task_queue_rescope.py
@@ -464,7 +464,7 @@ def test_abort_decision_matches_oracle(tmp_path: Path) -> None:
     )
 
     assert expected is True
-    registry.abort_task.assert_called_once_with("owner/repo")
+    registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
 
 
 def test_tasks_unblock_matches_oracle(tmp_path: Path) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1137,7 +1137,7 @@ class TestReorderTasks:
             tmp_path,
             "",
             agent=_client(raw),
-            _on_inprogress_affected=lambda: affected.append(1),
+            _on_inprogress_affected=lambda _task_id: affected.append(1),
         )
         assert affected == [1]
         # in-progress task is marked completed
@@ -1157,7 +1157,7 @@ class TestReorderTasks:
             tmp_path,
             "",
             agent=_client(raw),
-            _on_inprogress_affected=lambda: affected.append(1),
+            _on_inprogress_affected=lambda _task_id: affected.append(1),
         )
         assert affected == [1]
         # task reset to pending with preserved title and updated description
@@ -1179,7 +1179,7 @@ class TestReorderTasks:
             tmp_path,
             "",
             agent=_client(raw),
-            _on_inprogress_affected=lambda: affected.append(1),
+            _on_inprogress_affected=lambda _task_id: affected.append(1),
         )
         assert affected == []
         # task still in_progress (unchanged by Opus)
@@ -1199,7 +1199,7 @@ class TestReorderTasks:
             tmp_path,
             "",
             agent=_client(raw),
-            _on_inprogress_affected=lambda: affected.append(1),
+            _on_inprogress_affected=lambda _task_id: affected.append(1),
         )
         assert affected == []
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9752,6 +9752,86 @@ class TestExecuteTask:
         orig.side_effect = side_effect
         return orig
 
+    def test_preempt_pushes_committed_work_before_yielding(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #1192: when the provider turn commits and is then
+        preempted (webhook arrives between `git commit` and `git push`),
+        the worker must push the committed work before yielding.  Without
+        this guard the local commit lives forever in the workspace clone
+        while the PR remote is unchanged — the symptom that produced the
+        empty PR #1191.
+        """
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 1, "current_task_id": "t-preempt"})
+        task = {"id": "t-preempt", "title": "Commit then preempt", "status": "pending"}
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            # Mock the preempt detector so the turn looks cancelled.
+            patch.object(worker, "_provider_turn_was_preempted", return_value=True),
+            # Mock the leftover-commit helper to report HEAD moved during
+            # the turn (provider committed before the preempt fired).
+            patch.object(
+                worker,
+                "_commit_provider_leftovers_if_any",
+                return_value="sha-after-commit",
+            ),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True) as mock_push,
+            patch("fido.tasks.Tasks.complete_with_resolve") as mock_complete,
+            patch("fido.tasks.sync_tasks"),
+        ):
+            result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch-slug")
+        # Yielded (return True) because the turn was preempted.
+        assert result is True
+        # Push fired with the right remote and slug *before* yielding.
+        mock_push.assert_called_once_with("origin", "branch-slug")
+        # We yielded mid-task, not completed it.
+        mock_complete.assert_not_called()
+
+    def test_preempt_skips_push_when_no_commits_landed(self, tmp_path: Path) -> None:
+        """Companion to the push-before-yield test: when the provider was
+        preempted *before* it committed (HEAD didn't move), there's
+        nothing to push.  The push helper should be a no-op.
+        """
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 1, "current_task_id": "t-preempt-early"})
+        task = {
+            "id": "t-preempt-early",
+            "title": "Preempt before commit",
+            "status": "pending",
+        }
+        head_before = "sha-unchanged"
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_provider_turn_was_preempted", return_value=True),
+            # HEAD did not move — _commit_provider_leftovers_if_any
+            # returns the same SHA, so _push_committed_work_before_yield
+            # short-circuits.
+            patch.object(
+                worker,
+                "_commit_provider_leftovers_if_any",
+                return_value=head_before,
+            ),
+            patch.object(
+                worker, "_git", MagicMock(return_value=MagicMock(stdout=head_before))
+            ),
+            patch.object(worker, "ensure_pushed") as mock_push,
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch-slug")
+        assert result is True
+        mock_push.assert_not_called()
+
     def test_stale_abort_targeting_removed_task_does_not_clobber_next_task(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3671,7 +3671,7 @@ class TestProviderRun:
             retry_on_preempt=False,
         )
         client.run_turn.assert_called_once_with(
-            "skill text\n\n---\n\nprompt text",
+            "skill\n\n---\n\nprompt",
             model=client.work_model,
             retry_on_preempt=False,
             session_mode=TurnSessionMode.REUSE,
@@ -9119,6 +9119,7 @@ class TestExecuteTask:
             session=None,
             agent=ANY,
             session_mode=TurnSessionMode.REUSE,
+            retry_on_preempt=False,
         )
 
     def test_calls_ensure_pushed_with_origin_and_slug(self, tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -39,6 +39,7 @@ from fido.tasks import (
 from fido.types import GitIdentity
 from fido.worker import (
     _RETRY_COMMENT_MARKER,
+    AbortHandle,
     GitIdentityError,
     LockHeld,
     RepoContext,
@@ -8830,6 +8831,53 @@ class TestSquashWipCommit:
         assert rebase_call == ["rebase", "--onto", base, wip, "my-branch"]
 
 
+class TestAbortHandle:
+    """Tests for the per-task abort signal (closes #1193)."""
+
+    def test_request_then_is_active_for_matches(self) -> None:
+        h = AbortHandle()
+        h.request("task-A")
+        assert h.is_active_for("task-A") is True
+        assert h.is_set() is True
+
+    def test_request_then_is_active_for_other_task_is_false(self) -> None:
+        """The bug-fix invariant: an abort targeted at A doesn't fire on B."""
+        h = AbortHandle()
+        h.request("task-A")
+        assert h.is_active_for("task-B") is False
+        # The signal is still set — only its target is wrong for B.
+        assert h.is_set() is True
+
+    def test_untargeted_set_matches_any_task(self) -> None:
+        """Legacy untargeted form (set / request(None)) matches any task."""
+        h = AbortHandle()
+        h.set()
+        assert h.is_active_for("any-task") is True
+        h.clear()
+        h.request(None)
+        assert h.is_active_for("other-task") is True
+
+    def test_clear_resets_signal_and_target(self) -> None:
+        h = AbortHandle()
+        h.request("task-A")
+        h.clear()
+        assert h.is_set() is False
+        assert h.is_active_for("task-A") is False
+
+    def test_request_overwrites_prior_target(self) -> None:
+        """A second request changes the target; prior target no longer active."""
+        h = AbortHandle()
+        h.request("task-A")
+        h.request("task-B")
+        assert h.is_active_for("task-A") is False
+        assert h.is_active_for("task-B") is True
+
+    def test_default_state_is_inactive(self) -> None:
+        h = AbortHandle()
+        assert h.is_set() is False
+        assert h.is_active_for("anything") is False
+
+
 class TestExecuteTask:
     """Tests for Worker.execute_task."""
 
@@ -9703,6 +9751,53 @@ class TestExecuteTask:
 
         orig.side_effect = side_effect
         return orig
+
+    def test_stale_abort_targeting_removed_task_does_not_clobber_next_task(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end regression for #1193: an abort signal targeted at a
+        prior task that has since been removed (e.g. rescope marked it
+        completed without running cleanup) must NOT cause the next task
+        to be aborted on entry.
+
+        Pre-fix: `_abort_task` was a per-worker `threading.Event` that
+        stayed set across task boundaries; the next task hit
+        `_abort_task.is_set()` at the top of `execute_task` and was
+        cleaned up before any work ran (this is what dropped the
+        follow-up thread task on PR #1191).
+
+        Post-fix: the abort handle is per-task; an abort targeted at
+        "t-prior" does not match "t-next", so `is_active_for("t-next")`
+        is False and `execute_task` proceeds normally.
+        """
+        worker, _ = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 1})
+        next_task = {"id": "t-next", "title": "Next task", "status": "pending"}
+        # Stale abort from a prior task that's already been removed by rescope.
+        worker._abort_task.request("t-prior-removed")
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[next_task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch("fido.worker.provider_run", return_value=("sid", "")) as mock_run,
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch.object(worker, "git_clean") as mock_clean,
+            patch("fido.tasks.Tasks.remove") as mock_remove,
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
+        # The stale abort was for a different task — t-next must NOT have
+        # been auto-cleaned up.  provider_run runs.  git_clean and
+        # Tasks.remove (the abort-cleanup side effects) are NOT called.
+        mock_run.assert_called()
+        mock_clean.assert_not_called()
+        mock_remove.assert_not_called()
+        # The stale abort signal stays set (no cleanup ran for t-prior-removed)
+        # and remains scoped to t-prior-removed — not active for t-next.
+        assert worker._abort_task.is_active_for("t-next") is False
 
     def test_abort_after_initial_run_removes_task_and_returns_true(
         self, tmp_path: Path

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11422,6 +11422,85 @@ class TestHandlePromoteMerge:
             worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
         gh.pr_ready.assert_called_once_with("rhencke/myrepo", 9)
 
+    def test_draft_refuses_pr_ready_when_branch_has_no_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #1194: don't promote a PR whose remote diff is empty."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        completed = [{"id": "t1", "title": "Done", "status": "completed"}]
+        with (
+            patch("fido.tasks.Tasks.list", return_value=completed),
+            patch.object(worker, "_pr_has_real_diff", return_value=False),
+        ):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        gh.pr_ready.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
+        assert result == 0
+
+    def test_changes_requested_refuses_promote_when_branch_has_no_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #1194: same guard fires on the CHANGES_REQUESTED+draft path."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {
+            "reviews": [
+                {
+                    "author": {"login": "rhencke"},
+                    "state": "CHANGES_REQUESTED",
+                    "submittedAt": "2026-05-01T10:00:00Z",
+                }
+            ],
+            "commits": [{"committedDate": "2026-05-01T09:00:00Z"}],
+            "isDraft": True,
+        }
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        completed = [{"id": "t1", "title": "Done", "status": "completed"}]
+        with (
+            patch("fido.tasks.Tasks.list", return_value=completed),
+            patch.object(worker, "_pr_has_real_diff", return_value=False),
+        ):
+            result = worker.handle_promote_merge(
+                fido_dir, self._repo_ctx(), 9, "fix", 5
+            )
+        gh.pr_ready.assert_not_called()
+        assert result == 0
+
+    def test_pr_has_real_diff_returns_true_when_git_reports_diff(
+        self, tmp_path: Path
+    ) -> None:
+        """`git diff --quiet` exit 1 means diff present → True."""
+        worker, _ = self._make_worker(tmp_path)
+        fake_git = MagicMock(return_value=MagicMock(returncode=1, stdout="", stderr=""))
+        with patch.object(worker, "_git", fake_git):
+            assert worker._pr_has_real_diff("origin", "fix", "main") is True
+
+    def test_pr_has_real_diff_returns_false_on_clean_diff(self, tmp_path: Path) -> None:
+        """`git diff --quiet` exit 0 means no diff → False."""
+        worker, _ = self._make_worker(tmp_path)
+        fake_git = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+        with patch.object(worker, "_git", fake_git):
+            assert worker._pr_has_real_diff("origin", "fix", "main") is False
+
+    def test_pr_has_real_diff_fails_closed_on_unexpected_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Unknown git exit code → fail closed (False)."""
+        worker, _ = self._make_worker(tmp_path)
+        fake_git = MagicMock(
+            return_value=MagicMock(returncode=128, stdout="", stderr="bad ref")
+        )
+        with patch.object(worker, "_git", fake_git):
+            assert worker._pr_has_real_diff("origin", "fix", "main") is False
+
     def test_draft_with_completed_tasks_adds_reviewer(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8848,10 +8848,12 @@ class TestAbortHandle:
         # The signal is still set — only its target is wrong for B.
         assert h.is_set() is True
 
-    def test_untargeted_set_matches_any_task(self) -> None:
-        """Legacy untargeted form (set / request(None)) matches any task."""
+    def test_untargeted_request_matches_any_task(self) -> None:
+        """`request(None)` is the untargeted form, used only by the external
+        WorkerThread.abort_task() entry point that fires before any task
+        is in flight.  Real callers (preempt, rescope) always pass an id."""
         h = AbortHandle()
-        h.set()
+        h.request(None)
         assert h.is_active_for("any-task") is True
         h.clear()
         h.request(None)
@@ -9618,7 +9620,7 @@ class TestExecuteTask:
             run_calls += 1
             prompt_snapshots.append((fd / "prompt").read_text())
             if run_calls == 6:
-                worker._abort_task.set()
+                worker._abort_task.request(task["id"])
             return ("sess", "")
 
         with (
@@ -9886,7 +9888,7 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1, "current_task_id": "t-abort"})
         task = {"id": "t-abort", "title": "Abort me", "status": "pending"}
-        worker._abort_task.set()
+        worker._abort_task.request(task["id"])
         with (
             patch("fido.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
@@ -9918,7 +9920,7 @@ class TestExecuteTask:
             nonlocal call_count
             call_count += 1
             if call_count == 2:
-                worker._abort_task.set()
+                worker._abort_task.request(task["id"])
             return ("sid", "")
 
         with (
@@ -9944,7 +9946,7 @@ class TestExecuteTask:
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1})
         task = {"id": "t-no-complete", "title": "No complete", "status": "pending"}
-        worker._abort_task.set()
+        worker._abort_task.request(task["id"])
         with (
             patch("fido.tasks.Tasks.list", return_value=[task]),
             patch.object(worker, "set_status"),
@@ -11600,13 +11602,16 @@ class TestHandlePromoteMerge:
     def test_draft_refuses_pr_ready_when_branch_has_no_diff(
         self, tmp_path: Path
     ) -> None:
-        """Regression for #1194: don't promote a PR whose remote diff is empty."""
+        """Regression for #1194: don't promote a PR whose remote diff is empty.
+        Leave the PR open with a one-time BLOCKED comment so the human can
+        decide what to do."""
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
         gh.get_review_threads.return_value = []
+        gh.get_issue_comments.return_value = []  # no prior BLOCKED marker
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with (
             patch("fido.tasks.Tasks.list", return_value=completed),
@@ -11617,12 +11622,43 @@ class TestHandlePromoteMerge:
             )
         gh.pr_ready.assert_not_called()
         gh.add_pr_reviewers.assert_not_called()
+        # PR stays open with a one-time BLOCKED comment.
+        gh.comment_issue.assert_called_once()
+        comment_body = gh.comment_issue.call_args.args[2]
+        assert "BLOCKED" in comment_body
+        assert "<!-- fido:empty-pr-blocked -->" in comment_body
         assert result == 0
+
+    def test_draft_empty_diff_does_not_repost_blocked_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """The BLOCKED comment is one-shot: re-running the worker loop
+        with the same empty-diff state must not spam more comments."""
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.get_reviews.return_value = {"reviews": [], "commits": [], "isDraft": True}
+        gh.pr_checks.return_value = []
+        gh.get_required_checks.return_value = []
+        gh.get_review_threads.return_value = []
+        # Marker already present from a prior iteration.
+        gh.get_issue_comments.return_value = [
+            {"body": "BLOCKED: ...\n<!-- fido:empty-pr-blocked -->"}
+        ]
+        completed = [{"id": "t1", "title": "Done", "status": "completed"}]
+        with (
+            patch("fido.tasks.Tasks.list", return_value=completed),
+            patch.object(worker, "_pr_has_real_diff", return_value=False),
+        ):
+            worker.handle_promote_merge(fido_dir, self._repo_ctx(), 9, "fix", 5)
+        gh.pr_ready.assert_not_called()
+        # No second BLOCKED comment posted.
+        gh.comment_issue.assert_not_called()
 
     def test_changes_requested_refuses_promote_when_branch_has_no_diff(
         self, tmp_path: Path
     ) -> None:
-        """Regression for #1194: same guard fires on the CHANGES_REQUESTED+draft path."""
+        """Regression for #1194: same guard fires on the CHANGES_REQUESTED+draft
+        path, with the same one-time BLOCKED comment behaviour."""
         worker, gh = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         gh.get_reviews.return_value = {
@@ -11630,14 +11666,17 @@ class TestHandlePromoteMerge:
                 {
                     "author": {"login": "rhencke"},
                     "state": "CHANGES_REQUESTED",
-                    "submittedAt": "2026-05-01T10:00:00Z",
+                    "submittedAt": "2026-05-01T09:00:00Z",
                 }
             ],
-            "commits": [{"committedDate": "2026-05-01T09:00:00Z"}],
+            # Commit is *newer* than the review so should_rerequest_review
+            # returns True and the path reaches the empty-diff guard.
+            "commits": [{"committedDate": "2026-05-01T10:00:00Z"}],
             "isDraft": True,
         }
         gh.pr_checks.return_value = []
         gh.get_required_checks.return_value = []
+        gh.get_issue_comments.return_value = []
         completed = [{"id": "t1", "title": "Done", "status": "completed"}]
         with (
             patch("fido.tasks.Tasks.list", return_value=completed),
@@ -11647,6 +11686,7 @@ class TestHandlePromoteMerge:
                 fido_dir, self._repo_ctx(), 9, "fix", 5
             )
         gh.pr_ready.assert_not_called()
+        gh.comment_issue.assert_called_once()
         assert result == 0
 
     def test_pr_has_real_diff_returns_true_when_git_reports_diff(


### PR DESCRIPTION
## Summary

PR #1191 silently dropped Fido's work and got marked ready for review with zero diff. Three independent root causes fell out of the same incident:

- **#1192** preempt path skips \`ensure_pushed\` — committed work orphaned in the workspace clone.
- **#1193** \`_abort_task\` signal leaks across task boundaries — the next task gets cleaned up before any work happens.
- **#1194** PR marked ready_for_review when remote diff is empty — broken state advertised to reviewer.

This PR closes all three with three commits + three rounds of self-review polish:

1. push committed work before yielding on preempt
2. per-task abort handle (replaces the per-worker \`threading.Event\`)
3. empty-diff guard on promote-merge
4. (round 1) AbortHandle direct tests, leak-fix regression test, docstring
5. (round 2) preempt-push regression test (the missing test plan item)
6. (round 3) drop the AbortHandle.set() shim, empty-PR one-time BLOCKED comment, Rocq alignment verified

Bundled because the repro and the manual verification are the same incident (PR #1191 / issue #1163).

Long-term direction (per Rob): Fido should just write code and Python should own commit/push so the atomicity is structural. Not in scope here.

## Empty-PR policy (per Rob)

When the empty-diff guard fires the PR stays *open* with a one-time \`BLOCKED\` comment marked \`<!-- fido:empty-pr-blocked -->\`. The human decides what to do — comment with more guidance and Fido picks it up, or close the PR. No silent advertise-broken-state, no destructive auto-close.

## Rocq alignment

\`models/task_queue_rescope.v::abort_task(task, lease)\` already encodes per-task semantics (clears the lease only when \`lease_task == task\`). My \`AbortHandle\` brings the Python implementation back in line with the model — there was no model divergence to fix.

## Test plan
- [x] new test: provider commits + preempt → \`ensure_pushed\` called (\`test_preempt_pushes_committed_work_before_yielding\`)
- [x] companion: preempt before commit → no push (\`test_preempt_skips_push_when_no_commits_landed\`)
- [x] new test: rescope-completes a task → next task NOT auto-aborted (\`test_stale_abort_targeting_removed_task_does_not_clobber_next_task\`)
- [x] direct \`AbortHandle\` unit tests (six: targeted match, targeted mismatch, untargeted match, clear, overwrite, default-inactive)
- [x] new test: promote-merge refuses an empty PR + posts one-time BLOCKED comment (\`test_draft_refuses_pr_ready_when_branch_has_no_diff\`, \`test_changes_requested_refuses_promote_when_branch_has_no_diff\`)
- [x] new test: BLOCKED comment is one-shot (\`test_draft_empty_diff_does_not_repost_blocked_comment\`)
- [x] three \`_pr_has_real_diff\` unit tests
- [x] full \`./fido ci\` green

## Follow-ups filed
- #1197: pre-existing failing tests on main aren't gating CI (buildx cache reuse is masking real failures).