### PR TITLE
Blog overhaul: worker plumbing — auto-load sub/life.md when issue has Blog label (closes #1164)

### DIFF
--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -681,13 +681,14 @@ class GitHub:
         return data["resources"]
 
     def view_issue(self, repo: str, number: int | str) -> dict[str, Any]:
-        """Return issue data (state, title, body, created_at)."""
+        """Return issue data (state, title, body, created_at, labels)."""
         data = self._get(f"/repos/{repo}/issues/{number}")
         return {
             "state": data["state"].upper(),
             "title": data["title"],
             "body": data["body"] or "",
             "created_at": data.get("created_at", ""),
+            "labels": [lbl["name"] for lbl in data.get("labels", [])],
         }
 
     def get_issue_comments(self, repo: str, number: int | str) -> list[dict[str, Any]]:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -259,7 +259,12 @@ def create_compact_script(fido_dir: Path) -> Path:
     return script_path
 
 
-def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Path]:
+def build_prompt(
+    fido_dir: Path,
+    subskill: str,
+    context: str,
+    labels: list[str] | None = None,
+) -> tuple[Path, Path]:
     """Write system and prompt files for a sub-agent session.
 
     The system file contains ``persona.md`` and ``<subskill>.md`` joined by a
@@ -273,16 +278,32 @@ def build_prompt(fido_dir: Path, subskill: str, context: str) -> tuple[Path, Pat
 
     The prompt file contains the context string.
 
+    When *labels* contains ``"Blog"``, ``sub/life.md`` is injected between
+    persona and skill in both files so the sub-agent has world context for
+    blog/journal work (closes #1164).  If ``life.md`` is absent the label is
+    silently ignored.
+
     Returns ``(system_file, prompt_file)`` where both live in *fido_dir*.
     """
     sub = _sub_dir()
     persona = (sub / "persona.md").read_text().rstrip()
     skill = (sub / f"{subskill}.md").read_text().rstrip()
+
+    life: str | None = None
+    if "Blog" in (labels or []):
+        life_path = sub / "life.md"
+        if life_path.exists():
+            life = life_path.read_text().rstrip()
+
     system_file = fido_dir / "system"
     skill_file = fido_dir / "skill"
     prompt_file = fido_dir / "prompt"
-    system_file.write_text(f"{persona}\n\n{skill}\n")
-    skill_file.write_text(f"{skill}\n")
+    if life:
+        system_file.write_text(f"{persona}\n\n{life}\n\n{skill}\n")
+        skill_file.write_text(f"{life}\n\n{skill}\n")
+    else:
+        system_file.write_text(f"{persona}\n\n{skill}\n")
+        skill_file.write_text(f"{skill}\n")
     prompt_file.write_text(f"{context}\n")
     return system_file, prompt_file
 
@@ -1757,6 +1778,7 @@ class Worker:
         issue: int,
         issue_title: str,
         issue_body: str = "",
+        issue_labels: list[str] | None = None,
     ) -> tuple[int, str, bool]:
         """Find or create the branch and draft PR for *issue*.
 
@@ -1808,7 +1830,7 @@ class Worker:
                     f"Upstream: {remote}/{repo_ctx.default_branch}\n"
                     f"Work dir: {self.work_dir}"
                 )
-                build_prompt(fido_dir, "setup", context)
+                build_prompt(fido_dir, "setup", context, labels=issue_labels)
                 provider_start(
                     fido_dir,
                     agent=self._provider_agent,
@@ -1876,7 +1898,7 @@ class Worker:
             f"Upstream: {remote}/{repo_ctx.default_branch}\n"
             f"Work dir: {self.work_dir}"
         )
-        build_prompt(fido_dir, "setup", context)
+        build_prompt(fido_dir, "setup", context, labels=issue_labels)
         provider_start(
             fido_dir,
             agent=self._provider_agent,
@@ -1929,6 +1951,7 @@ class Worker:
         repo_ctx: RepoContext,
         pr_number: int,
         slug: str,
+        issue_labels: list[str] | None = None,
     ) -> bool:
         """Detect and remediate a merge conflict on the branch.
 
@@ -1956,7 +1979,7 @@ class Worker:
             f"Upstream: origin/{repo_ctx.default_branch}\n"
             f"Work dir: {self.work_dir}\n"
         )
-        build_prompt(fido_dir, "merge", context)
+        build_prompt(fido_dir, "merge", context, labels=issue_labels)
         session_id, _ = provider_run(
             fido_dir,
             agent=self._provider_agent,
@@ -2026,6 +2049,7 @@ class Worker:
         repo_ctx: RepoContext,
         pr_number: int,
         slug: str,
+        issue_labels: list[str] | None = None,
     ) -> bool:
         """Check for failing CI checks and run the ci sub-agent to fix them.
 
@@ -2093,7 +2117,7 @@ class Worker:
             f"\nReview threads related to this CI failure"
             f" (JSON — may be empty):\n{json.dumps(ci_threads)}"
         )
-        build_prompt(fido_dir, "ci", context)
+        build_prompt(fido_dir, "ci", context, labels=issue_labels)
         if not self._admit_worker_turn(pr_number):
             return True
         session_id, _ = provider_run(
@@ -2905,6 +2929,7 @@ class Worker:
         repo_ctx: RepoContext,
         pr_number: int,
         slug: str,
+        issue_labels: list[str] | None = None,
     ) -> bool:
         """Pick and execute the next pending task via the task sub-agent.
 
@@ -2954,7 +2979,7 @@ class Worker:
                     + ", ".join(str(comment_id) for comment_id in lineage_ids)
                 )
         context = "\n".join(context_parts)
-        build_prompt(fido_dir, "task", context)
+        build_prompt(fido_dir, "task", context, labels=issue_labels)
         prompts = self._get_prompts()
         state_path = fido_dir / "state.json"
         state_data = State(fido_dir).load() if state_path.exists() else {}
@@ -3679,11 +3704,17 @@ class Worker:
             issue_data = self.gh.view_issue(repo_ctx.repo, issue)
             issue_title = issue_data["title"]
             issue_body = issue_data.get("body", "") or ""
+            issue_labels = issue_data.get("labels", [])
             self._ensure_pickup_comment(
                 ctx.fido_dir, repo_ctx.repo, issue, issue_title, repo_ctx.gh_user
             )
             pr_number, slug, pr_is_fresh = self.find_or_create_pr(
-                ctx.fido_dir, repo_ctx, issue, issue_title, issue_body
+                ctx.fido_dir,
+                repo_ctx,
+                issue,
+                issue_title,
+                issue_body,
+                issue_labels=issue_labels,
             )
             if self._first_iteration:
                 recovered_comments = FidoStore(
@@ -3745,15 +3776,33 @@ class Worker:
                 log.info("fresh PR — skipping CI/thread/rescope checks")
             else:
                 self.rescope_before_pick()
-                if self.handle_merge_conflict(ctx.fido_dir, repo_ctx, pr_number, slug):
+                if self.handle_merge_conflict(
+                    ctx.fido_dir,
+                    repo_ctx,
+                    pr_number,
+                    slug,
+                    issue_labels=issue_labels,
+                ):
                     return 1
                 if self.handle_queued_comments(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1
-                if self.handle_ci(ctx.fido_dir, repo_ctx, pr_number, slug):
+                if self.handle_ci(
+                    ctx.fido_dir,
+                    repo_ctx,
+                    pr_number,
+                    slug,
+                    issue_labels=issue_labels,
+                ):
                     return 1
                 if self.handle_threads(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1
-            if self.execute_task(ctx.fido_dir, repo_ctx, pr_number, slug):
+            if self.execute_task(
+                ctx.fido_dir,
+                repo_ctx,
+                pr_number,
+                slug,
+                issue_labels=issue_labels,
+            ):
                 self.resolve_addressed_threads(repo_ctx, pr_number)
                 return 1
             promote_result = self.handle_promote_merge(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1327,6 +1327,7 @@ class TestGitHubClass:
             "title": "Bug",
             "body": "desc",
             "created_at": "2024-01-01T00:00:00Z",
+            "labels": [{"name": "Blog"}, {"name": "enhancement"}],
         }
         mock_s.get.return_value = mock_resp
         result = gh.view_issue("o/r", 5)
@@ -1335,7 +1336,38 @@ class TestGitHubClass:
             "title": "Bug",
             "body": "desc",
             "created_at": "2024-01-01T00:00:00Z",
+            "labels": ["Blog", "enhancement"],
         }
+
+    def test_view_issue_no_labels(self) -> None:
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "state": "closed",
+            "title": "Old thing",
+            "body": None,
+            "created_at": "2024-06-01T00:00:00Z",
+            "labels": [],
+        }
+        mock_s.get.return_value = mock_resp
+        result = gh.view_issue("o/r", 7)
+        assert result["labels"] == []
+        assert result["body"] == ""
+        assert result["state"] == "CLOSED"
+
+    def test_view_issue_labels_key_absent(self) -> None:
+        # Older API responses or mocks that omit "labels" should not crash.
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "state": "open",
+            "title": "No labels key",
+            "body": "hi",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        mock_s.get.return_value = mock_resp
+        result = gh.view_issue("o/r", 99)
+        assert result["labels"] == []
 
     def test_get_issue_comments(self) -> None:
         gh, mock_s = self._gh()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3339,6 +3339,68 @@ class TestBuildPrompt:
         assert content.startswith("Persona text\n\n")
         assert not content.startswith("Persona text\n\n\n\n")
 
+    def test_blog_label_injects_life_into_system_file(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        sub = self._setup_sub_dir(tmp_path)
+        (sub / "life.md").write_text("Rob is my person. I live in a cozy house.")
+        with patch("fido.worker._sub_dir", return_value=sub):
+            sys_file, _ = build_prompt(fido_dir, "task", "ctx", labels=["Blog"])
+        content = sys_file.read_text()
+        assert "I am Fido" in content
+        assert "Rob is my person." in content
+        assert "Implement the task carefully." in content
+        # life.md appears between persona and skill
+        persona_pos = content.index("I am Fido")
+        life_pos = content.index("Rob is my person.")
+        skill_pos = content.index("Implement the task carefully.")
+        assert persona_pos < life_pos < skill_pos
+
+    def test_blog_label_injects_life_into_skill_file(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        sub = self._setup_sub_dir(tmp_path)
+        (sub / "life.md").write_text("Rob is my person.")
+        with patch("fido.worker._sub_dir", return_value=sub):
+            _, _ = build_prompt(fido_dir, "task", "ctx", labels=["Blog"])
+        skill_content = (fido_dir / "skill").read_text()
+        assert "Rob is my person." in skill_content
+        assert "Implement the task carefully." in skill_content
+        # life.md appears before skill in skill file
+        life_pos = skill_content.index("Rob is my person.")
+        skill_pos = skill_content.index("Implement the task carefully.")
+        assert life_pos < skill_pos
+
+    def test_no_blog_label_omits_life(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        sub = self._setup_sub_dir(tmp_path)
+        (sub / "life.md").write_text("This should not appear.")
+        with patch("fido.worker._sub_dir", return_value=sub):
+            sys_file, _ = build_prompt(fido_dir, "task", "ctx", labels=["enhancement"])
+        assert "This should not appear." not in sys_file.read_text()
+
+    def test_no_labels_omits_life(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        sub = self._setup_sub_dir(tmp_path)
+        (sub / "life.md").write_text("This should not appear.")
+        with patch("fido.worker._sub_dir", return_value=sub):
+            sys_file, _ = build_prompt(fido_dir, "task", "ctx")
+        assert "This should not appear." not in sys_file.read_text()
+
+    def test_blog_label_missing_life_file_does_not_crash(self, tmp_path: Path) -> None:
+        fido_dir = tmp_path / "fido"
+        fido_dir.mkdir()
+        sub = self._setup_sub_dir(tmp_path)
+        # life.md intentionally absent
+        with patch("fido.worker._sub_dir", return_value=sub):
+            sys_file, _ = build_prompt(fido_dir, "task", "ctx", labels=["Blog"])
+        # Falls back to the normal persona + skill layout
+        content = sys_file.read_text()
+        assert "I am Fido" in content
+        assert "Implement the task carefully." in content
+
 
 class TestProviderStart:
     """Tests for provider_start."""
@@ -4486,7 +4548,7 @@ class TestFindOrCreatePr:
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
-        mock_build.assert_called_once_with(fido_dir, "setup", ANY)
+        mock_build.assert_called_once_with(fido_dir, "setup", ANY, labels=None)
         mock_start.assert_called_once_with(
             fido_dir,
             model=mock_client.voice_model,
@@ -4745,7 +4807,7 @@ class TestFindOrCreatePr:
             pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
-        mock_build.assert_called_once_with(fido_dir, "setup", ANY)
+        mock_build.assert_called_once_with(fido_dir, "setup", ANY, labels=None)
         mock_start.assert_called_once_with(
             fido_dir,
             model=mock_client.voice_model,


### PR DESCRIPTION
Fixes #1164.

Teaches the worker to notice the Blog label on an issue and automatically include `sub/life.md` in the system prompt alongside `sub/persona.md`, so blog tasks get world context without manual reminders. First plumbs labels through `view_issue()`, then threads them to `build_prompt()` with a conditional load.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Include labels in view_issue() response and add tests <!-- type:spec -->
- [x] Thread Blog label to build_prompt and conditionally load sub/life.md <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->