### PR TITLE
Bug: approved review webhook suppressed by CollapseReview — ~50s lag from approve to merge (closes #1198)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -115,9 +115,12 @@ class WebhookIngressOracle:
             The ``X-GitHub-Delivery`` header value identifying this delivery.
         collapse_review:
             When True, fire ``CollapseReview`` instead of ``Arrive``.
-            Used for ``pull_request_review / submitted`` events whose inline
-            comments are handled individually — the review-level event is
-            collapsed rather than dispatched.
+            Used for ``pull_request_review / submitted`` events with
+            ``review.state == "commented"`` — inline comments are handled
+            individually per ``pull_request_review_comment`` event, so the
+            review-level event is collapsed rather than dispatched.  Decisive
+            states (``approved``, ``changes_requested``, ``dismissed``) are
+            **not** collapsed so the worker wakes immediately.
 
         Returns
         -------
@@ -1201,15 +1204,23 @@ def dispatch(
     When *delivery_id* and *oracle* are provided the
     :class:`WebhookIngressOracle` is consulted before any routing logic runs.
     Duplicate deliveries (same delivery ID arriving a second time) and
-    collapsed ``pull_request_review / submitted`` events are suppressed by
-    returning ``None`` before any side effects execute.
+    ``pull_request_review / submitted`` events with ``review.state ==
+    "commented"`` are suppressed by returning ``None`` before any side
+    effects execute.  Decisive review states (``approved``,
+    ``changes_requested``, ``dismissed``) are dispatched normally so the
+    worker wakes up without waiting for the next poll cycle.
     """
     action = payload.get("action", "")
     repo = payload.get("repository", {}).get("full_name", "")
 
     # Oracle check — deduplicate at the ingress boundary.
     if delivery_id is not None and oracle is not None:
-        collapse_review = event == "pull_request_review" and action == "submitted"
+        review_state = payload.get("review", {}).get("state", "")
+        collapse_review = (
+            event == "pull_request_review"
+            and action == "submitted"
+            and review_state == "commented"
+        )
         ingress_result = oracle.check_dispatch(
             repo_cfg.name,
             delivery_id,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,6 +8,7 @@ from fido.config import Config, RepoMembership
 from fido.config import RepoConfig as _RepoConfig
 from fido.events import (
     Action,
+    WebhookIngressOracle,
     _apply_reply_result,
     _build_issue_comment_action,
     _configured_agent,
@@ -5770,6 +5771,95 @@ class TestDispatchPullRequestReview:
         }
         result = dispatch("pull_request_review", payload, cfg, _repo_cfg(tmp_path))
         assert result is None
+
+    def test_commented_review_collapsed_by_oracle(self, tmp_path: Path) -> None:
+        """Oracle collapses state=commented reviews — inline comments are handled
+        individually by pull_request_review_comment events, so the review-level
+        event must not also dispatch."""
+        cfg = _config(tmp_path)
+        oracle = WebhookIngressOracle()
+        payload = {
+            **_payload(),
+            "action": "submitted",
+            "review": {"id": 77, "state": "commented", "user": {"login": "owner"}},
+            "pull_request": {"number": 4},
+        }
+        result = dispatch(
+            "pull_request_review",
+            payload,
+            cfg,
+            _repo_cfg(tmp_path),
+            delivery_id="delivery-commented-1",
+            oracle=oracle,
+        )
+        assert result is None, "commented review should be collapsed (None)"
+
+    def test_approved_review_not_collapsed_by_oracle(self, tmp_path: Path) -> None:
+        """Oracle must NOT collapse approved reviews — the worker must wake
+        immediately rather than waiting for the next poll cycle (~60 s lag)."""
+        cfg = _config(tmp_path)
+        oracle = WebhookIngressOracle()
+        payload = {
+            **_payload(),
+            "action": "submitted",
+            "review": {"id": 78, "state": "approved", "user": {"login": "owner"}},
+            "pull_request": {"number": 5},
+        }
+        result = dispatch(
+            "pull_request_review",
+            payload,
+            cfg,
+            _repo_cfg(tmp_path),
+            delivery_id="delivery-approved-1",
+            oracle=oracle,
+        )
+        assert result is not None, "approved review must not be collapsed"
+
+    def test_changes_requested_not_collapsed_by_oracle(self, tmp_path: Path) -> None:
+        """changes_requested is a decisive review state — must dispatch so the
+        worker wakes up without waiting for the next poll cycle."""
+        cfg = _config(tmp_path)
+        oracle = WebhookIngressOracle()
+        payload = {
+            **_payload(),
+            "action": "submitted",
+            "review": {
+                "id": 79,
+                "state": "changes_requested",
+                "user": {"login": "owner"},
+            },
+            "pull_request": {"number": 6},
+        }
+        result = dispatch(
+            "pull_request_review",
+            payload,
+            cfg,
+            _repo_cfg(tmp_path),
+            delivery_id="delivery-changes-requested-1",
+            oracle=oracle,
+        )
+        assert result is not None, "changes_requested review must not be collapsed"
+
+    def test_dismissed_not_collapsed_by_oracle(self, tmp_path: Path) -> None:
+        """dismissed is a decisive review state — must dispatch so the worker
+        wakes up without waiting for the next poll cycle."""
+        cfg = _config(tmp_path)
+        oracle = WebhookIngressOracle()
+        payload = {
+            **_payload(),
+            "action": "submitted",
+            "review": {"id": 80, "state": "dismissed", "user": {"login": "owner"}},
+            "pull_request": {"number": 7},
+        }
+        result = dispatch(
+            "pull_request_review",
+            payload,
+            cfg,
+            _repo_cfg(tmp_path),
+            delivery_id="delivery-dismissed-1",
+            oracle=oracle,
+        )
+        assert result is not None, "dismissed review must not be collapsed"
 
 
 class TestDispatchCheckRunNoPrs:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2249,16 +2249,18 @@ class TestProcessAction:
         mock_ic.assert_called_once()
 
     def test_review_comments_handled(self, server: tuple) -> None:
-        # pull_request_review / submitted is collapsed by the ingress oracle
-        # (CollapseReview) so reply_to_review is never called — inline comments
-        # are handled individually by pull_request_review_comment events.
+        # pull_request_review / submitted with state="commented" is collapsed by
+        # the ingress oracle (CollapseReview) so reply_to_review is never called
+        # — inline comments are handled individually by pull_request_review_comment
+        # events.  Decisive states (approved, changes_requested, dismissed) are
+        # NOT collapsed and do wake the worker.
         url, cfg = server
         payload = {
             **self._payload(),
             "action": "submitted",
             "review": {
                 "id": 888,
-                "state": "changes_requested",
+                "state": "commented",
                 "user": {"login": "owner"},
             },
             "pull_request": {"number": 9},


### PR DESCRIPTION
Fixes #1198.

The CollapseReview dedup path unconditionally suppresses all `pull_request_review/submitted` webhooks — including approvals — so the worker never wakes and merge waits for the next 60s poll cycle. This narrows the collapse predicate to only suppress `commented` reviews, letting decisive states (`approved`, `changes_requested`, `dismissed`) dispatch immediately.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] Only collapse commented reviews — let approved/changes_requested/dismissed dispatch <!-- type:spec -->
- [x] Add tests for decisive review states bypassing CollapseReview <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->