### PR TITLE
Bug: copilot-cli model 'gpt-5.4' rejected — re-map to supported set (closes #1205)

### DIFF
--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -133,17 +133,24 @@ def extract_session_id(output: str) -> str:
     return result
 
 
+# Models Copilot CLI currently accepts.  Surfaces from the CLI as the
+# error message when an unknown name is requested ("Supported values:
+# auto, gpt-5-mini, gpt-4.1, claude-haiku-4.5").  Update this set when
+# the CLI's supported list changes (closes #1205).
+_COPILOT_SUPPORTED_MODELS: frozenset[str] = frozenset(
+    {"auto", "gpt-5-mini", "gpt-4.1", "claude-haiku-4.5"}
+)
+
+
 def _normalize_model(model: ProviderModel | str | None) -> ProviderModel | None:
     if model is None:
         return None
     normalized = coerce_provider_model(model)
     lowered = normalized.model.lower()
-    if lowered.startswith("claude-opus"):
-        return ProviderModel("gpt-5.4", normalized.effort)
-    if lowered.startswith("claude-sonnet"):
-        return ProviderModel("gpt-5.4", normalized.effort)
     if lowered.startswith("claude-haiku"):
-        return ProviderModel("gpt-5.4", normalized.effort)
+        return ProviderModel("claude-haiku-4.5", normalized.effort)
+    if lowered.startswith("claude-opus") or lowered.startswith("claude-sonnet"):
+        return ProviderModel("gpt-4.1", normalized.effort)
     return normalized
 
 
@@ -1148,9 +1155,9 @@ class CopilotCLIAPI(ProviderAPI):
 class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     """Injectable collaborator for Copilot CLI interactions."""
 
-    voice_model = ProviderModel("gpt-5.4", "high")
-    work_model = ProviderModel("gpt-5.4", "medium")
-    brief_model = ProviderModel("gpt-5.4", "low")
+    voice_model = ProviderModel("gpt-4.1", "high")
+    work_model = ProviderModel("gpt-4.1", "medium")
+    brief_model = ProviderModel("gpt-5-mini", "low")
 
     def __init__(
         self,

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -66,8 +66,37 @@ def _copilot_output(text: str = "OK", session_id: str = "sess-123") -> str:
 
 
 class TestNormalizeModel:
-    def test_maps_claude_haiku_to_gpt54(self) -> None:
-        assert _normalize_model("claude-haiku-4-5-20251001") == ProviderModel("gpt-5.4")
+    def test_maps_claude_haiku_to_haiku_4_5(self) -> None:
+        # Copilot CLI now offers the actual Haiku model; route there.
+        assert _normalize_model("claude-haiku-4-5-20251001") == ProviderModel(
+            "claude-haiku-4.5"
+        )
+
+    def test_maps_claude_opus_to_gpt_4_1(self) -> None:
+        assert _normalize_model("claude-opus-4-7") == ProviderModel("gpt-4.1")
+
+    def test_maps_claude_sonnet_to_gpt_4_1(self) -> None:
+        assert _normalize_model("claude-sonnet-4-6") == ProviderModel("gpt-4.1")
+
+    def test_passes_through_native_copilot_model(self) -> None:
+        # gpt-4.1 / gpt-5-mini / claude-haiku-4.5 / auto are native to
+        # Copilot CLI — pass through unchanged.
+        assert _normalize_model("gpt-4.1") == ProviderModel("gpt-4.1")
+
+    def test_default_models_are_supported(self) -> None:
+        # Regression for #1205: every default model on the CopilotCLIClient
+        # tier table must be in the Copilot-CLI-supported set, otherwise
+        # the worker crash-loops on its first turn.
+        from fido.copilotcli import _COPILOT_SUPPORTED_MODELS, CopilotCLIClient
+
+        for model in (
+            CopilotCLIClient.voice_model,
+            CopilotCLIClient.work_model,
+            CopilotCLIClient.brief_model,
+        ):
+            assert model.model in _COPILOT_SUPPORTED_MODELS, (
+                f"{model.model!r} not in Copilot CLI supported set"
+            )
 
 
 class FakeProcess:


### PR DESCRIPTION
## Summary

Copilot CLI dropped \`gpt-5.4\` from its supported models. Tracy's worker (provider copilot-cli) crash-looped on every turn with \`RequestError: Invalid model 'gpt-5.4'. Supported values: auto, gpt-5-mini, gpt-4.1, claude-haiku-4.5\`.

Re-map both hardcoded sites in \`src/fido/copilotcli.py\`:

- \`CopilotCLIClient.{voice,work,brief}_model\`: \`gpt-5.4\` → \`gpt-4.1\` (voice/work) and \`gpt-5-mini\` (brief).
- \`_normalize_model()\`: \`claude-haiku-*\` → \`claude-haiku-4.5\` (Copilot CLI now offers the actual Haiku model); \`claude-opus-*\` / \`claude-sonnet-*\` → \`gpt-4.1\`.
- New \`_COPILOT_SUPPORTED_MODELS\` frozenset documents the accepted set; regression test asserts every default tier model is in the set.

## Test plan
- [x] new \`TestNormalizeModel\` cases for haiku, opus, sonnet, native pass-through, and the \`test_default_models_are_supported\` regression
- [x] \`./fido ci\` green via pre-commit
- [ ] manual: after merge + restart, tracy worker no longer crash-loops on its first turn