### PR TITLE
Bug: refresh gh-CLI token at every identity-assertion boundary (closes #1207)

### DIFF
--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -99,16 +99,41 @@ class GitHub:
         token: str | None = None,
         session: _requests.Session | None = None,
         sleeper: Callable[[float], None] = time.sleep,
+        token_fetcher: Callable[[], str] = _gh_token,
     ) -> None:
         self._s = session if session is not None else _TimeoutSession()
+        self._token_fetcher = token_fetcher
+        self._token = token if token is not None else token_fetcher()
         self._s.headers.update(
             {
-                "Authorization": f"Bearer {token if token is not None else _gh_token()}",
+                "Authorization": f"Bearer {self._token}",
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28",
             }
         )
         self._sleep = sleeper
+
+    def refresh_token(self) -> bool:
+        """Re-resolve the gh-CLI token; update session headers if changed.
+
+        Catches the case where the host runs ``gh auth switch`` while
+        fido is running: without this, the GitHub client keeps using
+        the old token forever, the API's ``/user`` response stays
+        wrong, and :meth:`Worker.assert_git_identity` crash-loops the
+        worker until a process restart (closes #1207).
+
+        Called at every assertion boundary in the worker loop; the
+        per-call cost is one ``gh auth token`` subprocess invocation,
+        negligible at the natural iteration cadence.
+
+        Returns ``True`` when the token actually changed.
+        """
+        new_token = self._token_fetcher()
+        if new_token == self._token:
+            return False
+        self._token = new_token
+        self._s.headers["Authorization"] = f"Bearer {new_token}"
+        return True
 
     def _retryable_get(self, url: str) -> _requests.Response:
         """GET *url* with retry on transient upstream failures (#664).

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3602,7 +3602,13 @@ class Worker:
         A post-condition failure (``phase="post"``) is the scary case: it means
         something *during the iteration* mutated the config.  Either way the
         worker aborts and the watchdog restarts.
+
+        Refreshes the gh-CLI token before the comparison so a host-side
+        ``gh auth switch`` (rare, but happens during ops work) is picked
+        up automatically rather than crash-looping the worker until a
+        process restart (closes #1207).
         """
+        self.gh.refresh_token()
         expected = self.gh.get_authenticated_identity()
         actual = GitIdentity(
             name=self._git_config_get("user.name"),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -75,6 +75,28 @@ class TestGitHubClass:
         gh = GitHub("test-token")
         assert gh._s.headers["Authorization"] == "Bearer test-token"
 
+    def test_refresh_token_picks_up_new_value(self) -> None:
+        """Regression for #1207: re-resolve gh-CLI token mid-run.
+
+        When the host runs ``gh auth switch`` while fido is up, the
+        next ``refresh_token`` call must update the session header so
+        subsequent API requests use the new token.
+        """
+        tokens = iter(["old-token", "new-token"])
+        gh = GitHub(token=None, token_fetcher=lambda: next(tokens))
+        assert gh._s.headers["Authorization"] == "Bearer old-token"
+        changed = gh.refresh_token()
+        assert changed is True
+        assert gh._s.headers["Authorization"] == "Bearer new-token"
+
+    def test_refresh_token_noop_when_unchanged(self) -> None:
+        """When the token hasn't changed, refresh is a no-op and
+        returns False so callers can skip downstream work."""
+        gh = GitHub(token=None, token_fetcher=lambda: "same-token")
+        changed = gh.refresh_token()
+        assert changed is False
+        assert gh._s.headers["Authorization"] == "Bearer same-token"
+
     def test_sets_accept_header(self) -> None:
         gh = GitHub("test-token")
         assert gh._s.headers["Accept"] == "application/vnd.github+json"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2276,6 +2276,20 @@ class TestAssertGitIdentity:
     def test_git_identity_str_is_git_author_format(self) -> None:
         assert str(GitIdentity(name="A Dog", email="a@b.c")) == "A Dog <a@b.c>"
 
+    def test_refreshes_token_before_compare(self, tmp_path: Path) -> None:
+        """Regression for #1207: assert_git_identity must call
+        ``gh.refresh_token()`` so a host-side ``gh auth switch`` is
+        picked up automatically rather than crash-looping until a
+        process restart."""
+        self._init_repo(
+            tmp_path,
+            name="Fido Can Code",
+            email="190991155+FidoCanCode@users.noreply.github.com",
+        )
+        worker, gh = self._worker(tmp_path)
+        worker.assert_git_identity(phase="pre")
+        gh.refresh_token.assert_called_once_with()
+
 
 class TestNoCommitNudge:
     def test_early_attempt_is_gentle_and_includes_complete_command(self) -> None:


### PR DESCRIPTION
## Summary

Fido captured the gh-CLI token once at \`GitHub\`-client construction and reused it forever. When the host ran \`gh auth switch\` while fido was running, the cached token's \`/user\` response stayed wrong and \`Worker.assert_git_identity\` crash-looped every iteration with \`actual=<workspace identity> expected=<stale token's identity>\`. Recovery required a process restart.

This PR makes the GitHub client refreshable: \`GitHub.refresh_token()\` re-resolves the gh-CLI token and updates the session's \`Authorization\` header. \`Worker.assert_git_identity\` calls it before the comparison so a host-side \`gh auth switch\` is picked up on the very next worker iteration.

## Test plan
- [x] new \`test_refresh_token_picks_up_new_value\` and \`test_refresh_token_noop_when_unchanged\` in test_github.py
- [x] new \`test_refreshes_token_before_compare\` in test_worker.py asserts the wiring
- [x] \`./fido ci\` green via pre-commit
- [ ] manual: switch host gh user mid-run; observe fido recovers on next iteration without restart