### PR TITLE
Bug: container mirrors host paths (closes #1211)

### DIFF
--- a/fido
+++ b/fido
@@ -489,12 +489,12 @@ run_container() {
     --interactive
     --user "$(id -u):$(id -g)"
     --env "HOME=$HOME"
-    --env "PYTHONPATH=/workspace/src"
+    --env "PYTHONPATH=$repo_root/src"
     --network host
-    --volume "$repo_root:/workspace"
+    --volume "$repo_root:$repo_root"
     --volume "$HOME/workspace:$HOME/workspace"
     "${secret_args[@]}"
-    --workdir /workspace
+    --workdir "$repo_root"
   )
   if [ "$named_run" = "1" ]; then
     run_args=(--name "$container" "${run_args[@]}")
@@ -549,7 +549,7 @@ run_fido_test_python_image() {
 
 run_fido_pyproject_image() {
   build_image fido-test "$test_image"
-  container_entrypoint=/workspace/pyproject run_container "$@"
+  container_entrypoint="$repo_root/pyproject" run_container "$@"
 }
 
 run_fido_module_image() {


### PR DESCRIPTION
## Summary

Tracy worker (\`copilot-cli\`) crashed at setup because the runner clone was mounted at \`/workspace\` inside the container while every prompt references the host path \`/home/rhencke/home-runner\`. When copilot prefixed \`cd /home/rhencke/home-runner && ./fido task ...\` the cd failed in-container and copilot gave up. Claude self-corrected by retrying without the cd; copilot didn't.

This PR mounts the runner clone at the SAME path inside the container as on the host, mirroring the workspace mount's existing convention.  Four-line diff in the \`fido\` launcher.

## Test plan
- [x] \`./fido help\` and \`./fido ruff format --check\` work post-change
- [x] grep across \`src/fido/\` and \`tests/\` shows no Python references to \`/workspace\` to update
- [x] \`./fido ci\` green via pre-commit
- [ ] manual: after merge + restart, copilot's first \`cd /home/rhencke/home-runner && ./fido task ...\` succeeds and tracy's setup phase produces tasks