### PR TITLE
Feature: copilot-cli provider-pressure info (fido status + 95% pause) (closes #1213)

### DIFF
--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -13,6 +13,7 @@ import uuid
 from collections.abc import Callable, Sequence
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,7 @@ from fido.provider import (
     ProviderAPI,
     ProviderID,
     ProviderLimitSnapshot,
+    ProviderLimitWindow,
     ProviderModel,
     ReasoningEffort,
     coerce_provider_model,
@@ -140,6 +142,35 @@ def extract_session_id(output: str) -> str:
 _COPILOT_SUPPORTED_MODELS: frozenset[str] = frozenset(
     {"auto", "gpt-5-mini", "gpt-4.1", "claude-haiku-4.5"}
 )
+
+# How long to treat a recorded quota error as an active pause.  Copilot
+# does not expose a reset timestamp, so we use a conservative one-hour
+# window.  Update when real quota reset semantics are confirmed.
+_COPILOT_QUOTA_PAUSE_SECONDS = 3600.0
+
+# Strings that identify a Copilot error as quota / rate-limit related.
+# Copilot CLI has not (yet) been observed hitting quota in the wild, so
+# this list is speculative.  Expand it as real error messages appear.
+_COPILOT_QUOTA_PATTERNS: tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "quota",
+    "too many requests",
+    "429",
+    "limit exceeded",
+    "usage limit",
+)
+
+
+def _is_copilot_quota_error(exc: Exception) -> bool:
+    """Return True when *exc* looks like a Copilot quota or rate-limit error.
+
+    The check is intentionally broad because Copilot CLI has not yet been
+    observed surfacing quota failures in production.  The patterns will be
+    tightened once real error messages are confirmed.
+    """
+    lowered = str(exc).lower()
+    return any(pat in lowered for pat in _COPILOT_QUOTA_PATTERNS)
 
 
 def _normalize_model(model: ProviderModel | str | None) -> ProviderModel | None:
@@ -1142,14 +1173,71 @@ class CopilotCLISession(OwnedSession):
 
 
 class CopilotCLIAPI(ProviderAPI):
-    """Read-only account API for Copilot CLI."""
+    """Read-only account API for Copilot CLI.
+
+    Copilot CLI exposes no native quota endpoint, so limit state is derived
+    from observed errors: when a caller records a quota-shaped error via
+    :meth:`record_quota_error`, :meth:`get_limit_snapshot` returns a 100%-
+    usage window that expires after :data:`_COPILOT_QUOTA_PAUSE_SECONDS`.
+    Once the pause window expires the snapshot reverts to "unknown".
+    """
+
+    def __init__(
+        self,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        pause_seconds: float = _COPILOT_QUOTA_PAUSE_SECONDS,
+    ) -> None:
+        self._monotonic = monotonic
+        self._now = now
+        self._pause_seconds = pause_seconds
+        self._lock = threading.Lock()
+        self._quota_error_at_monotonic: float | None = None
+        self._quota_error_at_wall: datetime | None = None
 
     @property
     def provider_id(self) -> ProviderID:
         return ProviderID.COPILOT_CLI
 
+    def record_quota_error(self, exc: Exception) -> bool:
+        """Record *exc* as a quota error if it looks quota-shaped.
+
+        Returns ``True`` when the error was classified as quota-related and
+        the pause window was (re)started, ``False`` otherwise.
+        """
+        if not _is_copilot_quota_error(exc):
+            return False
+        with self._lock:
+            self._quota_error_at_monotonic = self._monotonic()
+            self._quota_error_at_wall = self._now()
+        log.warning(
+            "copilot-cli quota error recorded — pausing for %.0fs", self._pause_seconds
+        )
+        return True
+
     def get_limit_snapshot(self) -> ProviderLimitSnapshot:
-        return ProviderLimitSnapshot(provider=self.provider_id)
+        with self._lock:
+            recorded_at = self._quota_error_at_monotonic
+            wall = self._quota_error_at_wall
+        if recorded_at is None or wall is None:
+            return ProviderLimitSnapshot(provider=self.provider_id)
+        elapsed = self._monotonic() - recorded_at
+        if elapsed >= self._pause_seconds:
+            return ProviderLimitSnapshot(provider=self.provider_id)
+        resets_at = wall + timedelta(seconds=self._pause_seconds)
+        return ProviderLimitSnapshot(
+            provider=self.provider_id,
+            windows=(
+                ProviderLimitWindow(
+                    name="quota",
+                    used=100,
+                    limit=100,
+                    resets_at=resets_at,
+                    unit="%",
+                ),
+            ),
+        )
 
 
 class CopilotCLIClient(SessionBackedAgent, ProviderAgent):

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -148,26 +148,33 @@ _COPILOT_SUPPORTED_MODELS: frozenset[str] = frozenset(
 # window.  Update when real quota reset semantics are confirmed.
 _COPILOT_QUOTA_PAUSE_SECONDS = 3600.0
 
-# Strings that identify a Copilot error as quota / rate-limit related.
-# Copilot CLI has not (yet) been observed hitting quota in the wild, so
-# this list is speculative.  Expand it as real error messages appear.
+# Substrings that identify a Copilot error as quota / rate-limit related.
+# Grounded in the actual strings emitted by @github/copilot (sdk/index.js):
+#
+#   "You've reached your weekly rate limit."    ← user_weekly_rate_limited
+#   "You've hit the rate limit for this model." ← user_model_rate_limited
+#                                                   / integration_rate_limited
+#   "You've hit your global rate limit."        ← user_global_rate_limited
+#                                                   / rate_limited (fallback)
+#   "Rate limit reached, waiting 1 minute before retrying..."
+#   "Rate limit exceeded"
+#   "No remaining quota for premium requests"
+#   "Quota is insufficient to finish this session."
+#
+# All of the above fold to either "rate limit", "rate_limit", or "quota"
+# when lowercased and substring-matched.
 _COPILOT_QUOTA_PATTERNS: tuple[str, ...] = (
-    "rate limit",
-    "rate_limit",
-    "quota",
-    "too many requests",
-    "429",
-    "limit exceeded",
-    "usage limit",
+    "rate limit",  # covers all "You've … rate limit …" and "Rate limit …" messages
+    "rate_limit",  # covers error codes in ACP exceptions (e.g. user_weekly_rate_limited)
+    "quota",  # covers "No remaining quota" and "Quota is insufficient"
 )
 
 
 def _is_copilot_quota_error(exc: Exception) -> bool:
     """Return True when *exc* looks like a Copilot quota or rate-limit error.
 
-    The check is intentionally broad because Copilot CLI has not yet been
-    observed surfacing quota failures in production.  The patterns will be
-    tightened once real error messages are confirmed.
+    Matches against :data:`_COPILOT_QUOTA_PATTERNS`, which are grounded in the
+    actual error messages emitted by ``@github/copilot`` (sdk/index.js).
     """
     lowered = str(exc).lower()
     return any(pat in lowered for pat in _COPILOT_QUOTA_PATTERNS)

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1257,9 +1257,11 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
+        api: CopilotCLIAPI | None = None,
     ) -> None:
         self._runner = runner
         self._sleep_fn = sleep_fn
+        self._quota_api = api
         self._session_factory = (
             CopilotCLISession if session_factory is None else session_factory
         )
@@ -1297,6 +1299,9 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         exc: Exception,
         session: PromptSession,
     ) -> bool:
+        # Quota errors are not recoverable via session restart — record and halt.
+        if self._quota_api is not None and self._quota_api.record_quota_error(exc):
+            return False
         message = str(exc)
         return (
             isinstance(exc, (BrokenPipeError, OSError))
@@ -1398,15 +1403,16 @@ class CopilotCLI(Provider):
     def __init__(
         self,
         *,
-        api: ProviderAPI | None = None,
+        api: CopilotCLIAPI | None = None,
         agent: ProviderAgent | None = None,
         session: PromptSession | None = None,
     ) -> None:
+        api_instance = api if api is not None else CopilotCLIAPI()
         if agent is None:
-            agent = CopilotCLIClient(session=session)
+            agent = CopilotCLIClient(session=session, api=api_instance)
         elif session is not None:
             agent.attach_session(session)
-        self._api = CopilotCLIAPI() if api is None else api
+        self._api = api_instance
         self._agent = agent
 
     @property

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -60,13 +60,17 @@ class DefaultProviderFactory:
                     )
                 )
             case ProviderID.COPILOT_CLI:
+                shared_api = self.create_api(repo_cfg)
+                assert isinstance(shared_api, CopilotCLIAPI)
                 return CopilotCLI(
+                    api=shared_api,
                     agent=CopilotCLIClient(
+                        api=shared_api,
                         session_system_file=self._session_system_file,
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
-                    )
+                    ),
                 )
             case ProviderID.CODEX:
                 return Codex(

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1589,6 +1589,40 @@ class TestCopilotCLIClient:
             client.run_turn("fetch", model=client.voice_model)
         session.recover.assert_called_once_with()
 
+    def test_quota_error_records_on_api_and_is_not_retried(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = RuntimeError("rate limit exceeded")
+        api = CopilotCLIAPI()
+        client = CopilotCLIClient(session=session, api=api)
+        with pytest.raises(RuntimeError, match="rate limit exceeded"):
+            client.run_turn("fetch", model=client.voice_model)
+        # The error was recorded — snapshot now shows 100% pressure.
+        snapshot = api.get_limit_snapshot()
+        assert len(snapshot.windows) == 1
+        assert snapshot.windows[0].pressure == 1.0
+        # Session was NOT asked to recover — quota errors are not retryable.
+        session.recover.assert_not_called()
+
+    def test_quota_error_without_api_still_raises(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = RuntimeError("rate limit exceeded")
+        client = CopilotCLIClient(session=session)  # no api injected
+        with pytest.raises(RuntimeError, match="rate limit exceeded"):
+            client.run_turn("fetch", model=client.voice_model)
+
+    def test_non_quota_error_still_retried_with_api_wired(self) -> None:
+        session = MagicMock()
+        session.prompt.side_effect = [
+            ValueError("Separator is found, but chunk is longer than limit"),
+            "done",
+        ]
+        api = CopilotCLIAPI()
+        client = CopilotCLIClient(session=session, api=api)
+        assert client.run_turn("fetch", model=client.voice_model) == "done"
+        session.recover.assert_called_once_with()
+        # Non-quota error did not poison the snapshot.
+        assert api.get_limit_snapshot().windows == ()
+
     def test_json_and_one_shot_helpers(self, tmp_path: Path) -> None:
         runner = MagicMock(return_value=_completed(_copilot_output("line1\nline2")))
         system_file = tmp_path / "system"
@@ -1688,3 +1722,12 @@ class TestCopilotCLI:
         session = MagicMock()
         CopilotCLI(agent=agent, session=session)
         agent.attach_session.assert_called_once_with(session)
+
+    def test_default_construction_wires_api_to_default_agent(self) -> None:
+        # When neither api nor agent is injected, CopilotCLI must create a
+        # shared CopilotCLIAPI and wire it into the CopilotCLIClient so that
+        # quota errors recorded during prompts are visible via api.
+        copilot = CopilotCLI()
+        assert isinstance(copilot.api, CopilotCLIAPI)
+        assert isinstance(copilot.agent, CopilotCLIClient)
+        assert copilot.agent._quota_api is copilot.api

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1260,14 +1260,20 @@ class TestIsCopilotQuotaError:
     @pytest.mark.parametrize(
         "message",
         [
-            "rate limit exceeded",
-            "Rate Limit hit",
-            "rate_limit reached",
-            "quota exhausted",
-            "Too Many Requests",
-            "429 error from server",
-            "limit exceeded for user",
-            "usage limit reached",
+            # Exact messages from @github/copilot sdk/index.js ---------------
+            "You've reached your weekly rate limit.",  # user_weekly_rate_limited
+            "You've hit the rate limit for this model.",  # user_model_rate_limited
+            "You've hit your global rate limit.",  # user_global_rate_limited
+            "Rate limit reached, waiting 1 minute before retrying...",
+            "Rate limit exceeded",
+            "No remaining quota for premium requests",
+            "Quota is insufficient to finish this session.",
+            # Error codes that may surface in ACP exceptions -----------------
+            "user_weekly_rate_limited",
+            "user_model_rate_limited",
+            "user_global_rate_limited",
+            "integration_rate_limited",
+            "rate_limited",
         ],
     )
     def test_quota_patterns_match(self, message: str) -> None:
@@ -1280,6 +1286,8 @@ class TestIsCopilotQuotaError:
             "BrokenPipeError",
             "authentication failed",
             "context window overflow",
+            "Too Many Requests",  # generic HTTP — not a Copilot CLI pattern
+            "429",  # raw HTTP status — not surfaced by Copilot CLI
             "",
         ],
     )

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -18,6 +19,7 @@ from fido import provider
 from fido.copilotcli import (
     _ACP_STREAM_LIMIT,
     _COPILOT_CANCEL_SENTINEL,
+    _COPILOT_QUOTA_PAUSE_SECONDS,
     CopilotACPRuntime,
     CopilotCLI,
     CopilotCLIAPI,
@@ -26,6 +28,7 @@ from fido.copilotcli import (
     _combine_prompt,
     _CopilotACPClient,
     _is_cancel_sentinel,
+    _is_copilot_quota_error,
     _is_line_limit_overrun_error,
     _normalize_model,
     _preview_log_value,
@@ -1253,11 +1256,112 @@ class TestCopilotCLISession:
         assert "copilot result >>>\ndone\n<<< copilot result" in caplog.text
 
 
+class TestIsCopilotQuotaError:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "rate limit exceeded",
+            "Rate Limit hit",
+            "rate_limit reached",
+            "quota exhausted",
+            "Too Many Requests",
+            "429 error from server",
+            "limit exceeded for user",
+            "usage limit reached",
+        ],
+    )
+    def test_quota_patterns_match(self, message: str) -> None:
+        assert _is_copilot_quota_error(RuntimeError(message))
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "session not found",
+            "BrokenPipeError",
+            "authentication failed",
+            "context window overflow",
+            "",
+        ],
+    )
+    def test_non_quota_errors_do_not_match(self, message: str) -> None:
+        assert not _is_copilot_quota_error(RuntimeError(message))
+
+
 class TestCopilotCLIAPI:
-    def test_limit_snapshot_is_unknown(self) -> None:
-        assert CopilotCLIAPI().get_limit_snapshot() == ProviderLimitSnapshot(
+    _FIXED_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _api(
+        self,
+        *,
+        monotonic_start: float = 0.0,
+        pause_seconds: float = _COPILOT_QUOTA_PAUSE_SECONDS,
+    ) -> tuple["CopilotCLIAPI", list[float]]:
+        """Return an API instance with injectable monotonic clock."""
+        clock = [monotonic_start]
+        now_clock = [self._FIXED_NOW]
+        api = CopilotCLIAPI(
+            monotonic=lambda: clock[0],
+            now=lambda: now_clock[0],
+            pause_seconds=pause_seconds,
+        )
+        return api, clock
+
+    def test_limit_snapshot_is_unknown_by_default(self) -> None:
+        api, _ = self._api()
+        assert api.get_limit_snapshot() == ProviderLimitSnapshot(
             provider=ProviderID.COPILOT_CLI
         )
+
+    def test_record_quota_error_returns_true_for_quota_error(self) -> None:
+        api, _ = self._api()
+        assert api.record_quota_error(RuntimeError("rate limit exceeded")) is True
+
+    def test_record_quota_error_returns_false_for_non_quota_error(self) -> None:
+        api, _ = self._api()
+        assert api.record_quota_error(RuntimeError("session not found")) is False
+
+    def test_snapshot_shows_100_percent_after_quota_error(self) -> None:
+        api, clock = self._api(monotonic_start=0.0, pause_seconds=3600.0)
+        api.record_quota_error(RuntimeError("quota exhausted"))
+        clock[0] = 60.0  # 60 seconds into the pause window
+        snapshot = api.get_limit_snapshot()
+        assert len(snapshot.windows) == 1
+        window = snapshot.windows[0]
+        assert window.name == "quota"
+        assert window.used == 100
+        assert window.limit == 100
+        assert window.unit == "%"
+        assert window.pressure == 1.0
+
+    def test_snapshot_reset_time_is_recorded_at_plus_pause(self) -> None:
+        from datetime import timedelta
+
+        pause = 3600.0
+        api, _ = self._api(monotonic_start=0.0, pause_seconds=pause)
+        api.record_quota_error(RuntimeError("rate limit"))
+        snapshot = api.get_limit_snapshot()
+        assert snapshot.windows[0].resets_at == self._FIXED_NOW + timedelta(
+            seconds=pause
+        )
+
+    def test_snapshot_reverts_to_unknown_after_pause_expires(self) -> None:
+        pause = 3600.0
+        api, clock = self._api(monotonic_start=0.0, pause_seconds=pause)
+        api.record_quota_error(RuntimeError("quota exceeded"))
+        clock[0] = pause  # exactly at the boundary — expired
+        snapshot = api.get_limit_snapshot()
+        assert snapshot == ProviderLimitSnapshot(provider=ProviderID.COPILOT_CLI)
+
+    def test_non_quota_error_does_not_change_snapshot(self) -> None:
+        api, _ = self._api()
+        api.record_quota_error(RuntimeError("connection reset"))
+        assert api.get_limit_snapshot() == ProviderLimitSnapshot(
+            provider=ProviderID.COPILOT_CLI
+        )
+
+    def test_provider_id(self) -> None:
+        api = CopilotCLIAPI()
+        assert api.provider_id == ProviderID.COPILOT_CLI
 
 
 class TestCopilotCLIClient:

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from fido.config import RepoConfig
+from fido.copilotcli import CopilotCLIAPI, CopilotCLIClient
 from fido.provider import ProviderID
 from fido.provider_factory import DefaultProviderFactory
 
@@ -80,6 +81,30 @@ class TestDefaultProviderFactory:
         )
         assert provider.provider_id == ProviderID.COPILOT_CLI
         assert provider.agent.provider_id == ProviderID.COPILOT_CLI
+
+    def test_create_provider_shares_copilot_api_with_create_api(
+        self, tmp_path: Path
+    ) -> None:
+        # The same CopilotCLIAPI instance must back both the status check
+        # (create_api) and the prompt path (create_provider → CopilotCLIClient).
+        # If they differ, quota errors recorded on the client are invisible to
+        # the pressure-pause check.
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        repo = RepoConfig(
+            name="owner/repo",
+            work_dir=tmp_path,
+            provider=ProviderID.COPILOT_CLI,
+        )
+        api = factory.create_api(repo)
+        prov = factory.create_provider(
+            repo, work_dir=tmp_path, repo_name="owner/repo", session=None
+        )
+        assert isinstance(api, CopilotCLIAPI)
+        assert isinstance(prov.agent, CopilotCLIClient)
+        assert prov.agent._quota_api is api
+        assert prov.api is api
 
     def test_create_agent_uses_repo_provider(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"


### PR DESCRIPTION
Fixes #1213.

Copilot CLI has no quota API, so this adds error-driven pressure detection: when a prompt fails with a quota-shaped error, the failure is recorded on `CopilotCLIAPI` and surfaced through `get_limit_snapshot()` as a 100%-usage window with a configurable pause duration. The worker's existing 95% pressure-pause machinery then kicks in automatically, and `fido status` shows the pause state instead of "limits unknown." Error patterns will be grounded in the actual Copilot CLI source rather than speculated.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] [Inspect Copilot CLI source for actual quota error messages and replace speculative patterns with observed ones](https://github.com/FidoCanCode/home/pull/1215#issuecomment-4362212864) <!-- type:thread -->
- [x] Wire quota-error pause into CopilotCLISession prompt path <!-- type:spec -->
- [x] Add quota error detection to CopilotCLIAPI.get_limit_snapshot <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->