### PR TITLE
Feature: hoist active-work context (issue, PR, tasks, current task) into the system prompt (closes #1217)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -35,7 +35,7 @@ from fido.store import (
     append_reply_promise_markers,
 )
 from fido.tasks import Tasks, thread_comment_author_for_auto_resolve_oracle
-from fido.types import TaskType
+from fido.types import ActiveIssue, ActivePR, TaskType
 
 log = logging.getLogger(__name__)
 
@@ -2429,6 +2429,45 @@ def _rewrite_pr_description(
     )
 
 
+def _load_active_context_for_rescope(
+    work_dir: Path,
+    repo_name: str,
+    gh: Any,
+) -> tuple[ActiveIssue | None, ActivePR | None]:
+    """Read issue/PR snapshots from state and GitHub for the rescope prompt.
+
+    Returns ``(ActiveIssue, ActivePR)`` when both are resolvable, or
+    ``(ActiveIssue, None)`` / ``(None, None)`` on partial / missing data.
+    Silently returns ``(None, None)`` when state does not yet record an issue
+    (e.g. rescope fired before the worker set state.json).
+    """
+    fido_dir = work_dir / ".git" / "fido"
+    state_path = fido_dir / "state.json"
+    if not state_path.exists():
+        return None, None
+    state_data = State(fido_dir).load()
+    issue_number = state_data.get("issue")
+    pr_number = state_data.get("pr_number")
+    if not isinstance(issue_number, int):
+        return None, None
+    issue_data = gh.view_issue(repo_name, issue_number)
+    issue_ctx = ActiveIssue(
+        number=issue_number,
+        title=issue_data.get("title", ""),
+        body=issue_data.get("body", ""),
+    )
+    if not isinstance(pr_number, int):
+        return issue_ctx, None
+    pr_data = gh.get_pr(repo_name, pr_number)
+    pr_ctx = ActivePR(
+        number=pr_number,
+        title=pr_data.get("title", "") or "",
+        url=f"https://github.com/{repo_name}/pull/{pr_number}",
+        body=pr_data.get("body", "") or "",
+    )
+    return issue_ctx, pr_ctx
+
+
 def _make_reorder_kwargs(
     work_dir: Path,
     config: Config,
@@ -2477,6 +2516,14 @@ def _make_reorder_kwargs(
             registry.abort_task(repo_cfg.name, task_id=task_id)
 
         kwargs["_on_inprogress_affected"] = on_inprogress_affected
+    if repo_cfg is not None:
+        issue_ctx, pr_ctx = _load_active_context_for_rescope(
+            work_dir, repo_cfg.name, gh
+        )
+        if issue_ctx is not None:
+            kwargs["issue"] = issue_ctx
+        if pr_ctx is not None:
+            kwargs["pr"] = pr_ctx
     return kwargs
 
 

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1625,6 +1625,10 @@ def reply_to_comment(
         category, comment, ", ".join(titles), context, issue_url=issue_url
     )
 
+    issue_ctx, pr_ctx = _load_active_context_for_rescope(
+        repo_cfg.work_dir, repo_cfg.name, gh
+    )
+
     log.info(
         "reply generator: requesting %s reply for PR #%s comment %s",
         category,
@@ -1635,7 +1639,7 @@ def reply_to_comment(
         agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
-        system_prompt=prompts.reply_system_prompt(),
+        system_prompt=prompts.reply_system_prompt(issue=issue_ctx, pr=pr_ctx),
         log_prefix="reply_to_comment",
     )
     log.info(
@@ -2102,12 +2106,16 @@ def reply_to_issue_comment(
         category, comment, ", ".join(titles), action.context, issue_url=issue_url
     )
 
+    issue_ctx, pr_ctx = _load_active_context_for_rescope(
+        repo_cfg.work_dir, repo_cfg.name, gh
+    )
+
     log.info("generating %s reply for issue comment on PR #%s", category, number)
     body = safe_voice_turn(
         agent,
         prompts.persona_wrap(instr),
         model=agent.voice_model,
-        system_prompt=prompts.reply_system_prompt(),
+        system_prompt=prompts.reply_system_prompt(issue=issue_ctx, pr=pr_ctx),
         log_prefix="reply_to_issue_comment",
     )
     log.info(

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import requests as _requests
 
-from fido.types import GitIdentity
+from fido.types import ClosedPR, GitIdentity
 
 log = logging.getLogger(__name__)
 
@@ -545,6 +545,32 @@ class GitHub:
             if pr.get("state") == "CLOSED" and not pr.get("merged"):
                 closed_unmerged.append(pr_num)
         return closed_unmerged
+
+    def find_closed_prs_as_context(
+        self, repo: str, issue_number: int | str, user: str
+    ) -> list[ClosedPR]:
+        """Return :class:`~fido.types.ClosedPR` snapshots for closed-not-merged
+        PRs linked to *issue_number* by *user*, oldest first.
+
+        Delegates the timeline scan to
+        :meth:`find_closed_unmerged_prs_for_issue` to get PR numbers, then
+        fetches title and body for each via the REST API.  Used to populate
+        the ``prior_attempts`` block in the active-work context so the agent
+        can learn from earlier failed attempts.
+        """
+        pr_numbers = self.find_closed_unmerged_prs_for_issue(repo, issue_number, user)
+        result: list[ClosedPR] = []
+        for pr_num in pr_numbers:
+            data = self._get(f"/repos/{repo}/pulls/{pr_num}")
+            result.append(
+                ClosedPR(
+                    number=int(pr_num),
+                    title=data.get("title") or "",
+                    body=data.get("body") or "",
+                    close_reason="",
+                )
+            )
+        return result
 
     def comment_issue(self, repo: str, number: int | str, body: str) -> dict[str, Any]:
         """Post a comment on an issue."""

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any
 
-from fido.types import ActiveIssue, ActivePR, ClosedPR
+from fido.types import ActiveIssue, ActivePR, ClosedPR, TaskSnapshot
 
 # ── Prompt-level tool guardrails ──────────────────────────────────────────────
 #
@@ -51,11 +51,21 @@ READ_ONLY_CLAUSE = TRIAGE_CLAUSE
 # ── Active-work context renderer ─────────────────────────────────────────────
 
 
+def _task_snapshot_from_dict(t: dict[str, Any]) -> TaskSnapshot:
+    """Convert a raw task dict (from tasks.json) to a :class:`~fido.types.TaskSnapshot`."""
+    return TaskSnapshot(
+        title=t.get("title", ""),
+        type=t.get("type", "spec"),
+        status=t.get("status", "pending"),
+        description=t.get("description", ""),
+    )
+
+
 def render_active_context(
     issue: ActiveIssue,
     pr: ActivePR | None,
-    tasks: list[dict[str, Any]],
-    current_task: dict[str, Any] | None,
+    tasks: list[TaskSnapshot],
+    current_task: TaskSnapshot | None,
     prior_attempts: list[ClosedPR],
 ) -> str:
     """Render active-work context blocks for injection into any LLM system prompt.
@@ -112,18 +122,15 @@ def render_active_context(
 
     if tasks:
         task_lines = [
-            f"- {_STATUS_MARKER.get(t.get('status', 'pending'), '[ ]')} "
-            f"[{t.get('type', 'spec')}] {t.get('title', '')}"
+            f"- {_STATUS_MARKER.get(t.status, '[ ]')} [{t.type}] {t.title}"
             for t in tasks
         ]
         parts.append("## Tasks\n\n" + "\n".join(task_lines))
 
     if current_task is not None:
-        task_title = current_task.get("title", "")
-        task_desc = current_task.get("description", "")
-        now_text = f"## Right now\n\n{task_title}"
-        if task_desc:
-            now_text += f"\n\n{task_desc}"
+        now_text = f"## Right now\n\n{current_task.title}"
+        if current_task.description:
+            now_text += f"\n\n{current_task.description}"
         parts.append(now_text)
 
     return "\n\n".join(parts)
@@ -688,7 +695,7 @@ class Prompts:
                 render_active_context(
                     issue=issue,
                     pr=pr,
-                    tasks=task_list,
+                    tasks=[_task_snapshot_from_dict(t) for t in task_list],
                     current_task=None,
                     prior_attempts=prior_attempts or [],
                 )

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -3,6 +3,8 @@
 import json
 from typing import Any
 
+from fido.types import ActiveIssue, ActivePR, ClosedPR
+
 # ── Prompt-level tool guardrails ──────────────────────────────────────────────
 #
 # Every prompt that runs through ``session.prompt()`` must include one of the
@@ -44,6 +46,87 @@ TRIAGE_CLAUSE = (
 
 # Backward-compatible alias for call sites that predate the split.
 READ_ONLY_CLAUSE = TRIAGE_CLAUSE
+
+
+# ── Active-work context renderer ─────────────────────────────────────────────
+
+
+def render_active_context(
+    issue: ActiveIssue,
+    pr: ActivePR | None,
+    tasks: list[dict[str, Any]],
+    current_task: dict[str, Any] | None,
+    prior_attempts: list[ClosedPR],
+) -> str:
+    """Render active-work context blocks for injection into any LLM system prompt.
+
+    Produces up to five markdown sections in this order:
+
+    1. ``## Active issue``  — stable; issue number, title, and body
+    2. ``## Active PR``     — stable; PR number, title, URL, and body
+    3. ``## Prior attempts``— stable; closed PRs that referenced this issue
+    4. ``## Tasks``         — dynamic; full task list with status and type markers
+    5. ``## Right now``     — dynamic; current task title and description
+
+    Sections 1–3 form the **stable prefix**: their content is byte-identical
+    across every prompt rebuild during a session, which keeps them warm in
+    provider prompt caches.  Sections 4–5 are the **dynamic suffix** that
+    changes when tasks are added, completed, or switched.
+
+    Any section whose data is absent is omitted entirely so the output stays
+    compact and does not confuse the agent with empty headers.
+    """
+    _STATUS_MARKER = {
+        "completed": "[x]",
+        "in_progress": "[~]",
+        "pending": "[ ]",
+        "blocked": "[!]",
+    }
+    parts: list[str] = []
+
+    # ── stable prefix ────────────────────────────────────────────────────────
+
+    issue_text = f"## Active issue\n\n#{issue.number}: {issue.title}"
+    if issue.body:
+        issue_text += f"\n\n{issue.body}"
+    parts.append(issue_text)
+
+    if pr is not None:
+        pr_text = f"## Active PR\n\nPR #{pr.number}: {pr.title}\n{pr.url}"
+        if pr.body:
+            pr_text += f"\n\n{pr.body}"
+        parts.append(pr_text)
+
+    if prior_attempts:
+        attempt_blocks: list[str] = []
+        for attempt in prior_attempts:
+            entry = f"### PR #{attempt.number}: {attempt.title}"
+            if attempt.close_reason:
+                entry += f"\n\nClose reason: {attempt.close_reason}"
+            if attempt.body:
+                entry += f"\n\n{attempt.body}"
+            attempt_blocks.append(entry)
+        parts.append("## Prior attempts\n\n" + "\n\n".join(attempt_blocks))
+
+    # ── dynamic suffix ────────────────────────────────────────────────────────
+
+    if tasks:
+        task_lines = [
+            f"- {_STATUS_MARKER.get(t.get('status', 'pending'), '[ ]')} "
+            f"[{t.get('type', 'spec')}] {t.get('title', '')}"
+            for t in tasks
+        ]
+        parts.append("## Tasks\n\n" + "\n".join(task_lines))
+
+    if current_task is not None:
+        task_title = current_task.get("title", "")
+        task_desc = current_task.get("description", "")
+        now_text = f"## Right now\n\n{task_title}"
+        if task_desc:
+            now_text += f"\n\n{task_desc}"
+        parts.append(now_text)
+
+    return "\n\n".join(parts)
 
 
 # ── Triage ────────────────────────────────────────────────────────────────────

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -250,7 +250,11 @@ class Prompts:
     def __init__(self, persona: str) -> None:
         self.persona = persona
 
-    def reply_system_prompt(self) -> str:
+    def reply_system_prompt(
+        self,
+        issue: ActiveIssue | None = None,
+        pr: ActivePR | None = None,
+    ) -> str:
         """Return the system prompt for reply generation.
 
         Instils the Fido persona, strictly forbids preamble framing, and
@@ -259,9 +263,17 @@ class Prompts:
         launch Bash/Read/Edit calls to actually make the change — turning a
         ~5s reply into a multi-minute session turn that holds the lock and
         starves the worker.
+
+        When *issue* is provided, the rendered active-work context (issue, PR,
+        and tasks) is prepended so the reply model anchors on the same ground
+        truth as the task worker.
         """
+        active = ""
+        if issue is not None:
+            active = render_active_context(issue, pr, [], None, []) + "\n\n"
         return (
             f"{self.persona}\n\n"
+            f"{active}"
             "You are responding to a GitHub PR comment.  Reply composition "
             "is a TEXT-ONLY task: do NOT invoke any tools.  No Bash, no Read, "
             "no Edit, no Write, no Grep, no Glob, no Task sub-agents, no "

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -625,11 +625,19 @@ class Prompts:
         self,
         task_list: list[dict[str, Any]],
         commit_summary: str,
+        *,
+        issue: ActiveIssue | None = None,
+        pr: ActivePR | None = None,
+        prior_attempts: list[ClosedPR] | None = None,
     ) -> str:
         """Build an Opus prompt for dependency-aware task reordering.
 
         Presents the full task list and a summary of commits already made, then
         asks Opus to return a JSON array of the reordered pending tasks.
+
+        When *issue* is provided, the rendered active-context block (issue,
+        optional PR, prior attempts, task list) is prepended to the prompt so
+        Opus has full context about what is being worked on.
 
         Rules enforced in the prompt:
         - CI tasks (type "ci") must remain first.
@@ -662,8 +670,22 @@ class Prompts:
             else "(none)"
         )
 
+        active_ctx_prefix = ""
+        if issue is not None:
+            active_ctx_prefix = (
+                render_active_context(
+                    issue=issue,
+                    pr=pr,
+                    tasks=task_list,
+                    current_task=None,
+                    prior_attempts=prior_attempts or [],
+                )
+                + "\n\n"
+            )
+
         return (
             f"{TRIAGE_CLAUSE}\n\n"
+            f"{active_ctx_prefix}"
             "You are reviewing the pending work queue for a pull request in progress.\n\n"
             "Already completed tasks:\n"
             f"{completed_block}\n\n"

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -25,7 +25,7 @@ from fido.state import (
     State,
     _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
 )
-from fido.types import TaskStatus, TaskType
+from fido.types import ActiveIssue, ActivePR, ClosedPR, TaskStatus, TaskType
 
 log = logging.getLogger(__name__)
 
@@ -836,6 +836,9 @@ def reorder_tasks(
     *,
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
+    issue: ActiveIssue | None = None,
+    pr: ActivePR | None = None,
+    prior_attempts: list[ClosedPR] | None = None,
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
     _on_inprogress_affected: Callable[[str], None] | None = None,
     _on_done: Callable[[], None] | None = None,
@@ -877,7 +880,13 @@ def reorder_tasks(
         prompts = Prompts("")
 
     original_ids = frozenset(t["id"] for t in task_list)
-    prompt = prompts.rescope_prompt(task_list, commit_summary)
+    prompt = prompts.rescope_prompt(
+        task_list,
+        commit_summary,
+        issue=issue,
+        pr=pr,
+        prior_attempts=prior_attempts,
+    )
     raw = agent.run_turn(prompt, model=agent.voice_model)
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -55,6 +55,21 @@ class ClosedPR:
 
 
 @dataclass(frozen=True)
+class TaskSnapshot:
+    """Projection of a task dict for LLM context rendering.
+
+    Captures only the fields needed by :func:`~fido.prompts.render_active_context`
+    so the renderer does not depend on the full task dict shape from
+    ``tasks.json``.
+    """
+
+    title: str
+    type: str
+    status: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
 class GitIdentity:
     """GitHub-derived git commit identity.
 

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -18,6 +18,43 @@ class TaskStatus(StrEnum):
 
 
 @dataclass(frozen=True)
+class ActiveIssue:
+    """Snapshot of the GitHub issue being worked on.
+
+    Injected into the system prompt at every LLM call site so the agent
+    always has the spec in front of it, regardless of which turn it is on.
+    """
+
+    number: int
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class ActivePR:
+    """Snapshot of the pull request associated with the current work session."""
+
+    number: int
+    title: str
+    url: str
+    body: str
+
+
+@dataclass(frozen=True)
+class ClosedPR:
+    """A prior closed (not merged) PR that referenced the same issue.
+
+    Surfaced in the system prompt so the agent can learn from earlier
+    attempts and avoid repeating the same mistakes.
+    """
+
+    number: int
+    title: str
+    body: str
+    close_reason: str
+
+
+@dataclass(frozen=True)
 class GitIdentity:
     """GitHub-derived git commit identity.
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -49,6 +49,7 @@ from fido.types import (
     ActivePR,
     ClosedPR,
     GitIdentity,
+    TaskSnapshot,
     TaskStatus,
     TaskType,
 )
@@ -3046,8 +3047,21 @@ class Worker:
                 url=pr_url,
                 body=pr_body,
             ),
-            tasks=task_list,
-            current_task=task,
+            tasks=[
+                TaskSnapshot(
+                    title=t.get("title", ""),
+                    type=t.get("type", "spec"),
+                    status=t.get("status", "pending"),
+                    description=t.get("description", ""),
+                )
+                for t in task_list
+            ],
+            current_task=TaskSnapshot(
+                title=task.get("title", ""),
+                type=task.get("type", "spec"),
+                status=task.get("status", "pending"),
+                description=task.get("description", ""),
+            ),
             prior_attempts=prior_attempts,
         )
         context = f"{active_ctx}\n\n" + "\n".join(context_parts)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -22,7 +22,7 @@ from fido.claude import ClaudeCode
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.issue_cache import IssueNode, IssueTreeCache
-from fido.prompts import Prompts
+from fido.prompts import Prompts, render_active_context
 from fido.provider import (
     PromptSession,
     Provider,
@@ -44,7 +44,7 @@ from fido.state import (
 )
 from fido.store import FidoStore, PRCommentQueueRecord, ReplyPromiseRecord
 from fido.tasks import Tasks
-from fido.types import GitIdentity, TaskStatus, TaskType
+from fido.types import ActiveIssue, ActivePR, GitIdentity, TaskStatus, TaskType
 
 
 class GitIdentityError(Exception):
@@ -1821,7 +1821,22 @@ class Worker:
                 task_list = self._tasks.list()
             if not task_list:
                 log.info("PR #%s has no tasks — running setup", pr_number)
+                pr_body = self.gh.get_pr_body(repo_ctx.repo, pr_number)
+                pr_url = f"https://github.com/{repo_ctx.repo}/pull/{pr_number}"
+                active_ctx = render_active_context(
+                    issue=ActiveIssue(number=issue, title=issue_title, body=issue_body),
+                    pr=ActivePR(
+                        number=pr_number,
+                        title=pr_title,
+                        url=pr_url,
+                        body=pr_body,
+                    ),
+                    tasks=[],
+                    current_task=None,
+                    prior_attempts=[],
+                )
                 context = (
+                    f"{active_ctx}\n\n"
                     f"Request: {request}\n"
                     f"Repo: {repo_ctx.repo}\n"
                     f"Branch: {slug}\n"
@@ -1890,7 +1905,15 @@ class Worker:
 
         # Run setup sub-agent (plans tasks before PR is created)
         log.info("running setup (pre-PR)")
+        active_ctx = render_active_context(
+            issue=ActiveIssue(number=issue, title=issue_title, body=issue_body),
+            pr=None,
+            tasks=[],
+            current_task=None,
+            prior_attempts=[],
+        )
         context = (
+            f"{active_ctx}\n\n"
             f"Request: {request}\n"
             f"Repo: {repo_ctx.repo}\n"
             f"Branch: {slug}\n"

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -44,7 +44,14 @@ from fido.state import (
 )
 from fido.store import FidoStore, PRCommentQueueRecord, ReplyPromiseRecord
 from fido.tasks import Tasks
-from fido.types import ActiveIssue, ActivePR, GitIdentity, TaskStatus, TaskType
+from fido.types import (
+    ActiveIssue,
+    ActivePR,
+    ClosedPR,
+    GitIdentity,
+    TaskStatus,
+    TaskType,
+)
 
 
 class GitIdentityError(Exception):
@@ -1823,6 +1830,9 @@ class Worker:
                 log.info("PR #%s has no tasks — running setup", pr_number)
                 pr_body = self.gh.get_pr_body(repo_ctx.repo, pr_number)
                 pr_url = f"https://github.com/{repo_ctx.repo}/pull/{pr_number}"
+                prior_attempts = self.gh.find_closed_prs_as_context(
+                    repo_ctx.repo, issue, repo_ctx.gh_user
+                )
                 active_ctx = render_active_context(
                     issue=ActiveIssue(number=issue, title=issue_title, body=issue_body),
                     pr=ActivePR(
@@ -1833,7 +1843,7 @@ class Worker:
                     ),
                     tasks=[],
                     current_task=None,
-                    prior_attempts=[],
+                    prior_attempts=prior_attempts,
                 )
                 context = (
                     f"{active_ctx}\n\n"
@@ -1874,12 +1884,16 @@ class Worker:
         # closed-not-merged PRs exist, post a Fido-voiced retry-ack
         # comment naming them — idempotent on a marker.
         self._reset_local_workspace(fido_dir, repo_ctx, remote)
-        closed_prs = self.gh.find_closed_unmerged_prs_for_issue(
+        prior_attempts = self.gh.find_closed_prs_as_context(
             repo_ctx.repo, issue, repo_ctx.gh_user
         )
-        if closed_prs:
+        if prior_attempts:
             self._post_retry_acknowledgement(
-                repo_ctx.repo, issue, issue_title, repo_ctx.gh_user, closed_prs
+                repo_ctx.repo,
+                issue,
+                issue_title,
+                repo_ctx.gh_user,
+                [pr.number for pr in prior_attempts],
             )
 
         # Generate branch slug via the provider brief model
@@ -1910,7 +1924,7 @@ class Worker:
             pr=None,
             tasks=[],
             current_task=None,
-            prior_attempts=[],
+            prior_attempts=prior_attempts,
         )
         context = (
             f"{active_ctx}\n\n"
@@ -3006,10 +3020,14 @@ class Worker:
         issue_number = state_data.get("issue")
         issue_title = ""
         issue_body = ""
+        prior_attempts: list[ClosedPR] = []
         if isinstance(issue_number, int):
             issue_data = self.gh.view_issue(repo_ctx.repo, issue_number)
             issue_title = issue_data.get("title", "")
             issue_body = issue_data.get("body", "")
+            prior_attempts = self.gh.find_closed_prs_as_context(
+                repo_ctx.repo, issue_number, repo_ctx.gh_user
+            )
         else:
             issue_number = None
         pr_data = self.gh.get_pr(repo_ctx.repo, pr_number)
@@ -3030,7 +3048,7 @@ class Worker:
             ),
             tasks=task_list,
             current_task=task,
-            prior_attempts=[],
+            prior_attempts=prior_attempts,
         )
         context = f"{active_ctx}\n\n" + "\n".join(context_parts)
         build_prompt(fido_dir, "task", context, labels=issue_labels)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3001,9 +3001,6 @@ class Worker:
                     "Related thread comment_ids: "
                     + ", ".join(str(comment_id) for comment_id in lineage_ids)
                 )
-        context = "\n".join(context_parts)
-        build_prompt(fido_dir, "task", context, labels=issue_labels)
-        prompts = self._get_prompts()
         state_path = fido_dir / "state.json"
         state_data = State(fido_dir).load() if state_path.exists() else {}
         issue_number = state_data.get("issue")
@@ -3018,6 +3015,26 @@ class Worker:
         pr_data = self.gh.get_pr(repo_ctx.repo, pr_number)
         pr_title = pr_data.get("title", "") or ""
         pr_body = pr_data.get("body", "") or ""
+        pr_url = f"https://github.com/{repo_ctx.repo}/pull/{pr_number}"
+        active_ctx = render_active_context(
+            issue=ActiveIssue(
+                number=issue_number if isinstance(issue_number, int) else 0,
+                title=issue_title,
+                body=issue_body,
+            ),
+            pr=ActivePR(
+                number=pr_number,
+                title=pr_title,
+                url=pr_url,
+                body=pr_body,
+            ),
+            tasks=task_list,
+            current_task=task,
+            prior_attempts=[],
+        )
+        context = f"{active_ctx}\n\n" + "\n".join(context_parts)
+        build_prompt(fido_dir, "task", context, labels=issue_labels)
+        prompts = self._get_prompts()
         head_before = self._git(["rev-parse", "HEAD"]).stdout.strip()
         # Snapshot fido-authored PR comments so we can detect and delete any
         # improvised top-level BLOCKED/leak comments this task turn posts

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3059,6 +3059,80 @@ class TestReplyToComment:
         # the reply generation call, which must survive session preemption.
         assert any(kw.get("retry_on_preempt") is True for kw in all_run_turn_kwargs)
 
+    def test_active_context_injected_into_system_prompt(self, tmp_path: Path) -> None:
+        """reply_to_comment should inject active-issue context into reply_system_prompt."""
+        cfg = self._cfg(tmp_path)
+        # Set up state.json so _load_active_context_for_rescope finds active issue.
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        State(fido_dir).save({"issue": 7})
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 10},
+            comment_body="please add logging",
+            is_bot=False,
+        )
+        captured_system_prompts: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            if sp := kwargs.get("system_prompt"):
+                captured_system_prompts.append(sp)
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add logging"
+            if "Convert this PR review comment" in prompt:
+                return "Add logging"
+            return "I will add logging."
+
+        mock_gh = MagicMock()
+        mock_gh.view_issue.return_value = {"title": "Fix crash", "body": "It crashes."}
+        mock_gh.fetch_comment_thread.return_value = []
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+        assert any("## Active issue" in sp for sp in captured_system_prompts)
+        assert any("Fix crash" in sp for sp in captured_system_prompts)
+
+    def test_no_active_context_when_no_state(self, tmp_path: Path) -> None:
+        """reply_to_comment should not include active-issue header when no state.json."""
+        cfg = self._cfg(tmp_path)
+        action = Action(
+            prompt="comment",
+            reply_to={"repo": "owner/repo", "pr": 1, "comment_id": 10},
+            comment_body="please add logging",
+            is_bot=False,
+        )
+        captured_system_prompts: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            if sp := kwargs.get("system_prompt"):
+                captured_system_prompts.append(sp)
+            if model == "claude-haiku-4-5":
+                return "NO"
+            if "Triage" in prompt:
+                return "ACT: add logging"
+            if "Convert this PR review comment" in prompt:
+                return "Add logging"
+            return "I will add logging."
+
+        mock_gh = MagicMock()
+        mock_gh.fetch_comment_thread.return_value = []
+
+        reply_to_comment(
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+        assert all("## Active issue" not in sp for sp in captured_system_prompts)
+
 
 class TestReplyToReview:
     def _cfg(self, tmp_path: Path) -> Config:
@@ -3629,6 +3703,60 @@ class TestReplyToIssueComment:
         assert not claim_dir.exists() or not list(claim_dir.iterdir()), (
             "no claim files should be written when comment_id is absent"
         )
+
+    def test_active_context_injected_into_system_prompt(self, tmp_path: Path) -> None:
+        """reply_to_issue_comment should inject active-issue context into reply_system_prompt."""
+        cfg = self._cfg(tmp_path)
+        # Set up state.json so _load_active_context_for_rescope finds active issue.
+        fido_dir = tmp_path / ".git" / "fido"
+        fido_dir.mkdir(parents=True)
+        State(fido_dir).save({"issue": 7})
+        captured_system_prompts: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            if sp := kwargs.get("system_prompt"):
+                captured_system_prompts.append(sp)
+            if "Triage" in prompt:
+                return "ACT: fix the bug"
+            return "I'll fix that."
+
+        mock_gh = MagicMock()
+        mock_gh.view_issue.return_value = {"title": "Fix crash", "body": "It crashes."}
+        mock_gh.get_repo_info.return_value = "owner/repo"
+
+        reply_to_issue_comment(
+            self._action(),
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+        assert any("## Active issue" in sp for sp in captured_system_prompts)
+        assert any("Fix crash" in sp for sp in captured_system_prompts)
+
+    def test_no_active_context_when_no_state(self, tmp_path: Path) -> None:
+        """reply_to_issue_comment should not include active-issue header when no state.json."""
+        cfg = self._cfg(tmp_path)
+        captured_system_prompts: list[str] = []
+
+        def fake_pp(prompt, model, **kwargs):
+            if sp := kwargs.get("system_prompt"):
+                captured_system_prompts.append(sp)
+            if "Triage" in prompt:
+                return "ACT: fix the bug"
+            return "I'll fix that."
+
+        mock_gh = MagicMock()
+        mock_gh.get_repo_info.return_value = "owner/repo"
+
+        reply_to_issue_comment(
+            self._action(),
+            cfg,
+            self._repo_cfg(tmp_path),
+            mock_gh,
+            agent=_client(side_effect=fake_pp),
+        )
+        assert all("## Active issue" not in sp for sp in captured_system_prompts)
 
 
 class TestCreateTask:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -16,6 +16,8 @@ from fido.events import (
     _existing_reply_artifact,
     _get_commit_summary,
     _is_allowed,
+    _load_active_context_for_rescope,
+    _make_reorder_kwargs,
     _notify_thread_change,
     _open_defer_issue_idempotent,
     _posted_comment_id,
@@ -47,7 +49,9 @@ from fido.events import (
 )
 from fido.provider import ProviderID
 from fido.rocq import replied_comment_claims as oracle
+from fido.state import State
 from fido.store import FidoStore, ReplyPromiseRecord
+from fido.types import ActiveIssue, ActivePR
 
 
 class RepoConfig(_RepoConfig):
@@ -6992,3 +6996,168 @@ class TestTaskSnapshot:
         result = _task_snapshot(tasks)
         assert result[0][0] == "z"
         assert result[1][0] == "a"
+
+
+# ── _load_active_context_for_rescope ─────────────────────────────────────────
+
+
+class TestLoadActiveContextForRescope:
+    def _fido_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".git" / "fido"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_returns_none_none_when_no_state_file(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        issue, pr = _load_active_context_for_rescope(tmp_path, "owner/repo", gh)
+        assert issue is None
+        assert pr is None
+        gh.view_issue.assert_not_called()
+
+    def test_returns_none_none_when_no_issue_in_state(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"pr_number": 5})
+        gh = MagicMock()
+        issue, pr = _load_active_context_for_rescope(tmp_path, "owner/repo", gh)
+        assert issue is None
+        assert pr is None
+        gh.view_issue.assert_not_called()
+
+    def test_returns_active_issue_when_issue_in_state(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 7})
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "Fix crash", "body": "It crashes."}
+        issue, _ = _load_active_context_for_rescope(tmp_path, "owner/repo", gh)
+        assert isinstance(issue, ActiveIssue)
+        assert issue.number == 7
+        assert issue.title == "Fix crash"
+        assert issue.body == "It crashes."
+        gh.view_issue.assert_called_once_with("owner/repo", 7)
+
+    def test_returns_none_pr_when_no_pr_in_state(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 7})
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "Fix crash", "body": ""}
+        _, pr = _load_active_context_for_rescope(tmp_path, "owner/repo", gh)
+        assert pr is None
+        gh.get_pr.assert_not_called()
+
+    def test_returns_active_pr_when_pr_in_state(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 7, "pr_number": 42})
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "Fix crash", "body": ""}
+        gh.get_pr.return_value = {"title": "Fix crash (closes #7)", "body": "PR body."}
+        _, pr = _load_active_context_for_rescope(tmp_path, "owner/repo", gh)
+        assert isinstance(pr, ActivePR)
+        assert pr.number == 42
+        assert pr.title == "Fix crash (closes #7)"
+        assert pr.body == "PR body."
+        assert pr.url == "https://github.com/owner/repo/pull/42"
+        gh.get_pr.assert_called_once_with("owner/repo", 42)
+
+
+# ── _make_reorder_kwargs active-context injection ────────────────────────────
+
+
+class TestMakeReorderKwargsActiveContext:
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _repo_cfg(self, tmp_path: Path, name: str = "owner/repo") -> _RepoConfig:
+        return _RepoConfig(
+            name=name,
+            work_dir=tmp_path,
+            provider=ProviderID.CLAUDE_CODE,
+        )
+
+    def _fido_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / ".git" / "fido"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_no_issue_key_omitted_when_no_state(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        kwargs = _make_reorder_kwargs(
+            tmp_path,
+            self._cfg(tmp_path),
+            self._repo_cfg(tmp_path),
+            None,
+            gh,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert "issue" not in kwargs
+        assert "pr" not in kwargs
+
+    def test_issue_included_when_state_has_issue(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 5})
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "Do the thing", "body": "Details."}
+        kwargs = _make_reorder_kwargs(
+            tmp_path,
+            self._cfg(tmp_path),
+            self._repo_cfg(tmp_path),
+            None,
+            gh,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert "issue" in kwargs
+        issue = kwargs["issue"]
+        assert isinstance(issue, ActiveIssue)
+        assert issue.number == 5
+        assert issue.title == "Do the thing"
+        assert issue.body == "Details."
+
+    def test_pr_included_when_state_has_pr_number(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 5, "pr_number": 99})
+        gh = MagicMock()
+        gh.view_issue.return_value = {"title": "t", "body": ""}
+        gh.get_pr.return_value = {"title": "Fix it (closes #5)", "body": ""}
+        kwargs = _make_reorder_kwargs(
+            tmp_path,
+            self._cfg(tmp_path),
+            self._repo_cfg(tmp_path),
+            None,
+            gh,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert "pr" in kwargs
+        pr = kwargs["pr"]
+        assert isinstance(pr, ActivePR)
+        assert pr.number == 99
+        assert pr.url == "https://github.com/owner/repo/pull/99"
+
+    def test_no_issue_or_pr_when_repo_cfg_is_none(self, tmp_path: Path) -> None:
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 5, "pr_number": 10})
+        gh = MagicMock()
+        kwargs = _make_reorder_kwargs(
+            tmp_path,
+            self._cfg(tmp_path),
+            None,  # no repo_cfg
+            None,
+            gh,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert "issue" not in kwargs
+        assert "pr" not in kwargs
+        gh.view_issue.assert_not_called()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1065,6 +1065,70 @@ class TestGitHubClass:
         }
         assert gh.find_closed_unmerged_prs_for_issue("o/r", 206, "fido") == []
 
+    # --- find_closed_prs_as_context ---
+
+    def test_find_closed_prs_as_context_returns_empty_when_no_closed_prs(self) -> None:
+        gh, mock_s = self._gh()
+        mock_s.post.return_value.json.return_value = self._gql_timeline([])
+        result = gh.find_closed_prs_as_context("o/r", 206, "fido")
+        assert result == []
+        mock_s.get.assert_not_called()
+
+    def test_find_closed_prs_as_context_returns_closed_pr_with_title_and_body(
+        self,
+    ) -> None:
+        from fido.types import ClosedPR
+
+        gh, mock_s = self._gh()
+        pr = self._gql_pr_full(215, "CLOSED", "fido", "closes #206", merged=False)
+        pr["title"] = "Fix the crash"
+        mock_s.post.return_value.json.return_value = self._gql_timeline(
+            [self._cross_ref_node(pr)]
+        )
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"title": "Fix the crash", "body": "PR body text."}
+        mock_s.get.return_value = pr_resp
+        result = gh.find_closed_prs_as_context("o/r", 206, "fido")
+        assert len(result) == 1
+        assert result[0] == ClosedPR(
+            number=215,
+            title="Fix the crash",
+            body="PR body text.",
+            close_reason="",
+        )
+
+    def test_find_closed_prs_as_context_fetches_rest_pr_for_each_number(self) -> None:
+        gh, mock_s = self._gh()
+        pr1 = self._gql_pr_full(210, "CLOSED", "fido", "closes #206")
+        pr2 = self._gql_pr_full(215, "CLOSED", "fido", "closes #206")
+        mock_s.post.return_value.json.return_value = self._gql_timeline(
+            [self._cross_ref_node(pr1), self._cross_ref_node(pr2)]
+        )
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"title": "t", "body": ""}
+        mock_s.get.return_value = pr_resp
+        result = gh.find_closed_prs_as_context("o/r", 206, "fido")
+        assert len(result) == 2
+        assert result[0].number == 210
+        assert result[1].number == 215
+        assert mock_s.get.call_count == 2
+
+    def test_find_closed_prs_as_context_handles_none_body(self) -> None:
+        from fido.types import ClosedPR
+
+        gh, mock_s = self._gh()
+        pr = self._gql_pr_full(215, "CLOSED", "fido", "closes #206")
+        mock_s.post.return_value.json.return_value = self._gql_timeline(
+            [self._cross_ref_node(pr)]
+        )
+        pr_resp = MagicMock()
+        pr_resp.json.return_value = {"title": "Old attempt", "body": None}
+        mock_s.get.return_value = pr_resp
+        result = gh.find_closed_prs_as_context("o/r", 206, "fido")
+        assert result == [
+            ClosedPR(number=215, title="Old attempt", body="", close_reason="")
+        ]
+
     def test_get_user(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -11,7 +11,7 @@ from fido.prompts import (
     triage_categories,
     triage_context_block,
 )
-from fido.types import ActiveIssue, ActivePR, ClosedPR
+from fido.types import ActiveIssue, ActivePR, ClosedPR, TaskSnapshot
 
 # ── triage_categories ─────────────────────────────────────────────────────────
 
@@ -1029,13 +1029,13 @@ class TestRenderActiveContext:
         status: str = "pending",
         task_type: str = "spec",
         description: str = "",
-    ) -> dict:
-        return {
-            "title": title,
-            "status": status,
-            "type": task_type,
-            "description": description,
-        }
+    ) -> TaskSnapshot:
+        return TaskSnapshot(
+            title=title,
+            status=status,
+            type=task_type,
+            description=description,
+        )
 
     def _closed_pr(
         self,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -493,6 +493,34 @@ class TestPromptsReplySystemPrompt:
         result = Prompts("persona").reply_system_prompt()
         assert "meta-commentary" in result or "Here's the reply" in result
 
+    def test_active_context_included_when_issue_provided(self) -> None:
+        issue = ActiveIssue(number=7, title="Fix crash", body="It crashes.")
+        result = Prompts("persona").reply_system_prompt(issue=issue)
+        assert "## Active issue" in result
+        assert "Fix crash" in result
+        assert "It crashes." in result
+
+    def test_no_active_context_when_issue_is_none(self) -> None:
+        result = Prompts("persona").reply_system_prompt()
+        assert "## Active issue" not in result
+
+    def test_active_context_includes_pr_when_provided(self) -> None:
+        issue = ActiveIssue(number=7, title="Fix crash", body="")
+        pr = ActivePR(
+            number=42,
+            title="Fix crash PR",
+            url="https://github.com/a/b/pull/42",
+            body="",
+        )
+        result = Prompts("persona").reply_system_prompt(issue=issue, pr=pr)
+        assert "## Active PR" in result
+        assert "Fix crash PR" in result
+
+    def test_active_context_no_pr_section_when_pr_is_none(self) -> None:
+        issue = ActiveIssue(number=7, title="Fix crash", body="")
+        result = Prompts("persona").reply_system_prompt(issue=issue, pr=None)
+        assert "## Active PR" not in result
+
 
 class TestPromptsPersonaWrap:
     def test_includes_persona(self) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,10 +6,12 @@ from fido.prompts import (
     NO_TOOLS_CLAUSE,
     TRIAGE_CLAUSE,
     Prompts,
+    render_active_context,
     reply_context_block,
     triage_categories,
     triage_context_block,
 )
+from fido.types import ActiveIssue, ActivePR, ClosedPR
 
 # ── triage_categories ─────────────────────────────────────────────────────────
 
@@ -185,7 +187,7 @@ class TestTriagePrompt:
     def test_includes_bot_categories(self) -> None:
         result = Prompts("").triage_prompt("suggestion", is_bot=True)
         assert "DO" in result
-        assert "DEFER" in result
+        assert "DUMP" in result
 
     def test_includes_context(self) -> None:
         result = Prompts("").triage_prompt(
@@ -935,3 +937,348 @@ class TestRewriteDescriptionPrompt:
         result = Prompts("").rewrite_description_prompt(self._body(), [])
         assert isinstance(result, str)
         assert "(none)" in result
+
+
+# ── render_active_context ─────────────────────────────────────────────────────
+
+
+class TestRenderActiveContext:
+    """Tests for the render_active_context() module-level renderer."""
+
+    def _issue(
+        self,
+        number: int = 42,
+        title: str = "Fix the parser",
+        body: str = "It crashes on empty input.",
+    ) -> ActiveIssue:
+        return ActiveIssue(number=number, title=title, body=body)
+
+    def _pr(
+        self,
+        number: int = 10,
+        title: str = "Fix parser crash",
+        url: str = "https://github.com/owner/repo/pull/10",
+        body: str = "Implements the fix.",
+    ) -> ActivePR:
+        return ActivePR(number=number, title=title, url=url, body=body)
+
+    def _task(
+        self,
+        title: str = "Add tests",
+        status: str = "pending",
+        task_type: str = "spec",
+        description: str = "",
+    ) -> dict:
+        return {
+            "title": title,
+            "status": status,
+            "type": task_type,
+            "description": description,
+        }
+
+    def _closed_pr(
+        self,
+        number: int = 5,
+        title: str = "Prior attempt",
+        body: str = "Old description.",
+        close_reason: str = "scope creep",
+    ) -> ClosedPR:
+        return ClosedPR(
+            number=number, title=title, body=body, close_reason=close_reason
+        )
+
+    # ── Active issue block ────────────────────────────────────────────────────
+
+    def test_active_issue_number_and_title(self) -> None:
+        result = render_active_context(self._issue(42, "Fix crash"), None, [], None, [])
+        assert "## Active issue" in result
+        assert "#42: Fix crash" in result
+
+    def test_active_issue_body_included(self) -> None:
+        result = render_active_context(
+            self._issue(body="It panics on nil."), None, [], None, []
+        )
+        assert "It panics on nil." in result
+
+    def test_active_issue_empty_body_omitted(self) -> None:
+        result = render_active_context(
+            ActiveIssue(number=1, title="T", body=""), None, [], None, []
+        )
+        # Header still present, but no blank-line separator before missing body
+        assert "## Active issue" in result
+        lines = result.split("\n")
+        assert not any(
+            line.strip() == "" and i > 0 and lines[i - 1] == ""
+            for i, line in enumerate(lines)
+            if i > 0
+        )
+
+    # ── Active PR block ───────────────────────────────────────────────────────
+
+    def test_active_pr_number_and_title(self) -> None:
+        result = render_active_context(
+            self._issue(), self._pr(10, "Fix crash"), [], None, []
+        )
+        assert "## Active PR" in result
+        assert "PR #10: Fix crash" in result
+
+    def test_active_pr_url_included(self) -> None:
+        result = render_active_context(
+            self._issue(),
+            self._pr(url="https://github.com/x/y/pull/10"),
+            [],
+            None,
+            [],
+        )
+        assert "https://github.com/x/y/pull/10" in result
+
+    def test_active_pr_body_included(self) -> None:
+        result = render_active_context(
+            self._issue(), self._pr(body="Adds the cache layer."), [], None, []
+        )
+        assert "Adds the cache layer." in result
+
+    def test_active_pr_empty_body_omitted(self) -> None:
+        pr = ActivePR(number=1, title="T", url="https://example.com", body="")
+        result = render_active_context(self._issue(), pr, [], None, [])
+        # URL still there; no spurious blank body
+        assert "https://example.com" in result
+
+    def test_active_pr_absent_when_none(self) -> None:
+        result = render_active_context(self._issue(), None, [], None, [])
+        assert "## Active PR" not in result
+
+    # ── Prior attempts block ──────────────────────────────────────────────────
+
+    def test_prior_attempts_header_present(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [], None, [self._closed_pr()]
+        )
+        assert "## Prior attempts" in result
+
+    def test_prior_attempt_number_and_title(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [], None, [self._closed_pr(5, "Old attempt")]
+        )
+        assert "### PR #5: Old attempt" in result
+
+    def test_prior_attempt_close_reason(self) -> None:
+        result = render_active_context(
+            self._issue(),
+            None,
+            [],
+            None,
+            [self._closed_pr(close_reason="out of scope")],
+        )
+        assert "Close reason: out of scope" in result
+
+    def test_prior_attempt_body_included(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [], None, [self._closed_pr(body="Had a bug.")]
+        )
+        assert "Had a bug." in result
+
+    def test_prior_attempts_absent_when_empty(self) -> None:
+        result = render_active_context(self._issue(), None, [], None, [])
+        assert "## Prior attempts" not in result
+
+    def test_multiple_prior_attempts(self) -> None:
+        attempts = [
+            self._closed_pr(1, "First try"),
+            self._closed_pr(2, "Second try"),
+        ]
+        result = render_active_context(self._issue(), None, [], None, attempts)
+        assert "### PR #1: First try" in result
+        assert "### PR #2: Second try" in result
+
+    def test_prior_attempt_empty_close_reason_omitted(self) -> None:
+        pr = ClosedPR(number=3, title="Old", body="body", close_reason="")
+        result = render_active_context(self._issue(), None, [], None, [pr])
+        assert "Close reason:" not in result
+
+    # ── Tasks block ───────────────────────────────────────────────────────────
+
+    def test_tasks_header_present(self) -> None:
+        result = render_active_context(self._issue(), None, [self._task()], None, [])
+        assert "## Tasks" in result
+
+    def test_task_title_included(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task("Add caching")], None, []
+        )
+        assert "Add caching" in result
+
+    def test_pending_task_marker(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task(status="pending")], None, []
+        )
+        assert "[ ]" in result
+
+    def test_completed_task_marker(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task(status="completed")], None, []
+        )
+        assert "[x]" in result
+
+    def test_in_progress_task_marker(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task(status="in_progress")], None, []
+        )
+        assert "[~]" in result
+
+    def test_blocked_task_marker(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task(status="blocked")], None, []
+        )
+        assert "[!]" in result
+
+    def test_task_type_included(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [self._task(task_type="ci")], None, []
+        )
+        assert "[ci]" in result
+
+    def test_tasks_absent_when_empty(self) -> None:
+        result = render_active_context(self._issue(), None, [], None, [])
+        assert "## Tasks" not in result
+
+    def test_multiple_tasks_all_present(self) -> None:
+        tasks = [
+            self._task("Add tests", status="completed", task_type="spec"),
+            self._task("Fix lint", status="in_progress", task_type="ci"),
+            self._task("Update docs", status="pending", task_type="spec"),
+        ]
+        result = render_active_context(self._issue(), None, tasks, None, [])
+        assert "Add tests" in result
+        assert "Fix lint" in result
+        assert "Update docs" in result
+
+    # ── Right now block ───────────────────────────────────────────────────────
+
+    def test_right_now_header_present(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [], self._task("Write the test"), []
+        )
+        assert "## Right now" in result
+
+    def test_right_now_title_included(self) -> None:
+        result = render_active_context(
+            self._issue(), None, [], self._task("Write the test"), []
+        )
+        assert "Write the test" in result
+
+    def test_right_now_description_included(self) -> None:
+        task = self._task(description="Use pytest fixtures.")
+        result = render_active_context(self._issue(), None, [], task, [])
+        assert "Use pytest fixtures." in result
+
+    def test_right_now_empty_description_omitted(self) -> None:
+        task = self._task(description="")
+        result = render_active_context(self._issue(), None, [], task, [])
+        assert "## Right now" in result
+        # No trailing blank after header when no description
+        after_header = result.split("## Right now")[1]
+        assert after_header.strip() != ""
+
+    def test_right_now_absent_when_none(self) -> None:
+        result = render_active_context(self._issue(), None, [], None, [])
+        assert "## Right now" not in result
+
+    # ── Cache-stability: stable prefix is byte-identical across task changes ──
+
+    def test_stable_prefix_unchanged_after_task_add(self) -> None:
+        """Active issue + PR + prior attempts must be byte-identical before/after
+        a task is added to the list — so the provider's prompt cache stays warm."""
+        issue = self._issue()
+        pr = self._pr()
+        attempts = [self._closed_pr()]
+        current = self._task("Do something")
+
+        before = render_active_context(
+            issue, pr, [self._task("Task A")], current, attempts
+        )
+        after = render_active_context(
+            issue,
+            pr,
+            [self._task("Task A"), self._task("Task B")],
+            current,
+            attempts,
+        )
+
+        # Extract the stable prefix (everything before ## Tasks)
+        assert before.split("## Tasks")[0] == after.split("## Tasks")[0]
+
+    def test_stable_prefix_unchanged_after_task_complete(self) -> None:
+        issue = self._issue()
+        pr = self._pr()
+        attempts = [self._closed_pr()]
+        current = self._task("Remaining")
+
+        before = render_active_context(
+            issue,
+            pr,
+            [self._task("Done", status="pending"), self._task("Remaining")],
+            current,
+            attempts,
+        )
+        after = render_active_context(
+            issue,
+            pr,
+            [self._task("Done", status="completed"), self._task("Remaining")],
+            current,
+            attempts,
+        )
+
+        assert before.split("## Tasks")[0] == after.split("## Tasks")[0]
+
+    def test_tasks_section_changes_after_task_complete(self) -> None:
+        issue = self._issue()
+        before = render_active_context(
+            issue, None, [self._task("A", status="pending")], None, []
+        )
+        after = render_active_context(
+            issue, None, [self._task("A", status="completed")], None, []
+        )
+        assert "[ ]" in before
+        assert "[x]" in after
+
+    def test_right_now_changes_after_task_switch(self) -> None:
+        issue = self._issue()
+        before = render_active_context(issue, None, [], self._task("Old task"), [])
+        after = render_active_context(issue, None, [], self._task("New task"), [])
+        assert "Old task" in before
+        assert "New task" in after
+        assert "Old task" not in after
+
+    # ── Section order ─────────────────────────────────────────────────────────
+
+    def test_section_order_stable_prefix_before_dynamic(self) -> None:
+        """Stable prefix (issue, PR, attempts) must appear before Tasks / Right now."""
+        result = render_active_context(
+            self._issue(),
+            self._pr(),
+            [self._task()],
+            self._task("current"),
+            [self._closed_pr()],
+        )
+        issue_pos = result.index("## Active issue")
+        pr_pos = result.index("## Active PR")
+        attempts_pos = result.index("## Prior attempts")
+        tasks_pos = result.index("## Tasks")
+        now_pos = result.index("## Right now")
+
+        assert issue_pos < pr_pos < attempts_pos < tasks_pos < now_pos
+
+    # ── Returns a string ──────────────────────────────────────────────────────
+
+    def test_returns_string(self) -> None:
+        result = render_active_context(self._issue(), None, [], None, [])
+        assert isinstance(result, str)
+
+    def test_minimal_call_issue_only(self) -> None:
+        """Minimal valid call: only the required issue argument is meaningful."""
+        result = render_active_context(
+            ActiveIssue(number=1, title="T", body=""), None, [], None, []
+        )
+        assert "## Active issue" in result
+        assert "#1: T" in result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -772,6 +772,39 @@ class TestRescopePrompt:
         assert isinstance(result, str)
         assert "(none)" in result  # both completed and commit summary
 
+    def test_active_context_prefix_included_when_issue_provided(self) -> None:
+        tasks = [self._task("Do thing", task_id="1")]
+        issue = ActiveIssue(number=42, title="Fix crash", body="It crashes on startup.")
+        result = Prompts("").rescope_prompt(tasks, "", issue=issue)
+        assert "## Active issue" in result
+        assert "#42: Fix crash" in result
+        assert "It crashes on startup." in result
+
+    def test_no_active_context_prefix_when_issue_is_none(self) -> None:
+        tasks = [self._task("Do thing", task_id="1")]
+        result = Prompts("").rescope_prompt(tasks, "", issue=None)
+        assert "## Active issue" not in result
+
+    def test_active_context_includes_pr_when_provided(self) -> None:
+        tasks = [self._task("Do thing", task_id="1")]
+        issue = ActiveIssue(number=1, title="T", body="")
+        pr = ActivePR(
+            number=7,
+            title="Fix T (closes #1)",
+            url="https://github.com/o/r/pull/7",
+            body="",
+        )
+        result = Prompts("").rescope_prompt(tasks, "", issue=issue, pr=pr)
+        assert "## Active PR" in result
+        assert "PR #7" in result
+
+    def test_active_context_no_pr_section_when_pr_is_none(self) -> None:
+        tasks = [self._task("Do thing", task_id="1")]
+        issue = ActiveIssue(number=1, title="T", body="")
+        result = Prompts("").rescope_prompt(tasks, "", issue=issue, pr=None)
+        assert "## Active issue" in result
+        assert "## Active PR" not in result
+
 
 # ── Prompts.rescope_duplicate_nudge ──────────────────────────────────────────
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10438,6 +10438,87 @@ class TestExecuteTask:
 
         gh.resolve_thread.assert_called_once_with("thread-node-xyz")
 
+    def test_execute_task_context_includes_issue_body(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 7})
+        gh.view_issue.return_value = {
+            "title": "Fix the bug",
+            "body": "Repro steps here.",
+            "state": "OPEN",
+        }
+        gh.get_pr.return_value = {"title": "Fix the bug (closes #7)", "body": ""}
+        task = self._pending_task("Write a test")
+        mock_build = MagicMock()
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+        _, _, context = mock_build.call_args.args
+        assert "Repro steps here." in context
+        assert "#7: Fix the bug" in context
+
+    def test_execute_task_context_includes_pr_info(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        gh.get_pr.return_value = {
+            "title": "My PR title",
+            "body": "PR description text",
+        }
+        task = self._pending_task("Write a test")
+        mock_build = MagicMock()
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 42, "branch")
+        _, _, context = mock_build.call_args.args
+        assert "PR #42" in context
+        assert "https://github.com/owner/repo/pull/42" in context
+        assert "PR description text" in context
+
+    def test_execute_task_context_includes_current_task(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        gh.get_pr.return_value = {"title": "", "body": ""}
+        task = {
+            "id": "t1",
+            "title": "Implement the feature",
+            "status": "pending",
+            "type": "spec",
+            "description": "Details about the feature.",
+        }
+        mock_build = MagicMock()
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+        _, _, context = mock_build.call_args.args
+        assert "Implement the feature" in context
+        assert "Details about the feature." in context
+
 
 class TestYieldForUntriaged:
     """Tests for Worker._yield_for_untriaged and its two call sites in

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5043,6 +5043,94 @@ class TestFindOrCreatePr:
             "owner/proj", 206, "Migrate", "fido-bot", [215]
         )
 
+    def test_open_pr_setup_context_includes_issue_body(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_pr_body.return_value = ""
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="sess"),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(
+                fido_dir,
+                self._make_repo_ctx(),
+                5,
+                "Do the thing",
+                issue_body="Important requirement here.",
+            )
+        _, _, context = mock_build.call_args.args
+        assert "Important requirement here." in context
+        assert "#5: Do the thing" in context
+
+    def test_open_pr_setup_context_includes_pr_info(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_pr_body.return_value = "PR description body"
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="sess"),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "Do the thing")
+        _, _, context = mock_build.call_args.args
+        assert "PR #20" in context
+        assert "https://github.com/owner/proj/pull/20" in context
+        assert "PR description body" in context
+
+    def test_no_pr_setup_context_includes_issue_body(self, tmp_path: Path) -> None:
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
+        gh.find_pr.return_value = None
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(
+                fido_dir,
+                self._make_repo_ctx(),
+                7,
+                "Fix the bug",
+                issue_body="Steps to reproduce here.",
+            )
+        _, _, context = mock_build.call_args.args
+        assert "Steps to reproduce here." in context
+        assert "#7: Fix the bug" in context
+
+    def test_no_pr_setup_context_excludes_pr_section(self, tmp_path: Path) -> None:
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "do-work"
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
+        gh.find_pr.return_value = None
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
+        _, _, context = mock_build.call_args.args
+        assert "## Active PR" not in context
+
 
 class TestResetLocalWorkspaceAndRetryAck:
     """Fresh-retry workspace reset + retry-acknowledgement comment (closes

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4488,6 +4488,7 @@ class TestFindOrCreatePr:
         # an empty list so the fresh-retry path doesn't try to post a
         # retry-acknowledgement comment on every test.
         gh.find_closed_unmerged_prs_for_issue.return_value = []
+        gh.find_closed_prs_as_context.return_value = []
         return Worker(tmp_path, gh, provider_agent=provider_agent), gh
 
     def _make_repo_ctx(
@@ -5019,11 +5020,15 @@ class TestFindOrCreatePr:
     def test_no_pr_posts_retry_ack_when_closed_prs_exist(self, tmp_path: Path) -> None:
         """Fresh-retry path must post the retry-ack comment when prior
         closed-not-merged PRs exist for the issue (fix #802)."""
+        from fido.types import ClosedPR
+
         mock_client = _client()
         mock_client.generate_branch_name.return_value = "redo"
         worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
         gh.find_pr.return_value = None
-        gh.find_closed_unmerged_prs_for_issue.return_value = [215]
+        gh.find_closed_prs_as_context.return_value = [
+            ClosedPR(number=215, title="Old attempt", body="", close_reason="")
+        ]
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/300"
         fido_dir = self._fido_dir(tmp_path)
         mock_retry = MagicMock()
@@ -5130,6 +5135,65 @@ class TestFindOrCreatePr:
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
         assert "## Active PR" not in context
+
+    def test_no_pr_setup_context_includes_prior_attempts(self, tmp_path: Path) -> None:
+        """Prior closed PRs appear in the setup context for the fresh-PR path."""
+        from fido.types import ClosedPR
+
+        mock_client = _client()
+        mock_client.generate_branch_name.return_value = "redo"
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
+        gh.find_pr.return_value = None
+        gh.find_closed_prs_as_context.return_value = [
+            ClosedPR(
+                number=99,
+                title="Prior attempt",
+                body="Old description.",
+                close_reason="",
+            )
+        ]
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
+        _, _, context = mock_build.call_args.args
+        assert "## Prior attempts" in context
+        assert "PR #99" in context
+        assert "Prior attempt" in context
+
+    def test_open_pr_setup_context_includes_prior_attempts(
+        self, tmp_path: Path
+    ) -> None:
+        """Prior closed PRs appear in the setup context when an open PR has no tasks."""
+        from fido.types import ClosedPR
+
+        worker, gh = self._make_worker(tmp_path)
+        gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_pr_body.return_value = ""
+        gh.find_closed_prs_as_context.return_value = [
+            ClosedPR(number=88, title="First attempt", body="", close_reason="")
+        ]
+        fido_dir = self._fido_dir(tmp_path)
+        mock_build = MagicMock()
+        with (
+            patch.object(worker, "_git"),
+            patch("fido.tasks.Tasks.list", return_value=[]),
+            patch.object(worker, "seed_tasks_from_pr_body"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_start", return_value="sess"),
+            pytest.raises(RuntimeError),
+        ):
+            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
+        _, _, context = mock_build.call_args.args
+        assert "## Prior attempts" in context
+        assert "PR #88" in context
+        assert "First attempt" in context
 
 
 class TestResetLocalWorkspaceAndRetryAck:
@@ -9049,6 +9113,7 @@ class TestExecuteTask:
 
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
+        gh.find_closed_prs_as_context.return_value = []
         return Worker(tmp_path, gh), gh
 
     def _repo_ctx(self) -> RepoContext:
@@ -10519,6 +10584,42 @@ class TestExecuteTask:
         assert "Implement the feature" in context
         assert "Details about the feature." in context
 
+    def test_execute_task_context_includes_prior_attempts(self, tmp_path: Path) -> None:
+        """Prior closed PRs appear in the task-execution context when issue is set."""
+        from fido.types import ClosedPR
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        State(fido_dir).save({"issue": 7})
+        gh.view_issue.return_value = {
+            "title": "Fix the bug",
+            "body": "",
+            "state": "OPEN",
+        }
+        gh.get_pr.return_value = {"title": "", "body": ""}
+        gh.find_closed_prs_as_context.return_value = [
+            ClosedPR(
+                number=77, title="Previous fix", body="Attempted fix.", close_reason=""
+            )
+        ]
+        task = self._pending_task("Write a test")
+        mock_build = MagicMock()
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt", mock_build),
+            patch("fido.worker.provider_run", return_value=("sid", "")),
+            patch.object(worker, "_git", self._git_with_new_commits()),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+        _, _, context = mock_build.call_args.args
+        assert "## Prior attempts" in context
+        assert "PR #77" in context
+        assert "Previous fix" in context
+
 
 class TestYieldForUntriaged:
     """Tests for Worker._yield_for_untriaged and its two call sites in
@@ -10528,6 +10629,7 @@ class TestYieldForUntriaged:
         self, tmp_path: Path
     ) -> tuple[Worker, MagicMock, MagicMock]:
         gh = MagicMock()
+        gh.find_closed_prs_as_context.return_value = []
         registry = MagicMock()
         registry.assert_worker_turn_ok = MagicMock()
         worker = Worker(


### PR DESCRIPTION
Fixes #1217.

Adds a shared `render_active_context()` renderer that surfaces issue, PR, task list, current task, and prior attempts as stable system-prompt blocks — wired into all LLM call sites so every provider anchors on the same ground truth every turn. Remaining work replaces the loose `dict[str, Any]` task parameters with a typed `TaskSnapshot` structure and cleans up the dead `Any` import once that lands.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (9)</summary>

- [x] [Replace dict[str, Any] with a typed structure in render_active_context](https://github.com/FidoCanCode/home/pull/1223#discussion_r3175756174) <!-- type:thread -->
- [x] [Remove the unused `from typing import Any` import from prompts.py](https://github.com/FidoCanCode/home/pull/1223#discussion_r3175775382) <!-- type:thread -->
- [x] Inject active-context into voice/reply prompts <!-- type:spec -->
- [x] Inject active-context into rescope prompt <!-- type:spec -->
- [x] Inject active-context into worker task execution prompt <!-- type:spec -->
- [x] Add render_active_context() renderer and unit tests <!-- type:spec -->
- [x] [Include issue number and title fields in rendered active-context blocks](https://github.com/FidoCanCode/home/pull/1223#issuecomment-4362429747) <!-- type:thread -->
- [x] Inject active-context into setup/planning prompt <!-- type:spec -->
- [x] Add prior-attempts fetching and include in rendered context <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->