### PR TITLE
Bug: codex 'contextWindowExceeded' crashes worker — poisoned session_id is re-used after restart (closes #1231)

### DIFF
--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -15,6 +15,7 @@ from typing import IO, Any, NoReturn, Protocol
 import fido.provider as provider
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
+    ContextOverflowError,
     OwnedSession,
     PromptSession,
     Provider,
@@ -235,7 +236,7 @@ class CodexAppServerClient:
             response = self._responses.pop(request_id)
         if response.error is not None:
             message = response.error.get("message")
-            raise CodexProviderError(
+            _raise_provider_error(
                 message=message if isinstance(message, str) else str(response.error),
                 kind=_classify_provider_error(str(message or response.error)),
                 payload=response.error,
@@ -443,6 +444,21 @@ def _classify_provider_error(message: str) -> str:
     return "provider"
 
 
+def _raise_provider_error(
+    *, message: str, kind: str, payload: dict[str, Any]
+) -> "NoReturn":
+    """Build and raise the appropriate provider error for *kind*.
+
+    Raises :exc:`ContextOverflowError` when *kind* is ``"context_overflow"``
+    (chained from the underlying :exc:`CodexProviderError` for traceability),
+    and :exc:`CodexProviderError` for everything else.
+    """
+    error = CodexProviderError(message=message, kind=kind, payload=payload)
+    if kind == "context_overflow":
+        raise ContextOverflowError(message) from error
+    raise error
+
+
 def _provider_error_from_event(obj: dict[str, Any]) -> CodexProviderError | None:
     event_type = obj.get("type")
     message: str | None = None
@@ -471,7 +487,11 @@ def raise_for_provider_error_output(output: str) -> None:
     for obj in _iter_jsonl(output):
         provider_error = _provider_error_from_event(obj)
         if provider_error is not None:
-            raise provider_error
+            _raise_provider_error(
+                message=str(provider_error),
+                kind=provider_error.kind,
+                payload=provider_error.payload,
+            )
 
 
 def _normalize_limit_name(value: object, fallback: str) -> str:
@@ -784,7 +804,7 @@ class CodexSession(OwnedSession):
             params = notification["params"]
             if method == "error":
                 message = params.get("message")
-                raise CodexProviderError(
+                _raise_provider_error(
                     message=message if isinstance(message, str) else str(params),
                     kind=_classify_provider_error(str(message or params)),
                     payload=params,
@@ -981,7 +1001,7 @@ class CodexSession(OwnedSession):
         if isinstance(status, str) and status.lower() in {"failed", "error"}:
             error = params.get("error")
             message = error.get("message") if isinstance(error, dict) else str(params)
-            raise CodexProviderError(
+            _raise_provider_error(
                 message=message if isinstance(message, str) else str(error),
                 kind=_classify_provider_error(str(message)),
                 payload=params,

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -432,6 +432,8 @@ def extract_result_text(output: str) -> str:
 
 def _classify_provider_error(message: str) -> str:
     lowered = message.lower()
+    if "contextWindowExceeded" in message or "context window" in lowered:
+        return "context_overflow"
     if "rate limit" in lowered or "rate_limit" in lowered or "quota" in lowered:
         return "rate_limit"
     if "auth" in lowered or "login" in lowered or "unauthorized" in lowered:

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -38,6 +38,16 @@ def is_recoverable_provider_wedge(exc: BaseException) -> bool:
     return isinstance(exc, RecoverableProviderWedgeError)
 
 
+class ContextOverflowError(RuntimeError):
+    """Provider session hit the context-window limit — session must be retired.
+
+    This is not a transient error.  The session is poisoned: re-using the
+    same thread id will produce the same failure.  The worker must clear the
+    persisted session_id, reset the session to a fresh thread, and resume
+    the in-progress task.
+    """
+
+
 class ProviderID(StrEnum):
     """Supported LLM providers for fido."""
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -24,6 +24,7 @@ from fido.github import GitHub
 from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.prompts import Prompts, render_active_context
 from fido.provider import (
+    ContextOverflowError,
     PromptSession,
     Provider,
     ProviderAgent,
@@ -4209,6 +4210,39 @@ class WorkerThread(threading.Thread):
         except OSError as exc:
             log.warning("failed to persist session_id: %s", exc)
 
+    def _retire_poisoned_session(self) -> None:
+        """Discard the persisted and live session after a context-window overflow.
+
+        The session thread is full and cannot be used again — re-using the same
+        ``session_id`` would produce an immediate ``contextWindowExceeded`` crash.
+        This method:
+        - removes ``session_id`` from ``state.json`` (so a fido restart doesn't
+          reload the poisoned id),
+        - calls ``reset()`` on the live session (so the next iteration starts a
+          fresh provider thread),
+        - clears ``_session_issue`` (so the next iteration uses
+          ``TurnSessionMode.FRESH`` and fully re-establishes the system prompt).
+        """
+        log.warning(
+            "context overflow — retiring poisoned session for %s", self._repo_name
+        )
+        fido_dir = self._resolve_fido_dir()
+        if fido_dir is not None:
+            try:
+                with State(fido_dir).modify() as data:
+                    data.pop("session_id", None)
+            except OSError as exc:
+                log.warning(
+                    "failed to clear session_id after context overflow: %s", exc
+                )
+        with self._provider_lock:
+            provider = self._provider
+        if provider is not None:
+            session = provider.agent.session
+            if session is not None:
+                session.reset()
+        self._session_issue = None
+
     def run(self) -> None:
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
@@ -4244,30 +4278,37 @@ class WorkerThread(threading.Thread):
                 worker._provider = provider  # pyright: ignore[reportPrivateUsage]
                 worker._provider_agent = provider.agent  # pyright: ignore[reportPrivateUsage]
                 try:
-                    result = worker.run()
-                finally:
-                    with self._provider_lock:
-                        self._provider = worker._provider  # pyright: ignore[reportPrivateUsage]
-                    self._session_issue = worker._session_issue  # pyright: ignore[reportPrivateUsage]
-                    self._persist_session_id()
-                    self._is_first_iteration = False
+                    try:
+                        result = worker.run()
+                    finally:
+                        with self._provider_lock:
+                            self._provider = worker._provider  # pyright: ignore[reportPrivateUsage]
+                        self._session_issue = worker._session_issue  # pyright: ignore[reportPrivateUsage]
+                        self._persist_session_id()
+                        self._is_first_iteration = False
 
-                if result == 1:
-                    # Did work — loop immediately without waiting.
-                    continue
+                    if result == 1:
+                        # Did work — loop immediately without waiting.
+                        continue
 
-                if self._registry is not None:
-                    waiting_what = (
-                        "waiting: lock held"
-                        if result == 2
-                        else "waiting: no issues found"
-                    )
-                    self._registry.report_activity(
-                        self._repo_name, waiting_what, busy=False
-                    )
-                timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
-                self._wake.wait(timeout=timeout)
-                self._wake.clear()
+                    if self._registry is not None:
+                        waiting_what = (
+                            "waiting: lock held"
+                            if result == 2
+                            else "waiting: no issues found"
+                        )
+                        self._registry.report_activity(
+                            self._repo_name, waiting_what, busy=False
+                        )
+                    timeout = _RETRY_TIMEOUT if result == 2 else _IDLE_TIMEOUT
+                    self._wake.wait(timeout=timeout)
+                    self._wake.clear()
+                except ContextOverflowError:
+                    # The provider session hit its context-window limit.
+                    # Retire the poisoned session and immediately retry —
+                    # the task stays in_progress and the fresh session picks
+                    # it right back up.
+                    self._retire_poisoned_session()
         except SessionLeakError:
             # A worker and webhook tried to talk to the same repo's claude
             # at the same time — halt fido so the supervisor restarts fresh

--- a/tests/fixtures/codex/context-window-exceeded.jsonl
+++ b/tests/fixtures/codex/context-window-exceeded.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"context-window-thread"}
+{"type":"turn.started"}
+{"type":"turn.failed","error":{"message":"Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.","codexErrorInfo":"contextWindowExceeded"}}

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -202,6 +202,12 @@ class TestCodexProviderErrors:
         assert exc_info.value.kind == "cancelled"
         assert "cancelled" in str(exc_info.value)
 
+    def test_context_window_exceeded_fixture_classified(self) -> None:
+        with pytest.raises(CodexProviderError) as exc_info:
+            raise_for_provider_error_output(_fixture("context-window-exceeded.jsonl"))
+        assert exc_info.value.kind == "context_overflow"
+        assert "context window" in str(exc_info.value).lower()
+
     def test_ignores_successful_fixture(self) -> None:
         raise_for_provider_error_output(_fixture("normal.jsonl"))
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -21,7 +21,12 @@ from fido.codex import (
     run_codex_exec,
     run_codex_exec_resume,
 )
-from fido.provider import ProviderID, ProviderInterruptTimeout, ProviderModel
+from fido.provider import (
+    ContextOverflowError,
+    ProviderID,
+    ProviderInterruptTimeout,
+    ProviderModel,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures" / "codex"
 
@@ -202,10 +207,9 @@ class TestCodexProviderErrors:
         assert exc_info.value.kind == "cancelled"
         assert "cancelled" in str(exc_info.value)
 
-    def test_context_window_exceeded_fixture_classified(self) -> None:
-        with pytest.raises(CodexProviderError) as exc_info:
+    def test_context_window_exceeded_raises_context_overflow_error(self) -> None:
+        with pytest.raises(ContextOverflowError) as exc_info:
             raise_for_provider_error_output(_fixture("context-window-exceeded.jsonl"))
-        assert exc_info.value.kind == "context_overflow"
         assert "context window" in str(exc_info.value).lower()
 
     def test_ignores_successful_fixture(self) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17,6 +17,7 @@ from fido.config import Config, RepoConfig, RepoMembership
 from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.prompts import Prompts
 from fido.provider import (
+    ContextOverflowError,
     ProviderID,
     ProviderLimitSnapshot,
     ProviderLimitWindow,
@@ -14452,6 +14453,37 @@ class TestWorkerThread:
         provider.agent.session_received_count = 38
         wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
         assert wt.session_received_count == 38
+
+    def test_context_overflow_calls_retire_and_loops(self, tmp_path: Path) -> None:
+        """ContextOverflowError from Worker.run() must not crash the thread.
+
+        The loop should call _retire_poisoned_session() and immediately retry
+        without waiting — the task stays in_progress so the fresh session picks
+        it right back up on the next iteration.
+        """
+        wt = self._make_thread(tmp_path)
+        wt._wake = MagicMock()
+        call_count = 0
+
+        def fake_worker_run(self_ignored=None) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ContextOverflowError("context window exceeded")
+            wt._stop = True
+            return 0
+
+        with (
+            patch.object(Worker, "run", fake_worker_run),
+            patch.object(WorkerThread, "_retire_poisoned_session") as mock_retire,
+        ):
+            self._run_thread(wt)
+
+        assert call_count == 2  # first raised, second ran normally
+        mock_retire.assert_called_once()  # retirement triggered exactly once
+        # No wait after the overflow — it loops immediately back to check _stop.
+        # Only the clean second iteration (result 0) triggers a wait.
+        wt._wake.wait.assert_called_once()
 
     def test_run_halts_on_claude_leak_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_worker_persist_session_id.py
+++ b/tests/test_worker_persist_session_id.py
@@ -163,3 +163,101 @@ def test_persist_session_id_swallows_state_modify_oserror(
     with caplog.at_level(logging.WARNING, logger="fido"):
         thread._persist_session_id()
     assert "failed to persist session_id" in caplog.text
+
+
+# ── _retire_poisoned_session ──────────────────────────────────────────────────
+
+
+def test_retire_poisoned_session_clears_session_id_from_state(
+    tmp_path: Path,
+) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(json.dumps({"session_id": "poisoned-sid"}))
+    thread = _make_thread(tmp_path)
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    persisted = json.loads((fido_dir / "state.json").read_text())
+    assert "session_id" not in persisted
+
+
+def test_retire_poisoned_session_preserves_other_state_keys(tmp_path: Path) -> None:
+    fido_dir = _init_git_repo(tmp_path)
+    (fido_dir / "state.json").write_text(
+        json.dumps({"session_id": "poisoned-sid", "issue": 42})
+    )
+    thread = _make_thread(tmp_path)
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    persisted = json.loads((fido_dir / "state.json").read_text())
+    assert persisted == {"issue": 42}
+
+
+def test_retire_poisoned_session_calls_session_reset(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    session = MagicMock()
+    agent = MagicMock()
+    agent.session = session
+    provider = MagicMock()
+    provider.agent = agent
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    session.reset.assert_called_once()
+
+
+def test_retire_poisoned_session_clears_session_issue(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    thread = _make_thread(tmp_path)
+    thread._session_issue = 99  # pyright: ignore[reportPrivateUsage]
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    assert thread._session_issue is None  # pyright: ignore[reportPrivateUsage]
+
+
+def test_retire_poisoned_session_logs_warning(tmp_path: Path, caplog) -> None:
+    import logging
+
+    _init_git_repo(tmp_path)
+    thread = _make_thread(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="fido"):
+        thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    assert "context overflow" in caplog.text
+
+
+def test_retire_poisoned_session_noop_when_no_git_repo(tmp_path: Path) -> None:
+    """Not a git repo — no fido_dir — must not raise."""
+    thread = _make_thread(tmp_path)
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_retire_poisoned_session_noop_when_no_provider(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    thread = _make_thread(tmp_path)
+    thread._provider = None  # pyright: ignore[reportPrivateUsage]
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]  # must not raise
+
+
+def test_retire_poisoned_session_noop_when_no_session(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    provider = MagicMock()
+    provider.agent.session = None
+    thread = _make_thread(tmp_path, provider=provider)
+    thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]  # must not raise
+
+
+def test_retire_poisoned_session_swallows_state_modify_oserror(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    import logging
+    from contextlib import contextmanager
+
+    from fido import state as state_mod
+
+    _init_git_repo(tmp_path)
+    thread = _make_thread(tmp_path)
+
+    @contextmanager
+    def boom(self):
+        raise OSError("state.json locked")
+        yield  # unreachable
+
+    monkeypatch.setattr(state_mod.State, "modify", boom)
+    with caplog.at_level(logging.WARNING, logger="fido"):
+        thread._retire_poisoned_session()  # pyright: ignore[reportPrivateUsage]
+    assert "failed to clear session_id after context overflow" in caplog.text


### PR DESCRIPTION
Fixes #1231.

Detect codex `contextWindowExceeded` as a provider-neutral `ContextOverflowError`, catch it in the worker loop, clear the poisoned persisted session_id, reset the session to a fresh thread, and resume the in-progress task instead of crash-looping.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Add session retirement to WorkerThread: catch ContextOverflowError, clear persisted session_id, reset session, and resume <!-- type:spec -->
- [x] Add regression tests for context-overflow detection and session retirement <!-- type:spec -->
- [x] Add provider-neutral ContextOverflowError and map codex contextWindowExceeded to it <!-- type:spec -->
- [x] Add context-overflow error kind to CodexProviderError classification <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->