### PR TITLE
Bug: copilot-cli session reset on no-commits is too eager — destroys accumulated PR context (closes #1233)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1637,6 +1637,10 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
     def provider_id(self) -> ProviderID:
         return ProviderID.CLAUDE_CODE
 
+    @property
+    def supports_no_commit_reset(self) -> bool:
+        return True
+
     def _spawn_owned_session(
         self,
         model: ProviderModel | None = None,

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -1152,6 +1152,10 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
     def provider_id(self) -> ProviderID:
         return ProviderID.CODEX
 
+    @property
+    def supports_no_commit_reset(self) -> bool:
+        return True
+
     def _spawn_owned_session(
         self, model: ProviderModel, *, session_id: str | None = None
     ) -> PromptSession:

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1286,6 +1286,10 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
     def provider_id(self) -> ProviderID:
         return ProviderID.COPILOT_CLI
 
+    @property
+    def supports_no_commit_reset(self) -> bool:
+        return False
+
     def _spawn_owned_session(
         self, model: ProviderModel, *, session_id: str | None = None
     ) -> PromptSession:

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -370,6 +370,25 @@ class Prompts:
             f"{plain}"
         )
 
+    def task_stuck_no_commit_comment_prompt(self, task_title: str, attempt: int) -> str:
+        """Prompt for a Fido-voiced PR note when a task is blocked after N nudges."""
+        plain = (
+            f"After {attempt} attempts without producing any commits, I gave up "
+            "on this task and marked it blocked. The model kept responding with "
+            "prose instead of making file changes. A human comment on this PR "
+            "will unblock it so I can try again. "
+            f"Task: {task_title}"
+        )
+        return (
+            f"{self.persona}\n\n"
+            "Rewrite the following GitHub pull request comment in character as "
+            "Fido. Keep it to 2-3 sentences. Say you tried multiple times, "
+            "produced no code changes, and have marked the task blocked — "
+            "a comment on this PR will unblock it so you can try again. "
+            "Output only the comment text, no quotes, no explanation.\n\n"
+            f"{plain}"
+        )
+
     def status_prompt(self, activities: list[tuple[str, str, bool]]) -> str:
         """Build the combined status-text + emoji prompt for a session nudge.
 

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -441,6 +441,43 @@ class Prompts:
             "Do not respond with a plan — just act."
         )
 
+    def no_commit_persistent_nudge(
+        self,
+        *,
+        attempt: int,
+        task_title: str,
+        task_id: str,
+        work_dir: str,
+        pr_number: int | None,
+    ) -> str:
+        """Build a directive in-session nudge for providers that must not be reset.
+
+        Used when the provider produced no commits and a session reset would
+        destroy accumulated context (e.g. copilot-cli).  The nudge stays
+        in-session and explicitly demands a tool-use action — not prose.
+        """
+        complete_cmd = f"fido task complete {work_dir} {task_id}"
+        pr_comment_cmd = (
+            f"gh pr comment {pr_number} --body 'BLOCKED: ...'"
+            if pr_number is not None
+            else "gh pr comment <pr> --body 'BLOCKED: ...'"
+        )
+        return (
+            f"You're working on: {task_title}\n\n"
+            f"Attempt {attempt}: your last turn produced no commits. "
+            "You must make at least one tool call that changes a file this "
+            "turn — an Edit, Write, or Bash call that modifies or creates a "
+            "file. Prose without tool calls does not count as progress.\n\n"
+            "Take exactly one of these actions right now:\n"
+            "1. Edit or write a file to make progress on the task.\n"
+            f"2. If the task is already complete: `{complete_cmd}`\n"
+            f"3. If something outside your control is blocking you: "
+            f"`{pr_comment_cmd}` — with a concrete explanation, not a "
+            "description of uncertainty. Do not describe the situation "
+            "internally; post the comment so a human can unblock you.\n\n"
+            "Do not reply with a plan or analysis. Act."
+        )
+
     def fresh_session_retry_prompt(
         self,
         *,

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -944,6 +944,11 @@ class ProviderAgent(Protocol):
         """Return the number of stream-json events received from the current session subprocess since spawn."""
         ...
 
+    @property
+    def supports_no_commit_reset(self) -> bool:
+        """Return whether this provider supports resetting the session when no commits are produced."""
+        ...
+
     voice_model: ProviderModel
     work_model: ProviderModel
     brief_model: ProviderModel

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3144,7 +3144,9 @@ class Worker:
                 break
             attempt += 1
             use_fresh_session = (
-                attempt >= _FRESH_SESSION_NUDGE_ATTEMPT and not fresh_session_retry_used
+                self._provider_agent.supports_no_commit_reset
+                and attempt >= _FRESH_SESSION_NUDGE_ATTEMPT
+                and not fresh_session_retry_used
             )
             nudge = (
                 prompts.fresh_session_retry_prompt(

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -863,6 +863,9 @@ def _has_pending_asks(task_list: list[dict[str, Any]]) -> bool:
 
 _DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED"}
 _FRESH_SESSION_NUDGE_ATTEMPT = 4
+# How many persistent nudge turns to allow for providers that cannot reset
+# (supports_no_commit_reset = False) before marking the task blocked.
+_PERSISTENT_NO_COMMIT_CAP = 6
 
 
 def _no_commit_nudge(  # pyright: ignore[reportUnusedFunction]
@@ -2962,6 +2965,42 @@ class Worker:
         body = f"{msg}\n\n<!-- fido:task-complete-no-commit -->"
         self.gh.comment_issue(repo, pr_number, body)
 
+    def _report_task_stuck_no_commits(
+        self,
+        fido_dir: Path,
+        repo: str,
+        pr_number: int,
+        task_id: str,
+        task_title: str,
+        attempt: int,
+    ) -> None:
+        """Mark task blocked and post a PR comment when persistent nudges fail.
+
+        Called when a non-resettable provider (supports_no_commit_reset = False)
+        exceeds _PERSISTENT_NO_COMMIT_CAP attempts without producing any commits.
+        Marks the task BLOCKED, clears current_task_id, and posts a comment so a
+        human knows the task is stuck.  unblock_tasks() transitions it back to
+        PENDING when a new PR comment arrives.
+        """
+        log.warning(
+            "task %s stuck after %d no-commit attempts — marking blocked",
+            task_id,
+            attempt,
+        )
+        self._tasks.update(task_id, TaskStatus.BLOCKED)
+        with State(fido_dir).modify() as state:
+            state.pop("current_task_id", None)
+        prompts = self._get_prompts()
+        prompt = prompts.task_stuck_no_commit_comment_prompt(task_title, attempt)
+        msg = self._provider_agent.generate_reply(
+            prompt, self._provider_agent.voice_model
+        )
+        if not msg:
+            raise ValueError("task stuck no-commit comment was empty")
+        body = f"{msg}\n\n<!-- fido:task-stuck-no-commit -->"
+        self.gh.comment_issue(repo, pr_number, body)
+        tasks.sync_tasks(self.work_dir, self.gh, blocking=True)
+
     def execute_task(
         self,
         fido_dir: Path,
@@ -3143,6 +3182,22 @@ class Worker:
                 completed_without_commit = True
                 break
             attempt += 1
+            if (
+                not self._provider_agent.supports_no_commit_reset
+                and attempt > _PERSISTENT_NO_COMMIT_CAP
+            ):
+                self._report_task_stuck_no_commits(
+                    fido_dir,
+                    repo_ctx.repo,
+                    pr_number,
+                    task["id"],
+                    task_title,
+                    attempt,
+                )
+                self._delete_leaked_task_comments(
+                    repo_ctx.repo, pr_number, repo_ctx.gh_user, leak_before_ids
+                )
+                return True
             use_fresh_session = (
                 self._provider_agent.supports_no_commit_reset
                 and attempt >= _FRESH_SESSION_NUDGE_ATTEMPT

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3148,8 +3148,8 @@ class Worker:
                 and attempt >= _FRESH_SESSION_NUDGE_ATTEMPT
                 and not fresh_session_retry_used
             )
-            nudge = (
-                prompts.fresh_session_retry_prompt(
+            if use_fresh_session:
+                nudge = prompts.fresh_session_retry_prompt(
                     task_title=task_title,
                     task_id=task["id"],
                     work_dir=str(self.work_dir),
@@ -3161,15 +3161,22 @@ class Worker:
                     pr_title=pr_title,
                     pr_body=pr_body,
                 )
-                if use_fresh_session
-                else prompts.task_resume_nudge(
+            elif not self._provider_agent.supports_no_commit_reset:
+                nudge = prompts.no_commit_persistent_nudge(
                     attempt=attempt,
                     task_title=task_title,
                     task_id=task["id"],
                     work_dir=str(self.work_dir),
                     pr_number=pr_number,
                 )
-            )
+            else:
+                nudge = prompts.task_resume_nudge(
+                    attempt=attempt,
+                    task_title=task_title,
+                    task_id=task["id"],
+                    work_dir=str(self.work_dir),
+                    pr_number=pr_number,
+                )
             (fido_dir / "prompt").write_text(nudge)
             if use_fresh_session:
                 fresh_session_retry_used = True

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2733,6 +2733,9 @@ class TestClaudeClientSessionAttachment:
         client = ClaudeClient()
         assert str(client.provider_id) == "claude-code"
 
+    def test_supports_no_commit_reset_is_true(self) -> None:
+        assert ClaudeClient().supports_no_commit_reset is True
+
     def test_ensure_session_requires_session_system_file_and_work_dir(self) -> None:
         client = ClaudeClient()
         with pytest.raises(

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -717,6 +717,9 @@ class TestCodexClient:
         assert client.work_model == ProviderModel("gpt-5.5", "medium")
         assert client.brief_model == ProviderModel("gpt-5.5", "low")
 
+    def test_supports_no_commit_reset_is_true(self) -> None:
+        assert CodexClient(session=MagicMock()).supports_no_commit_reset is True
+
     def test_spawns_owned_session_with_resume_id(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("persona")

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1404,6 +1404,9 @@ class TestCopilotCLIClient:
         client.attach_session(attached)
         assert client.session is attached
 
+    def test_supports_no_commit_reset_is_false(self) -> None:
+        assert CopilotCLIClient().supports_no_commit_reset is False
+
     def test_session_id_none_branches(self) -> None:
         assert CopilotCLIClient().session_id is None
         assert CopilotCLIClient(session=object()).session_id is None

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -235,6 +235,65 @@ class TestFreshSessionRetryPrompt:
         assert "Issue description:\nIt blows up on empty input." in result
 
 
+class TestNoCommitPersistentNudge:
+    def test_includes_task_title_attempt_and_task_id(self) -> None:
+        result = Prompts("").no_commit_persistent_nudge(
+            attempt=3,
+            task_title="Refactor widget",
+            task_id="task-42",
+            work_dir="/repo/work",
+            pr_number=99,
+        )
+        assert "Refactor widget" in result
+        assert "Attempt 3" in result
+        assert "fido task complete /repo/work task-42" in result
+
+    def test_demands_tool_call_edit_or_write(self) -> None:
+        result = Prompts("").no_commit_persistent_nudge(
+            attempt=1,
+            task_title="Fix lint",
+            task_id="task-7",
+            work_dir="/repo",
+            pr_number=5,
+        )
+        assert "Edit" in result or "Write" in result
+        assert "tool call" in result.lower() or "tool" in result.lower()
+
+    def test_includes_blocked_command_with_pr(self) -> None:
+        result = Prompts("").no_commit_persistent_nudge(
+            attempt=2,
+            task_title="Add tests",
+            task_id="task-9",
+            work_dir="/repo",
+            pr_number=77,
+        )
+        assert "gh pr comment 77 --body 'BLOCKED:" in result
+
+    def test_includes_blocked_command_placeholder_when_no_pr(self) -> None:
+        result = Prompts("").no_commit_persistent_nudge(
+            attempt=2,
+            task_title="Add tests",
+            task_id="task-9",
+            work_dir="/repo",
+            pr_number=None,
+        )
+        assert "gh pr comment <pr> --body 'BLOCKED:" in result
+
+
+class TestTaskStuckNoCommitCommentPrompt:
+    def test_includes_task_title(self) -> None:
+        result = Prompts("persona").task_stuck_no_commit_comment_prompt(
+            "Fix the parser", 7
+        )
+        assert "Fix the parser" in result
+
+    def test_includes_attempt_count(self) -> None:
+        result = Prompts("persona").task_stuck_no_commit_comment_prompt(
+            "Fix the parser", 7
+        )
+        assert "7" in result
+
+
 # ── reply_context_block ───────────────────────────────────────────────────────
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9880,6 +9880,110 @@ class TestExecuteTask:
         assert "Task title: Fix widget" in prompt_snapshots[4]
         assert "Branch: br-42" in prompt_snapshots[4]
 
+    def test_non_resettable_provider_never_uses_fresh_session(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-resettable provider (supports_no_commit_reset=False) stays REUSE
+        past attempt >= 4 and uses no_commit_persistent_nudge instead."""
+        mock_agent = _client()
+        mock_agent.supports_no_commit_reset = False
+        gh = MagicMock()
+        gh.find_closed_prs_as_context.return_value = []
+        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        fido_dir = self._fido_dir(tmp_path)
+        (fido_dir / "prompt").write_text("initial prompt")
+        task = self._pending_task("Port to Python 3")
+        git_mock = MagicMock(
+            side_effect=lambda args, **kw: MagicMock(
+                returncode=0,
+                stdout="aaa" if args == ["rev-parse", "HEAD"] else "",
+                stderr="",
+            )
+        )
+        prompt_snapshots: list[str] = []
+        run_calls = 0
+
+        def fake_run(fd, *args, **kwargs):
+            nonlocal run_calls
+            run_calls += 1
+            prompt_snapshots.append((fd / "prompt").read_text())
+            if run_calls == 5:
+                worker._abort_task.request(task["id"])
+            return ("sess", "")
+
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch("fido.worker.provider_run", side_effect=fake_run) as mock_run,
+            patch.object(worker, "_git", git_mock),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.complete_with_resolve"),
+            patch("fido.tasks.sync_tasks"),
+        ):
+            worker.execute_task(fido_dir, self._repo_ctx(), 42, "br-42")
+
+        session_modes = [
+            call.kwargs["session_mode"] for call in mock_run.call_args_list
+        ]
+        # All modes are REUSE — no FRESH even after attempt >= 4.
+        assert all(m == TurnSessionMode.REUSE for m in session_modes)
+        # The nudge prompt for attempt >= 1 uses no_commit_persistent_nudge format.
+        assert "Attempt 1" in prompt_snapshots[1]
+        assert "Port to Python 3" in prompt_snapshots[1]
+
+    def test_non_resettable_provider_marks_blocked_past_cap(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-resettable provider marks task BLOCKED and posts a comment when
+        attempt exceeds _PERSISTENT_NO_COMMIT_CAP (6)."""
+        from fido.types import TaskStatus
+
+        mock_agent = _client()
+        mock_agent.supports_no_commit_reset = False
+        mock_agent.generate_reply.return_value = (
+            "Woof — I gave up after too many tries."
+        )
+        gh = MagicMock()
+        gh.find_closed_prs_as_context.return_value = []
+        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        fido_dir = self._fido_dir(tmp_path)
+        (fido_dir / "prompt").write_text("initial prompt")
+        task = self._pending_task("Add type hints")
+
+        git_mock = MagicMock(
+            side_effect=lambda args, **kw: MagicMock(
+                returncode=0,
+                stdout="aaa" if args == ["rev-parse", "HEAD"] else "",
+                stderr="",
+            )
+        )
+
+        with (
+            patch("fido.tasks.Tasks.list", return_value=[task]),
+            patch.object(worker, "set_status"),
+            patch("fido.worker.build_prompt"),
+            patch(
+                "fido.worker.provider_run",
+                return_value=("sess", ""),
+            ) as mock_run,
+            patch.object(worker, "_git", git_mock),
+            patch.object(worker, "ensure_pushed", return_value=True),
+            patch("fido.tasks.Tasks.update") as mock_update,
+            patch("fido.tasks.sync_tasks"),
+        ):
+            result = worker.execute_task(fido_dir, self._repo_ctx(), 55, "br-55")
+
+        assert result is True
+        # 1 initial turn + 6 nudge turns = 7 total calls (cap is 6, blocked at attempt 7)
+        assert mock_run.call_count == 7
+        mock_update.assert_any_call(task["id"], TaskStatus.BLOCKED)
+        gh.comment_issue.assert_called_once()
+        comment_args = gh.comment_issue.call_args.args
+        assert comment_args[0] == "owner/repo"
+        assert comment_args[1] == 55
+        assert "<!-- fido:task-stuck-no-commit -->" in comment_args[2]
+
     def test_saves_current_task_id_to_state_before_provider_run(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #1233.

Makes the no-commits session reset provider-aware: providers that lose critical context on reset (copilot-cli) stay in-session with stronger nudges instead of wiping conversation history, while providers that handle resets well (claude-code, codex) keep existing behavior. When a non-resettable provider hits the retry cap, the task is marked blocked and surfaced to the user rather than silently resetting.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Mark task blocked instead of resetting when no-commit cap reached on non-resettable providers <!-- type:spec -->
- [x] Add tests for provider-aware no-commit session reset logic <!-- type:spec -->
- [x] Add stronger in-session nudge for copilot-cli no-commits retries <!-- type:spec -->
- [x] Guard no-commits fresh-session logic behind supports_no_commit_reset <!-- type:spec -->
- [x] Add supports_no_commit_reset property to ProviderAgent protocol <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->