### PR TITLE
Bug: cap pytest invocations with cgroup memory + wall-clock timeout

### DIFF
--- a/fido
+++ b/fido
@@ -528,7 +528,38 @@ run_container() {
     fi
   fi
 
+  # Test paths set _container_cap_memory and _container_cap_timeout to bound
+  # pytest runs.  The cgroup-backed --memory cap stops the box from soft-locking
+  # under a leaky test (see #1248); the wall-clock timeout stops a hung worker
+  # from sitting forever paging through swap.
+  if [ -n "${_container_cap_memory:-}" ]; then
+    run_args+=(--memory="$_container_cap_memory" --memory-swap="$_container_cap_memory")
+  fi
+
   log INFO "starting container image=$run_image"
+  if [ -n "${_container_cap_timeout:-}" ]; then
+    set +e
+    timeout --foreground --kill-after=10s "$_container_cap_timeout" \
+      docker run "${run_args[@]}" "$run_image" "$@"
+    rc=$?
+    set -e
+    case "$rc" in
+      124)
+        echo >&2
+        echo "TIMEOUT: container exceeded ${_container_cap_timeout} wall-clock cap (#1248)." >&2
+        for f in /tmp/pyfh-*.log; do
+          [ -f "$f" ] || continue
+          echo "--- $f (last 40 lines) ---" >&2
+          tail -40 "$f" >&2
+        done
+        ;;
+      137)
+        echo >&2
+        echo "OOM: container killed by cgroup memory cap ${_container_cap_memory} (#1248)." >&2
+        ;;
+    esac
+    return "$rc"
+  fi
   docker run "${run_args[@]}" "$run_image" "$@"
 }
 
@@ -550,6 +581,12 @@ run_fido_test_python_image() {
 run_fido_pyproject_image() {
   build_image fido-test "$test_image"
   container_entrypoint="$repo_root/pyproject" run_container "$@"
+}
+
+run_fido_pyproject_image_capped() {
+  _container_cap_memory="${FIDO_TEST_MEMORY_CAP:-8g}" \
+    _container_cap_timeout="${FIDO_TEST_TIMEOUT:-300}" \
+    run_fido_pyproject_image "$@"
 }
 
 run_fido_module_image() {
@@ -1006,7 +1043,7 @@ case "$command" in
     run_fido_module_image fido.sync_tasks_cli "${@:2}"
     ;;
   tests)
-    run_fido_pyproject_image python3 -m fido.tests_main "${@:2}"
+    run_fido_pyproject_image_capped python3 -m fido.tests_main "${@:2}"
     ;;
   traceback)
     run_fido_test_python_image -m fido.rocq_traceback "${@:2}"
@@ -1027,7 +1064,7 @@ case "$command" in
     run_fido_pyproject_image pyright "${@:2}"
     ;;
   pytest)
-    run_fido_pyproject_image pytest "${@:2}"
+    run_fido_pyproject_image_capped pytest "${@:2}"
     ;;
   *)
     echo "unsupported fido command: $command" >&2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,36 @@
 """Shared pytest fixtures for fido tests."""
 
+import faulthandler
+import os
+import signal
+from typing import TextIO
+
 import pytest
 
 from fido import provider
+
+
+def _open_faulthandler_log() -> TextIO:
+    """Open a per-pid log file for SIGUSR1-driven Python stack dumps.
+
+    Mirrors the production hook at :data:`fido.server` so any pytest worker
+    can be inspected mid-hang via ``kill -SIGUSR1 <pid>`` (#1248).  The file
+    is intentionally left open for the lifetime of the process — closing it
+    would defeat the handler when it fires.
+    """
+    return open(f"/tmp/pyfh-{os.getpid()}.log", "w", encoding="utf-8", buffering=1)
+
+
+# Each pytest process — controller and every xdist worker — registers its own
+# SIGUSR1 handler at module import.  Importing conftest is the earliest hook
+# pytest runs in a worker, well before any test collection or teardown.
+_FAULTHANDLER_LOG = _open_faulthandler_log()
+faulthandler.register(
+    signal.SIGUSR1,
+    file=_FAULTHANDLER_LOG,
+    all_threads=True,
+    chain=False,
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pytest_caps.py
+++ b/tests/test_pytest_caps.py
@@ -19,9 +19,7 @@ def test_faulthandler_is_registered_on_sigusr1() -> None:
     SIGUSR1 is the signal conftest hooks (#1248).
     """
     log_path = Path(f"/tmp/pyfh-{os.getpid()}.log")
-    assert log_path.exists(), (
-        f"conftest should have opened {log_path} at import time"
-    )
+    assert log_path.exists(), f"conftest should have opened {log_path} at import time"
     assert log_path.is_file()
     # Simply having the SIGUSR1 module attribute confirms our import path.
     assert hasattr(signal, "SIGUSR1")

--- a/tests/test_pytest_caps.py
+++ b/tests/test_pytest_caps.py
@@ -1,0 +1,87 @@
+"""Regression tests for the pytest-cap layered defense (#1248).
+
+These do not invoke a sub-pytest run — that would explode CI time.  Instead
+they verify the *plumbing* that the launcher and conftest install so a leaky
+test or hung worker cannot soft-lock the box again.
+"""
+
+import os
+import re
+import signal
+from pathlib import Path
+
+
+def test_faulthandler_is_registered_on_sigusr1() -> None:
+    """conftest.py registers a SIGUSR1 handler that dumps Python stacks.
+
+    We can't easily catch the handler firing without forking, but we can
+    assert the per-pid log file was opened at import time and that
+    SIGUSR1 is the signal conftest hooks (#1248).
+    """
+    log_path = Path(f"/tmp/pyfh-{os.getpid()}.log")
+    assert log_path.exists(), (
+        f"conftest should have opened {log_path} at import time"
+    )
+    assert log_path.is_file()
+    # Simply having the SIGUSR1 module attribute confirms our import path.
+    assert hasattr(signal, "SIGUSR1")
+
+
+def test_launcher_test_paths_use_capped_runner() -> None:
+    """The fido launcher routes ``./fido tests`` and ``./fido pytest`` through
+    the capped image runner so every pytest invocation gets cgroup memory and
+    wall-clock bounds.  Without this every leak repeats #1248.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    launcher = (repo_root / "fido").read_text()
+
+    tests_block = re.search(
+        r"^  tests\)\n(?P<body>.+?)\n    ;;\n",
+        launcher,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert tests_block, "tests case missing from launcher"
+    assert "run_fido_pyproject_image_capped" in tests_block.group("body"), (
+        "tests case must use the capped runner — see #1248"
+    )
+
+    pytest_block = re.search(
+        r"^  pytest\)\n(?P<body>.+?)\n    ;;\n",
+        launcher,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert pytest_block, "pytest case missing from launcher"
+    assert "run_fido_pyproject_image_capped" in pytest_block.group("body"), (
+        "pytest case must use the capped runner — see #1248"
+    )
+
+
+def test_run_container_emits_diagnostic_on_timeout_and_oom() -> None:
+    """``run_container`` must emit a clear, grep-able message on the two
+    cap-trip exit codes (124 timeout, 137 OOM) so a CI failure points at the
+    cause instead of a silent dead container.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    launcher = (repo_root / "fido").read_text()
+
+    assert (
+        "TIMEOUT: container exceeded ${_container_cap_timeout} wall-clock cap (#1248)."
+        in launcher
+    ), "timeout diagnostic missing from run_container"
+    assert (
+        "OOM: container killed by cgroup memory cap ${_container_cap_memory} (#1248)."
+        in launcher
+    ), "OOM diagnostic missing from run_container"
+
+
+def test_run_container_dumps_faulthandler_logs_on_timeout() -> None:
+    """On wall-clock timeout, the launcher must surface any
+    ``/tmp/pyfh-*.log`` files produced by SIGUSR1 dumps so the operator can
+    see *which* worker hung instead of guessing from the empty stderr.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    launcher = (repo_root / "fido").read_text()
+
+    assert "/tmp/pyfh-*.log" in launcher, (
+        "timeout branch should iterate /tmp/pyfh-*.log dumps"
+    )


### PR DESCRIPTION
Fixes #1248.

`./fido tests` and `./fido pytest` now route through a capped container
runner: 8 GiB cgroup memory cap, 5-minute wall-clock timeout.  On trip the
launcher prints a grep-able diagnostic; on timeout it also tails any
`/tmp/pyfh-<pid>.log` SIGUSR1 dumps so the operator sees *which* worker
hung instead of an empty stderr.

`tests/conftest.py` registers `faulthandler` on `SIGUSR1` in every pytest
process (controller + every xdist worker), mirroring the production hook
at `src/fido/server.py:1527`.

The triple-layer is deliberate:

| layer        | mechanism                          | catches                     |
|--------------|------------------------------------|-----------------------------|
| process      | SIGUSR1 → faulthandler dump        | forensics for next hang     |
| container    | docker `--memory=8g`               | leaky test eats RAM         |
| wall-clock   | `timeout 300 docker run ...`       | hung worker in swap forever |

Any one alone reduces pain; all three together close the gap that
produced this morning's box soft-lock + reboot.

## Out of scope

The CI buildx-bake test path (`docker buildx bake test` in
`./fido ci`) is not covered by this PR — bake doesn't use `docker run`
and needs a separate mechanism.  That gap surfaced today as the leaky
pytest worker inside the bake step that I had to SIGKILL.  Filing as
follow-up.

## Test plan

- [ ] `./fido tests` baseline passes after the cap (sanity)
- [ ] Deliberate >8 GiB allocation in a test → exit 137 + clear OOM message
- [ ] `time.sleep(3600)` in a test → exit 124 + clear timeout message + SIGUSR1 dumps surfaced
- [ ] `kill -SIGUSR1 <pytest pid>` mid-run → `/tmp/pyfh-<pid>.log` populated with per-thread stacks