### PR TITLE
Bug: 5 free-threaded data races (3.14t, no GIL) — counters, _stop, crash_error, _threads, _restart_fsm_state (closes #1261)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -551,6 +551,10 @@ class ClaudeSession(OwnedSession):
         # Cumulative message counters — they accumulate since boot and are NOT
         # reset on :meth:`_respawn`, so per-subprocess resets from model
         # switches or recoveries don't erase the history.
+        # _metrics_lock guards both counters: they are written by the worker
+        # thread (send / iter_events) and read from other threads (status,
+        # registry).  Python 3.14t has no GIL, so += is not atomic.
+        self._metrics_lock = threading.Lock()
         self._sent_count: int = 0
         self._received_count: int = 0
         self._proc = self._spawn()
@@ -734,7 +738,8 @@ class ClaudeSession(OwnedSession):
         Accumulates across subprocess respawns — model switches and recoveries
         do not reset the count.
         """
-        return self._sent_count
+        with self._metrics_lock:
+            return self._sent_count
 
     @property
     def received_count(self) -> int:
@@ -743,7 +748,8 @@ class ClaudeSession(OwnedSession):
         Accumulates across subprocess respawns — model switches and recoveries
         do not reset the count.
         """
-        return self._received_count
+        with self._metrics_lock:
+            return self._received_count
 
     def _respawn(self, *, clear_session_id: bool, reason: str) -> None:
         """Stop the current subprocess and spawn a replacement."""
@@ -894,7 +900,8 @@ class ClaudeSession(OwnedSession):
         assert self._proc.stdin is not None
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
-        self._sent_count += 1
+        with self._metrics_lock:
+            self._sent_count += 1
 
     def _drain_to_boundary(self, deadline: float = 10.0) -> None:
         """Abort the in-flight turn and read events until ``type=result`` /
@@ -1322,7 +1329,8 @@ class ClaudeSession(OwnedSession):
                     continue
                 obj = json.loads(line)
                 self._log_event(obj)
-                self._received_count += 1
+                with self._metrics_lock:
+                    self._received_count += 1
                 idle_deadline.reset()
                 # First non-empty event after Send transitions Sending →
                 # AwaitingReply.  Other states (AwaitingReply, Draining,

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -962,6 +962,10 @@ class CopilotCLISession(OwnedSession):
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
+        # _metrics_lock guards both counters: they are written by the worker
+        # thread (send / prompt) and read from other threads (status,
+        # registry).  Python 3.14t has no GIL, so += is not atomic.
+        self._metrics_lock = threading.Lock()
         self._sent_count: int = 0
         self._received_count: int = 0
         # Resume an existing Copilot ACP session when *session_id* is given
@@ -1001,7 +1005,8 @@ class CopilotCLISession(OwnedSession):
         Accumulates across session switches and recoveries — model changes and
         resets do not reset the count.
         """
-        return self._sent_count
+        with self._metrics_lock:
+            return self._sent_count
 
     @property
     def received_count(self) -> int:
@@ -1010,7 +1015,8 @@ class CopilotCLISession(OwnedSession):
         Accumulates across session switches and recoveries — model changes and
         resets do not reset the count.
         """
-        return self._received_count
+        with self._metrics_lock:
+            return self._received_count
 
     @property
     def last_turn_cancelled(self) -> bool:
@@ -1158,13 +1164,15 @@ class CopilotCLISession(OwnedSession):
             "%s",
             _transcript_block("copilot prompt", prompt),
         )
-        self._sent_count += 1
+        with self._metrics_lock:
+            self._sent_count += 1
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
             prompt,
             effective_model,
         )
-        self._received_count += 1
+        with self._metrics_lock:
+            self._received_count += 1
         self._session_id = session_id
         if model is not None:
             self._model = coerce_provider_model(model)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -178,7 +178,7 @@ class WorkerRegistry:
         (``Launch`` vs ``Rescue``) into the extracted ``registry_fsm.transition``
         and dispatches on the returned state, replacing the hand-written
         ``old_thread is not None and not old_thread.is_alive() and not
-        old_thread._stop`` guard entirely.
+        old_thread.was_stopped`` guard entirely.
         """
         provider = None
         session_issue = None
@@ -186,9 +186,7 @@ class WorkerRegistry:
         if old_thread is None:
             # No predecessor — initial start: Absent → Active.
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())
-        elif (
-            not old_thread.is_alive() and not old_thread._stop  # pyright: ignore[reportPrivateUsage]
-        ):
+        elif not old_thread.is_alive() and not old_thread.was_stopped:
             # Crashed predecessor — rescue the live provider:
             # Active → Crashed (ThreadDies) → Active (Rescue).
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.ThreadDies())
@@ -205,7 +203,7 @@ class WorkerRegistry:
             if provider is not None:
                 provider.agent.recover_session()
         elif not old_thread.is_alive():
-            # Orderly-stopped predecessor (_stop is True):
+            # Orderly-stopped predecessor (was_stopped is True):
             # Active → Stopped (ThreadStops) → Active (Launch).
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.ThreadStops())
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -95,6 +95,10 @@ class WorkerRegistry:
 
     def __init__(self, thread_factory: Callable[..., WorkerThread]) -> None:
         self._threads: dict[str, WorkerThread] = {}
+        # _threads_lock guards _threads: written by start() on the watchdog
+        # thread, read from HTTP handler threads (wake, abort_task, get_session,
+        # etc.).  Python 3.14t has no GIL — dict reads and writes are not atomic.
+        self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._activities: dict[str, WorkerActivity] = {}
         self._activity_lock = threading.Lock()
@@ -182,7 +186,8 @@ class WorkerRegistry:
         """
         provider = None
         session_issue = None
-        old_thread = self._threads.get(repo_cfg.name)
+        with self._threads_lock:
+            old_thread = self._threads.get(repo_cfg.name)
         if old_thread is None:
             # No predecessor — initial start: Absent → Active.
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())
@@ -212,7 +217,8 @@ class WorkerRegistry:
             # the no_start_while_active violation as an immediate AssertionError.
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())
         thread = self._factory(repo_cfg, provider=provider, session_issue=session_issue)
-        self._threads[repo_cfg.name] = thread
+        with self._threads_lock:
+            self._threads[repo_cfg.name] = thread
         with self._started_at_lock:
             self._started_at[repo_cfg.name] = _utcnow()
         thread.start()
@@ -228,7 +234,8 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         if thread:
             thread.wake()
 
@@ -242,13 +249,15 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         if thread:
             thread.abort_task(task_id=task_id)
 
     def recover_provider(self, repo_name: str) -> bool:
         """Recover the attached provider session for *repo_name*, if present."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         if thread is None:
             return False
         return thread.recover_provider()
@@ -385,7 +394,9 @@ class WorkerRegistry:
 
     def stop_all(self) -> None:
         """Request every managed thread to stop after its current iteration."""
-        for thread in self._threads.values():
+        with self._threads_lock:
+            threads = list(self._threads.values())
+        for thread in threads:
             thread.stop()
 
     def stop_and_join(self, repo_name: str, timeout: float = 30.0) -> None:
@@ -393,19 +404,22 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         if thread:
             thread.stop()
             thread.join(timeout=timeout)
 
     def is_alive(self, repo_name: str) -> bool:
         """Return True if the thread for *repo_name* is currently alive."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread is not None and thread.is_alive()
 
     def get_thread_crash_error(self, repo_name: str) -> str | None:
         """Return the crash_error stored on the thread for *repo_name*, or None."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.crash_error if thread is not None else None
 
     def get_session_owner(self, repo_name: str) -> str | None:
@@ -415,7 +429,8 @@ class WorkerRegistry:
         registered thread.  Returns ``None`` when no thread is registered for
         the repo, no session exists, or the lock is currently free.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_owner if thread is not None else None
 
     def get_session_alive(self, repo_name: str) -> bool:
@@ -425,7 +440,8 @@ class WorkerRegistry:
         currently holds still reports ``session_alive=True`` so status display
         can distinguish "session exists, idle" from "no session".
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_alive if thread is not None else False
 
     def get_session_pid(self, repo_name: str) -> int | None:
@@ -435,22 +451,26 @@ class WorkerRegistry:
         pgrep — the system prompt file path changed in #456 so the pgrep
         heuristic in :mod:`fido.status` can no longer locate it.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_pid if thread is not None else None
 
     def get_session_dropped_count(self, repo_name: str) -> int:
         """Return how many stale persistent session ids were dropped for *repo_name*."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_dropped_count if thread is not None else 0
 
     def get_session_sent_count(self, repo_name: str) -> int:
         """Return the number of messages sent to the current session subprocess for *repo_name*."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_sent_count if thread is not None else 0
 
     def get_session_received_count(self, repo_name: str) -> int:
         """Return the number of events received from the current session subprocess for *repo_name*."""
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread.session_received_count if thread is not None else 0
 
     def set_rescoping(self, repo_name: str, active: bool) -> None:
@@ -653,7 +673,8 @@ class WorkerRegistry:
         when no worker thread is registered for the repo or the thread has
         not yet created its session.
         """
-        thread = self._threads.get(repo_name)
+        with self._threads_lock:
+            thread = self._threads.get(repo_name)
         return thread._session if thread is not None else None  # pyright: ignore[reportPrivateUsage]
 
     def get_issue_cache(self, repo_name: str) -> IssueTreeCache:

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -646,6 +646,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # "running normally" before any restart trigger fires.  Reset to Running()
     # after an Aborted episode so a subsequent trigger can begin a fresh one.
     _restart_fsm_state: restart_fsm.State = restart_fsm.Running()
+    # _restart_fsm_lock serialises all reads and writes of _restart_fsm_state
+    # across ThreadingHTTPServer handler threads.  Python 3.14t has no GIL —
+    # the read-modify-write in _restart_fsm_transition is not atomic without
+    # an explicit lock.  Class-level so every handler instance shares it.
+    _restart_fsm_lock: threading.Lock = threading.Lock()
 
     def _restart_fsm_transition(self, event: restart_fsm.Event) -> restart_fsm.State:
         """Fire *event* against the process-level self-restart FSM.
@@ -657,14 +662,15 @@ class WebhookHandler(BaseHTTPRequestHandler):
         Uses ``type(self)`` so the class-level state is updated and visible
         to every subsequent handler instance in the same process.
         """
-        prev = type(self)._restart_fsm_state
-        new_state = restart_fsm.transition(prev, event)
-        if new_state is None:
-            raise AssertionError(
-                f"self_restart FSM: {type(event).__name__} rejected in "
-                f"state {type(prev).__name__}"
-            )
-        type(self)._restart_fsm_state = new_state
+        with type(self)._restart_fsm_lock:
+            prev = type(self)._restart_fsm_state
+            new_state = restart_fsm.transition(prev, event)
+            if new_state is None:
+                raise AssertionError(
+                    f"self_restart FSM: {type(event).__name__} rejected in "
+                    f"state {type(prev).__name__}"
+                )
+            type(self)._restart_fsm_state = new_state
         log.debug(
             "self-restart FSM: %s →%s via %s",
             type(prev).__name__,
@@ -1182,7 +1188,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # confirming workers were never touched.  Reset to Running() so a
             # subsequent trigger can begin a fresh episode.
             self._restart_fsm_transition(restart_fsm.SyncFail())
-            type(self)._restart_fsm_state = restart_fsm.Running()
+            with type(self)._restart_fsm_lock:
+                type(self)._restart_fsm_state = restart_fsm.Running()
             return
         # FSM oracle: Syncing → StoppingWorkers.
         self._restart_fsm_transition(restart_fsm.SyncOk())

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4043,7 +4043,7 @@ class WorkerThread(threading.Thread):
         self._membership = membership if membership is not None else RepoMembership()
         self._wake = threading.Event()
         self._abort_task = AbortHandle()
-        self._stop = False
+        self._stop = threading.Event()
         self.crash_error: str | None = None
         self._provider_lock = threading.Lock()
         # Per-repo issue tree cache (closes #812).  Required — hands the
@@ -4199,9 +4199,20 @@ class WorkerThread(threading.Thread):
         self._abort_task.request(task_id)
         self._wake.set()
 
+    @property
+    def was_stopped(self) -> bool:
+        """True if :meth:`stop` was called (orderly shutdown), False if the
+        thread died without a stop request (crash).
+
+        Thread-safe: backed by :class:`threading.Event` so reads from the
+        registry watchdog and writes from the registry's ``stop()`` call are
+        synchronised without explicit locking.
+        """
+        return self._stop.is_set()
+
     def stop(self) -> None:
         """Request the thread to exit after the current iteration."""
-        self._stop = True
+        self._stop.set()
         self._wake.set()
 
     def _ensure_provider(self) -> Provider:
@@ -4329,7 +4340,7 @@ class WorkerThread(threading.Thread):
         set_thread_repo(self._repo_name)
         set_thread_kind("worker")
         try:
-            while not self._stop:
+            while not self._stop.is_set():
                 if self._registry is not None:
                     self._registry.report_activity(
                         self._repo_name, "scanning for work", busy=False
@@ -4407,7 +4418,7 @@ class WorkerThread(threading.Thread):
             set_thread_repo(None)
             # Only stop the session on orderly shutdown — a crashed thread
             # leaves it alive so the registry can hand it to the replacement.
-            if self._stop:
+            if self._stop.is_set():
                 with self._provider_lock:
                     provider = self._provider
                 if provider is not None:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4044,7 +4044,11 @@ class WorkerThread(threading.Thread):
         self._wake = threading.Event()
         self._abort_task = AbortHandle()
         self._stop = threading.Event()
-        self.crash_error: str | None = None
+        # _crash_error_lock guards crash_error: the worker thread writes it on
+        # exception and the registry/watchdog reads it from a different thread.
+        # Python 3.14t has no GIL, so bare attribute publication is not safe.
+        self._crash_error_lock = threading.Lock()
+        self._crash_error: str | None = None
         self._provider_lock = threading.Lock()
         # Per-repo issue tree cache (closes #812).  Required — hands the
         # same cache to every Worker iteration so it survives Worker
@@ -4209,6 +4213,22 @@ class WorkerThread(threading.Thread):
         synchronised without explicit locking.
         """
         return self._stop.is_set()
+
+    @property
+    def crash_error(self) -> str | None:
+        """Error string set when this thread exits due to an unhandled exception.
+
+        ``None`` until the thread crashes.  Thread-safe: guarded by
+        ``_crash_error_lock`` because the worker thread writes it and the
+        registry/watchdog reads it from a different thread.
+        """
+        with self._crash_error_lock:
+            return self._crash_error
+
+    @crash_error.setter
+    def crash_error(self, value: str | None) -> None:
+        with self._crash_error_lock:
+            self._crash_error = value
 
     def stop(self) -> None:
         """Request the thread to exit after the current iteration."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -52,9 +52,9 @@ class TestWorkerRegistry:
         cfg = _repo("foo/bar", tmp_path)
         # First start — no prior thread
         reg.start(cfg)
-        # Simulate crash: thread died, _stop is False, provider is still attached
+        # Simulate crash: thread died, was_stopped is False, provider is still attached
         threads[0].is_alive.return_value = False
-        threads[0]._stop = False
+        threads[0].was_stopped = False
         threads[0].detach_provider.return_value = mock_provider
         threads[0]._session_issue = 42
         # Second start — should rescue provider from crashed thread
@@ -81,7 +81,7 @@ class TestWorkerRegistry:
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         threads[0].is_alive.return_value = False
-        threads[0]._stop = False
+        threads[0].was_stopped = False
         threads[0].detach_provider.return_value = mock_provider
         reg.start(cfg)
         mock_provider.agent.recover_session.assert_called_once_with()
@@ -95,9 +95,9 @@ class TestWorkerRegistry:
         reg = WorkerRegistry(factory)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
-        # Simulate orderly shutdown: _stop is True (session was already stopped)
+        # Simulate orderly shutdown: was_stopped is True (session was already stopped)
         threads[0].is_alive.return_value = False
-        threads[0]._stop = True
+        threads[0].was_stopped = True
         threads[0].detach_provider.return_value = MagicMock()
         reg.start(cfg)
         _, kwargs = factory.call_args_list[1]
@@ -615,7 +615,7 @@ class TestWorkerRegistry:
         # Simulate a crash so the FSM accepts the second start
         # (no_start_while_active: start() on a live thread is rejected).
         threads[0].is_alive.return_value = False
-        threads[0]._stop = False
+        threads[0].was_stopped = False
         reg.start(cfg)
         assert factory.call_count == 2
         # Second start — latest thread is in registry
@@ -1341,7 +1341,7 @@ class TestRegistryFsmOracle:
         )
         # Simulate crash
         threads[0].is_alive.return_value = False
-        threads[0]._stop = False
+        threads[0].was_stopped = False
         reg.start(cfg)
         assert isinstance(
             reg._registry_fsm_states.get("foo/bar"),
@@ -1359,7 +1359,7 @@ class TestRegistryFsmOracle:
         reg.start(cfg)
         # Simulate orderly stop
         threads[0].is_alive.return_value = False
-        threads[0]._stop = True
+        threads[0].was_stopped = True
         reg.start(cfg)
         assert isinstance(
             reg._registry_fsm_states.get("foo/bar"),

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14022,8 +14022,17 @@ class TestWorkerThread:
     def test_stop_sets_flag_and_wakes(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         wt.stop()
-        assert wt._stop is True
+        assert wt._stop.is_set()
         assert wt._wake.is_set()
+
+    def test_was_stopped_false_initially(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        assert wt.was_stopped is False
+
+    def test_was_stopped_true_after_stop(self, tmp_path: Path) -> None:
+        wt = self._make_thread(tmp_path)
+        wt.stop()
+        assert wt.was_stopped is True
 
     # ── loop behaviour ────────────────────────────────────────────────────
 
@@ -14044,7 +14053,7 @@ class TestWorkerThread:
             calls.append(len(calls))
             if len(calls) < 3:
                 return 1
-            wt._stop = True
+            wt._stop.set()
             return 1
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14062,7 +14071,7 @@ class TestWorkerThread:
         wt._wake = mock_wake
 
         def fake_worker_run(self_ignored: object = None) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14079,7 +14088,7 @@ class TestWorkerThread:
         wt._wake = mock_wake
 
         def fake_worker_run(self_ignored: object = None) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 2
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14165,7 +14174,7 @@ class TestWorkerThread:
             nonlocal call_count
             call_count += 1
             if call_count == 2:
-                wt._stop = True
+                wt._stop.set()
             return 0
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14198,7 +14207,7 @@ class TestWorkerThread:
             import fido.worker as wmod
 
             captured.append(getattr(wmod._thread_repo, "repo_name", None))
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14236,7 +14245,7 @@ class TestWorkerThread:
             self_w._session_issue = session_issue
 
         def fake_worker_run(self_w: object) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (
@@ -14260,7 +14269,7 @@ class TestWorkerThread:
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
-                wt._stop = True
+                wt._stop.set()
             return 0
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14285,7 +14294,7 @@ class TestWorkerThread:
         wt._wake = MagicMock()
 
         def fake_worker_run(self_ignored: object = None) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 2
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14302,7 +14311,7 @@ class TestWorkerThread:
         wt._wake = MagicMock()
 
         def fake_worker_run(self_ignored: object = None) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14349,7 +14358,7 @@ class TestWorkerThread:
             call_count += 1
             if call_count == 1:
                 return 1
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (
@@ -14404,7 +14413,7 @@ class TestWorkerThread:
             if call_count == 1:
                 self_w._session_issue = 42  # first worker picks issue 42
                 return 1
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (
@@ -14434,7 +14443,7 @@ class TestWorkerThread:
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
         wt._session = mock_session
-        wt._stop = True  # exit immediately without running any Worker
+        wt._stop.set()  # exit immediately without running any Worker
 
         with patch.object(Worker, "run"):
             wt.run()
@@ -14552,7 +14561,7 @@ class TestWorkerThread:
             self_w._session_issue = session_issue
 
         def fake_worker_run(self_w: object) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (
@@ -14657,7 +14666,7 @@ class TestWorkerThread:
             call_count += 1
             if call_count == 1:
                 raise ContextOverflowError("context window exceeded")
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (
@@ -14839,7 +14848,7 @@ class TestWorkerThread:
             received_repo_cfg.append(repo_cfg)
 
         def fake_worker_run(self_w: object) -> int:
-            wt._stop = True
+            wt._stop.set()
             return 0
 
         with (


### PR DESCRIPTION
Fixes #1261.

Fixes five free-threaded data races exposed by Python 3.14t (no GIL): unguarded counter increments in ClaudeSession and CopilotCLISession, a bare bool `_stop` flag replaced with `threading.Event`, unsynchronized `crash_error` string publication, an unprotected `_threads` dict in WorkerRegistry, and raw class-level FSM state mutation in WebhookHandler.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] Add _threads_lock to WorkerRegistry for all _threads dict access <!-- type:spec -->
- [x] Add lock to WebhookHandler._restart_fsm_state transitions <!-- type:spec -->
- [x] Synchronize WorkerThread.crash_error publish/read with a lock <!-- type:spec -->
- [x] Replace WorkerThread._stop bool with threading.Event <!-- type:spec -->
- [x] Guard CopilotCLISession counters with _metrics_lock <!-- type:spec -->
- [x] Guard ClaudeSession counters with _metrics_lock (mirror codex.py pattern) <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->