### PR TITLE
Fix 3 CLAUDE.md drift violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Extra arguments are passed through to `docker buildx bake` before the
 `make-rocq` target:
 
 ```bash
-./fido make-rocq --no-cache
+./fido make-rocq --set='*.args.ROCQ_JOBS=4'
 ```
 
 All Python checks run inside buildx bake targets. Rocq test artifacts are

--- a/fido
+++ b/fido
@@ -1095,6 +1095,9 @@ case "$command" in
   pytest)
     run_fido_pyproject_image_capped pytest "${@:2}"
     ;;
+  smoke)
+    run_fido_test_python_image tools/codex_appserver_smoke.py "${@:2}"
+    ;;
   *)
     echo "unsupported fido command: $command" >&2
     echo "run ./fido help for supported commands" >&2

--- a/src/fido/fido_help.py
+++ b/src/fido/fido_help.py
@@ -25,7 +25,8 @@ Commands:
   lsp               Query Rocq navigation, actions, graph, rename, and tokens.
   ruff              Run ruff from the prebuilt container toolchain.
   pyright           Run pyright from the prebuilt container toolchain.
-  pytest            Run pytest from the prebuilt container toolchain."""
+  pytest            Run pytest from the prebuilt container toolchain.
+  smoke             Run the Codex app-server smoke test."""
     )
 
 

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -8,8 +8,6 @@ that no other test currently covers.  Tests are grouped by source
 module.
 """
 
-from __future__ import annotations
-
 import io
 import queue
 from pathlib import Path

--- a/tools/codex_appserver_smoke.py
+++ b/tools/codex_appserver_smoke.py
@@ -4,9 +4,9 @@
 This is intentionally not part of CI: it talks to the local Codex install and
 account. Run it when changing Codex app-server integration code:
 
-    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --turn
-    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --resume
-    PYTHONPATH=src ./pyproject .venv/bin/python tools/codex_appserver_smoke.py --interrupt
+    ./fido smoke --turn
+    ./fido smoke --resume
+    ./fido smoke --interrupt
 """
 
 import argparse


### PR DESCRIPTION
## Summary

- **README.md**: removed `--no-cache` from the `make-rocq` example — CLAUDE.md forbids passing `--no-cache` to any buildx-backed command
- **tests/test_coverage_fills.py**: deleted `from __future__ import annotations` — project targets 3.14t only, no `__future__` imports allowed
- **tools/codex_appserver_smoke.py**: replaced host `.venv/bin/python` invocation with new `./fido smoke` subcommand that runs the script through the container launcher

## Test plan

- [x] All 3857 tests pass, 100% coverage
- [x] `./fido help` shows the new `smoke` subcommand
- [x] Full CI passes via pre-commit hook

Closes #1262