### PR TITLE
Bug: finalize PR on zero-task setup instead of crash-looping (closes #1275)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -86,6 +86,15 @@ _RETRY_COMMENT_MARKER = "<!-- fido:retry-ack -->"
 # subsequent iteration.
 _EMPTY_PR_COMMENT_MARKER = "<!-- fido:empty-pr-blocked -->"
 
+# Invisible HTML marker on the one-time comment fido posts when the
+# setup turn legitimately produces zero tasks because the work appears
+# already complete on the branch.  Closes #1275 (worker crash-loop):
+# previously the worker raised RuntimeError on zero tasks and the
+# watchdog respawned it into the same setup turn forever.  Now we
+# post a Fido-voice justification, mark the PR ready, and request
+# review.  The marker keeps the comment idempotent across re-entry.
+_NO_TASKS_PR_COMMENT_MARKER = "<!-- fido:no-tasks-finalize -->"
+
 log = logging.getLogger(__name__)
 
 _thread_repo: threading.local = threading.local()
@@ -1873,7 +1882,13 @@ class Worker:
                     session_mode=self._consume_turn_session_mode(),
                 )
                 if not self._tasks.list():
-                    raise RuntimeError(f"setup produced no tasks for PR #{pr_number}")
+                    # Setup legitimately produced zero tasks — the work on this
+                    # branch already covers the issue.  Finalize rather than
+                    # crash (closes #1275): post a Fido-voice comment, mark
+                    # the PR ready, request review.
+                    self._finalize_setup_with_no_tasks(
+                        repo_ctx, issue, issue_title, pr_number, slug
+                    )
             log.info(
                 "PR: #%s  https://github.com/%s/pull/%s",
                 pr_number,
@@ -1953,9 +1968,6 @@ class Worker:
             session_mode=self._consume_turn_session_mode(),
         )
 
-        if not self._tasks.list():
-            raise RuntimeError("setup produced no tasks")
-
         # Create draft PR, then write the description using the same function
         # used for post-rescope rewrites so both paths share one code path.
         url = self.gh.create_pr(
@@ -1969,6 +1981,22 @@ class Worker:
         with State(fido_dir).modify() as state:
             state["pr_number"] = pr_number
             state["pr_title"] = request
+
+        if not self._tasks.list():
+            # Setup legitimately produced zero tasks — the model decided no
+            # further work is needed beyond what's already on the branch.
+            # Finalize rather than crash (closes #1275): post a Fido-voice
+            # comment, mark the PR ready, request review.  The PR was just
+            # created so it has only the wip:start commit; the finalize
+            # helper's diff guard will leave it as draft if there's nothing
+            # to review (#1194), and the comment will still explain why.
+            self._finalize_setup_with_no_tasks(
+                repo_ctx, issue, issue_title, pr_number, slug
+            )
+            log.info("PR: #%s opened with 0 tasks (setup found no work)", pr_number)
+            log.info("PR: #%s  %s", pr_number, url)
+            return pr_number, slug, True
+
         _write_pr_description(
             self.work_dir,
             self.gh,
@@ -2722,6 +2750,71 @@ class Worker:
                     repo,
                     pr_number,
                 )
+
+    def _finalize_setup_with_no_tasks(
+        self,
+        repo_ctx: RepoContext,
+        issue: int,
+        issue_title: str,
+        pr_number: int,
+        slug: str,
+    ) -> None:
+        """Setup produced 0 tasks because the work appears already complete —
+        finalize the PR rather than crash.
+
+        Generates a Fido-voice comment justifying why no further tasks are
+        needed, posts it, marks the PR ready for review, and requests review
+        from the configured collaborators.  Closes #1275 (worker crash-loop
+        on the previous ``RuntimeError("setup produced no tasks ...")``).
+
+        Idempotent on :data:`_NO_TASKS_PR_COMMENT_MARKER`: a second call on
+        a PR already finalized via this path will not re-post or re-mark.
+        The diff guard from #1194 still applies — if the branch has no diff
+        vs base, the PR is left as draft (still with the explanation comment).
+        """
+        existing = self.gh.get_issue_comments(repo_ctx.repo, pr_number)
+        if any(_NO_TASKS_PR_COMMENT_MARKER in (c.get("body") or "") for c in existing):
+            log.info(
+                "PR #%s: setup produced no tasks — finalize already posted, skipping",
+                pr_number,
+            )
+            return
+        body_text = safe_voice_turn(
+            self._provider_agent,
+            (
+                f'Setup just finished for issue #{issue} ("{issue_title}") and '
+                "produced zero new tasks because the work on this branch already "
+                "covers what the issue asked for. Write a PR comment in your "
+                "voice (1-2 short paragraphs) justifying why this PR has no "
+                "further tasks left to plan. Reference what's actually on the "
+                "branch vs what the issue asked for, and conclude that the PR "
+                "is ready for review. Output ONLY the comment body — no "
+                "preamble, no markdown fence, no signature."
+            ),
+            model=self._provider_agent.voice_model,
+            log_prefix="finalize_setup_no_tasks",
+        )
+        body = f"{body_text.strip()}\n\n{_NO_TASKS_PR_COMMENT_MARKER}"
+        self.gh.comment_issue(repo_ctx.repo, pr_number, body)
+        log.info("PR #%s: setup produced no tasks — posted finalize comment", pr_number)
+        if not self._pr_has_real_diff("origin", slug, repo_ctx.default_branch):
+            log.warning(
+                "PR #%s: setup produced no tasks but branch has no diff vs %s — "
+                "leaving as draft (#1194)",
+                pr_number,
+                repo_ctx.default_branch,
+            )
+            return
+        self.gh.pr_ready(repo_ctx.repo, pr_number)
+        log.info("PR #%s: setup produced no tasks — marked ready for review", pr_number)
+        if repo_ctx.collaborators:
+            reviewers = sorted(repo_ctx.collaborators)
+            self.gh.add_pr_reviewers(repo_ctx.repo, pr_number, reviewers)
+            log.info(
+                "PR #%s: setup produced no tasks — requested review from %s",
+                pr_number,
+                ", ".join(reviewers),
+            )
 
     def _post_empty_pr_comment_once(self, repo: str, pr_number: int) -> None:
         """Post a one-time BLOCKED comment when the empty-diff guard refuses

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4584,9 +4584,10 @@ class TestFindOrCreatePr:
         assert "resuming" in caplog.text
 
     def test_open_pr_runs_setup_when_no_tasks(self, tmp_path: Path) -> None:
-        mock_client = _client()
+        mock_client = _client(return_value="No work needed.")
         worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
         gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_issue_comments.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
         mock_start = MagicMock(return_value="sess-1")
@@ -4594,9 +4595,9 @@ class TestFindOrCreatePr:
             patch.object(worker, "_git"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", mock_start),
-            pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY, labels=None)
@@ -4610,35 +4611,48 @@ class TestFindOrCreatePr:
         )
 
     def test_open_pr_setup_context_includes_work_dir(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+        mock_client = _client(return_value="No work needed.")
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
         gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_issue_comments.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
         with (
             patch.object(worker, "_git"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="sess"),
-            pytest.raises(RuntimeError),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
         assert f"Work dir: {tmp_path}" in context
 
-    def test_open_pr_setup_no_tasks_raises(self, tmp_path: Path) -> None:
-        worker, gh = self._make_worker(tmp_path)
+    def test_open_pr_setup_no_tasks_finalizes(self, tmp_path: Path) -> None:
+        """Closes #1275: setup with 0 tasks finalizes (comment + ready + reviewer)
+        instead of raising and crash-looping."""
+        mock_client = _client(return_value="Branch already covers the issue.")
+        worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
         gh.find_pr.return_value = self._open_pr(number=20, slug="my-br")
+        gh.get_issue_comments.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
+            patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt"),
             patch("fido.worker.provider_start", return_value="sess"),
-            pytest.raises(RuntimeError, match="setup produced no tasks"),
         ):
-            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
+            result = worker.find_or_create_pr(
+                fido_dir, self._make_repo_ctx(), 5, "Issue title"
+            )
+        assert result == (20, "my-br", False)
+        gh.comment_issue.assert_called_once()
+        body = gh.comment_issue.call_args.args[2]
+        assert "<!-- fido:no-tasks-finalize -->" in body
+        gh.pr_ready.assert_called_once_with("owner/proj", 20)
 
     def test_open_pr_setup_persists_session_id(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -4837,7 +4851,7 @@ class TestFindOrCreatePr:
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="fido"),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert "new branch" in caplog.text
@@ -4857,7 +4871,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.provider_start", mock_start),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         mock_build.assert_called_once_with(fido_dir, "setup", ANY, labels=None)
@@ -4884,7 +4898,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.provider_start", return_value="s"),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
@@ -4939,7 +4953,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.provider_start", return_value=""),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         # _reset_local_workspace fires first: checkout default, fetch, reset
@@ -4979,7 +4993,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.provider_start", return_value=""),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         assert ["branch", "-D", "slug"] in git_calls
@@ -5015,22 +5029,33 @@ class TestFindOrCreatePr:
         assert "!" not in slug
         assert is_fresh is True
 
-    def test_no_pr_setup_no_tasks_raises(self, tmp_path: Path) -> None:
-        """New-PR path: setup produces no tasks → raises RuntimeError, skips PR creation."""
-        mock_client = _client()
+    def test_no_pr_setup_no_tasks_finalizes(self, tmp_path: Path) -> None:
+        """Closes #1275: fresh-PR path with 0 tasks creates the PR and finalizes
+        (comment + ready + reviewer) instead of raising and crash-looping."""
+        mock_client = _client(return_value="Nothing to plan — already done.")
         mock_client.generate_branch_name.return_value = "fix-bug"
         worker, gh = self._make_worker(tmp_path, provider_agent=mock_client)
         gh.find_pr.return_value = None
+        gh.create_pr.return_value = "https://github.com/owner/proj/pull/77"
+        gh.get_issue_comments.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         with (
             patch.object(worker, "_git"),
+            patch.object(worker, "_reset_local_workspace"),
+            patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt"),
             patch("fido.worker.provider_start", return_value="sess"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError, match="setup produced no tasks"),
         ):
-            worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
-        gh.create_pr.assert_not_called()
+            result = worker.find_or_create_pr(
+                fido_dir, self._make_repo_ctx(), 5, "Issue title"
+            )
+        assert result == (77, "fix-bug", True)
+        gh.create_pr.assert_called_once()
+        gh.comment_issue.assert_called_once()
+        body = gh.comment_issue.call_args.args[2]
+        assert "<!-- fido:no-tasks-finalize -->" in body
+        gh.pr_ready.assert_called_once_with("owner/proj", 77)
 
     def test_no_pr_logs_pr_number(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -5100,7 +5125,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="sess"),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(
                 fido_dir,
@@ -5125,7 +5150,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="sess"),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "Do the thing")
         _, _, context = mock_build.call_args.args
@@ -5145,7 +5170,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="s"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(
                 fido_dir,
@@ -5170,7 +5195,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="s"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
@@ -5199,7 +5224,7 @@ class TestFindOrCreatePr:
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="s"),
             patch("fido.tasks.Tasks.list", return_value=[]),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
@@ -5227,13 +5252,118 @@ class TestFindOrCreatePr:
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
             patch("fido.worker.provider_start", return_value="sess"),
-            pytest.raises(RuntimeError),
+            patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
         assert "## Prior attempts" in context
         assert "PR #88" in context
         assert "First attempt" in context
+
+
+class TestFinalizeSetupWithNoTasks:
+    """Tests for Worker._finalize_setup_with_no_tasks (closes #1275).
+
+    The helper handles the legitimate "setup turn produced zero tasks" case
+    by posting a Fido-voice explanation, marking the PR ready, and requesting
+    review — instead of the prior RuntimeError that crash-looped the worker.
+    """
+
+    def _make_worker(
+        self,
+        tmp_path: Path,
+        *,
+        comment_text: str = "Branch already covers the issue.",
+    ) -> tuple[Worker, MagicMock, MagicMock]:
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        agent = _client(return_value=comment_text)
+        return Worker(tmp_path, gh, provider_agent=agent), gh, agent
+
+    def _make_repo_ctx(
+        self, *, collaborators: frozenset[str] = frozenset({"rhencke"})
+    ) -> RepoContext:
+        return RepoContext(
+            repo="owner/proj",
+            owner="owner",
+            repo_name="proj",
+            gh_user="fido-bot",
+            default_branch="main",
+            membership=RepoMembership(collaborators=collaborators),
+        )
+
+    def test_posts_voice_comment_marks_ready_requests_review(
+        self, tmp_path: Path
+    ) -> None:
+        worker, gh, agent = self._make_worker(
+            tmp_path, comment_text="Looks like this PR is already cooked through."
+        )
+        with patch.object(worker, "_pr_has_real_diff", return_value=True):
+            worker._finalize_setup_with_no_tasks(
+                self._make_repo_ctx(), 5, "Issue title", 42, "fix-bug"
+            )
+        agent.run_turn.assert_called_once()
+        gh.comment_issue.assert_called_once()
+        repo_arg, num_arg, body_arg = gh.comment_issue.call_args.args
+        assert repo_arg == "owner/proj"
+        assert num_arg == 42
+        assert "Looks like this PR is already cooked through." in body_arg
+        assert "<!-- fido:no-tasks-finalize -->" in body_arg
+        gh.pr_ready.assert_called_once_with("owner/proj", 42)
+        gh.add_pr_reviewers.assert_called_once_with("owner/proj", 42, ["rhencke"])
+
+    def test_skips_ready_when_branch_has_no_diff(self, tmp_path: Path) -> None:
+        """#1194 diff guard: comment still posted, but PR stays draft."""
+        worker, gh, _agent = self._make_worker(tmp_path)
+        with patch.object(worker, "_pr_has_real_diff", return_value=False):
+            worker._finalize_setup_with_no_tasks(
+                self._make_repo_ctx(), 5, "Issue title", 42, "fix-bug"
+            )
+        gh.comment_issue.assert_called_once()
+        gh.pr_ready.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
+
+    def test_idempotent_on_marker(self, tmp_path: Path) -> None:
+        """Re-entry when finalize comment already exists — no-op."""
+        worker, gh, agent = self._make_worker(tmp_path)
+        gh.get_issue_comments.return_value = [
+            {"body": "earlier finalize\n\n<!-- fido:no-tasks-finalize -->"},
+        ]
+        with patch.object(worker, "_pr_has_real_diff", return_value=True):
+            worker._finalize_setup_with_no_tasks(
+                self._make_repo_ctx(), 5, "Issue title", 42, "fix-bug"
+            )
+        agent.run_turn.assert_not_called()
+        gh.comment_issue.assert_not_called()
+        gh.pr_ready.assert_not_called()
+        gh.add_pr_reviewers.assert_not_called()
+
+    def test_handles_none_body_in_existing_comments(self, tmp_path: Path) -> None:
+        """A None body field on an existing comment must not crash the marker check."""
+        worker, gh, _agent = self._make_worker(tmp_path)
+        gh.get_issue_comments.return_value = [
+            {"body": None},
+            {"body": "unrelated comment"},
+        ]
+        with patch.object(worker, "_pr_has_real_diff", return_value=True):
+            worker._finalize_setup_with_no_tasks(
+                self._make_repo_ctx(), 5, "Issue title", 42, "fix-bug"
+            )
+        gh.comment_issue.assert_called_once()
+
+    def test_skips_reviewer_request_when_no_collaborators(self, tmp_path: Path) -> None:
+        worker, gh, _agent = self._make_worker(tmp_path)
+        with patch.object(worker, "_pr_has_real_diff", return_value=True):
+            worker._finalize_setup_with_no_tasks(
+                self._make_repo_ctx(collaborators=frozenset()),
+                5,
+                "Issue title",
+                42,
+                "fix-bug",
+            )
+        gh.comment_issue.assert_called_once()
+        gh.pr_ready.assert_called_once()
+        gh.add_pr_reviewers.assert_not_called()
 
 
 class TestResetLocalWorkspaceAndRetryAck:


### PR DESCRIPTION
## Summary

- Worker was crash-looping on PR #1274: setup turn legitimately produced 0 tasks (work already done on the branch), worker raised ``RuntimeError(\"setup produced no tasks for PR #1274\")``, watchdog respawned it into the same setup turn → infinite loop burning provider quota.
- Replace both raise sites in ``find_or_create_pr`` with a finalize path: post a Fido-voice comment justifying why no further tasks are needed, mark the PR ready for review (with the existing #1194 empty-diff guard), and request review from collaborators. Idempotent on ``_NO_TASKS_PR_COMMENT_MARKER``.
- Two paths handled: **resume** (existing PR, 0 tasks after setup → finalize) and **fresh** (no PR yet, 0 tasks after setup → create PR, then finalize).

Closes #1275.

## Test plan

- [ ] Unit: resume path with non-empty existing tasks goes through unchanged.
- [ ] Unit: resume path with 0 tasks calls finalize helper and returns ``(pr_number, slug, False)`` instead of raising.
- [ ] Unit: fresh path with non-empty tasks goes through unchanged.
- [ ] Unit: fresh path with 0 tasks creates PR, calls finalize helper, returns ``(pr_number, slug, True)``.
- [ ] Unit: ``_finalize_setup_with_no_tasks`` posts comment + marks ready + requests reviewers when branch has diff.
- [ ] Unit: ``_finalize_setup_with_no_tasks`` skips ready-mark when branch has no diff (#1194 guard) but still posts comment.
- [ ] Unit: ``_finalize_setup_with_no_tasks`` is idempotent on the marker — second call no-ops.
- [ ] Unit: ``_finalize_setup_with_no_tasks`` skips reviewer request when ``repo_ctx.collaborators`` is empty.
- [ ] ``./fido ci`` passes (100% coverage, lint, format, typecheck).