### PR TITLE
Bug: webhook hot path swallows malformed events — index required keys + narrow broad except (closes #1263)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1141,10 +1141,10 @@ def dispatch(
         return None
 
     if event == "issues" and action == "assigned":
-        assignee = payload.get("assignee", {}).get("login", "")
-        issue = payload.get("issue", {})
-        number = issue.get("number")
-        title = issue.get("title", "")
+        assignee = payload["assignee"]["login"]
+        issue = payload["issue"]
+        number = issue["number"]
+        title = issue["title"]
         if not number:
             return None
         log.info("issue #%s assigned to %s: %s", number, assignee, title)
@@ -1154,11 +1154,11 @@ def dispatch(
         return Action(prompt=f"New issue #{number} assigned to {assignee}: {title}")
 
     if event == "pull_request_review" and action == "submitted":
-        review = payload.get("review", {})
-        pr = payload.get("pull_request", {})
+        review = payload["review"]
+        pr = payload["pull_request"]
         number = pr.get("number")
-        state = review.get("state", "")
-        user = review.get("user", {}).get("login", "")
+        state = review["state"]
+        user = review["user"]["login"]
         review_id = review.get("id")
         if not number:
             return None
@@ -1178,11 +1178,11 @@ def dispatch(
         )
 
     if event == "pull_request_review_comment" and action in {"created", "edited"}:
-        comment = payload.get("comment", {})
-        pr = payload.get("pull_request", {})
+        comment = payload["comment"]
+        pr = payload["pull_request"]
         number = pr.get("number")
-        user = comment.get("user", {}).get("login", "")
-        comment_id = comment.get("id")
+        user = comment["user"]["login"]
+        comment_id = comment["id"]
         if user.lower() in ("fidocancode", "fido-can-code"):
             log.debug("ignoring own comment on PR #%s", number)
             return None
@@ -1194,57 +1194,55 @@ def dispatch(
         comment_body = comment.get("body", "") or ""
         log.info("comment on PR #%s by %s: %s", number, user, comment_body[:80])
         is_bot = user.endswith("[bot]")
-        if comment_id is not None:
-            comment_id = int(comment_id)
-            wev = wct_oracle.EvtReviewComment(1, number, comment_id, user, is_bot)
-            cmd = wct_oracle.translate(wev)
-            assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
-            assert isinstance(cmd.cmd_kind, wct_oracle.ReviewLine), "translate_total"
-            _enqueue_pr_comment_webhook(
-                repo_cfg=repo_cfg,
-                repo=repo,
-                pr_number=number,
-                comment_type="pulls",
-                comment=comment,
-                author=user,
-                is_bot=is_bot,
-                body=comment_body,
-                delivery_id=delivery_id,
-                payload=payload,
-            )
-            prefix = (
-                "Queued edited review comment"
-                if action == "edited"
-                else "Queued review comment"
-            )
-            return _queued_pr_comment_action(
-                prompt=(
-                    f"{prefix} on PR #{number} by {user}"
-                    f" ({'bot' if is_bot else 'human/owner'})"
-                ),
-                repo=repo,
-                pr_number=number,
-                comment_type="pulls",
-                comment_id=comment_id,
-                html_url=comment.get("html_url", ""),
-                author=user,
-                is_bot=is_bot,
-                context={
-                    "comment_body": comment_body,
-                    "delivery_id": delivery_id,
-                    "pr_title": pr.get("title", ""),
-                    "pr_body": pr.get("body", "") or "",
-                    "file": comment.get("path", ""),
-                    "line": comment.get("line"),
-                    "diff_hunk": comment.get("diff_hunk", ""),
-                },
-            )
-        return None
+        comment_id = int(comment_id)
+        wev = wct_oracle.EvtReviewComment(1, number, comment_id, user, is_bot)
+        cmd = wct_oracle.translate(wev)
+        assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
+        assert isinstance(cmd.cmd_kind, wct_oracle.ReviewLine), "translate_total"
+        _enqueue_pr_comment_webhook(
+            repo_cfg=repo_cfg,
+            repo=repo,
+            pr_number=number,
+            comment_type="pulls",
+            comment=comment,
+            author=user,
+            is_bot=is_bot,
+            body=comment_body,
+            delivery_id=delivery_id,
+            payload=payload,
+        )
+        prefix = (
+            "Queued edited review comment"
+            if action == "edited"
+            else "Queued review comment"
+        )
+        return _queued_pr_comment_action(
+            prompt=(
+                f"{prefix} on PR #{number} by {user}"
+                f" ({'bot' if is_bot else 'human/owner'})"
+            ),
+            repo=repo,
+            pr_number=number,
+            comment_type="pulls",
+            comment_id=comment_id,
+            html_url=comment.get("html_url", ""),
+            author=user,
+            is_bot=is_bot,
+            context={
+                "comment_body": comment_body,
+                "delivery_id": delivery_id,
+                "pr_title": pr.get("title", ""),
+                "pr_body": pr.get("body", "") or "",
+                "file": comment.get("path", ""),
+                "line": comment.get("line"),
+                "diff_hunk": comment.get("diff_hunk", ""),
+            },
+        )
 
     if event == "issue_comment" and action in {"created", "edited"}:
-        comment = payload.get("comment", {})
-        issue = payload.get("issue", {})
-        user = comment.get("user", {}).get("login", "")
+        comment = payload["comment"]
+        issue = payload["issue"]
+        user = comment["user"]["login"]
         pr = issue.get("pull_request")
         if not pr:
             log.debug("issue_comment on non-PR issue — ignoring")
@@ -1255,61 +1253,58 @@ def dispatch(
         if not _is_allowed(user, repo_cfg, config):
             log.debug("ignoring comment by %s (not allowed)", user)
             return None
-        number = issue.get("number")
+        number = issue["number"]
         comment_body = comment.get("body", "") or ""
-        comment_id = comment.get("id")
+        comment_id = int(comment["id"])
         is_bot = user.endswith("[bot]")
         log.info("PR comment on #%s by %s: %s", number, user, comment_body[:80])
-        if number is not None and comment_id is not None:
-            comment_id = int(comment_id)
-            wev = wct_oracle.EvtIssueComment(1, number, comment_id, user, is_bot)
-            cmd = wct_oracle.translate(wev)
-            assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
-            assert isinstance(cmd.cmd_kind, wct_oracle.TopLevelPR), "translate_total"
-            _enqueue_pr_comment_webhook(
-                repo_cfg=repo_cfg,
-                repo=repo,
-                pr_number=number,
-                comment_type="issues",
-                comment=comment,
-                author=user,
-                is_bot=is_bot,
-                body=comment_body,
-                delivery_id=delivery_id,
-                payload=payload,
-            )
-            prefix = (
-                "Queued edited PR top-level comment"
-                if action == "edited"
-                else "Queued PR top-level comment"
-            )
-            return _queued_pr_comment_action(
-                prompt=f"{prefix} on #{number} by {user}",
-                repo=repo,
-                pr_number=number,
-                comment_type="issues",
-                comment_id=comment_id,
-                html_url=comment.get("html_url", ""),
-                author=user,
-                is_bot=is_bot,
-                context={
-                    "comment_body": comment_body,
-                    "delivery_id": delivery_id,
-                    "pr_title": issue.get("title", ""),
-                    "pr_body": issue.get("body", "") or "",
-                },
-            )
-        return None
+        wev = wct_oracle.EvtIssueComment(1, number, comment_id, user, is_bot)
+        cmd = wct_oracle.translate(wev)
+        assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
+        assert isinstance(cmd.cmd_kind, wct_oracle.TopLevelPR), "translate_total"
+        _enqueue_pr_comment_webhook(
+            repo_cfg=repo_cfg,
+            repo=repo,
+            pr_number=number,
+            comment_type="issues",
+            comment=comment,
+            author=user,
+            is_bot=is_bot,
+            body=comment_body,
+            delivery_id=delivery_id,
+            payload=payload,
+        )
+        prefix = (
+            "Queued edited PR top-level comment"
+            if action == "edited"
+            else "Queued PR top-level comment"
+        )
+        return _queued_pr_comment_action(
+            prompt=f"{prefix} on #{number} by {user}",
+            repo=repo,
+            pr_number=number,
+            comment_type="issues",
+            comment_id=comment_id,
+            html_url=comment.get("html_url", ""),
+            author=user,
+            is_bot=is_bot,
+            context={
+                "comment_body": comment_body,
+                "delivery_id": delivery_id,
+                "pr_title": issue.get("title", ""),
+                "pr_body": issue.get("body", "") or "",
+            },
+        )
 
     if event == "check_run" and action == "completed":
-        check = payload.get("check_run", {})
-        conclusion = check.get("conclusion", "")
+        check = payload["check_run"]
+        conclusion = check["conclusion"]
         if conclusion not in ("failure", "timed_out"):
             log.debug("check_run completed with %s — ignoring", conclusion)
             return None
-        name = check.get("name", "")
-        prs = check.get("pull_requests", [])
-        pr_nums = [pr.get("number") for pr in prs if pr.get("number")]
+        name = check["name"]
+        prs = check["pull_requests"]
+        pr_nums = [pr["number"] for pr in prs]
         log.info("CI failure: %s (%s) on PRs %s", name, conclusion, pr_nums)
         _ci_conclusion = (
             wct_oracle.CIFailure()
@@ -1326,25 +1321,21 @@ def dispatch(
         )
 
     if event == "pull_request" and action == "closed":
-        pr = payload.get("pull_request", {})
-        number = pr.get("number")
-        if number is not None:
-            removed = FidoStore(repo_cfg.work_dir).clear_pr_comment_queue(
-                repo=repo,
-                pr_number=int(number),
-            )
-            if removed:
-                log.info(
-                    "cleared %d queued comment(s) for closed PR #%s", removed, number
-                )
-        if not pr.get("merged"):
+        pr = payload["pull_request"]
+        number = pr["number"]
+        removed = FidoStore(repo_cfg.work_dir).clear_pr_comment_queue(
+            repo=repo,
+            pr_number=int(number),
+        )
+        if removed:
+            log.info("cleared %d queued comment(s) for closed PR #%s", removed, number)
+        if not pr["merged"]:
             log.debug("PR #%s closed without merge — ignoring", number)
             return None
         log.info("PR #%s merged", number)
-        if number is not None:
-            wev = wct_oracle.EvtPRMerged(1, number)
-            cmd = wct_oracle.translate(wev)
-            assert isinstance(cmd, wct_oracle.CmdPRMerged), "translate_total"
+        wev = wct_oracle.EvtPRMerged(1, number)
+        cmd = wct_oracle.translate(wev)
+        assert isinstance(cmd, wct_oracle.CmdPRMerged), "translate_total"
         return Action(prompt=f"PR #{number} merged — cleanup")
 
     log.debug("ignored event: %s (action=%s)", event, action)
@@ -2060,7 +2051,7 @@ def _task_snapshot(task_list: list[dict[str, Any]]) -> list[tuple[str, str, str]
     Used by :func:`_rewrite_pr_description` to detect whether the task list
     changed while Opus was generating the PR description.
     """
-    return [(t["id"], t.get("status", ""), t.get("title", "")) for t in task_list]
+    return [(t["id"], t["status"], t["title"]) for t in task_list]
 
 
 def _rewrite_pr_description(
@@ -2173,17 +2164,17 @@ def _load_active_context_for_rescope(
     issue_data = gh.view_issue(repo_name, issue_number)
     issue_ctx = ActiveIssue(
         number=issue_number,
-        title=issue_data.get("title", ""),
-        body=issue_data.get("body", ""),
+        title=issue_data["title"],
+        body=issue_data.get("body") or "",
     )
     if not isinstance(pr_number, int):
         return issue_ctx, None
     pr_data = gh.get_pr(repo_name, pr_number)
     pr_ctx = ActivePR(
         number=pr_number,
-        title=pr_data.get("title", "") or "",
+        title=pr_data["title"],
         url=f"https://github.com/{repo_name}/pull/{pr_number}",
-        body=pr_data.get("body", "") or "",
+        body=pr_data["body"] or "",
     )
     return issue_ctx, pr_ctx
 

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1117,8 +1117,8 @@ def dispatch(
     ``changes_requested``, ``dismissed``) are dispatched normally so the
     worker wakes up without waiting for the next poll cycle.
     """
-    action = payload.get("action", "")
-    repo = payload.get("repository", {}).get("full_name", "")
+    action = payload.get("action")
+    repo = repo_cfg.name  # validated at routing time
 
     # Oracle check — deduplicate at the ingress boundary.
     if delivery_id is not None and oracle is not None:

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -731,7 +731,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 event == "push" and payload["ref"] == f"refs/heads/{default_branch}"
             )
         except KeyError as exc:
-            log.warning(
+            log.exception(
                 "webhook: malformed payload, missing key %s (event=%s delivery=%s)",
                 exc,
                 event,

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -19,6 +19,8 @@ from typing import IO, Any, cast
 from urllib.parse import urlparse
 from xml.etree.ElementTree import Element, SubElement, register_namespace, tostring
 
+import requests
+
 from fido import provider
 from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
@@ -35,7 +37,7 @@ from fido.events import (
     reply_to_review,
     thread_lineage_comment_ids,
 )
-from fido.github import GitHub
+from fido.github import GitHub, GraphQLError
 from fido.infra import (
     Clock,
     Filesystem,
@@ -1146,7 +1148,18 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # Let the outer _process_action handler halt fido — we must not
             # swallow a leak into the generic "confused reaction" path below.
             raise
-        except Exception:
+        except (
+            requests.RequestException,
+            GraphQLError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+        ):
+            # Recoverable: transient GitHub/network failures and task-file I/O
+            # contention.  Signal confused reaction so the author sees something
+            # went wrong, then let this webhook thread exit cleanly.
+            # Logic bugs (KeyError, TypeError, AttributeError, etc.) are NOT
+            # caught here — they propagate and crash the thread loudly.
             log.exception("error processing action")
             self._signal_action_error(action)
 
@@ -1428,7 +1441,15 @@ def bootstrap_issue_caches(
             inventory = gh.find_all_open_issues(owner, repo_name)
             cache.load_inventory(inventory, snapshot_started_at=snapshot_started_at)
             registry.wake(name)
-        except Exception:
+        except (
+            requests.RequestException,
+            GraphQLError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ):
+            # Transient GitHub/network failure — ReconcileWatchdog heals within
+            # the hour.  Auth errors (RuntimeError) and logic bugs are NOT
+            # caught; they crash startup loud so misconfiguration is visible.
             log.exception(
                 "startup: failed to bootstrap issue cache for %s — "
                 "ReconcileWatchdog will heal within the hour",

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -711,8 +711,32 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self._respond(400, "invalid json")
             return
 
-        # Route by repo
-        repo_name = payload.get("repository", {}).get("full_name", "")
+        # Route by repo — all keys below are schema-required on real GitHub
+        # webhook payloads.  KeyError means malformed payload → 500 so GitHub
+        # retries and the failure surfaces rather than silently routing to
+        # "unregistered repo" or disabling self-restart.
+        try:
+            repo_name = payload["repository"]["full_name"]
+            # Pre-compute self-restart triggers — needed for both registered and
+            # unregistered repos (_self_restart verifies the runner's git remote).
+            default_branch = payload["repository"]["default_branch"]
+            is_pr_merged = (
+                event == "pull_request"
+                and payload["action"] == "closed"
+                and bool(payload["pull_request"]["merged"])
+            )
+            is_default_push = (
+                event == "push" and payload["ref"] == f"refs/heads/{default_branch}"
+            )
+        except KeyError as exc:
+            log.warning(
+                "webhook: malformed payload, missing key %s (event=%s delivery=%s)",
+                exc,
+                event,
+                delivery,
+            )
+            self._respond(500, "malformed payload")
+            return
         repo_cfg = self.config.repos.get(repo_name)
 
         log.info(
@@ -721,20 +745,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
             payload.get("action", "-"),
             repo_name,
             delivery,
-        )
-
-        # Pre-compute self-restart triggers — needed for both registered and
-        # unregistered repos (_self_restart verifies the runner's git remote).
-        default_branch = payload.get("repository", {}).get("default_branch", "")
-        is_pr_merged = (
-            event == "pull_request"
-            and payload.get("action") == "closed"
-            and bool(payload.get("pull_request", {}).get("merged"))
-        )
-        is_default_push = (
-            event == "push"
-            and bool(default_branch)
-            and payload.get("ref") == f"refs/heads/{default_branch}"
         )
 
         if not repo_cfg:

--- a/src/fido/watchdog.py
+++ b/src/fido/watchdog.py
@@ -1,12 +1,15 @@
 """Watchdog — check WorkerThread health and restart dead threads."""
 
 import logging
+import subprocess
 import threading
 import time
 from datetime import datetime, timezone
 
+import requests
+
 from fido.config import RepoConfig
-from fido.github import GitHub
+from fido.github import GitHub, GraphQLError
 from fido.registry import WorkerRegistry
 from fido.rocq import watchdog_transitions as watchdog_fsm
 
@@ -156,9 +159,10 @@ class ReconcileWatchdog:
     bootstrapped yet — the worker thread does that on its first
     ``find_next_issue`` iteration.
 
-    A failed ``find_all_open_issues`` (rate limit, transient network
-    blip) logs the exception and continues to the next repo — the next
-    hourly tick will retry.
+    A failed ``find_all_open_issues`` due to a transient GitHub/network
+    error logs the exception and continues to the next repo — the next
+    hourly tick will retry.  Logic bugs propagate and crash the thread
+    loudly so they aren't silently swallowed by the last safety net.
     """
 
     def __init__(
@@ -188,7 +192,15 @@ class ReconcileWatchdog:
             snapshot_started_at = datetime.now(tz=timezone.utc)
             try:
                 inventory = self.gh.find_all_open_issues(owner, name)
-            except Exception:
+            except (
+                requests.RequestException,
+                GraphQLError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ):
+                # Transient GitHub/network failure — next hourly tick retries.
+                # Logic bugs (KeyError, TypeError, AttributeError, …) are NOT
+                # caught; they propagate and crash this thread loudly.
                 log.exception(
                     "reconcile-watchdog[%s]: find_all_open_issues failed — "
                     "next hourly tick will retry",

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2362,8 +2362,8 @@ class Worker:
         if config is None or repo_cfg is None:
             raise RuntimeError("thread handling requires explicit config and repo_cfg")
         pr_data = self.gh.get_pr(repo_ctx.repo, pr_number)
-        pr_title = pr_data.get("title") or ""
-        pr_body = pr_data.get("body") or ""
+        pr_title = pr_data["title"]
+        pr_body = pr_data["body"] or ""
         promise_by_anchor = {
             promise.anchor_comment_id: promise
             for promise in promises
@@ -2455,8 +2455,8 @@ class Worker:
         if config is None or repo_cfg is None:
             raise RuntimeError("queued comment handling requires explicit config")
         pr_data = self.gh.get_pr(repo_ctx.repo, queued.pr_number)
-        pr_title = pr_data.get("title") or ""
-        pr_body = pr_data.get("body") or ""
+        pr_title = pr_data["title"]
+        pr_body = pr_data["body"] or ""
         promise: ReplyPromiseRecord | None = None
         try:
             action = self._queued_comment_action(
@@ -3176,8 +3176,8 @@ class Worker:
         else:
             issue_number = None
         pr_data = self.gh.get_pr(repo_ctx.repo, pr_number)
-        pr_title = pr_data.get("title", "") or ""
-        pr_body = pr_data.get("body", "") or ""
+        pr_title = pr_data["title"]
+        pr_body = pr_data["body"] or ""
         pr_url = f"https://github.com/{repo_ctx.repo}/pull/{pr_number}"
         active_ctx = render_active_context(
             issue=ActiveIssue(
@@ -3457,7 +3457,7 @@ class Worker:
         if self._tasks.list():
             return  # already have tasks — nothing to seed
         pr_data = self.gh.get_pr(repo, pr_number)
-        body = pr_data.get("body") or ""
+        body = pr_data["body"] or ""
         match = re.search(
             r"<!-- WORK_QUEUE_START -->(.*?)<!-- WORK_QUEUE_END -->",
             body,

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -2455,65 +2455,6 @@ class TestEventsIngressFsmCollapsed:
             oracle.check_dispatch("test/repo", "delivery-1")
 
 
-class TestEventsDispatchTrailingNone:
-    """Cover the trailing ``return None`` fall-throughs in dispatch
-    (events.py:1335, 1395)."""
-
-    @staticmethod
-    def _config_and_repo_cfg() -> object:
-        config = MagicMock()
-        config.allowed_bots = frozenset()
-        config.repos = {}
-        repo_cfg = MagicMock()
-        repo_cfg.name = "test/repo"
-        repo_cfg.membership = MagicMock()
-        repo_cfg.membership.collaborators = frozenset(["alice"])
-        repo_cfg.membership.team_members = frozenset()
-        return config, repo_cfg
-
-    def test_review_comment_with_no_comment_id_falls_through(self) -> None:
-        # events.py:1335 — pull_request_review_comment with comment_id None
-        # passes the early-returns but skips the enqueue branch.
-        from fido.events import dispatch
-
-        config, repo_cfg = self._config_and_repo_cfg()
-        payload = {
-            "action": "created",
-            "repository": {"full_name": "test/repo"},
-            "comment": {
-                "user": {"login": "alice"},
-                "body": "comment",
-                # no "id" key → comment_id stays None
-            },
-            "pull_request": {"number": 1, "title": "T", "body": "B"},
-        }
-        result = dispatch("pull_request_review_comment", payload, config, repo_cfg)
-        assert result is None
-
-    def test_issue_comment_with_no_number_falls_through(self) -> None:
-        # events.py:1395 — issue_comment with number/comment_id None.
-        from fido.events import dispatch
-
-        config, repo_cfg = self._config_and_repo_cfg()
-        payload = {
-            "action": "created",
-            "repository": {"full_name": "test/repo"},
-            "comment": {
-                "user": {"login": "alice"},
-                "body": "comment",
-                "id": 42,
-            },
-            "issue": {
-                # number missing
-                "pull_request": {"url": "https://github.com/.../pull/1"},
-                "title": "T",
-                "body": "B",
-            },
-        }
-        result = dispatch("issue_comment", payload, config, repo_cfg)
-        assert result is None
-
-
 class TestEventsThreadResolved:
     """Cover ``_thread_task_is_stale_resolved`` early-return branches."""
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1385,13 +1385,13 @@ class TestDispatchIssuesAssigned:
         assert result is not None
         assert "#1" in result.prompt
 
-    def test_no_number_returns_none(self, tmp_path: Path) -> None:
+    def test_zero_number_returns_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         payload = {
             **_payload(),
             "action": "assigned",
             "assignee": {"login": "fido"},
-            "issue": {"title": "test"},
+            "issue": {"number": 0, "title": "test"},
         }
         result = dispatch("issues", payload, cfg, _repo_cfg(tmp_path))
         assert result is None
@@ -6622,10 +6622,6 @@ class TestTaskSnapshot:
 
     def test_empty_list(self) -> None:
         assert _task_snapshot([]) == []
-
-    def test_missing_fields_default_to_empty_string(self) -> None:
-        tasks = [{"id": "x"}]
-        assert _task_snapshot(tasks) == [("x", "", "")]
 
     def test_order_is_preserved(self) -> None:
         tasks = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2456,9 +2456,13 @@ class TestProcessActionInner:
     def test_action_with_reply_to_failure_marks_promise_retryable(
         self, cfg: Config, repo_cfg: RepoConfig, tmp_path: Path
     ) -> None:
-        """When reply_to_comment raises, _fail_reply marks the promise
-        retryable and the outer try/except swallows the exception
-        (signaling a 'confused' reaction via _signal_action_error)."""
+        """When reply_to_comment raises a recoverable error, _fail_reply marks
+        the promise retryable and the narrowed except swallows the exception
+        (signaling a 'confused' reaction via _signal_action_error).
+        Logic bugs (KeyError, TypeError, etc.) are NOT swallowed — only
+        requests.RequestException and friends are caught."""
+        import requests
+
         action = Action(
             prompt="comment",
             reply_to={
@@ -2471,17 +2475,42 @@ class TestProcessActionInner:
             },
             comment_body="boom",
         )
-        mock_reply = MagicMock(side_effect=RuntimeError("boom"))
+        mock_reply = MagicMock(side_effect=requests.RequestException("API down"))
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
-        # _process_action_inner swallows the exception (logs + signal).
+        # _process_action_inner swallows the recoverable exception (logs + signal).
         handler._process_action_inner(action, repo_cfg, self._activity())
         # _signal_action_error fired → confused reaction posted.
         handler.gh.add_reaction.assert_called_with(
             "owner/repo", "pulls", 200, "confused"
         )
+
+    def test_action_with_reply_to_logic_bug_propagates(
+        self, cfg: Config, repo_cfg: RepoConfig, tmp_path: Path
+    ) -> None:
+        """Logic bugs (e.g. KeyError) from reply_to_comment are NOT swallowed —
+        they propagate so the watchdog sees the crash."""
+        action = Action(
+            prompt="comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 201,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="boom",
+        )
+        mock_reply = MagicMock(side_effect=KeyError("missing_key"))
+        WebhookHandler._fn_reply_to_comment = mock_reply
+        WebhookHandler._fn_unblock_tasks = MagicMock()
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        with pytest.raises(KeyError):
+            handler._process_action_inner(action, repo_cfg, self._activity())
 
     def test_action_with_review_comments_calls_reply_to_review(
         self, cfg: Config, repo_cfg: RepoConfig
@@ -2555,8 +2584,10 @@ class TestProcessActionInner:
     def test_action_with_comment_body_failure_marks_promise_retryable(
         self, cfg: Config, repo_cfg: RepoConfig, tmp_path: Path
     ) -> None:
-        """Issue-comment path: handler raises → _fail_reply marks
-        retryable, outer try/except swallows + signals."""
+        """Issue-comment path: recoverable error raises → _fail_reply marks
+        retryable, narrowed except swallows + signals.  Logic bugs propagate."""
+        import requests
+
         action = Action(
             prompt="issue comment",
             thread={
@@ -2569,7 +2600,7 @@ class TestProcessActionInner:
             },
             comment_body="boom",
         )
-        mock_reply = MagicMock(side_effect=RuntimeError("boom"))
+        mock_reply = MagicMock(side_effect=requests.RequestException("API down"))
         WebhookHandler._fn_reply_to_issue_comment = mock_reply
         WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
@@ -2648,6 +2679,13 @@ class TestProcessActionInner:
             },
         )
         handler._signal_action_error(action)  # should not raise
+
+    def test_signal_action_error_no_op_when_no_thread(self, cfg: Config) -> None:
+        """_signal_action_error is a no-op when the action has no thread or
+        reply_to — non-comment events have no comment to react on."""
+        handler = self._handler(cfg)
+        handler._signal_action_error(Action(prompt="push event"))
+        handler.gh.add_reaction.assert_not_called()
 
 
 class TestSynchronousPreemption:
@@ -3252,7 +3290,9 @@ class TestBootstrapIssueCaches:
         mock_gh.find_all_open_issues.assert_any_call("b", "r2")
 
     def test_per_repo_failure_is_swallowed(self, tmp_path: Path) -> None:
-        """A single GitHub API error must not prevent fido from starting."""
+        """A single transient GitHub API error must not prevent fido from starting."""
+        import requests
+
         from fido.server import bootstrap_issue_caches
 
         repos = {
@@ -3260,7 +3300,10 @@ class TestBootstrapIssueCaches:
             "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
         }
         mock_gh = MagicMock()
-        mock_gh.find_all_open_issues.side_effect = [RuntimeError("API down"), []]
+        mock_gh.find_all_open_issues.side_effect = [
+            requests.RequestException("API down"),
+            [],
+        ]
         mock_cache_r2 = MagicMock()
         mock_registry = MagicMock()
         mock_registry.get_issue_cache.side_effect = lambda name: (
@@ -3272,6 +3315,19 @@ class TestBootstrapIssueCaches:
 
         # Second repo should still be bootstrapped.
         mock_cache_r2.load_inventory.assert_called_once()
+
+    def test_logic_bug_in_bootstrap_propagates(self, tmp_path: Path) -> None:
+        """Non-transient errors (logic bugs, auth failures) must propagate
+        loudly so misconfiguration is caught at startup, not silently deferred."""
+        from fido.server import bootstrap_issue_caches
+
+        repos = {"a/r1": RepoConfig(name="a/r1", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_gh.find_all_open_issues.side_effect = RuntimeError("not logged in")
+        mock_registry = MagicMock()
+
+        with pytest.raises(RuntimeError, match="not logged in"):
+            bootstrap_issue_caches(repos, mock_gh, mock_registry)
 
     def test_wakes_worker_after_successful_load(self, tmp_path: Path) -> None:
         """Worker is woken after a successful cache load so it rescans immediately (#995)."""
@@ -3307,6 +3363,8 @@ class TestBootstrapIssueCaches:
 
     def test_does_not_wake_worker_on_failed_load(self, tmp_path: Path) -> None:
         """A failed bootstrap must not wake the worker — the cache is cold (#995)."""
+        import requests
+
         from fido.server import bootstrap_issue_caches
 
         repos = {
@@ -3314,7 +3372,10 @@ class TestBootstrapIssueCaches:
             "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
         }
         mock_gh = MagicMock()
-        mock_gh.find_all_open_issues.side_effect = [RuntimeError("API down"), []]
+        mock_gh.find_all_open_issues.side_effect = [
+            requests.RequestException("API down"),
+            [],
+        ]
         mock_registry = MagicMock()
         mock_registry.get_issue_cache.return_value = MagicMock()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -168,7 +168,12 @@ def server(tmp_path: Path) -> object:
 class TestSignatureVerification:
     def test_valid_signature(self, server: tuple) -> None:
         url, cfg = server
-        body = json.dumps({"hook_id": 1}).encode()
+        body = json.dumps(
+            {
+                "hook_id": 1,
+                "repository": {"full_name": "other/repo", "default_branch": "main"},
+            }
+        ).encode()
         sig = _sign(body, cfg.secret)
         req = urllib.request.Request(
             url,
@@ -1601,6 +1606,58 @@ class TestInvalidJson:
         assert exc_info.value.code == 400
 
 
+class TestMalformedPayload:
+    """Payloads missing schema-required keys return 500 so GitHub retries."""
+
+    def _post_signed(self, url: str, cfg: Config, event: str, payload: dict) -> int:
+        body = json.dumps(payload).encode()
+        sig = _sign(body, cfg.secret)
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-GitHub-Event": event,
+                "X-GitHub-Delivery": "test",
+                "X-Hub-Signature-256": sig,
+            },
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+        return exc_info.value.code
+
+    def test_missing_repository_returns_500(self, server: tuple) -> None:
+        url, cfg = server
+        assert self._post_signed(url, cfg, "issues", {"action": "opened"}) == 500
+
+    def test_missing_default_branch_returns_500(self, server: tuple) -> None:
+        url, cfg = server
+        assert (
+            self._post_signed(
+                url, cfg, "issues", {"repository": {"full_name": "owner/repo"}}
+            )
+            == 500
+        )
+
+    def test_missing_action_on_pull_request_returns_500(self, server: tuple) -> None:
+        url, cfg = server
+        assert (
+            self._post_signed(
+                url,
+                cfg,
+                "pull_request",
+                {
+                    "repository": {
+                        "full_name": "owner/repo",
+                        "default_branch": "main",
+                    }
+                },
+            )
+            == 500
+        )
+
+
 def _post_webhook(url: str, cfg: Config, event: str, payload: dict) -> int:
     body = json.dumps(payload).encode()
     sig = _sign(body, cfg.secret)
@@ -1664,6 +1721,7 @@ class TestPatchIssueCache:
             "repository": {
                 "full_name": f"{repo_owner}/repo",
                 "owner": {"login": repo_owner},
+                "default_branch": "main",
             },
         }
 
@@ -1753,6 +1811,7 @@ class TestProcessAction:
             "repository": {
                 "full_name": f"{repo_owner}/repo",
                 "owner": {"login": repo_owner},
+                "default_branch": "main",
             },
         }
 
@@ -2606,6 +2665,7 @@ class TestSynchronousPreemption:
             "repository": {
                 "full_name": f"{repo_owner}/repo",
                 "owner": {"login": repo_owner},
+                "default_branch": "main",
             },
         }
 
@@ -2905,6 +2965,7 @@ class TestUntriagedInboxWiring:
             "repository": {
                 "full_name": f"{repo_owner}/repo",
                 "owner": {"login": repo_owner},
+                "default_branch": "main",
             },
         }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1658,6 +1658,17 @@ class TestMalformedPayload:
         )
 
 
+def _payload(repo_owner: str = "owner") -> dict:
+    """Base webhook payload fragment with the repository block every event needs."""
+    return {
+        "repository": {
+            "full_name": f"{repo_owner}/repo",
+            "owner": {"login": repo_owner},
+            "default_branch": "main",
+        },
+    }
+
+
 def _post_webhook(url: str, cfg: Config, event: str, payload: dict) -> int:
     body = json.dumps(payload).encode()
     sig = _sign(body, cfg.secret)
@@ -1716,21 +1727,12 @@ class TestReplyPromiseKey:
 class TestPatchIssueCache:
     """Tests for ``_patch_issue_cache`` — webhook → cache event patcher (#812)."""
 
-    def _payload(self, repo_owner: str = "owner") -> dict:
-        return {
-            "repository": {
-                "full_name": f"{repo_owner}/repo",
-                "owner": {"login": repo_owner},
-                "default_branch": "main",
-            },
-        }
-
     def test_assigned_event_patches_cache(self, server: tuple) -> None:
         url, cfg = server
         cache = MagicMock()
         WebhookHandler.registry.get_issue_cache.return_value = cache
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "assigned",
             "issue": {
                 "number": 42,
@@ -1755,7 +1757,7 @@ class TestPatchIssueCache:
         cache = MagicMock()
         WebhookHandler.registry.get_issue_cache.return_value = cache
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "synchronize",
             "pull_request": {"number": 7},
         }
@@ -1768,7 +1770,7 @@ class TestPatchIssueCache:
         cache = MagicMock()
         WebhookHandler.registry.get_issue_cache.return_value = cache
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "labeled",  # not a picker-relevant action
             "issue": {
                 "number": 42,
@@ -1789,7 +1791,7 @@ class TestPatchIssueCache:
         cache.apply_event.side_effect = RuntimeError("boom")
         WebhookHandler.registry.get_issue_cache.return_value = cache
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "assigned",
             "issue": {
                 "number": 42,
@@ -1806,19 +1808,10 @@ class TestPatchIssueCache:
 class TestProcessAction:
     """Tests for _process_action — the background thread that dispatches actions."""
 
-    def _payload(self, repo_owner: str = "owner") -> dict:
-        return {
-            "repository": {
-                "full_name": f"{repo_owner}/repo",
-                "owner": {"login": repo_owner},
-                "default_branch": "main",
-            },
-        }
-
     def test_dispatch_triggers_worker_on_merged_pr(self, server: tuple) -> None:
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 7, "merged": True},
         }
@@ -1833,7 +1826,7 @@ class TestProcessAction:
         """DEFER files a GitHub issue instead — no tasks.json entry."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 202,
@@ -1863,7 +1856,7 @@ class TestProcessAction:
         )
         assert promise is not None
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 203,
@@ -1893,7 +1886,7 @@ class TestProcessAction:
         creation."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 510,
@@ -1926,7 +1919,7 @@ class TestProcessAction:
 
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 511,
@@ -1959,7 +1952,7 @@ class TestProcessAction:
         # NOT collapsed and do wake the worker.
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "submitted",
             "review": {
                 "id": 888,
@@ -1983,7 +1976,7 @@ class TestProcessAction:
         """
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 14, "merged": True},
         }
@@ -2045,7 +2038,7 @@ class TestProcessAction:
 
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 99, "merged": True},
         }
@@ -2061,7 +2054,7 @@ class TestProcessAction:
     def test_exception_in_process_action_does_not_crash(self, server: tuple) -> None:
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 13, "merged": True},
         }
@@ -2077,7 +2070,7 @@ class TestProcessAction:
         """On exception with no comment context (e.g., merged PR), no reaction."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 22, "merged": True},
         }
@@ -2094,7 +2087,7 @@ class TestProcessAction:
         url, cfg = server
         # review submission: reply_to=None, thread=None, review_comments set
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "submitted",
             "review": {
                 "id": 888,
@@ -2175,7 +2168,7 @@ class TestProcessAction:
     def test_dispatch_error_returns_500(self, server: tuple) -> None:
         """When dispatch raises, return 500 so GitHub retries the delivery."""
         url, cfg = server
-        payload = {**self._payload(), "action": "created"}
+        payload = {**_payload(), "action": "created"}
         WebhookHandler._fn_dispatch = MagicMock(side_effect=RuntimeError("boom"))
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
@@ -2185,7 +2178,7 @@ class TestProcessAction:
         """dispatch() must be called before the HTTP response is written."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 999,
@@ -2221,7 +2214,7 @@ class TestProcessAction:
         """A pull_request_review_comment triggers unblock_tasks so BLOCKED tasks resume."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 700,
@@ -2246,7 +2239,7 @@ class TestProcessAction:
         """A top-level PR comment triggers unblock_tasks so BLOCKED tasks resume."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 701,
@@ -2276,7 +2269,7 @@ class TestProcessAction:
         """A PR merge event (no comment body) must NOT trigger unblock_tasks."""
         url, cfg = server
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 72, "merged": True},
         }
@@ -2297,7 +2290,7 @@ class TestProcessAction:
         WebhookHandler._fn_create_task = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 950,
@@ -2326,7 +2319,7 @@ class TestProcessAction:
         WebhookHandler._fn_create_task = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": 1007,
@@ -2698,19 +2691,10 @@ class TestSynchronousPreemption:
     can be de-scheduled and the worker turn can complete.
     """
 
-    def _payload(self, repo_owner: str = "owner") -> dict:
-        return {
-            "repository": {
-                "full_name": f"{repo_owner}/repo",
-                "owner": {"login": repo_owner},
-                "default_branch": "main",
-            },
-        }
-
     def _issue_comment_payload(self, comment_id: int = 900) -> dict:
         """An issue_comment on a PR produces a durable-demand wakeup action."""
         return {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": comment_id,
@@ -2960,7 +2944,7 @@ class TestSynchronousPreemption:
         WebhookHandler._fn_create_task = MagicMock()
 
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 81, "merged": True},
         }
@@ -2998,19 +2982,10 @@ class TestUntriagedInboxWiring:
     """Verify that _do_post_inner / _process_action correctly enter/exit the
     per-repo untriaged inbox for preempting webhook actions (#1067)."""
 
-    def _payload(self, repo_owner: str = "owner") -> dict:
-        return {
-            "repository": {
-                "full_name": f"{repo_owner}/repo",
-                "owner": {"login": repo_owner},
-                "default_branch": "main",
-            },
-        }
-
     def _issue_comment_payload(self, comment_id: int = 950) -> dict:
         """An issue_comment on a PR produces a durable-demand wakeup action."""
         return {
-            **self._payload(),
+            **_payload(),
             "action": "created",
             "comment": {
                 "id": comment_id,
@@ -3030,7 +3005,7 @@ class TestUntriagedInboxWiring:
 
     def _check_run_failure_payload(self) -> dict:
         return {
-            **self._payload(),
+            **_payload(),
             "action": "completed",
             "check_run": {
                 "name": "ci",
@@ -3072,7 +3047,7 @@ class TestUntriagedInboxWiring:
         WebhookHandler._fn_launch_worker = MagicMock()
 
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 81, "merged": True},
         }
@@ -3121,7 +3096,7 @@ class TestUntriagedInboxWiring:
         WebhookHandler._fn_launch_worker = MagicMock()
 
         payload = {
-            **self._payload(),
+            **_payload(),
             "action": "closed",
             "pull_request": {"number": 82, "merged": True},
         }

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -4,6 +4,9 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+import requests
+
 from fido.config import RepoConfig as _RepoConfig
 from fido.provider import ProviderID
 from fido.watchdog import (
@@ -254,19 +257,29 @@ class TestReconcileWatchdogRun:
         assert "snapshot_started_at" in kwargs
 
     def test_continues_to_next_repo_when_inventory_call_raises(self) -> None:
+        """Transient GitHub/network errors are swallowed — the next hourly
+        tick will retry.  The second repo still runs."""
         repo_a = _repo("org/a")
         repo_b = _repo("org/b")
         rw, _registry, cache, gh = _reconcile({"org/a": repo_a, "org/b": repo_b})
 
         def side_effect(owner: str, _name: str) -> list:
             if owner == "org" and _name == "a":
-                raise RuntimeError("rate limited")
+                raise requests.RequestException("rate limited")
             return [{"number": 9}]
 
         gh.find_all_open_issues.side_effect = side_effect
         rw.run()
         # b succeeded even though a raised
         cache.reconcile_with_inventory.assert_called_once()
+
+    def test_logic_bug_propagates_from_reconcile(self) -> None:
+        """Logic bugs (e.g. KeyError) are NOT swallowed — they propagate so
+        the watchdog thread crashes loudly rather than silently corrupting."""
+        rw, _registry, _cache, gh = _reconcile()
+        gh.find_all_open_issues.side_effect = KeyError("unexpected_key")
+        with pytest.raises(KeyError):
+            rw.run()
 
     def test_handles_multiple_repos_independently(self) -> None:
         repo_a = _repo("org/a")


### PR DESCRIPTION
Fixes #1263.

Replace `.get()` defaults with direct indexing on schema-required webhook keys across `server.py`, `events.py`, and `worker.py` so malformed payloads raise `KeyError` instead of silently routing into no-ops. Narrow the broad `except Exception:` blocks in `_process_action`, `bootstrap_issue_caches`, and the reconcile watchdog to known recoverable types so logic bugs propagate loudly. Fix `log.warning` → `log.exception` in the malformed-payload handler and consolidate duplicated test payload helpers along the way.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] [Change `log.warning` to `log.exception` in the KeyError handler for malformed webhook payloads in server.py](https://github.com/FidoCanCode/home/pull/1277#discussion_r3178663887) <!-- type:thread -->
- [x] Consolidate duplicated test payload helpers in test_server.py <!-- type:spec -->
- [x] Narrow broad except Exception in watchdog.py reconcile loop <!-- type:spec -->
- [x] Narrow broad except Exception in server.py _process_action and bootstrap <!-- type:spec -->
- [x] Index required keys in events.py helpers and worker.py PR data lookups <!-- type:spec -->
- [x] Index required webhook keys in events.py dispatch instead of .get() defaults <!-- type:spec -->
- [x] Index required webhook keys in server.py instead of .get() defaults <!-- type:spec -->
- [x] Fix log.warning → log.exception in server.py malformed-payload handler <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->