### PR TITLE
Bug: untriaged-inbox leak parks worker indefinitely (closes #1280)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2336,19 +2336,29 @@ def _reorder_tasks_background(
         kw = kwargs
         current_intents: list[RescopeIntent] = list(intents or [])
         release_untriaged = 0
+        iteration = 0
         # Register as "webhook" so the session talker reflects the true nature of
         # this thread: it is triggered by webhooks and should not be treated as the
         # worker for preemption purposes.  Without this, current_thread_kind()
         # defaults to "worker", causing real webhooks to fire _fire_worker_cancel
         # against the reorder thread and misidentify it as the running worker (#955).
-        set_thread_kind("webhook")
-        if repo_cfg is not None:
-            set_thread_repo(repo_cfg.name)
-        if registry is not None and repo_cfg is not None:
-            registry.set_rescoping(repo_cfg.name, True)
+        #
+        # IMPORTANT: every line from here through the end of the finally must be
+        # inside the try/finally — if a prelude line (set_thread_kind,
+        # set_rescoping, etc.) raises, the finally still has to release the
+        # inbox holds; otherwise the worker parks forever (#1280).
         try:
+            set_thread_kind("webhook")
+            if repo_cfg is not None:
+                set_thread_repo(repo_cfg.name)
+            if registry is not None and repo_cfg is not None:
+                registry.set_rescoping(repo_cfg.name, True)
+            log.info("rescope BG: starting (work_dir=%s)", work_dir)
             while True:
+                iteration += 1
+                log.info("rescope BG: iteration %d starting", iteration)
                 reorder(work_dir, cs, intents=current_intents or None, **kw)
+                log.info("rescope BG: iteration %d complete", iteration)
                 with _reorder_coalesce_lock:
                     pending = state[key].get("pending")
                     if pending is None:
@@ -2356,19 +2366,28 @@ def _reorder_tasks_background(
                     state[key]["pending"] = None
                     cs, kw, current_intents = pending
         finally:
+            log.info("rescope BG: entering finally (iterations=%d)", iteration)
             with _reorder_coalesce_lock:
                 entry = state.get(key)
                 if entry is not None:
                     release_untriaged += int(entry.get("untriaged_holds", 0))
                     entry["untriaged_holds"] = 0
                     entry["running"] = False
+            # Release the inbox holds FIRST. A failure in any subsequent
+            # cleanup step (set_rescoping, set_thread_repo, set_thread_kind)
+            # must not skip the exit_untriaged calls — losing them leaves the
+            # worker permanently blocked on a non-empty inbox counter (#1280).
             if registry is not None and repo_cfg is not None:
-                registry.set_rescoping(repo_cfg.name, False)
                 for _ in range(release_untriaged):
                     registry.exit_untriaged(repo_cfg.name)
+                registry.set_rescoping(repo_cfg.name, False)
             if repo_cfg is not None:
                 set_thread_repo(None)
             set_thread_kind(None)
+            log.info(
+                "rescope BG: finally complete (released %d untriaged hold(s))",
+                release_untriaged,
+            )
 
     t = threading.Thread(
         target=run_loop,
@@ -2386,10 +2405,11 @@ def _reorder_tasks_background(
                 entry["untriaged_holds"] = 0
                 entry["running"] = False
                 entry["pending"] = None
+        # Same ordering as run_loop's finally — release before set_rescoping.
         if registry is not None and repo_cfg is not None:
-            registry.set_rescoping(repo_cfg.name, False)
             for _ in range(release_untriaged):
                 registry.exit_untriaged(repo_cfg.name)
+            registry.set_rescoping(repo_cfg.name, False)
         raise
 
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -651,6 +651,30 @@ class WorkerRegistry:
             ev = self._untriaged_drained[repo_name]
         return ev.wait(timeout=timeout)
 
+    def force_clear_untriaged(self, repo_name: str) -> int:
+        """Reset the untriaged inbox to zero, log loud, and signal drained.
+
+        Backstop for the case where some producer ``enter_untriaged`` call
+        leaks (no matching ``exit_untriaged`` ever fires) and the worker is
+        otherwise stuck waiting forever (#1280).  Returns the count that was
+        cleared.  No-op when the count is already zero.
+        """
+        with self._untriaged_lock:
+            cleared = self._untriaged.get(repo_name, 0)
+            if cleared <= 0:
+                return 0
+            self._untriaged[repo_name] = 0
+            ev = self._untriaged_drained.get(repo_name)
+            if ev is not None:
+                ev.set()
+        log.warning(
+            "untriaged inbox[%s]: force-cleared %d leaked hold(s) — "
+            "some enter_untriaged call had no matching exit_untriaged",
+            repo_name,
+            cleared,
+        )
+        return cleared
+
     def assert_worker_turn_ok(self, repo_name: str) -> None:
         """Assert that the worker may start a provider turn for *repo_name*.
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -95,6 +95,11 @@ _EMPTY_PR_COMMENT_MARKER = "<!-- fido:empty-pr-blocked -->"
 # review.  The marker keeps the comment idempotent across re-entry.
 _NO_TASKS_PR_COMMENT_MARKER = "<!-- fido:no-tasks-finalize -->"
 
+# Cap on ``wait_for_inbox_drain`` so a leaked ``enter_untriaged`` cannot park
+# the worker forever (#1280).  Five minutes is well past the longest
+# legitimate rescope path; a wait that exceeds it is the leak signature.
+_INBOX_DRAIN_TIMEOUT_SECONDS = 300.0
+
 log = logging.getLogger(__name__)
 
 _thread_repo: threading.local = threading.local()
@@ -200,6 +205,8 @@ class ActivityReporter(Protocol):
     def note_durable_demand_drained(self, repo_name: str) -> None: ...
 
     def assert_worker_turn_ok(self, repo_name: str) -> None: ...
+
+    def force_clear_untriaged(self, repo_name: str) -> int: ...
 
 
 class LockHeld(Exception):
@@ -3011,7 +3018,16 @@ class Worker:
                 "inbox non-empty for %s before provider turn — waiting",
                 self._repo_name,
             )
-            self._registry.wait_for_inbox_drain(self._repo_name, timeout=None)
+            # Backstop the wait so a leaked enter_untriaged with no matching
+            # exit_untriaged cannot park the worker forever (#1280).  A real
+            # rescope settles in tens of seconds; a five-minute wait is well
+            # past the longest legitimate path and still small enough that
+            # surfacing the leak via a warning beats waiting silently.
+            drained = self._registry.wait_for_inbox_drain(
+                self._repo_name, timeout=_INBOX_DRAIN_TIMEOUT_SECONDS
+            )
+            if not drained:
+                self._registry.force_clear_untriaged(self._repo_name)
         if self._has_durable_webhook_demand(pr_number):
             log.info(
                 "durable webhook demand pending for %s — yielding worker turn",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4058,6 +4058,40 @@ class TestGetCommitSummary:
         assert result == ""
 
 
+class _FakeRescopeRegistry:
+    """Hand-rolled fake of the registry slice used by `_reorder_tasks_background`.
+
+    Records calls in order in ``self.calls`` so tests can assert on
+    sequencing — notably the #1280 ordering invariant: the inbox release
+    must run before the late-cleanup steps that could fail.
+
+    No MagicMock — see Rob's no-magicmock feedback (#1280 epic).
+    """
+
+    def __init__(
+        self,
+        *,
+        raise_on_set_rescoping_true: bool = False,
+        raise_on_set_rescoping_false: bool = False,
+    ) -> None:
+        self.calls: list[tuple] = []
+        self._raise_on_true = raise_on_set_rescoping_true
+        self._raise_on_false = raise_on_set_rescoping_false
+
+    def set_rescoping(self, repo_name: str, active: bool) -> None:
+        self.calls.append(("set_rescoping", repo_name, active))
+        if active and self._raise_on_true:
+            raise RuntimeError("rescoping flag broken (true)")
+        if not active and self._raise_on_false:
+            raise RuntimeError("rescoping flag broken (false)")
+
+    def exit_untriaged(self, repo_name: str) -> None:
+        self.calls.append(("exit_untriaged", repo_name))
+
+    def abort_task(self, repo_name: str, *, task_id: str | None = None) -> None:
+        self.calls.append(("abort_task", repo_name, task_id))
+
+
 class TestReorderTasksBackground:
     def _cfg(self, tmp_path: Path) -> Config:
         return Config(
@@ -4240,6 +4274,106 @@ class TestReorderTasksBackground:
 
         registry.set_rescoping.assert_called_once_with("owner/repo", False)
         registry.exit_untriaged.assert_called_once_with("owner/repo")
+
+    def test_release_runs_before_set_rescoping_in_finally(self, tmp_path: Path) -> None:
+        """Release must fire BEFORE set_rescoping so a failure in the latter
+        cannot leave the inbox stuck (#1280).
+        """
+        started: list = []
+        registry = _FakeRescopeRegistry()
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        _, mock_reorder = self._capture_reorder_calls()
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            MagicMock(),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+            _release_untriaged_on_finish=True,
+        )
+        self._run_thread(started)
+
+        # set_rescoping(True) at thread start, then exit_untriaged in finally,
+        # then set_rescoping(False) — exit must precede the False call.
+        assert registry.calls == [
+            ("set_rescoping", "owner/repo", True),
+            ("exit_untriaged", "owner/repo"),
+            ("set_rescoping", "owner/repo", False),
+        ]
+
+    def test_release_runs_even_when_prelude_set_rescoping_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """If `set_rescoping(True)` in the BG prelude raises, the inbox hold
+        must still be released. The prelude is now inside the try/finally
+        for exactly this reason — without that move, any prelude failure
+        would skip the release and leak the count (#1280).
+
+        In production the BG thread is a daemon, so the propagated exception
+        is just printed and the thread dies. Here we run it synchronously,
+        so we catch the propagated exception and inspect the calls list.
+        """
+        started: list = []
+        registry = _FakeRescopeRegistry(raise_on_set_rescoping_true=True)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        _, mock_reorder = self._capture_reorder_calls()
+
+        _reorder_tasks_background(
+            tmp_path,
+            "commits",
+            self._cfg(tmp_path),
+            MagicMock(),
+            repo_cfg=repo_cfg,
+            registry=registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state={},
+            _release_untriaged_on_finish=True,
+        )
+        with pytest.raises(RuntimeError, match="rescoping flag broken"):
+            self._run_thread(started)
+
+        # The prelude raised, so reorder never ran — but the finally must
+        # still have released the inbox hold added synchronously.
+        assert ("exit_untriaged", "owner/repo") in registry.calls
+
+    def test_release_survives_set_rescoping_raising_on_thread_start_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """In the spawn-failure path, exit_untriaged must fire before
+        set_rescoping(False) so a raise in the latter cannot swallow the
+        release (#1280).
+        """
+        registry = _FakeRescopeRegistry(raise_on_set_rescoping_false=True)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+
+        def fail_start(_thread: object) -> Never:
+            raise RuntimeError("cannot start")
+
+        with pytest.raises(RuntimeError):
+            _reorder_tasks_background(
+                tmp_path,
+                "commits",
+                self._cfg(tmp_path),
+                MagicMock(),
+                repo_cfg=repo_cfg,
+                registry=registry,
+                _start=fail_start,
+                _reorder_fn=MagicMock(),
+                _coalesce_state={},
+                _release_untriaged_on_finish=True,
+            )
+
+        # exit_untriaged must come before the failing set_rescoping(False).
+        assert ("exit_untriaged", "owner/repo") in registry.calls
+        exit_idx = registry.calls.index(("exit_untriaged", "owner/repo"))
+        set_false_idx = registry.calls.index(("set_rescoping", "owner/repo", False))
+        assert exit_idx < set_false_idx
 
     def test_on_inprogress_affected_not_in_kwargs_when_no_registry(
         self, tmp_path: Path

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,6 @@
 """Tests for fido.registry — WorkerRegistry lifecycle management."""
 
+import logging
 import threading
 import time
 from pathlib import Path
@@ -1040,6 +1041,47 @@ class TestUntriagedInbox:
         assert not errors, f"concurrent errors: {errors}"
         # After equal enters and exits, count returns to the pre-filled value
         assert reg.has_untriaged("foo/bar") is True
+
+    # ── force_clear_untriaged (#1280) ─────────────────────────────────────
+
+    def test_force_clear_returns_zero_when_count_already_zero(self) -> None:
+        reg = self._reg()
+        assert reg.force_clear_untriaged("foo/bar") == 0
+
+    def test_force_clear_resets_leaked_count_and_returns_it(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        reg = self._reg()
+        reg.enter_untriaged("foo/bar")
+        reg.enter_untriaged("foo/bar")
+        reg.enter_untriaged("foo/bar")
+
+        with caplog.at_level(logging.WARNING):
+            cleared = reg.force_clear_untriaged("foo/bar")
+
+        assert cleared == 3
+        assert reg.has_untriaged("foo/bar") is False
+        assert any(
+            "force-cleared 3 leaked hold(s)" in rec.message for rec in caplog.records
+        )
+
+    def test_force_clear_signals_drained_event_so_waiter_unblocks(self) -> None:
+        reg = self._reg()
+        reg.enter_untriaged("foo/bar")
+        unblocked = threading.Event()
+
+        def waiter() -> None:
+            reg.wait_for_inbox_drain("foo/bar", timeout=2.0)
+            unblocked.set()
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        time.sleep(0.05)
+        assert not unblocked.is_set(), "waiter should still be blocked pre-clear"
+
+        reg.force_clear_untriaged("foo/bar")
+        t.join(timeout=2.0)
+        assert unblocked.is_set(), "force_clear should unblock waiter"
 
 
 class TestPreemptionFsmOracle:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,9 +1,11 @@
 """Tests for fido.worker — WorkerContext, lock acquisition, git context."""
 
+import contextlib
 import logging
 import subprocess
 import threading
 import time
+from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
@@ -11119,22 +11121,87 @@ class TestAssertWorkerTurnOk:
             worker._assert_worker_turn_ok()  # pyright: ignore[reportPrivateUsage]
 
 
+class _FakeActivityReporter:
+    """Hand-rolled fake satisfying ``ActivityReporter`` for inbox-flow tests.
+
+    No MagicMock — see Rob's no-magicmock feedback (#1280 epic).
+    """
+
+    def __init__(
+        self,
+        *,
+        has_untriaged: bool = False,
+        wait_returns: bool = True,
+    ) -> None:
+        self._has_untriaged = has_untriaged
+        self._wait_returns = wait_returns
+        self.wait_calls: list[tuple[str, float | None]] = []
+        self.force_clear_calls: list[str] = []
+        self.assert_calls: list[str] = []
+        self.note_demand_calls: list[str] = []
+        self.note_drained_calls: list[str] = []
+
+    def report_activity(
+        self, repo_name: str, what: str, busy: bool
+    ) -> None:  # pragma: no cover — unused in these tests
+        _ = (repo_name, what, busy)
+
+    def get_all_activities(self) -> list[object]:  # pragma: no cover — unused
+        return []
+
+    def status_update(
+        self,
+    ) -> AbstractContextManager[None]:  # pragma: no cover — unused
+        return contextlib.nullcontext()
+
+    def has_untriaged(self, repo_name: str) -> bool:
+        _ = repo_name
+        return self._has_untriaged
+
+    def wait_for_inbox_drain(
+        self, repo_name: str, timeout: float | None = None
+    ) -> bool:
+        self.wait_calls.append((repo_name, timeout))
+        return self._wait_returns
+
+    def force_clear_untriaged(self, repo_name: str) -> int:
+        self.force_clear_calls.append(repo_name)
+        return 0
+
+    def note_durable_demand(self, repo_name: str) -> None:
+        self.note_demand_calls.append(repo_name)
+
+    def note_durable_demand_drained(self, repo_name: str) -> None:
+        self.note_drained_calls.append(repo_name)
+
+    def assert_worker_turn_ok(self, repo_name: str) -> None:
+        self.assert_calls.append(repo_name)
+
+
 class TestAdmitWorkerTurn:
     """Tests for Worker._admit_worker_turn — the pre-provider gate."""
 
     def test_waits_before_asserting_when_inbox_non_empty(self, tmp_path: Path) -> None:
         gh = MagicMock()
-        registry = MagicMock()
-        registry.assert_worker_turn_ok = MagicMock()
-        registry.has_untriaged.return_value = True
+        registry = _FakeActivityReporter(has_untriaged=True, wait_returns=True)
         worker = Worker(tmp_path, gh, repo_name="owner/repo", registry=registry)
 
         worker._admit_worker_turn(1)  # pyright: ignore[reportPrivateUsage]
 
-        registry.wait_for_inbox_drain.assert_called_once_with(
-            "owner/repo", timeout=None
-        )
-        registry.assert_worker_turn_ok.assert_called_once_with("owner/repo")
+        assert registry.wait_calls == [("owner/repo", 300.0)]
+        assert registry.force_clear_calls == []
+        assert registry.assert_calls == ["owner/repo"]
+
+    def test_force_clears_when_inbox_drain_times_out(self, tmp_path: Path) -> None:
+        gh = MagicMock()
+        registry = _FakeActivityReporter(has_untriaged=True, wait_returns=False)
+        worker = Worker(tmp_path, gh, repo_name="owner/repo", registry=registry)
+
+        worker._admit_worker_turn(1)  # pyright: ignore[reportPrivateUsage]
+
+        assert registry.wait_calls == [("owner/repo", 300.0)]
+        assert registry.force_clear_calls == ["owner/repo"]
+        assert registry.assert_calls == ["owner/repo"]
 
     def test_does_not_wait_when_inbox_empty(self, tmp_path: Path) -> None:
         gh = MagicMock()


### PR DESCRIPTION
## Summary

Closes #1280 — the inbox-counter leak that parked the home worker for ~58 min after a single PR comment landed.

**Most likely root cause** (consistent with the 19:48:28 timeline): the BG rescope thread either crashed in the prelude or hung inside an Opus call. Either way the finally never ran, the inbox hold leaked, and the worker yielded forever waiting on `wait_for_inbox_drain(timeout=None)`.

Three layers, root-cause first:

1. **Move BG prelude into the try/finally** (`events.py`).
   `set_thread_kind`, `set_thread_repo`, `set_rescoping(True)` were OUTSIDE the try. A raise from any of them would skip the finally entirely and leak the count. Now everything from the first prelude line through the loop is inside the try; the finally fires regardless of where the thread crashes.

2. **Reorder the finally so release fires first**.
   `exit_untriaged` calls now run BEFORE `set_rescoping(False)` and the thread-context cleanup. A failure in any later cleanup step can't swallow the release. Same reordering for the spawn-failure except path.

3. **Backstop watchdog + breadcrumb logs**.
   `WorkerRegistry.force_clear_untriaged` zeroes a leaked count, signals the drained event, and logs WARNING with the count cleared. `_admit_worker_turn` caps `wait_for_inbox_drain` at 5 minutes and force-clears on timeout. The BG thread now logs `starting`, `iteration N starting/complete`, `entering finally (iterations=N)`, and `finally complete` — so the next leak is immediately diagnosable from journalctl.

## Tests

- `test_release_runs_before_set_rescoping_in_finally` — call-order invariant via `mock_calls` ordering
- `test_release_runs_even_when_prelude_set_rescoping_raises` — the new prelude-inside-try invariant; without #1, this would leak
- `test_release_survives_set_rescoping_raising_on_thread_start_failure` — same invariant on the spawn-failure path
- `test_force_clear_*` (registry) — three cases: no-op, warns + resets, signals waiter event
- `test_force_clears_when_inbox_drain_times_out` (worker) — backstop fires on timeout
- `test_waits_before_asserting_when_inbox_non_empty` — updated assertion, no force-clear in the happy path

New tests use hand-rolled `_FakeRescopeRegistry` / `_FakeActivityReporter` per Rob's no-MagicMock feedback. Existing MagicMock tests in the same files left alone.

## Test plan

- [x] `./fido tests` — 3869 passed, 100% coverage
- [x] Manual review confirmed prelude-into-try is the most plausible-and-cheapest root-cause patch for the field leak