### PR TITLE
Bug: gh.get_pr drops 'title' — confusio crash-loops on rescope

### DIFF
--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -980,7 +980,7 @@ class GitHub:
             return False
 
     def get_pr(self, repo: str, pr: int | str) -> dict[str, Any]:
-        """Return PR data (reviews, isDraft, mergeStateStatus, body, commits)."""
+        """Return PR data (title, reviews, isDraft, mergeStateStatus, body, commits)."""
         pr_data = self._get(f"/repos/{repo}/pulls/{pr}")
         reviews_data = list(
             self._paginate(f"{self.BASE}/repos/{repo}/pulls/{pr}/reviews")
@@ -1006,6 +1006,7 @@ class GitHub:
             for c in commits_data
         ]
         return {
+            "title": pr_data["title"],
             "reviews": reviews,
             "isDraft": pr_data["draft"],
             "mergeStateStatus": (pr_data.get("mergeable_state") or "").upper(),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2012,6 +2012,7 @@ class TestGitHubClass:
         gh, mock_s = self._gh()
         pr_resp = MagicMock()
         pr_resp.json.return_value = {
+            "title": "Fix bug",
             "draft": False,
             "mergeable_state": "clean",
             "body": "desc",
@@ -2058,11 +2059,16 @@ class TestGitHubClass:
                 "committedDate": "2024-01-02T00:00:00Z",
             }
         ]
+        # Title must be propagated — _load_active_context_for_rescope reads it
+        # directly via pr_data["title"]; missing it crashes the worker (#1280
+        # neighborhood, observed as confusio crash-loop on PR #365).
+        assert result["title"] == "Fix bug"
 
     def test_get_pr_null_body(self) -> None:
         gh, mock_s = self._gh()
         pr_resp = MagicMock()
         pr_resp.json.return_value = {
+            "title": "Draft title",
             "draft": True,
             "mergeable_state": None,
             "body": None,


### PR DESCRIPTION
## Summary

`gh.get_pr` never propagated `title` from the PR payload — its return dict was `{reviews, isDraft, mergeStateStatus, body, commits}`. After PR #1277 tightened `_load_active_context_for_rescope` (events.py:2175) to use `pr_data[\"title\"]`, every rescope crashed with `KeyError: 'title'` and the watchdog crash-looped the confusio worker.

Fix: propagate `title` from the underlying GitHub response. Updated tests; added regression assertion.

## Test plan

- [x] `test_get_pr_returns_dict` now asserts `result[\"title\"]`
- [x] `test_get_pr_null_body` mock includes `title` (matches real responses)
- [x] Full suite green via pre-commit (3873 passed, 100% coverage)