### PR TITLE
Bug: synthetic-success returns mask real failures (commit summary, GitHub fetch, usage snapshot) (closes #1264)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1592,7 +1592,7 @@ class ClaudeAPI(ProviderAPI):
                                 "Claude usage is only available for subscription plans."
                             ),
                         )
-                except Exception as exc:
+                except _requests.RequestException as exc:
                     log.exception("ClaudeAPI: failed to fetch usage snapshot")
                     snapshot = ProviderLimitSnapshot(
                         provider=self.provider_id,

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -638,7 +638,7 @@ class CodexAPI(ProviderAPI):
                         unavailable_reason="Codex rate limits did not include usable windows.",
                     )
                 )
-            except Exception as exc:
+            except (CodexProviderError, CodexProtocolError, OSError) as exc:
                 log.exception("CodexAPI: failed to fetch rate limit snapshot")
                 snapshot = ProviderLimitSnapshot(
                     provider=self.provider_id,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1939,23 +1939,20 @@ def _maybe_abort_for_new_task(
 def _get_commit_summary(work_dir: Path) -> str:
     """Return a short ``git log --oneline`` summary of recent commits.
 
-    Best-effort enrichment: used to give Opus context about what has already
-    been implemented when it reorders the pending task list.  Returns an empty
-    string on nonzero exit, subprocess error, or missing git binary — callers
-    must not treat the result as authoritative.
+    Used to give Opus context about what has already been implemented when it
+    reorders the pending task list.  Raises on subprocess error or nonzero git
+    exit so callers see real failures rather than silently receiving an empty
+    string.
     """
-    try:
-        result = subprocess.run(
-            ["git", "log", "--oneline", "-20"],
-            cwd=work_dir,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=True,
-        )
-        return result.stdout.strip()
-    except subprocess.SubprocessError, OSError:
-        return ""
+    result = subprocess.run(
+        ["git", "log", "--oneline", "-20"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 def _notify_thread_change(

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -313,13 +313,9 @@ class GitHub:
 
         Each entry is {path, line, comments: [{author, body}, ...]}.
         Root comments (no in_reply_to_id) start a new thread; replies are appended.
-        Returns [] on any error.
+        Raises on network or HTTP errors — callers must not treat failure as empty.
         """
-        try:
-            raw = self.get_pull_comments(repo, pr)
-        except Exception:
-            log.exception("failed to fetch sibling threads for %s#%s", repo, pr)
-            return []
+        raw = self.get_pull_comments(repo, pr)
 
         threads: dict[int, dict[str, Any]] = {}
         for c in raw:
@@ -347,13 +343,10 @@ class GitHub:
     ) -> list[dict[str, Any]]:
         """Return all comments in the review thread containing comment_id.
 
-        Returns [{author, body}, ...] in posting order, empty on error.
+        Returns [{author, body}, ...] in posting order.
+        Raises on network or HTTP errors — callers must not treat failure as empty.
         """
-        try:
-            raw = self.get_pull_comments(repo, pr)
-        except Exception:
-            log.exception("failed to fetch comment thread for %s#%s", repo, pr)
-            return []
+        raw = self.get_pull_comments(repo, pr)
 
         by_id = {c["id"]: c for c in raw}
         comment = by_id.get(comment_id)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from fido import provider
 from fido.claude import (
@@ -3083,7 +3084,9 @@ class TestClaudeAPI:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         response = MagicMock()
-        response.raise_for_status.side_effect = RuntimeError("boom")
+        response.raise_for_status.side_effect = requests.ConnectionError(
+            "connection failed"
+        )
         session = MagicMock()
         session.get.return_value = response
         api = ClaudeAPI(
@@ -3096,13 +3099,15 @@ class TestClaudeAPI:
             snapshot = api.get_limit_snapshot()
         assert snapshot == ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE,
-            unavailable_reason="Claude usage unavailable: boom",
+            unavailable_reason="Claude usage unavailable: connection failed",
         )
         assert "ClaudeAPI: failed to fetch usage snapshot" in caplog.text
 
-    def test_limit_snapshot_logs_and_marks_unavailable_when_payload_is_not_an_object(
-        self, caplog: pytest.LogCaptureFixture
+    def test_limit_snapshot_propagates_value_error_when_payload_is_not_an_object(
+        self,
     ) -> None:
+        # ValueError from the shape guard is not a network/auth error — it
+        # propagates so a regression in the API response shape is loud.
         response = MagicMock()
         response.json.return_value = []
         session = MagicMock()
@@ -3113,15 +3118,10 @@ class TestClaudeAPI:
                 "OAuthState", (), {"access_token": "tok-123"}
             )(),
         )
-        with caplog.at_level(logging.ERROR, logger="fido.claude"):
-            snapshot = api.get_limit_snapshot()
-        assert snapshot == ProviderLimitSnapshot(
-            provider=ProviderID.CLAUDE_CODE,
-            unavailable_reason=(
-                "Claude usage unavailable: Claude usage response must be a JSON object"
-            ),
-        )
-        assert "ClaudeAPI: failed to fetch usage snapshot" in caplog.text
+        with pytest.raises(
+            ValueError, match="Claude usage response must be a JSON object"
+        ):
+            api.get_limit_snapshot()
 
 
 class TestClaudeCode:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -535,16 +535,22 @@ class TestCodexAPI:
             "codex_secondary",
         ]
 
-    def test_malformed_response_is_unavailable_snapshot(self) -> None:
+    def test_malformed_response_propagates_value_error(self) -> None:
+        # {"rateLimits": "bad"} causes _codex_limit_windows to raise
+        # ValueError — a shape regression, not a network/auth failure, so
+        # it propagates loudly after the synthetic-success fix.
         fake = _FakeAppServer()
         fake.responses["account/rateLimits/read"] = {"rateLimits": "bad"}
-        snapshot = CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
-        assert snapshot.provider == ProviderID.CODEX
-        assert snapshot.unavailable_reason is not None
+        with pytest.raises(
+            ValueError, match="Codex rateLimits must be an object or list"
+        ):
+            CodexAPI(client_factory=lambda: fake).get_limit_snapshot()
 
     def test_client_factory_failure_is_unavailable_snapshot(self) -> None:
+        # OSError is the realistic exception when the subprocess can't be spawned
+        # (e.g. binary not found). It is in the narrowed catch set.
         def fail() -> _FakeAppServer:
-            raise RuntimeError("codex unavailable")
+            raise OSError("codex unavailable")
 
         snapshot = CodexAPI(client_factory=fail).get_limit_snapshot()
         assert snapshot.provider == ProviderID.CODEX

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -2751,16 +2751,21 @@ class TestCodexLeafBranches:
 class TestCodexAPIBranches:
     """Cover defensive branches in CodexAPI.get_limit_snapshot."""
 
-    def test_get_limit_snapshot_handles_non_dict_response(self) -> None:
-        # codex.py:631 — non-dict payload raises ValueError, caught by
-        # the surrounding except → returns unavailable_reason snapshot.
+    def test_get_limit_snapshot_propagates_value_error_on_non_dict_response(
+        self,
+    ) -> None:
+        # codex.py:631 — non-dict payload raises ValueError; after the
+        # synthetic-success fix this propagates rather than being caught,
+        # so an unexpected API response shape crashes loudly.
         from fido.codex import CodexAPI
 
         bad_client = MagicMock()
         bad_client.request.return_value = "not-a-dict"
         api = CodexAPI(client_factory=lambda: bad_client)
-        snapshot = api.get_limit_snapshot()
-        assert snapshot.unavailable_reason is not None
+        with pytest.raises(
+            ValueError, match="Codex rate limit response must be a JSON object"
+        ):
+            api.get_limit_snapshot()
 
     def test_codex_limit_windows_marks_pressure_one_as_reached(self) -> None:
         # codex.py:580-581 — window with pressure >= 1.0 added to

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -1840,20 +1840,18 @@ class TestEventsCreateTaskExitUntriaged:
 
         with patch.object(events, "_reorder_tasks_background", new=boom):
             with patch.object(events, "launch_sync"):
-                with patch.object(
-                    events, "_get_commit_summary", return_value="summary"
-                ):
-                    with pytest.raises(RuntimeError, match="explode"):
-                        events.create_task(
-                            "prompt",
-                            config,
-                            repo_cfg,
-                            gh,
-                            thread=thread,
-                            registry=registry,
-                            _reorder_background_fn=boom,
-                            _tasks=tasks,
-                        )
+                with pytest.raises(RuntimeError, match="explode"):
+                    events.create_task(
+                        "prompt",
+                        config,
+                        repo_cfg,
+                        gh,
+                        thread=thread,
+                        registry=registry,
+                        _reorder_background_fn=boom,
+                        _get_commit_summary_fn=lambda wd: "summary",
+                        _tasks=tasks,
+                    )
         registry.enter_untriaged.assert_called_once_with("test/repo")
         registry.exit_untriaged.assert_called_once_with("test/repo")
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3258,6 +3258,7 @@ class TestCreateTask:
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3310,6 +3311,7 @@ class TestCreateTask:
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3368,6 +3370,7 @@ class TestCreateTask:
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3420,6 +3423,7 @@ class TestCreateTask:
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         mock_tasks.add.assert_called_once()
 
@@ -3500,6 +3504,7 @@ class TestCreateTask:
                 thread=thread,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )  # no registry
         registry.abort_task.assert_not_called()
 
@@ -3570,6 +3575,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -3616,6 +3622,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -3643,6 +3650,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -3674,6 +3682,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -3705,6 +3714,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -3760,6 +3770,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # ABORT_KEEP: current task stays in tasks.json
@@ -3791,6 +3802,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # task should still be in tasks.json (ABORT_KEEP)
@@ -3821,6 +3833,7 @@ class TestCreateTask:
                 registry=registry,
                 _tasks=mock_tasks,
                 _reorder_background_fn=MagicMock(),
+                _get_commit_summary_fn=lambda wd: "",
             )
         registry.abort_task.assert_not_called()
 
@@ -4023,39 +4036,37 @@ class TestGetCommitSummary:
             check=True,
         )
 
-    def test_returns_empty_on_file_not_found(self, tmp_path: Path) -> None:
+    def test_raises_on_file_not_found(self, tmp_path: Path) -> None:
         with patch("fido.events.subprocess.run", side_effect=FileNotFoundError):
-            result = _get_commit_summary(tmp_path)
-        assert result == ""
+            with pytest.raises(FileNotFoundError):
+                _get_commit_summary(tmp_path)
 
-    def test_returns_empty_on_timeout(self, tmp_path: Path) -> None:
+    def test_raises_on_timeout(self, tmp_path: Path) -> None:
         import subprocess as sp
 
         with patch(
             "fido.events.subprocess.run",
             side_effect=sp.TimeoutExpired(cmd="git", timeout=10),
         ):
-            result = _get_commit_summary(tmp_path)
-        assert result == ""
+            with pytest.raises(sp.TimeoutExpired):
+                _get_commit_summary(tmp_path)
 
-    def test_returns_empty_on_nonzero_exit(self, tmp_path: Path) -> None:
-        # check=True turns a non-zero exit into CalledProcessError, which the
-        # ``except (SubprocessError, OSError)`` arm catches → "".
+    def test_raises_on_nonzero_exit(self, tmp_path: Path) -> None:
         import subprocess as sp
 
         with patch(
             "fido.events.subprocess.run",
             side_effect=sp.CalledProcessError(128, ["git"]),
         ):
-            result = _get_commit_summary(tmp_path)
-        assert result == ""
+            with pytest.raises(sp.CalledProcessError):
+                _get_commit_summary(tmp_path)
 
-    def test_returns_empty_on_oserror(self, tmp_path: Path) -> None:
+    def test_raises_on_oserror(self, tmp_path: Path) -> None:
         with patch(
             "fido.events.subprocess.run", side_effect=OSError("permission denied")
         ):
-            result = _get_commit_summary(tmp_path)
-        assert result == ""
+            with pytest.raises(OSError):
+                _get_commit_summary(tmp_path)
 
 
 class _FakeRescopeRegistry:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -449,13 +449,13 @@ class TestGitHubClass:
         result = gh.fetch_sibling_threads("o/r", 7)
         assert result == []
 
-    def test_fetch_sibling_threads_returns_empty_on_error(self) -> None:
+    def test_fetch_sibling_threads_propagates_error(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()
         mock_resp.raise_for_status.side_effect = Exception("403")
         mock_s.get.return_value = mock_resp
-        result = gh.fetch_sibling_threads("o/r", 7)
-        assert result == []
+        with pytest.raises(Exception, match="403"):
+            gh.fetch_sibling_threads("o/r", 7)
 
     def test_fetch_comment_thread_returns_thread(self) -> None:
         gh, mock_s = self._gh()
@@ -537,13 +537,13 @@ class TestGitHubClass:
         result = gh.fetch_comment_thread("o/r", 7, 999)
         assert result == []
 
-    def test_fetch_comment_thread_returns_empty_on_error(self) -> None:
+    def test_fetch_comment_thread_propagates_error(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()
         mock_resp.raise_for_status.side_effect = Exception("403")
         mock_s.get.return_value = mock_resp
-        result = gh.fetch_comment_thread("o/r", 7, 10)
-        assert result == []
+        with pytest.raises(Exception, match="403"):
+            gh.fetch_comment_thread("o/r", 7, 10)
 
     def test_get_run_log_skips_non_failing_jobs(self) -> None:
         gh, mock_s = self._gh()


### PR DESCRIPTION
Fixes #1264.

Remove synthetic-success returns from four error-handling sites that silently convert real failures into empty strings, empty lists, or fake "unavailable" snapshots. `_get_commit_summary` and the two GitHub thread-fetch methods now let their exceptions propagate, and the usage-snapshot catches in `ClaudeAPI` and `CodexAPI` are narrowed to known network/auth errors so shape mismatches crash loudly.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] Let fetch_sibling_threads and fetch_comment_thread propagate HTTPError <!-- type:spec -->
- [x] Narrow usage-snapshot catch to network/auth errors in ClaudeAPI and CodexAPI <!-- type:spec -->
- [x] Propagate _get_commit_summary exceptions instead of returning empty string <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->