### PR TITLE
Bug: 3 explicit compatibility shims still alive (tasks.py, worker.py session, registry legacy preempt API) (closes #1265)

### DIFF
--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -239,13 +239,12 @@ class WorkerRegistry:
         if thread:
             thread.wake()
 
-    def abort_task(self, repo_name: str, *, task_id: str | None = None) -> None:
+    def abort_task(self, repo_name: str, *, task_id: str) -> None:
         """Signal the worker for *repo_name* to abort *task_id*.
 
-        ``task_id=None`` is the legacy untargeted form (matches whichever
-        task is running).  Real callers should pass the id of the task
-        they intend to abort so a leaked signal cannot clobber a
-        different task on the next loop iteration (closes #1193).
+        Callers must pass the id of the task they intend to abort so a
+        leaked signal cannot clobber a different task on the next loop
+        iteration (closes #1193).
 
         No-op if no thread is registered for that repo.
         """

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -699,7 +699,10 @@ class WorkerRegistry:
         """
         with self._threads_lock:
             thread = self._threads.get(repo_name)
-        return thread._session if thread is not None else None  # pyright: ignore[reportPrivateUsage]
+        if thread is None:
+            return None
+        provider = thread.current_provider()
+        return provider.agent.session if provider is not None else None
 
     def get_issue_cache(self, repo_name: str) -> IssueTreeCache:
         """Return (lazily creating) the per-repo issue tree cache (#812).

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -53,7 +53,7 @@ from fido.state import State
 from fido.static_files import StaticFiles
 from fido.status import provider_statuses_for_repo_configs
 from fido.store import FidoStore, ReplyPromiseRecord
-from fido.tasks import Tasks, unblock_tasks
+from fido.tasks import Tasks
 from fido.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
     ReconcileWatchdog,
@@ -631,7 +631,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
     _fn_reply_to_issue_comment = staticmethod(reply_to_issue_comment)
     _fn_create_task = staticmethod(create_task)
     _fn_launch_worker = staticmethod(launch_worker)
-    _fn_unblock_tasks = staticmethod(unblock_tasks)
     _fn_spawn_bg = staticmethod(_spawn_bg)
     _fn_after_do_post = staticmethod(_noop_after_post)
     _fn_runner_dir = staticmethod(_runner_dir)
@@ -1141,7 +1140,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # When a human comments on a PR, transition any BLOCKED tasks back
             # to PENDING so the worker can re-evaluate and resume.
             if action.reply_to or action.comment_body or action.thread:
-                type(self)._fn_unblock_tasks(repo_cfg.work_dir)
+                Tasks(repo_cfg.work_dir).unblock_tasks()
             # Non-comment events just trigger fido worker — no task needed
             type(self)._fn_launch_worker(repo_cfg, self.registry)
         except provider.SessionLeakError:

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -454,53 +454,6 @@ class _TaskFileLock:
         fd.flush()
 
 
-# Compatibility shims — callers are migrated to Tasks in subsequent commits.
-
-
-def add_task(
-    work_dir: Path,
-    title: str,
-    task_type: TaskType,
-    description: str = "",
-    status: TaskStatus = TaskStatus.PENDING,
-    thread: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Add a task.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).add(
-        title, task_type, description=description, status=status, thread=thread
-    )
-
-
-def update_task(work_dir: Path, task_id: str, status: TaskStatus) -> bool:
-    """Update a task's status.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).update(task_id, status)
-
-
-def list_tasks(work_dir: Path) -> list[dict[str, Any]]:
-    """Read all tasks.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).list()
-
-
-def complete_by_id(work_dir: Path, task_id: str) -> dict[str, Any] | None:
-    """Mark a task completed.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).complete_by_id(task_id)
-
-
-def has_pending_tasks_for_comment(work_dir: Path, comment_id: int | str) -> bool:
-    """Check pending tasks for comment.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).has_pending_for_comment(comment_id)
-
-
-def remove_task(work_dir: Path, task_id: str) -> bool:
-    """Remove a task.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).remove(task_id)
-
-
-def unblock_tasks(work_dir: Path) -> int:
-    """Transition all BLOCKED tasks to PENDING.  Compatibility shim — prefer :class:`Tasks`."""
-    return Tasks(work_dir).unblock_tasks()
-
-
 def _format_work_queue(task_list: list[dict[str, Any]]) -> str:
     """Format a task list into work-queue markdown.
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1089,11 +1089,7 @@ class AbortHandle:
     very next task to enter :meth:`Worker.execute_task`.
 
     The handle binds an abort request to a specific ``task_id``.  Only
-    the cleanup path for the *targeted* task consumes it.  An untargeted
-    request (``task_id=None``) is the legacy "abort whatever is running"
-    semantic, kept available for the external
-    :meth:`WorkerThread.abort_task` entry point that fires before any
-    task is in flight.
+    the cleanup path for the *targeted* task consumes it.
     """
 
     def __init__(self) -> None:
@@ -1101,28 +1097,26 @@ class AbortHandle:
         self._target_task_id: str | None = None
         self._event = threading.Event()
 
-    def request(self, task_id: str | None) -> None:
+    def request(self, task_id: str) -> None:
         """Request abort of *task_id*.
 
-        ``task_id=None`` is an untargeted request that matches whichever
-        task happens to be running.  Real callers (preempt, rescope)
-        always know the task they're aborting and should pass it.
+        All callers (preempt, rescope) know the task they're aborting and
+        must pass it so a leaked signal cannot clobber a different task.
         """
         with self._lock:
             self._target_task_id = task_id
             self._event.set()
 
     def is_active_for(self, task_id: str) -> bool:
-        """Return ``True`` when an abort request matches *task_id*.
+        """Return ``True`` when an abort request targets *task_id*.
 
-        An untargeted (legacy) request matches any task.  A targeted
-        request matches only its named task — a leaked abort from a
+        A request matches only its named task — a leaked abort from a
         prior, since-removed task no longer fires here.
         """
         with self._lock:
             if not self._event.is_set():
                 return False
-            return self._target_task_id is None or self._target_task_id == task_id
+            return self._target_task_id == task_id
 
     def is_set(self) -> bool:
         """Return whether *any* abort request is pending."""
@@ -2943,7 +2937,7 @@ class Worker:
         """Discard uncommitted changes and remove task after an abort signal.
 
         Called when ``self._abort_task`` is *active for* this task —
-        i.e. an abort was requested with this ``task_id`` (or untargeted)
+        i.e. an abort was requested with this ``task_id``
         and ``execute_task`` observed it mid-execution.  Runs
         ``git_clean`` to restore the working tree, removes the task from
         the queue, clears ``current_task_id`` from state, clears the
@@ -4261,14 +4255,12 @@ class WorkerThread(threading.Thread):
         """Signal the thread to wake up and check for work immediately."""
         self._wake.set()
 
-    def abort_task(self, task_id: str | None = None) -> None:
+    def abort_task(self, task_id: str) -> None:
         """Signal the worker to abort *task_id* after provider_run returns.
 
-        ``task_id=None`` is the legacy untargeted form, used by external
-        entry points that want to abort whichever task is running.  Real
-        callers (preempt, rescope) always know the task they're aborting
-        and should pass it so a leaked abort cannot clobber a different,
-        unrelated task on the next loop iteration.
+        All callers must pass the id of the task they intend to abort so
+        a leaked signal cannot clobber a different, unrelated task on the
+        next loop iteration.
         """
         self._abort_task.request(task_id)
         self._wake.set()

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1190,7 +1190,7 @@ class Worker:
             if provider_factory is None
             else provider_factory
         )
-        self.__dict__["_bootstrap_session"] = session
+        self._bootstrap_session: PromptSession | None = session
         if provider is not None:
             self._provider = provider
             if session is not None:
@@ -1207,20 +1207,7 @@ class Worker:
         else:
             self._provider = None
         if self._provider is not None:
-            self.__dict__["_bootstrap_session"] = self._provider.agent.session
-
-    @property
-    def _session(self) -> PromptSession | None:
-        if hasattr(self, "_provider") and self._provider is not None:
-            return self._provider.agent.session
-        return self.__dict__.get("_bootstrap_session")
-
-    @_session.setter
-    def _session(self, session: PromptSession | None) -> None:
-        if hasattr(self, "_provider") and self._provider is not None:
-            self._provider.agent.attach_session(session)
-            return
-        self.__dict__["_bootstrap_session"] = session
+            self._bootstrap_session = self._provider.agent.session
 
     def _ensure_provider(self) -> Provider:
         """Return the owned provider, creating the configured provider if needed."""
@@ -1232,7 +1219,7 @@ class Worker:
                 self._repo_cfg,
                 work_dir=self.work_dir,
                 repo_name=self._repo_name,
-                session=self._session,
+                session=self._bootstrap_session,
             )
             self._provider = provider
         return provider
@@ -1311,7 +1298,6 @@ class Worker:
     def stop_session(self) -> None:
         """Stop the persistent provider session, if one exists."""
         self._provider_agent.stop_session()
-        self._session = None
 
     def _consume_turn_session_mode(self) -> TurnSessionMode:
         session_mode = self._next_turn_session_mode
@@ -1392,9 +1378,9 @@ class Worker:
         (closes #505) — no provider spawn overhead, no hang class, and the
         preempt/cancel plumbing handles webhook interleaving cleanly.
 
-        When ``self._session`` is ``None`` (worker has not yet created a
-        session), logs and returns — status is best-effort and callers should
-        not block on it.
+        When no provider session exists (worker has not yet created a session),
+        logs and returns — status is best-effort and callers should not block
+        on it.
         """
         prompts = self._get_prompts(_sub_dir_fn=_sub_dir_fn)
 
@@ -1413,7 +1399,7 @@ class Worker:
             else:
                 activities = [(self.work_dir.name, what, busy)]
 
-            if self._session is None:
+            if self._provider is None or self._provider.agent.session is None:
                 log.info("set_status: no session available — skipping")
                 return
 
@@ -3940,7 +3926,7 @@ class Worker:
         )
 
         compact_cmd, sync_cmd = self.setup_hooks(ctx.fido_dir)
-        session_fresh = self._session is None
+        session_fresh = self._provider is None or self._provider.agent.session is None
         if session_fresh:
             self.create_session()
         try:
@@ -4114,8 +4100,8 @@ class WorkerThread(threading.Thread):
     ``_provider`` and ``_session_issue`` survive individual :class:`Worker`
     crashes: each new ``Worker`` receives the existing provider via the
     constructor and hands it back after ``run()`` returns (even on exception).
-    The provider owns the persistent session object, while ``_session`` remains
-    a compatibility shim over that attached session for existing worker code.
+    The provider owns the persistent session object and is the authoritative
+    session store for all worker code.
     When this thread itself crashes, :class:`~fido.registry.WorkerRegistry`
     rescues the live provider from the dead thread and passes it to the
     replacement thread via the *provider* constructor parameter, so both the
@@ -4187,35 +4173,10 @@ class WorkerThread(threading.Thread):
         self._session_issue: int | None = session_issue
         self._config = config
         self._repo_cfg = repo_cfg
-        self.__dict__["_bootstrap_session"] = session
+        self._bootstrap_session: PromptSession | None = session
         # True until the first ``Worker.run()`` returns — flipped after that so
         # the one-shot startup backfill (fix #794) only fires once per thread.
         self._is_first_iteration = True
-
-    @property
-    def _session(self) -> PromptSession | None:
-        with self._provider_lock:
-            provider = self._provider
-        if provider is not None:
-            return provider.agent.session
-        return self.__dict__.get("_bootstrap_session")
-
-    @_session.setter
-    def _session(self, session: PromptSession | None) -> None:
-        with self._provider_lock:
-            provider = self._provider
-            if provider is None:
-                if self._repo_cfg is None:
-                    self.__dict__["_bootstrap_session"] = session
-                    return
-                provider = self._provider_factory.create_provider(
-                    self._repo_cfg,
-                    work_dir=self.work_dir,
-                    repo_name=self._repo_name,
-                    session=session,
-                )
-                self._provider = provider
-        provider.agent.attach_session(session)
 
     def detach_provider(self) -> Provider | None:
         """Detach and return the owned provider for crash rescue."""
@@ -4357,7 +4318,7 @@ class WorkerThread(threading.Thread):
                     self._repo_cfg,
                     work_dir=self.work_dir,
                     repo_name=self._repo_name,
-                    session=self._session,
+                    session=self._bootstrap_session,
                 )
                 self._provider = provider
             return provider

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.cli import Cmd, build_parser, main
+from fido.tasks import Tasks
 from fido.types import TaskType
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -94,9 +95,8 @@ class TestCmdAdd:
             tmp_path, TaskType.SPEC, "my task", "some description"
         )
         capsys.readouterr()  # consume add output
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert len(tasks) == 1
         assert tasks[0]["title"] == "my task"
         assert tasks[0]["description"] == "some description"
@@ -108,9 +108,8 @@ class TestCmdAdd:
         _task_file(tmp_path)
         Cmd(github=MagicMock()).add(tmp_path, TaskType.CI, "bare task", "")
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["description"] == ""
         assert tasks[0]["type"] == "ci"
 
@@ -122,9 +121,8 @@ class TestCmdAdd:
             tmp_path, TaskType.THREAD, "threaded", "", comment_id=42, repo="a/b", pr=7
         )
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["thread"] == {"comment_id": 42, "repo": "a/b", "pr": 7}
 
     def test_adds_task_comment_id_only(
@@ -136,9 +134,8 @@ class TestCmdAdd:
             tmp_path, TaskType.THREAD, "threaded", "", comment_id=99
         )
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["thread"] == {"comment_id": 99}
 
     def test_add_deduplicates_by_comment_id(
@@ -165,9 +162,8 @@ class TestCmdAdd:
             pr=7,
         )
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert len(tasks) == 1
         assert tasks[0]["title"] == "first title"
 
@@ -194,9 +190,8 @@ class TestCmdComplete:
         task = cmd.add(tmp_path, TaskType.SPEC, "task to finish", "")
         capsys.readouterr()
         cmd.complete(tmp_path, task["id"])
-        from fido.tasks import list_tasks
 
-        assert list_tasks(tmp_path)[0]["status"] == "completed"
+        assert Tasks(tmp_path).list()[0]["status"] == "completed"
 
     def test_completes_task_with_thread_resolves(
         self,
@@ -205,11 +200,10 @@ class TestCmdComplete:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(
-            tmp_path, title="threaded task", task_type=TaskType.THREAD, thread=thread
+        task = Tasks(tmp_path).add(
+            title="threaded task", task_type=TaskType.THREAD, thread=thread
         )
 
         mock_github = MagicMock()
@@ -258,11 +252,10 @@ class TestCmdComplete:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(
-            tmp_path, title="threaded task", task_type=TaskType.THREAD, thread=thread
+        task = Tasks(tmp_path).add(
+            title="threaded task", task_type=TaskType.THREAD, thread=thread
         )
 
         mock_github = MagicMock()
@@ -312,11 +305,10 @@ class TestCmdComplete:
         self, tmp_path: Path
     ) -> None:
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(
-            tmp_path, title="threaded task", task_type=TaskType.THREAD, thread=thread
+        task = Tasks(tmp_path).add(
+            title="threaded task", task_type=TaskType.THREAD, thread=thread
         )
 
         mock_github = MagicMock()
@@ -331,11 +323,10 @@ class TestCmdComplete:
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(
-            tmp_path, title="threaded task", task_type=TaskType.THREAD, thread=thread
+        task = Tasks(tmp_path).add(
+            title="threaded task", task_type=TaskType.THREAD, thread=thread
         )
 
         mock_github = MagicMock()
@@ -348,11 +339,10 @@ class TestCmdComplete:
 
     def test_completes_task_with_thread_already_resolved(self, tmp_path: Path) -> None:
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(
-            tmp_path, title="threaded task", task_type=TaskType.THREAD, thread=thread
+        task = Tasks(tmp_path).add(
+            title="threaded task", task_type=TaskType.THREAD, thread=thread
         )
 
         mock_github = MagicMock()
@@ -380,11 +370,10 @@ class TestCmdComplete:
     def test_thread_missing_fields_skips(self, tmp_path: Path) -> None:
         """Thread dict with missing fields should silently skip resolution."""
         _task_file(tmp_path)
-        from fido.tasks import add_task
 
         # thread missing 'pr' and 'comment_id'
-        task = add_task(
-            tmp_path, title="task", task_type=TaskType.THREAD, thread={"repo": "a/b"}
+        task = Tasks(tmp_path).add(
+            title="task", task_type=TaskType.THREAD, thread={"repo": "a/b"}
         )
 
         mock_github = MagicMock()
@@ -437,9 +426,8 @@ class TestMain:
         _task_file(tmp_path)
         main([str(tmp_path), "add", "spec", "task title"], _GitHub=MagicMock)
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["title"] == "task title"
 
     def test_add_via_main_with_comment_id(
@@ -462,9 +450,8 @@ class TestMain:
             _GitHub=MagicMock,
         )
         capsys.readouterr()
-        from fido.tasks import list_tasks
 
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["thread"] == {"comment_id": 55, "repo": "r/r", "pr": 3}
 
     def test_complete_via_main(
@@ -475,9 +462,8 @@ class TestMain:
         out = capsys.readouterr().out
         task_id = json.loads(out)["id"]
         main([str(tmp_path), "complete", task_id], _GitHub=MagicMock)
-        from fido.tasks import list_tasks
 
-        assert list_tasks(tmp_path)[0]["status"] == "completed"
+        assert Tasks(tmp_path).list()[0]["status"] == "completed"
 
     def test_list_via_main(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4012,9 +4012,10 @@ class TestCreateTask:
         with patch("fido.events.launch_sync"):
             result = create_task("do a thing", cfg, repo_cfg, MagicMock())
         assert result["title"] == "do a thing"
-        from fido.tasks import list_tasks
 
-        assert any(t["title"] == "do a thing" for t in list_tasks(tmp_path))
+        from fido.tasks import Tasks
+
+        assert any(t["title"] == "do a thing" for t in Tasks(tmp_path).list())
 
 
 class TestGetCommitSummary:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -179,12 +179,12 @@ class TestWorkerRegistry:
         reg, factory = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
-        reg.abort_task("foo/bar")
-        factory.return_value.abort_task.assert_called_once()
+        reg.abort_task("foo/bar", task_id="t-1")
+        factory.return_value.abort_task.assert_called_once_with(task_id="t-1")
 
     def test_abort_task_unknown_repo_is_noop(self) -> None:
         reg, factory = self._make_registry()
-        reg.abort_task("unknown/repo")  # must not raise
+        reg.abort_task("unknown/repo", task_id="t-1")  # must not raise
         factory.return_value.abort_task.assert_not_called()
 
     def test_recover_provider_calls_thread_recover_provider(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -300,7 +300,7 @@ class TestWorkerRegistry:
     def test_get_session_delegates_to_thread(self, tmp_path: Path) -> None:
         reg, factory = self._make_registry()
         fake_session = MagicMock()
-        factory.return_value._session = fake_session
+        factory.return_value.current_provider.return_value.agent.session = fake_session
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session("foo/bar") is fake_session
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,6 +27,8 @@ from fido.infra import Infra
 from fido.provider import ProviderID
 from fido.server import FidoHTTPServer, PreflightError, WebhookHandler, _repo_status
 from fido.store import FidoStore
+from fido.tasks import Tasks
+from fido.types import TaskStatus, TaskType
 
 
 class RepoConfig(_RepoConfig):
@@ -116,7 +118,6 @@ def _restore_handler_fns() -> object:
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
         "_fn_create_task": WebhookHandler._fn_create_task,
         "_fn_launch_worker": WebhookHandler._fn_launch_worker,
-        "_fn_unblock_tasks": WebhookHandler._fn_unblock_tasks,
         "_fn_spawn_bg": WebhookHandler._fn_spawn_bg,
         "_fn_after_do_post": WebhookHandler._fn_after_do_post,
         "_fn_runner_dir": WebhookHandler._fn_runner_dir,
@@ -2211,8 +2212,10 @@ class TestProcessAction:
         assert call_order == ["dispatch", "respond_200"]
 
     def test_review_comment_calls_unblock_tasks(self, server: tuple) -> None:
-        """A pull_request_review_comment triggers unblock_tasks so BLOCKED tasks resume."""
+        """A pull_request_review_comment transitions BLOCKED tasks to PENDING."""
         url, cfg = server
+        work_dir = cfg.repos["owner/repo"].work_dir
+        Tasks(work_dir).add("blocked task", TaskType.SPEC, status=TaskStatus.BLOCKED)
         payload = {
             **_payload(),
             "action": "created",
@@ -2227,17 +2230,18 @@ class TestProcessAction:
             },
             "pull_request": {"number": 71, "title": "My PR", "body": ""},
         }
-        mock_unblock = MagicMock(return_value=0)
         WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
         WebhookHandler._fn_launch_worker = MagicMock()
-        WebhookHandler._fn_unblock_tasks = mock_unblock
         status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert status == 200
-        mock_unblock.assert_called_once_with(cfg.repos["owner/repo"].work_dir)
+        tasks = Tasks(work_dir).list()
+        assert all(t["status"] == str(TaskStatus.PENDING) for t in tasks)
 
     def test_issue_comment_calls_unblock_tasks(self, server: tuple) -> None:
-        """A top-level PR comment triggers unblock_tasks so BLOCKED tasks resume."""
+        """A top-level PR comment transitions BLOCKED tasks to PENDING."""
         url, cfg = server
+        work_dir = cfg.repos["owner/repo"].work_dir
+        Tasks(work_dir).add("blocked task", TaskType.SPEC, status=TaskStatus.BLOCKED)
         payload = {
             **_payload(),
             "action": "created",
@@ -2254,31 +2258,31 @@ class TestProcessAction:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        mock_unblock = MagicMock(return_value=0)
         WebhookHandler.gh = MagicMock()
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             return_value=("ANSWER", [])
         )
         WebhookHandler._fn_launch_worker = MagicMock()
-        WebhookHandler._fn_unblock_tasks = mock_unblock
         status = _post_webhook(url, cfg, "issue_comment", payload)
         assert status == 200
-        mock_unblock.assert_called_once_with(cfg.repos["owner/repo"].work_dir)
+        tasks = Tasks(work_dir).list()
+        assert all(t["status"] == str(TaskStatus.PENDING) for t in tasks)
 
     def test_non_comment_event_does_not_call_unblock_tasks(self, server: tuple) -> None:
-        """A PR merge event (no comment body) must NOT trigger unblock_tasks."""
+        """A PR merge event (no comment body) must NOT unblock BLOCKED tasks."""
         url, cfg = server
+        work_dir = cfg.repos["owner/repo"].work_dir
+        Tasks(work_dir).add("blocked task", TaskType.SPEC, status=TaskStatus.BLOCKED)
         payload = {
             **_payload(),
             "action": "closed",
             "pull_request": {"number": 72, "merged": True},
         }
-        mock_unblock = MagicMock(return_value=0)
         WebhookHandler._fn_launch_worker = MagicMock()
-        WebhookHandler._fn_unblock_tasks = mock_unblock
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
-        mock_unblock.assert_not_called()
+        tasks = Tasks(work_dir).list()
+        assert all(t["status"] == str(TaskStatus.BLOCKED) for t in tasks)
 
     def test_review_comment_handler_stays_off_provider(self, server: tuple) -> None:
         """Review-comment ingestion queues durably without entering provider."""
@@ -2409,7 +2413,6 @@ class TestProcessActionInner:
         mock_task = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = mock_task
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())
@@ -2440,7 +2443,6 @@ class TestProcessActionInner:
         mock_reply = MagicMock()
         WebhookHandler._fn_reply_to_comment = mock_reply
         WebhookHandler._fn_create_task = MagicMock()
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())
@@ -2470,7 +2472,6 @@ class TestProcessActionInner:
         )
         mock_reply = MagicMock(side_effect=requests.RequestException("API down"))
         WebhookHandler._fn_reply_to_comment = mock_reply
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         # _process_action_inner swallows the recoverable exception (logs + signal).
@@ -2499,7 +2500,6 @@ class TestProcessActionInner:
         )
         mock_reply = MagicMock(side_effect=KeyError("missing_key"))
         WebhookHandler._fn_reply_to_comment = mock_reply
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         with pytest.raises(KeyError):
@@ -2515,7 +2515,6 @@ class TestProcessActionInner:
         )
         mock_reply = MagicMock()
         WebhookHandler._fn_reply_to_review = mock_reply
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())
@@ -2540,7 +2539,6 @@ class TestProcessActionInner:
         mock_reply = MagicMock(return_value=("ANSWER", []))
         WebhookHandler._fn_reply_to_issue_comment = mock_reply
         WebhookHandler._fn_create_task = MagicMock()
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())
@@ -2568,7 +2566,6 @@ class TestProcessActionInner:
         )
         mock_reply = MagicMock()
         WebhookHandler._fn_reply_to_issue_comment = mock_reply
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())
@@ -2595,7 +2592,6 @@ class TestProcessActionInner:
         )
         mock_reply = MagicMock(side_effect=requests.RequestException("API down"))
         WebhookHandler._fn_reply_to_issue_comment = mock_reply
-        WebhookHandler._fn_unblock_tasks = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock()
         handler = self._handler(cfg)
         handler._process_action_inner(action, repo_cfg, self._activity())

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -27,15 +27,8 @@ from fido.tasks import (
     _task_source_comment_for_oracle,
     _task_status_for_oracle,
     _task_store_for_oracle,
-    add_task,
-    complete_by_id,
-    has_pending_tasks_for_comment,
-    list_tasks,
-    remove_task,
     reorder_tasks,
     review_thread_for_auto_resolve_oracle,
-    unblock_tasks,
-    update_task,
 )
 from fido.types import TaskStatus, TaskType
 
@@ -291,47 +284,46 @@ class TestRescopeOracleAdapter:
 
 class TestAddTask:
     def test_creates_file(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="test task", task_type=TaskType.SPEC)
+        task = Tasks(tmp_path).add(title="test task", task_type=TaskType.SPEC)
         assert task["title"] == "test task"
         assert task["status"] == "pending"
         assert task["type"] == "spec"
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert len(tasks) == 1
 
     def test_appends(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="one", task_type=TaskType.SPEC)
-        add_task(tmp_path, title="two", task_type=TaskType.SPEC)
-        tasks = list_tasks(tmp_path)
+        Tasks(tmp_path).add(title="one", task_type=TaskType.SPEC)
+        Tasks(tmp_path).add(title="two", task_type=TaskType.SPEC)
+        tasks = Tasks(tmp_path).list()
         assert len(tasks) == 2
 
     def test_with_thread(self, tmp_path: Path) -> None:
         thread = {"repo": "a/b", "pr": 1, "comment_id": 123}
-        task = add_task(tmp_path, title="t", task_type=TaskType.THREAD, thread=thread)
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.THREAD, thread=thread)
         assert task["thread"] == thread
 
     def test_id_is_unique(self, tmp_path: Path) -> None:
-        t1 = add_task(tmp_path, title="a", task_type=TaskType.SPEC)
-        t2 = add_task(tmp_path, title="b", task_type=TaskType.SPEC)
+        t1 = Tasks(tmp_path).add(title="a", task_type=TaskType.SPEC)
+        t2 = Tasks(tmp_path).add(title="b", task_type=TaskType.SPEC)
         assert t1["id"] != t2["id"]
 
     def test_appends_at_end(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="first", task_type=TaskType.SPEC)
-        add_task(tmp_path, title="second", task_type=TaskType.SPEC)
-        tasks = list_tasks(tmp_path)
+        Tasks(tmp_path).add(title="first", task_type=TaskType.SPEC)
+        Tasks(tmp_path).add(title="second", task_type=TaskType.SPEC)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["title"] == "first"
         assert tasks[1]["title"] == "second"
 
     def test_returns_existing_pending_task_if_title_matches(
         self, tmp_path: Path
     ) -> None:
-        t1 = add_task(tmp_path, title="duplicate task", task_type=TaskType.SPEC)
-        t2 = add_task(tmp_path, title="duplicate task", task_type=TaskType.SPEC)
+        t1 = Tasks(tmp_path).add(title="duplicate task", task_type=TaskType.SPEC)
+        t2 = Tasks(tmp_path).add(title="duplicate task", task_type=TaskType.SPEC)
         assert t1["id"] == t2["id"]
-        assert len(list_tasks(tmp_path)) == 1
+        assert len(Tasks(tmp_path).list()) == 1
 
     def test_sanitizes_multiline_title(self, tmp_path: Path) -> None:
-        task = add_task(
-            tmp_path,
+        task = Tasks(tmp_path).add(
             title="first line\n\nsecond paragraph\n- bullet\n- another",
             task_type=TaskType.SPEC,
         )
@@ -339,57 +331,55 @@ class TestAddTask:
         assert "\n" not in task["title"]
 
     def test_collapses_whitespace_in_title(self, tmp_path: Path) -> None:
-        task = add_task(
-            tmp_path,
+        task = Tasks(tmp_path).add(
             title="  too   many    spaces  \t\there  ",
             task_type=TaskType.SPEC,
         )
         assert task["title"] == "too many spaces here"
 
     def test_does_not_deduplicate_completed_tasks(self, tmp_path: Path) -> None:
-        t1 = add_task(tmp_path, title="done task", task_type=TaskType.SPEC)
-        complete_by_id(tmp_path, t1["id"])
-        t2 = add_task(tmp_path, title="done task", task_type=TaskType.SPEC)
+        t1 = Tasks(tmp_path).add(title="done task", task_type=TaskType.SPEC)
+        Tasks(tmp_path).complete_by_id(t1["id"])
+        t2 = Tasks(tmp_path).add(title="done task", task_type=TaskType.SPEC)
         assert t1["id"] != t2["id"]
-        assert len(list_tasks(tmp_path)) == 2
+        assert len(Tasks(tmp_path).list()) == 2
 
     def test_thread_task_appends_at_end(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="existing", task_type=TaskType.SPEC)
+        Tasks(tmp_path).add(title="existing", task_type=TaskType.SPEC)
         thread = {"repo": "r/r", "pr": 1, "comment_id": 42}
-        add_task(
-            tmp_path, title="comment task", task_type=TaskType.THREAD, thread=thread
+        Tasks(tmp_path).add(
+            title="comment task", task_type=TaskType.THREAD, thread=thread
         )
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["title"] == "existing"
         assert tasks[1]["title"] == "comment task"
 
     def test_deduplicates_by_comment_id(self, tmp_path: Path) -> None:
         thread = {"repo": "r/r", "pr": 1, "comment_id": 99}
-        t1 = add_task(
-            tmp_path, title="first title", task_type=TaskType.THREAD, thread=thread
+        t1 = Tasks(tmp_path).add(
+            title="first title", task_type=TaskType.THREAD, thread=thread
         )
-        t2 = add_task(
-            tmp_path, title="second title", task_type=TaskType.THREAD, thread=thread
+        t2 = Tasks(tmp_path).add(
+            title="second title", task_type=TaskType.THREAD, thread=thread
         )
         assert t1["id"] == t2["id"]
-        assert len(list_tasks(tmp_path)) == 1
+        assert len(Tasks(tmp_path).list()) == 1
 
     def test_deduplicates_by_comment_id_even_when_completed(
         self, tmp_path: Path
     ) -> None:
         thread = {"repo": "r/r", "pr": 1, "comment_id": 55}
-        t1 = add_task(
-            tmp_path, title="handle feedback", task_type=TaskType.THREAD, thread=thread
+        t1 = Tasks(tmp_path).add(
+            title="handle feedback", task_type=TaskType.THREAD, thread=thread
         )
-        complete_by_id(tmp_path, t1["id"])
-        t2 = add_task(
-            tmp_path,
+        Tasks(tmp_path).complete_by_id(t1["id"])
+        t2 = Tasks(tmp_path).add(
             title="handle feedback again",
             task_type=TaskType.THREAD,
             thread=thread,
         )
         assert t1["id"] == t2["id"]
-        assert len(list_tasks(tmp_path)) == 1
+        assert len(Tasks(tmp_path).list()) == 1
 
     def test_deduplicates_by_comment_lineage_and_merges_sources(
         self, tmp_path: Path
@@ -409,150 +399,142 @@ class TestAddTask:
             "lineage_comment_ids": [100, 102],
         }
 
-        first = add_task(
-            tmp_path,
+        first = Tasks(tmp_path).add(
             title="handle first comment",
             task_type=TaskType.THREAD,
             thread=first_thread,
         )
-        second = add_task(
-            tmp_path,
+        second = Tasks(tmp_path).add(
             title="handle follow-up comment",
             task_type=TaskType.THREAD,
             thread=second_thread,
         )
 
         assert first["id"] == second["id"]
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert len(tasks) == 1
         assert tasks[0]["thread"]["comment_id"] == 101
         assert tasks[0]["thread"]["lineage_comment_ids"] == [100, 101, 102]
 
     def test_different_comment_ids_are_not_deduplicated(self, tmp_path: Path) -> None:
-        t1 = add_task(
-            tmp_path,
+        t1 = Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 1},
         )
-        t2 = add_task(
-            tmp_path,
+        t2 = Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 2},
         )
         assert t1["id"] != t2["id"]
-        assert len(list_tasks(tmp_path)) == 2
+        assert len(Tasks(tmp_path).list()) == 2
 
     def test_task_type_required(self, tmp_path: Path) -> None:
         import pytest
 
         with pytest.raises(TypeError, match="task_type must be TaskType"):
-            add_task(tmp_path, title="t", task_type="spec")  # type: ignore[arg-type]
+            Tasks(tmp_path).add(title="t", task_type="spec")  # type: ignore[arg-type]
 
 
 class TestUpdateTask:
     def test_updates_status(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        assert update_task(tmp_path, task["id"], TaskStatus.COMPLETED)
-        tasks = list_tasks(tmp_path)
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert Tasks(tmp_path).update(task["id"], TaskStatus.COMPLETED)
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["status"] == "completed"
 
     def test_returns_false_if_not_found(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        assert not update_task(tmp_path, "nonexistent", TaskStatus.COMPLETED)
+        Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert not Tasks(tmp_path).update("nonexistent", TaskStatus.COMPLETED)
 
 
 class TestListTasks:
     def test_empty(self, tmp_path: Path) -> None:
         _task_file(tmp_path).write_text("[]")
-        assert list_tasks(tmp_path) == []
+        assert Tasks(tmp_path).list() == []
 
     def test_corrupt_json(self, tmp_path: Path) -> None:
         _task_file(tmp_path).write_text("not json")
         with pytest.raises(ValueError, match="corrupt tasks.json"):
-            list_tasks(tmp_path)
+            Tasks(tmp_path).list()
 
     def test_raises_on_missing_type_field(self, tmp_path: Path) -> None:
         tf = _task_file(tmp_path)
         tf.write_text('[{"id": "bad", "title": "no type", "status": "pending"}]')
         with pytest.raises(ValueError, match="missing required type field"):
-            list_tasks(tmp_path)
+            Tasks(tmp_path).list()
 
 
 class TestCompleteById:
     def test_marks_completed_returns_none_when_no_thread(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="do something", task_type=TaskType.SPEC)
-        result = complete_by_id(tmp_path, task["id"])
+        task = Tasks(tmp_path).add(title="do something", task_type=TaskType.SPEC)
+        result = Tasks(tmp_path).complete_by_id(task["id"])
         assert result is None
-        assert list_tasks(tmp_path)[0]["status"] == "completed"
+        assert Tasks(tmp_path).list()[0]["status"] == "completed"
 
     def test_returns_thread_when_present(self, tmp_path: Path) -> None:
         thread = {"repo": "a/b", "pr": 1, "comment_id": 99}
-        task = add_task(tmp_path, title="t", task_type=TaskType.THREAD, thread=thread)
-        result = complete_by_id(tmp_path, task["id"])
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.THREAD, thread=thread)
+        result = Tasks(tmp_path).complete_by_id(task["id"])
         assert result == thread
 
     def test_returns_none_when_not_found(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="other", task_type=TaskType.SPEC)
-        assert complete_by_id(tmp_path, "missing") is None
-        assert list_tasks(tmp_path)[0]["status"] == "pending"
+        Tasks(tmp_path).add(title="other", task_type=TaskType.SPEC)
+        assert Tasks(tmp_path).complete_by_id("missing") is None
+        assert Tasks(tmp_path).list()[0]["status"] == "pending"
 
     def test_skips_already_completed(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        complete_by_id(tmp_path, task["id"])
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        Tasks(tmp_path).complete_by_id(task["id"])
         # second call on already-completed task returns None
-        assert complete_by_id(tmp_path, task["id"]) is None
+        assert Tasks(tmp_path).complete_by_id(task["id"]) is None
 
     def test_completes_correct_task_by_id(self, tmp_path: Path) -> None:
-        t1 = add_task(tmp_path, title="a", task_type=TaskType.SPEC)
-        add_task(tmp_path, title="b", task_type=TaskType.SPEC)
-        complete_by_id(tmp_path, t1["id"])
-        tasks = list_tasks(tmp_path)
+        t1 = Tasks(tmp_path).add(title="a", task_type=TaskType.SPEC)
+        Tasks(tmp_path).add(title="b", task_type=TaskType.SPEC)
+        Tasks(tmp_path).complete_by_id(t1["id"])
+        tasks = Tasks(tmp_path).list()
         assert tasks[0]["status"] == "completed"
         assert tasks[1]["status"] == "pending"
 
 
 class TestHasPendingTasksForComment:
     def test_returns_true_when_pending_task_exists(self, tmp_path: Path) -> None:
-        add_task(
-            tmp_path,
+        Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 42},
         )
-        assert has_pending_tasks_for_comment(tmp_path, 42)
+        assert Tasks(tmp_path).has_pending_for_comment(42)
 
     def test_returns_false_when_no_tasks(self, tmp_path: Path) -> None:
-        assert not has_pending_tasks_for_comment(tmp_path, 42)
+        assert not Tasks(tmp_path).has_pending_for_comment(42)
 
     def test_returns_false_when_task_completed(self, tmp_path: Path) -> None:
-        task = add_task(
-            tmp_path,
+        task = Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 42},
         )
-        complete_by_id(tmp_path, task["id"])
-        assert not has_pending_tasks_for_comment(tmp_path, 42)
+        Tasks(tmp_path).complete_by_id(task["id"])
+        assert not Tasks(tmp_path).has_pending_for_comment(42)
 
     def test_returns_false_for_different_comment_id(self, tmp_path: Path) -> None:
-        add_task(
-            tmp_path,
+        Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 99},
         )
-        assert not has_pending_tasks_for_comment(tmp_path, 42)
+        assert not Tasks(tmp_path).has_pending_for_comment(42)
 
     def test_accepts_string_comment_id(self, tmp_path: Path) -> None:
-        add_task(
-            tmp_path,
+        Tasks(tmp_path).add(
             title="t",
             task_type=TaskType.THREAD,
             thread={"repo": "r/r", "pr": 1, "comment_id": 42},
         )
-        assert has_pending_tasks_for_comment(tmp_path, "42")
+        assert Tasks(tmp_path).has_pending_for_comment("42")
 
     def test_only_pending_tasks_count(self, tmp_path: Path) -> None:
         import json
@@ -579,57 +561,50 @@ class TestHasPendingTasksForComment:
                 ]
             )
         )
-        assert has_pending_tasks_for_comment(tmp_path, 42)
+        assert Tasks(tmp_path).has_pending_for_comment(42)
 
 
 class TestRemoveTask:
     def test_removes(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        assert remove_task(tmp_path, task["id"])
-        assert list_tasks(tmp_path) == []
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert Tasks(tmp_path).remove(task["id"])
+        assert Tasks(tmp_path).list() == []
 
     def test_returns_false_if_not_found(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        assert not remove_task(tmp_path, "nonexistent")
+        Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert not Tasks(tmp_path).remove("nonexistent")
 
 
 class TestUnblockTasks:
     def test_unblocks_blocked_tasks(self, tmp_path: Path) -> None:
-        t1 = add_task(tmp_path, title="first", task_type=TaskType.SPEC)
-        t2 = add_task(tmp_path, title="second", task_type=TaskType.SPEC)
-        update_task(tmp_path, t1["id"], TaskStatus.BLOCKED)
-        update_task(tmp_path, t2["id"], TaskStatus.BLOCKED)
-        count = unblock_tasks(tmp_path)
+        t1 = Tasks(tmp_path).add(title="first", task_type=TaskType.SPEC)
+        t2 = Tasks(tmp_path).add(title="second", task_type=TaskType.SPEC)
+        Tasks(tmp_path).update(t1["id"], TaskStatus.BLOCKED)
+        Tasks(tmp_path).update(t2["id"], TaskStatus.BLOCKED)
+        count = Tasks(tmp_path).unblock_tasks()
         assert count == 2
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert all(t["status"] == str(TaskStatus.PENDING) for t in tasks)
 
     def test_returns_zero_when_nothing_blocked(self, tmp_path: Path) -> None:
-        add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        assert unblock_tasks(tmp_path) == 0
+        Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert Tasks(tmp_path).unblock_tasks() == 0
 
     def test_does_not_touch_non_blocked_tasks(self, tmp_path: Path) -> None:
-        t1 = add_task(tmp_path, title="pending", task_type=TaskType.SPEC)
-        t2 = add_task(tmp_path, title="done", task_type=TaskType.SPEC)
-        t3 = add_task(tmp_path, title="blocked", task_type=TaskType.SPEC)
-        update_task(tmp_path, t2["id"], TaskStatus.COMPLETED)
-        update_task(tmp_path, t3["id"], TaskStatus.BLOCKED)
-        count = unblock_tasks(tmp_path)
+        t1 = Tasks(tmp_path).add(title="pending", task_type=TaskType.SPEC)
+        t2 = Tasks(tmp_path).add(title="done", task_type=TaskType.SPEC)
+        t3 = Tasks(tmp_path).add(title="blocked", task_type=TaskType.SPEC)
+        Tasks(tmp_path).update(t2["id"], TaskStatus.COMPLETED)
+        Tasks(tmp_path).update(t3["id"], TaskStatus.BLOCKED)
+        count = Tasks(tmp_path).unblock_tasks()
         assert count == 1
-        tasks = {t["id"]: t for t in list_tasks(tmp_path)}
+        tasks = {t["id"]: t for t in Tasks(tmp_path).list()}
         assert tasks[t1["id"]]["status"] == str(TaskStatus.PENDING)
         assert tasks[t2["id"]]["status"] == str(TaskStatus.COMPLETED)
         assert tasks[t3["id"]]["status"] == str(TaskStatus.PENDING)
 
     def test_returns_zero_on_empty_file(self, tmp_path: Path) -> None:
-        assert unblock_tasks(tmp_path) == 0
-
-    def test_tasks_unblock_tasks_method(self, tmp_path: Path) -> None:
-        task = add_task(tmp_path, title="t", task_type=TaskType.SPEC)
-        update_task(tmp_path, task["id"], TaskStatus.BLOCKED)
-        count = Tasks(tmp_path).unblock_tasks()
-        assert count == 1
-        assert list_tasks(tmp_path)[0]["status"] == str(TaskStatus.PENDING)
+        assert Tasks(tmp_path).unblock_tasks() == 0
 
 
 # ── _parse_reorder_response ───────────────────────────────────────────────────
@@ -1066,7 +1041,7 @@ class TestReorderTasks:
     def _add(
         self, tmp_path: Path, title: str, task_type: TaskType = TaskType.SPEC
     ) -> dict:
-        return add_task(tmp_path, title=title, task_type=task_type)
+        return Tasks(tmp_path).add(title=title, task_type=task_type)
 
     def _response(self, items: list[dict]) -> str:
         return json.dumps({"tasks": items})
@@ -1089,15 +1064,15 @@ class TestReorderTasks:
 
     def test_skips_on_empty_opus_response(self, tmp_path: Path) -> None:
         self._add(tmp_path, "Task A")
-        result_before = list_tasks(tmp_path)
+        result_before = Tasks(tmp_path).list()
         reorder_tasks(tmp_path, "", agent=_client(""))
-        assert list_tasks(tmp_path) == result_before
+        assert Tasks(tmp_path).list() == result_before
 
     def test_skips_on_unparseable_response(self, tmp_path: Path) -> None:
         self._add(tmp_path, "Task A")
-        result_before = list_tasks(tmp_path)
+        result_before = Tasks(tmp_path).list()
         reorder_tasks(tmp_path, "", agent=_client("not json"))
-        assert list_tasks(tmp_path) == result_before
+        assert Tasks(tmp_path).list() == result_before
 
     def test_preserves_snapshot_order_for_non_ci_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "First")
@@ -1110,7 +1085,7 @@ class TestReorderTasks:
             ]
         )
         reorder_tasks(tmp_path, "", agent=_client(raw))
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         assert result[0]["id"] == t1["id"]
         assert result[1]["id"] == t2["id"]
 
@@ -1120,24 +1095,24 @@ class TestReorderTasks:
             [{"id": t1["id"], "title": "New title", "description": ""}]
         )
         reorder_tasks(tmp_path, "", agent=_client(raw))
-        assert list_tasks(tmp_path)[0]["title"] == "Old title"
+        assert Tasks(tmp_path).list()[0]["title"] == "Old title"
 
     def test_marks_completed_task_opus_excludes(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Keep")
         t2 = self._add(tmp_path, "No longer needed")
         raw = self._response([{"id": t1["id"], "title": "Keep", "description": ""}])
         reorder_tasks(tmp_path, "", agent=_client(raw))
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         task2 = next(t for t in result if t["id"] == t2["id"])
         assert task2["status"] == "completed"
 
     def test_preserves_completed_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Done")
-        complete_by_id(tmp_path, t1["id"])
+        Tasks(tmp_path).complete_by_id(t1["id"])
         t2 = self._add(tmp_path, "Pending")
         raw = self._response([{"id": t2["id"], "title": "Pending", "description": ""}])
         reorder_tasks(tmp_path, "", agent=_client(raw))
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         statuses = {t["id"]: t["status"] for t in result}
         assert statuses[t1["id"]] == "completed"
 
@@ -1164,8 +1139,8 @@ class TestReorderTasks:
 
         def slow_run_turn(prompt: str, *, model: object = None, **kw: object) -> object:
             # Simulate a new task arriving while Opus is running
-            t2 = add_task(
-                tmp_path, title="Arrived mid-reorder", task_type=TaskType.SPEC
+            t2 = Tasks(tmp_path).add(
+                title="Arrived mid-reorder", task_type=TaskType.SPEC
             )
             new_task_id.append(t2["id"])
             return json.dumps(
@@ -1184,7 +1159,7 @@ class TestReorderTasks:
         client = _client()
         client.run_turn.side_effect = slow_run_turn
         reorder_tasks(tmp_path, "", agent=client)
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         ids = [t["id"] for t in result]
         assert new_task_id[0] in ids  # not silently dropped
         assert ids == [t1["id"], new_task_id[0]]
@@ -1201,8 +1176,8 @@ class TestReorderTasks:
             "comment_id": 99,
             "url": "https://example.com",
         }
-        t1 = add_task(
-            tmp_path, title="Thread task", task_type=TaskType.THREAD, thread=thread
+        t1 = Tasks(tmp_path).add(
+            title="Thread task", task_type=TaskType.THREAD, thread=thread
         )
         t2 = self._add(tmp_path, "Keep this")
         received: list = []
@@ -1226,8 +1201,7 @@ class TestReorderTasks:
             "comment_id": 99,
             "url": "https://example.com",
         }
-        t1 = add_task(
-            tmp_path,
+        t1 = Tasks(tmp_path).add(
             title="Stable title",
             task_type=TaskType.THREAD,
             thread=thread,
@@ -1265,22 +1239,22 @@ class TestReorderTasks:
 
     def test_on_changes_none_does_not_error(self, tmp_path: Path) -> None:
         thread = {"repo": "r/r", "pr": 1, "comment_id": 42, "url": "https://x.com"}
-        t1 = add_task(
-            tmp_path, title="Thread task", task_type=TaskType.THREAD, thread=thread
+        t1 = Tasks(tmp_path).add(
+            title="Thread task", task_type=TaskType.THREAD, thread=thread
         )
         t2 = self._add(tmp_path, "Keep")
         raw = self._response([{"id": t2["id"], "title": "Keep", "description": ""}])
         # Should not raise even though t1 is completed and _on_changes is None
         reorder_tasks(tmp_path, "", agent=_client(raw), _on_changes=None)
         # t1 should be marked completed
-        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
         assert task1["status"] == "completed"
 
     def test_on_inprogress_affected_called_when_inprogress_task_completed(
         self, tmp_path: Path
     ) -> None:
         t1 = self._add(tmp_path, "In-progress task")
-        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
         t2 = self._add(tmp_path, "Keep this")
         raw = self._response(
             [{"id": t2["id"], "title": "Keep this", "description": ""}]
@@ -1294,14 +1268,14 @@ class TestReorderTasks:
         )
         assert affected == [1]
         # in-progress task is marked completed
-        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
         assert task1["status"] == "completed"
 
     def test_on_inprogress_affected_called_when_inprogress_task_modified(
         self, tmp_path: Path
     ) -> None:
         t1 = self._add(tmp_path, "Stable title")
-        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
         raw = self._response(
             [{"id": t1["id"], "title": "Changed title", "description": "new"}]
         )
@@ -1314,7 +1288,7 @@ class TestReorderTasks:
         )
         assert affected == [1]
         # task reset to pending with preserved title and updated description
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         assert result[0]["title"] == "Stable title"
         assert result[0]["description"] == "new"
         assert result[0]["status"] == str(TaskStatus.PENDING)
@@ -1323,7 +1297,7 @@ class TestReorderTasks:
         self, tmp_path: Path
     ) -> None:
         t1 = self._add(tmp_path, "Stable task")
-        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
         raw = self._response(
             [{"id": t1["id"], "title": "Stable task", "description": ""}]
         )
@@ -1336,7 +1310,7 @@ class TestReorderTasks:
         )
         assert affected == []
         # task still in_progress (unchanged by Opus)
-        result = list_tasks(tmp_path)
+        result = Tasks(tmp_path).list()
         assert result[0]["status"] == str(TaskStatus.IN_PROGRESS)
 
     def test_on_inprogress_affected_not_called_when_no_inprogress_task(
@@ -1358,7 +1332,7 @@ class TestReorderTasks:
 
     def test_on_inprogress_affected_none_does_not_error(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "In-progress task")
-        update_task(tmp_path, t1["id"], TaskStatus.IN_PROGRESS)
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
         t2 = self._add(tmp_path, "Keep this")
         raw = self._response(
             [{"id": t2["id"], "title": "Keep this", "description": ""}]
@@ -1370,7 +1344,7 @@ class TestReorderTasks:
             agent=_client(raw),
             _on_inprogress_affected=None,
         )
-        task1 = next(t for t in list_tasks(tmp_path) if t["id"] == t1["id"])
+        task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
         assert task1["status"] == "completed"
 
     def test_on_done_called_after_successful_reorder(self, tmp_path: Path) -> None:
@@ -1444,7 +1418,7 @@ class TestReorderTasks:
             ["Shared name"], attempts_remaining=2
         )
         assert client.run_turn.call_count == 2
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Alpha"
         assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
 
@@ -1468,7 +1442,7 @@ class TestReorderTasks:
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
         # All 3 nudges fired (1 initial + 3 nudge calls = 4 total)
         assert client.run_turn.call_count == 4
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Alpha"
         assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
 
@@ -1513,7 +1487,7 @@ class TestReorderTasks:
         mock_prompts.rescope_prompt.return_value = "prompt"
         mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Alpha"
         assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
 
@@ -1534,7 +1508,7 @@ class TestReorderTasks:
         mock_prompts.rescope_prompt.return_value = "prompt"
         mock_prompts.rescope_duplicate_nudge.return_value = "nudge"
         reorder_tasks(tmp_path, "", agent=client, prompts=mock_prompts)
-        tasks = list_tasks(tmp_path)
+        tasks = Tasks(tmp_path).list()
         assert next(t for t in tasks if t["id"] == t1["id"])["title"] == "Alpha"
         assert next(t for t in tasks if t["id"] == t2["id"])["title"] == "Beta"
 
@@ -1637,61 +1611,6 @@ class TestComputeThreadChanges:
 
 
 class TestTasks:
-    def test_list_returns_all_tasks(self, tmp_path: Path) -> None:
-        from fido.types import TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        add_task(work_dir, "Task A", TaskType.SPEC)
-        result = Tasks(work_dir).list()
-        assert len(result) == 1
-        assert result[0]["title"] == "Task A"
-
-    def test_add_creates_task(self, tmp_path: Path) -> None:
-        from fido.types import TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        task = Tasks(work_dir).add("Task B", TaskType.CI)
-        assert task["title"] == "Task B"
-        assert task["type"] == "ci"
-
-    def test_complete_by_id_marks_task_completed(self, tmp_path: Path) -> None:
-        from fido.types import TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        task = add_task(work_dir, "Task C", TaskType.SPEC)
-        Tasks(work_dir).complete_by_id(task["id"])
-        assert list_tasks(work_dir)[0]["status"] == "completed"
-
-    def test_has_pending_for_comment_returns_bool(self, tmp_path: Path) -> None:
-        from fido.types import TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        add_task(work_dir, "Task D", TaskType.THREAD, thread={"comment_id": 7})
-        assert Tasks(work_dir).has_pending_for_comment(7) is True
-        assert Tasks(work_dir).has_pending_for_comment(99) is False
-
-    def test_remove_deletes_task(self, tmp_path: Path) -> None:
-        from fido.types import TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        task = add_task(work_dir, "Task E", TaskType.SPEC)
-        assert Tasks(work_dir).remove(task["id"]) is True
-        assert list_tasks(work_dir) == []
-
-    def test_update_changes_status(self, tmp_path: Path) -> None:
-        from fido.types import TaskStatus, TaskType
-
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        task = add_task(work_dir, "Task F", TaskType.SPEC)
-        Tasks(work_dir).update(task["id"], TaskStatus.IN_PROGRESS)
-        assert list_tasks(work_dir)[0]["status"] == "in_progress"
-
     def test_modify_yields_empty_list_when_no_tasks(self, tmp_path: Path) -> None:
         work_dir = tmp_path / "work"
         work_dir.mkdir()
@@ -1703,10 +1622,10 @@ class TestTasks:
 
         work_dir = tmp_path / "work"
         work_dir.mkdir()
-        add_task(work_dir, "Existing task", TaskType.SPEC)
+        Tasks(work_dir).add("Existing task", TaskType.SPEC)
         with Tasks(work_dir).modify() as tasks:
             tasks[0]["title"] = "Modified task"
-        assert list_tasks(work_dir)[0]["title"] == "Modified task"
+        assert Tasks(work_dir).list()[0]["title"] == "Modified task"
 
     def test_modify_raises_on_corrupt_json(self, tmp_path: Path) -> None:
         work_dir = tmp_path / "work"
@@ -1737,13 +1656,13 @@ class TestTasksCompleteWithResolve:
 
     def test_marks_task_completed(self, tmp_path: Path) -> None:
         work_dir = self._work_dir(tmp_path)
-        task = add_task(work_dir, "task", TaskType.SPEC)
+        task = Tasks(work_dir).add("task", TaskType.SPEC)
         Tasks(work_dir).complete_with_resolve(task["id"], MagicMock())
-        assert list_tasks(work_dir)[0]["status"] == "completed"
+        assert Tasks(work_dir).list()[0]["status"] == "completed"
 
     def test_no_thread_does_not_call_github(self, tmp_path: Path) -> None:
         work_dir = self._work_dir(tmp_path)
-        task = add_task(work_dir, "task", TaskType.SPEC)
+        task = Tasks(work_dir).add("task", TaskType.SPEC)
         gh = MagicMock()
         Tasks(work_dir).complete_with_resolve(task["id"], gh)
         gh.get_user.assert_not_called()
@@ -1752,7 +1671,7 @@ class TestTasksCompleteWithResolve:
     def test_thread_missing_fields_skips_resolve(self, tmp_path: Path) -> None:
         """Thread dict with missing pr/comment_id skips resolution."""
         work_dir = self._work_dir(tmp_path)
-        task = add_task(work_dir, "task", TaskType.THREAD, thread={"repo": "a/b"})
+        task = Tasks(work_dir).add("task", TaskType.THREAD, thread={"repo": "a/b"})
         gh = MagicMock()
         Tasks(work_dir).complete_with_resolve(task["id"], gh)
         gh.resolve_thread.assert_not_called()
@@ -1766,7 +1685,7 @@ class TestTasksCompleteWithResolve:
         checkbox flips even when the worker loop doesn't sync between
         the completion and the PR-ready/merge step (#988)."""
         work_dir = self._work_dir(tmp_path)
-        task = add_task(work_dir, "task", TaskType.SPEC)
+        task = Tasks(work_dir).add("task", TaskType.SPEC)
         gh = MagicMock()
         with patch("fido.tasks.sync_tasks_background") as mock_sync:
             Tasks(work_dir).complete_with_resolve(task["id"], gh)
@@ -1788,7 +1707,7 @@ class TestTasksCompleteWithResolve:
 
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.return_value = "fido-bot"
@@ -1818,7 +1737,7 @@ class TestTasksCompleteWithResolve:
 
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.return_value = "fido-bot"
@@ -1844,7 +1763,7 @@ class TestTasksCompleteWithResolve:
     def test_skips_resolve_when_no_matching_comments(self, tmp_path: Path) -> None:
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.return_value = "fido-bot"
@@ -1859,7 +1778,7 @@ class TestTasksCompleteWithResolve:
     ) -> None:
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.return_value = "fido-bot"
@@ -1884,7 +1803,7 @@ class TestTasksCompleteWithResolve:
     def test_skips_resolve_when_thread_already_resolved(self, tmp_path: Path) -> None:
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.return_value = "fido-bot"
@@ -1909,9 +1828,8 @@ class TestTasksCompleteWithResolve:
 
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
-        add_task(
-            work_dir,
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
+        Tasks(work_dir).add(
             "pending sibling",
             TaskType.THREAD,
             thread={"repo": "a/b", "pr": 1, "comment_id": 77},
@@ -1946,7 +1864,7 @@ class TestTasksCompleteWithResolve:
 
         work_dir = self._work_dir(tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
-        task = add_task(work_dir, "threaded task", TaskType.THREAD, thread=thread)
+        task = Tasks(work_dir).add("threaded task", TaskType.THREAD, thread=thread)
 
         gh = MagicMock()
         gh.get_user.side_effect = RuntimeError("network error")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9252,17 +9252,6 @@ class TestAbortHandle:
         # The signal is still set — only its target is wrong for B.
         assert h.is_set() is True
 
-    def test_untargeted_request_matches_any_task(self) -> None:
-        """`request(None)` is the untargeted form, used only by the external
-        WorkerThread.abort_task() entry point that fires before any task
-        is in flight.  Real callers (preempt, rescope) always pass an id."""
-        h = AbortHandle()
-        h.request(None)
-        assert h.is_active_for("any-task") is True
-        h.clear()
-        h.request(None)
-        assert h.is_active_for("other-task") is True
-
     def test_clear_resets_signal_and_target(self) -> None:
         h = AbortHandle()
         h.request("task-A")
@@ -14373,13 +14362,13 @@ class TestWorkerThread:
     def test_abort_task_sets_abort_event(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         assert not wt._abort_task.is_set()
-        wt.abort_task()
+        wt.abort_task("task-1")
         assert wt._abort_task.is_set()
 
     def test_abort_task_also_wakes_thread(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         assert not wt._wake.is_set()
-        wt.abort_task()
+        wt.abort_task("task-1")
         assert wt._wake.is_set()
 
     def test_run_sets_thread_local_repo_name(self, tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ import time
 from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -920,14 +920,7 @@ class TestWorker:
         claude.ClaudeSession.return_value = mock_session
         worker = Worker(tmp_path, MagicMock())
         worker.create_session()
-        assert worker._session is mock_session
-
-    def test_session_getter_reads_bootstrap_session_before_provider_exists(
-        self,
-    ) -> None:
-        worker = Worker.__new__(Worker)
-        worker.__dict__["_bootstrap_session"] = "boot"
-        assert worker._session == "boot"
+        assert worker._provider.agent.session is mock_session  # pyright: ignore[reportPrivateUsage]
 
     def test_ensure_provider_creates_provider_from_repo_cfg(
         self, tmp_path: Path
@@ -959,24 +952,24 @@ class TestWorker:
         )
         worker = Worker(tmp_path, MagicMock(), provider=provider, session=session)
         provider.agent.attach_session.assert_called_once_with(session)
-        assert worker._session is session
+        assert worker._provider.agent.session is session  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_calls_stop(self, tmp_path: Path) -> None:
         mock_session = MagicMock()
         worker = Worker(tmp_path, MagicMock())
-        worker._session = mock_session
+        worker._provider.agent.attach_session(mock_session)  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
         mock_session.stop.assert_called_once()
 
     def test_stop_session_clears_session(self, tmp_path: Path) -> None:
         worker = Worker(tmp_path, MagicMock())
-        worker._session = MagicMock()
+        worker._provider.agent.attach_session(MagicMock())  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
-        assert worker._session is None
+        assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_is_noop_when_none(self, tmp_path: Path) -> None:
         worker = Worker(tmp_path, MagicMock())
-        assert worker._session is None
+        assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()  # must not raise
 
     def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
@@ -14433,7 +14426,7 @@ class TestWorkerThread:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
-            self_w._session = session
+            self_w._bootstrap_session = session  # pyright: ignore[reportPrivateUsage]
             self_w._session_issue = session_issue
 
         def fake_worker_run(self_w: object) -> int:
@@ -14539,7 +14532,7 @@ class TestWorkerThread:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
-            self_w._session = session
+            self_w._bootstrap_session = session  # pyright: ignore[reportPrivateUsage]
             self_w._session_issue = session_issue
             sessions_received.append(session)
 
@@ -14593,7 +14586,7 @@ class TestWorkerThread:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
-            self_w._session = session
+            self_w._bootstrap_session = session  # pyright: ignore[reportPrivateUsage]
             self_w._session_issue = session_issue
             issues_received.append(session_issue)
 
@@ -14634,14 +14627,14 @@ class TestWorkerThread:
         """WorkerThread stops the session when its loop finishes."""
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
-        wt._session = mock_session
+        wt.current_provider().agent.attach_session(mock_session)
         wt._stop.set()  # exit immediately without running any Worker
 
         with patch.object(Worker, "run"):
             wt.run()
 
         mock_session.stop.assert_called_once()
-        assert wt._session is None
+        assert wt.current_provider().agent.session is None
 
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_session_preserved_when_worker_raises(self, tmp_path: Path) -> None:
@@ -14654,7 +14647,7 @@ class TestWorkerThread:
         mock_session = MagicMock()
 
         def fake_worker_run(self_w: object) -> int:
-            self_w._session = mock_session
+            self_w._provider.agent.attach_session(mock_session)  # pyright: ignore[reportPrivateUsage]
             raise RuntimeError("boom")
 
         with patch.object(Worker, "run", fake_worker_run):
@@ -14663,7 +14656,9 @@ class TestWorkerThread:
 
         assert not wt.is_alive()
         mock_session.stop.assert_not_called()  # session must NOT be stopped
-        assert wt._session is mock_session  # still reachable for registry to rescue
+        assert (
+            wt.current_provider().agent.session is mock_session
+        )  # still reachable for registry to rescue
 
     def test_session_accepted_via_constructor(self, tmp_path: Path) -> None:
         """Session passed to WorkerThread constructor is used as the initial session."""
@@ -14671,7 +14666,7 @@ class TestWorkerThread:
         wt = WorkerThread(
             tmp_path, "owner/repo", MagicMock(), session=mock_session, session_issue=7
         )
-        assert wt._session is mock_session
+        assert wt.current_provider().agent.session is mock_session
         assert wt._session_issue == 7
 
     def test_provider_accepted_via_constructor(self, tmp_path: Path) -> None:
@@ -14689,7 +14684,7 @@ class TestWorkerThread:
         )
         provider.agent.attach_session.assert_called_once_with(session)
         assert wt.current_provider() is provider
-        assert wt._session is provider.agent.session
+        assert wt.current_provider().agent.session is provider.agent.session
         assert wt._session_issue == 7
 
     def test_detach_provider_returns_and_clears(self, tmp_path: Path) -> None:
@@ -14713,95 +14708,59 @@ class TestWorkerThread:
         assert wt.recover_provider() is True
         provider.agent.recover_session.assert_called_once_with()
 
-    def test_session_setter_recreates_provider_when_detached(
-        self, tmp_path: Path
-    ) -> None:
-        wt = self._make_thread(tmp_path)
-        wt.detach_provider()
-        session = MagicMock()
-        wt._session = session
-        assert wt.current_provider() is not None
-        assert wt._session is session
-
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
     def test_run_recreates_provider_when_missing(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         wt.detach_provider()
         wt._wake = MagicMock()
         carried_session = MagicMock()
-
-        def fake_worker_init(
-            self_w: object,
-            work_dir: Path,
-            gh: MagicMock,
-            abort_task: object = None,
-            repo_name: str = "",
-            registry: object = None,
-            membership: object = None,
-            session: object = None,
-            session_issue: int | None = None,
-            config: object = None,
-            repo_cfg: object = None,
-            provider_factory: object = None,
-            first_iteration: bool = False,
-        ) -> None:
-            del provider_factory, first_iteration
-            self_w.work_dir = work_dir
-            self_w.gh = gh
-            self_w._abort_task = abort_task
-            self_w._session = session
-            self_w._session_issue = session_issue
+        wt._bootstrap_session = carried_session  # pyright: ignore[reportPrivateUsage]
 
         def fake_worker_run(self_w: object) -> int:
             wt._stop.set()
             return 0
 
         with (
-            patch.object(
-                WorkerThread, "_session", new_callable=PropertyMock
-            ) as session_prop,
-            patch.object(Worker, "__init__", fake_worker_init),
             patch.object(Worker, "run", fake_worker_run),
         ):
-            session_prop.return_value = carried_session
             self._run_thread(wt)
 
         assert wt.current_provider() is not None
 
     def test_session_owner_returns_none_when_no_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
-        assert wt._session is None
+        assert wt.current_provider().agent.session is None
         assert wt.session_owner is None
 
     def test_session_owner_delegates_to_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
         mock_session.owner = "worker-home"
-        wt._session = mock_session
+        wt.current_provider().agent.attach_session(mock_session)
         assert wt.session_owner == "worker-home"
 
     def test_session_alive_false_when_no_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
-        assert wt._session is None
+        assert wt.current_provider().agent.session is None
         assert wt.session_alive is False
 
     def test_session_pid_none_when_no_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
-        assert wt._session is None
+        assert wt.current_provider().agent.session is None
         assert wt.session_pid is None
 
     def test_session_pid_delegates_to_session_pid(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
         mock_session.pid = 54321
-        wt._session = mock_session
+        wt.current_provider().agent.attach_session(mock_session)
         assert wt.session_pid == 54321
 
     def test_session_alive_delegates_to_session_is_alive(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         mock_session = MagicMock()
         mock_session.is_alive.return_value = True
-        wt._session = mock_session
+        wt.current_provider().agent.attach_session(mock_session)
         assert wt.session_alive is True
         mock_session.is_alive.return_value = False
         assert wt.session_alive is False
@@ -14964,26 +14923,7 @@ class TestWorkerThread:
     ) -> None:
         wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=None)
         assert wt.current_provider() is None
-        assert wt._session is None
-
-    def test_session_getter_reads_bootstrap_session_when_provider_missing(
-        self, tmp_path: Path
-    ) -> None:
-        session = MagicMock()
-        wt = WorkerThread(
-            tmp_path, "owner/repo", MagicMock(), repo_cfg=None, session=session
-        )
-        assert wt.current_provider() is None
-        assert wt._session is session
-
-    def test_session_setter_stores_bootstrap_session_when_repo_cfg_none(
-        self, tmp_path: Path
-    ) -> None:
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=None)
-        session = MagicMock()
-        wt._session = session
-        assert wt.current_provider() is None
-        assert wt._session is session
+        assert wt._bootstrap_session is None  # pyright: ignore[reportPrivateUsage]
 
     def test_ensure_provider_requires_repo_cfg(self, tmp_path: Path) -> None:
         wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=None)
@@ -15034,7 +14974,7 @@ class TestWorkerThread:
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
-            self_w._session = session
+            self_w._bootstrap_session = session  # pyright: ignore[reportPrivateUsage]
             self_w._session_issue = session_issue
             received_config.append(config)
             received_repo_cfg.append(repo_cfg)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -32,6 +32,7 @@ from fido.state import (
 )
 from fido.store import FidoStore, PRCommentQueueRecord, ReplyPromiseRecord
 from fido.tasks import (
+    Tasks,
     _apply_queue_to_body,
     _auto_complete_ask_tasks,
     _format_work_queue,
@@ -7561,7 +7562,6 @@ class TestResolveAddressedThreads:
     def test_skips_resolve_when_pending_sibling_tasks_remain(
         self, tmp_path: Path
     ) -> None:
-        from fido import tasks as tasks_mod
 
         worker, gh = self._make_worker(tmp_path)
         # node whose originating comment has databaseId=55
@@ -7578,8 +7578,7 @@ class TestResolveAddressedThreads:
         gh.get_review_threads.return_value = [node]
         from fido.types import TaskType
 
-        tasks_mod.add_task(
-            tmp_path,
+        Tasks(tmp_path).add(
             title="pending sibling",
             task_type=TaskType.THREAD,
             thread={"repo": "owner/repo", "pr": 1, "comment_id": 55},
@@ -7592,7 +7591,6 @@ class TestResolveAddressedThreads:
         self, tmp_path: Path
     ) -> None:
         """Task comment_id matches a non-root comment — must still block resolution."""
-        from fido import tasks as tasks_mod
         from fido.types import TaskType
 
         worker, gh = self._make_worker(tmp_path)
@@ -7610,8 +7608,7 @@ class TestResolveAddressedThreads:
         }
         gh.get_review_threads.return_value = [node]
         # Task references reply comment (id=11), not the root (id=10)
-        tasks_mod.add_task(
-            tmp_path,
+        Tasks(tmp_path).add(
             title="pending reply task",
             task_type=TaskType.THREAD,
             thread={"repo": "owner/repo", "pr": 1, "comment_id": 11},
@@ -7621,7 +7618,6 @@ class TestResolveAddressedThreads:
         gh.resolve_thread.assert_not_called()
 
     def test_resolves_when_all_sibling_tasks_complete(self, tmp_path: Path) -> None:
-        from fido import tasks as tasks_mod
 
         worker, gh = self._make_worker(tmp_path)
         node = {
@@ -7637,13 +7633,12 @@ class TestResolveAddressedThreads:
         gh.get_review_threads.return_value = [node]
         from fido.types import TaskType
 
-        task = tasks_mod.add_task(
-            tmp_path,
+        task = Tasks(tmp_path).add(
             title="completed sibling",
             task_type=TaskType.THREAD,
             thread={"repo": "owner/repo", "pr": 1, "comment_id": 77},
         )
-        tasks_mod.complete_by_id(tmp_path, task["id"])
+        Tasks(tmp_path).complete_by_id(task["id"])
         result = worker.resolve_addressed_threads(self._repo_ctx(), 1)
         assert result is True
         gh.resolve_thread.assert_called_once_with("tid-resolve")


### PR DESCRIPTION
## What this fixes

Closes #1265. Three compatibility shims from the OO migration are gone.

## Changes

### 1. `server.py` — remove `_fn_unblock_tasks` callable-slot seam

`WebhookHandler` used to hold a bound function reference (`_fn_unblock_tasks`) pointing at the `unblock_tasks` free function. Now it creates a `Tasks` instance directly: `Tasks(repo_cfg.work_dir).unblock_tasks()`. The test suite lost 8 mock-suppression lines and gained real behavior tests that seed a BLOCKED task and assert it becomes PENDING.

### 2. `tasks.py` — delete 7 free-function shims

`add_task`, `update_task`, `list_tasks`, `complete_by_id`, `has_pending_tasks_for_comment`, `remove_task`, and `unblock_tasks` were thin wrappers that just did `Tasks(work_dir).method(...)`. All callers in test_cli.py, test_events.py, test_tasks.py, and test_worker.py migrated to `Tasks(…).method()` directly. Seven duplicate tests removed after the migration collapsed them into their counterparts.

### 3. `worker.py` — remove `Worker._session` and `WorkerThread._session` property shims

Both classes had a `_session` property that proxied reads/writes through to `provider.agent.session`, with a `_bootstrap_session` fallback for the pre-provider window. The shim is gone; `_bootstrap_session` is now a typed plain attribute. Call sites updated:
- `_ensure_provider` in both classes: `session=self._bootstrap_session`
- `stop_session`: line deleted (redundant — `provider_agent.stop_session()` already clears it internally)
- `set_status` and `_run_iteration`: check `self._provider is None or self._provider.agent.session is None` directly
- `registry.get_session()`: uses `thread.current_provider()` instead of the removed property
- 5 shim-behaviour tests deleted; remaining tests updated to go through `provider.agent.session` and `provider.agent.attach_session`

### 4. `worker.py` / `registry.py` — make `task_id` required on `abort_task`

`AbortHandle.request`, `WorkerThread.abort_task`, and `WorkerRegistry.abort_task` all accepted `task_id=None` as a legacy "abort whatever is running" escape hatch. Both production callers in `events.py` already pass an explicit task_id. The `None` branch is dropped:
- `AbortHandle.is_active_for` no longer has a `None` guard — a set signal only fires for the exact task named
- The `test_untargeted_request_matches_any_task` test is deleted
- WorkerThread and registry tests updated to pass explicit IDs

## Test summary

- All 3861 tests pass, 100% coverage maintained throughout.
- Net change: ~100 lines removed from tests (shims + duplicates + shim-behaviour tests), ~140 lines removed from production code.