### PR TITLE
Bug: extract `Dispatcher` collaborator from WebhookHandler `_fn_*` (#1266) (closes #1310)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1102,29 +1102,31 @@ def _is_allowed(user: str, repo_cfg: RepoConfig, config: Config) -> bool:
 class Dispatcher:
     """Typed collaborator that owns the dispatch, backfill, and sync logic.
 
-    Accepts ``config`` and optionally ``gh`` at construction time — these are
-    stable across requests.  ``repo_cfg`` is passed at call time because it is
-    resolved per-webhook from the incoming repository name.
+    One ``Dispatcher`` is constructed per repo at startup — accepting
+    ``config``, ``repo_cfg``, and optionally ``gh`` — so every method call
+    uses the repo context already baked into the instance.
 
     This is the replacement for the ``_fn_dispatch`` callable-slot pattern on
-    :class:`~fido.server.WebhookHandler`.  Callers construct one instance and
-    hold it as a proper collaborator rather than reaching into a class-level
-    function slot.
+    :class:`~fido.server.WebhookHandler`.  Callers construct one instance per
+    repo and hold them in a ``dict[str, Dispatcher]`` collaborator rather than
+    reaching into a class-level function slot.
 
     ``gh`` is optional because :meth:`dispatch` does not use it.  Pass ``gh``
     when constructing a ``Dispatcher`` that will call
     :meth:`backfill_missed_pr_comments` or :meth:`launch_sync`.
     """
 
-    def __init__(self, config: Config, gh: GitHub | None = None) -> None:
+    def __init__(
+        self, config: Config, repo_cfg: RepoConfig, gh: GitHub | None = None
+    ) -> None:
         self._config = config
+        self._repo_cfg = repo_cfg
         self._gh = gh
 
     def dispatch(
         self,
         event: str,
         payload: dict[str, Any],
-        repo_cfg: RepoConfig,
         *,
         delivery_id: str | None = None,
         oracle: WebhookIngressOracle | None = None,
@@ -1141,6 +1143,7 @@ class Dispatcher:
         worker wakes up without waiting for the next poll cycle.
         """
         action = payload.get("action")
+        repo_cfg = self._repo_cfg
         repo = repo_cfg.name  # validated at routing time
 
         # Oracle check — deduplicate at the ingress boundary.
@@ -1370,7 +1373,6 @@ class Dispatcher:
 
     def backfill_missed_pr_comments(
         self,
-        repo_cfg: RepoConfig,
         pr_number: int,
         *,
         gh_user: str,
@@ -1390,6 +1392,7 @@ class Dispatcher:
         WorkerThread lifetime** (at startup) — not every iteration.
         """
         assert self._gh is not None, "gh required for backfill_missed_pr_comments"
+        repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
         comments = self._gh.get_issue_comments(repo_cfg.name, pr_number)
         for c in comments:
@@ -1427,12 +1430,12 @@ class Dispatcher:
         log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
         return len(comments)
 
-    def launch_sync(self, repo_cfg: RepoConfig) -> None:
+    def launch_sync(self) -> None:
         """Sync tasks.json → PR body in a background thread."""
         assert self._gh is not None, "gh required for launch_sync"
         from fido.tasks import sync_tasks_background
 
-        sync_tasks_background(repo_cfg.work_dir, self._gh)
+        sync_tasks_background(self._repo_cfg.work_dir, self._gh)
         log.info("sync-tasks launched")
 
 
@@ -1450,8 +1453,8 @@ def dispatch(
     Use :meth:`Dispatcher.dispatch` directly; this free function is kept
     only until all callers have migrated.
     """
-    return Dispatcher(config).dispatch(
-        event, payload, repo_cfg, delivery_id=delivery_id, oracle=oracle
+    return Dispatcher(config, repo_cfg).dispatch(
+        event, payload, delivery_id=delivery_id, oracle=oracle
     )
 
 
@@ -2654,7 +2657,7 @@ def create_task(
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
     if dispatcher is not None:
-        dispatcher.launch_sync(repo_cfg)
+        dispatcher.launch_sync()
     else:
         launch_sync(config, repo_cfg, gh)
     if thread:
@@ -2696,8 +2699,8 @@ def backfill_missed_pr_comments(
     Use :meth:`Dispatcher.backfill_missed_pr_comments` directly; this free
     function is kept only until all callers have migrated.
     """
-    return Dispatcher(config, gh).backfill_missed_pr_comments(
-        repo_cfg, pr_number, gh_user=gh_user
+    return Dispatcher(config, repo_cfg, gh).backfill_missed_pr_comments(
+        pr_number, gh_user=gh_user
     )
 
 
@@ -2707,7 +2710,7 @@ def launch_sync(config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
     Use :meth:`Dispatcher.launch_sync` directly; this free function is kept
     only until all callers have migrated.
     """
-    Dispatcher(config, gh).launch_sync(repo_cfg)
+    Dispatcher(config, repo_cfg, gh).launch_sync()
 
 
 def launch_worker(repo_cfg: RepoConfig, registry: WorkerRegistry) -> None:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2638,3 +2638,61 @@ def launch_worker(repo_cfg: RepoConfig, registry: WorkerRegistry) -> None:
     """Wake the per-repo WorkerThread via the registry."""
     log.info("waking worker thread for %s", repo_cfg.name)
     registry.wake(repo_cfg.name)
+
+
+class Dispatcher:
+    """Typed collaborator that owns :func:`dispatch`, :func:`backfill_missed_pr_comments`,
+    and :func:`launch_sync`.
+
+    Accepts ``config`` and ``gh`` at construction time — these are stable
+    across requests.  ``repo_cfg`` is passed at call time because it is
+    resolved per-webhook from the incoming repository name.
+
+    This is the replacement for the ``_fn_dispatch`` callable-slot pattern on
+    :class:`~fido.server.WebhookHandler`.  Callers construct one instance and
+    hold it as a proper collaborator rather than reaching into a class-level
+    function slot.
+    """
+
+    def __init__(self, config: Config, gh: GitHub) -> None:
+        self._config = config
+        self._gh = gh
+
+    def dispatch(
+        self,
+        event: str,
+        payload: dict[str, Any],
+        repo_cfg: RepoConfig,
+        *,
+        delivery_id: str | None = None,
+        oracle: WebhookIngressOracle | None = None,
+    ) -> Action | None:
+        """Delegate to the module-level :func:`dispatch` free function."""
+        return dispatch(
+            event,
+            payload,
+            self._config,
+            repo_cfg,
+            delivery_id=delivery_id,
+            oracle=oracle,
+        )
+
+    def backfill_missed_pr_comments(
+        self,
+        repo_cfg: RepoConfig,
+        pr_number: int,
+        *,
+        gh_user: str,
+    ) -> int:
+        """Delegate to the module-level :func:`backfill_missed_pr_comments`."""
+        return backfill_missed_pr_comments(
+            self._config,
+            repo_cfg,
+            self._gh,
+            pr_number,
+            gh_user=gh_user,
+        )
+
+    def launch_sync(self, repo_cfg: RepoConfig) -> None:
+        """Delegate to the module-level :func:`launch_sync`."""
+        launch_sync(self._config, repo_cfg, self._gh)

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1099,6 +1099,343 @@ def _is_allowed(user: str, repo_cfg: RepoConfig, config: Config) -> bool:
     return user in repo_cfg.membership.collaborators or user in config.allowed_bots
 
 
+class Dispatcher:
+    """Typed collaborator that owns the dispatch, backfill, and sync logic.
+
+    Accepts ``config`` and optionally ``gh`` at construction time — these are
+    stable across requests.  ``repo_cfg`` is passed at call time because it is
+    resolved per-webhook from the incoming repository name.
+
+    This is the replacement for the ``_fn_dispatch`` callable-slot pattern on
+    :class:`~fido.server.WebhookHandler`.  Callers construct one instance and
+    hold it as a proper collaborator rather than reaching into a class-level
+    function slot.
+
+    ``gh`` is optional because :meth:`dispatch` does not use it.  Pass ``gh``
+    when constructing a ``Dispatcher`` that will call
+    :meth:`backfill_missed_pr_comments` or :meth:`launch_sync`.
+    """
+
+    def __init__(self, config: Config, gh: GitHub | None = None) -> None:
+        self._config = config
+        self._gh = gh
+
+    def dispatch(
+        self,
+        event: str,
+        payload: dict[str, Any],
+        repo_cfg: RepoConfig,
+        *,
+        delivery_id: str | None = None,
+        oracle: WebhookIngressOracle | None = None,
+    ) -> Action | None:
+        """Map a GitHub webhook event to an action. Returns None if ignored.
+
+        When *delivery_id* and *oracle* are provided the
+        :class:`WebhookIngressOracle` is consulted before any routing logic
+        runs.  Duplicate deliveries (same delivery ID arriving a second time)
+        and ``pull_request_review / submitted`` events with ``review.state ==
+        "commented"`` are suppressed by returning ``None`` before any side
+        effects execute.  Decisive review states (``approved``,
+        ``changes_requested``, ``dismissed``) are dispatched normally so the
+        worker wakes up without waiting for the next poll cycle.
+        """
+        action = payload.get("action")
+        repo = repo_cfg.name  # validated at routing time
+
+        # Oracle check — deduplicate at the ingress boundary.
+        if delivery_id is not None and oracle is not None:
+            review_state = payload.get("review", {}).get("state", "")
+            collapse_review = (
+                event == "pull_request_review"
+                and action == "submitted"
+                and review_state == "commented"
+            )
+            ingress_result = oracle.check_dispatch(
+                repo_cfg.name,
+                delivery_id,
+                collapse_review=collapse_review,
+            )
+            if ingress_result is None:
+                return None
+
+        if event == "ping":
+            log.info("ping received — hook_id=%s", payload.get("hook_id"))
+            return None
+
+        if event == "issues" and action == "assigned":
+            assignee = payload["assignee"]["login"]
+            issue = payload["issue"]
+            number = issue["number"]
+            title = issue["title"]
+            if not number:
+                return None
+            log.info("issue #%s assigned to %s: %s", number, assignee, title)
+            wev = wct_oracle.EvtIssueAssigned(1, number, assignee)
+            cmd = wct_oracle.translate(wev)
+            assert isinstance(cmd, wct_oracle.CmdIssueAssigned), "translate_total"
+            return Action(prompt=f"New issue #{number} assigned to {assignee}: {title}")
+
+        if event == "pull_request_review" and action == "submitted":
+            review = payload["review"]
+            pr = payload["pull_request"]
+            number = pr.get("number")
+            state = review["state"]
+            user = review["user"]["login"]
+            review_id = review.get("id")
+            if not number:
+                return None
+            if not _is_allowed(user, repo_cfg, self._config):
+                log.debug("ignoring review on PR #%s by %s (not allowed)", number, user)
+                return None
+            log.info("review on PR #%s: %s by %s", number, state, user)
+            if review_id is not None:
+                wev = wct_oracle.EvtReviewSubmitted(1, number, review_id, user)
+                cmd = wct_oracle.translate(wev)
+                assert isinstance(cmd, wct_oracle.CmdReviewSubmitted), "translate_total"
+            return Action(
+                prompt=f"Review on PR #{number}: {state} by {user}",
+                review_comments={"repo": repo, "pr": number, "review_id": review_id}
+                if review_id
+                else None,
+            )
+
+        if event == "pull_request_review_comment" and action in {"created", "edited"}:
+            comment = payload["comment"]
+            pr = payload["pull_request"]
+            number = pr.get("number")
+            user = comment["user"]["login"]
+            comment_id = comment["id"]
+            if user.lower() in ("fidocancode", "fido-can-code"):
+                log.debug("ignoring own comment on PR #%s", number)
+                return None
+            if not number:
+                return None
+            if not _is_allowed(user, repo_cfg, self._config):
+                log.debug(
+                    "ignoring comment on PR #%s by %s (not allowed)", number, user
+                )
+                return None
+            comment_body = comment.get("body", "") or ""
+            log.info("comment on PR #%s by %s: %s", number, user, comment_body[:80])
+            is_bot = user.endswith("[bot]")
+            comment_id = int(comment_id)
+            wev = wct_oracle.EvtReviewComment(1, number, comment_id, user, is_bot)
+            cmd = wct_oracle.translate(wev)
+            assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
+            assert isinstance(cmd.cmd_kind, wct_oracle.ReviewLine), "translate_total"
+            _enqueue_pr_comment_webhook(
+                repo_cfg=repo_cfg,
+                repo=repo,
+                pr_number=number,
+                comment_type="pulls",
+                comment=comment,
+                author=user,
+                is_bot=is_bot,
+                body=comment_body,
+                delivery_id=delivery_id,
+                payload=payload,
+            )
+            prefix = (
+                "Queued edited review comment"
+                if action == "edited"
+                else "Queued review comment"
+            )
+            return _queued_pr_comment_action(
+                prompt=(
+                    f"{prefix} on PR #{number} by {user}"
+                    f" ({'bot' if is_bot else 'human/owner'})"
+                ),
+                repo=repo,
+                pr_number=number,
+                comment_type="pulls",
+                comment_id=comment_id,
+                html_url=comment.get("html_url", ""),
+                author=user,
+                is_bot=is_bot,
+                context={
+                    "comment_body": comment_body,
+                    "delivery_id": delivery_id,
+                    "pr_title": pr.get("title", ""),
+                    "pr_body": pr.get("body", "") or "",
+                    "file": comment.get("path", ""),
+                    "line": comment.get("line"),
+                    "diff_hunk": comment.get("diff_hunk", ""),
+                },
+            )
+
+        if event == "issue_comment" and action in {"created", "edited"}:
+            comment = payload["comment"]
+            issue = payload["issue"]
+            user = comment["user"]["login"]
+            pr = issue.get("pull_request")
+            if not pr:
+                log.debug("issue_comment on non-PR issue — ignoring")
+                return None
+            if user.lower() in ("fidocancode", "fido-can-code"):
+                log.debug("ignoring own comment on PR")
+                return None
+            if not _is_allowed(user, repo_cfg, self._config):
+                log.debug("ignoring comment by %s (not allowed)", user)
+                return None
+            number = issue["number"]
+            comment_body = comment.get("body", "") or ""
+            comment_id = int(comment["id"])
+            is_bot = user.endswith("[bot]")
+            log.info("PR comment on #%s by %s: %s", number, user, comment_body[:80])
+            wev = wct_oracle.EvtIssueComment(1, number, comment_id, user, is_bot)
+            cmd = wct_oracle.translate(wev)
+            assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
+            assert isinstance(cmd.cmd_kind, wct_oracle.TopLevelPR), "translate_total"
+            _enqueue_pr_comment_webhook(
+                repo_cfg=repo_cfg,
+                repo=repo,
+                pr_number=number,
+                comment_type="issues",
+                comment=comment,
+                author=user,
+                is_bot=is_bot,
+                body=comment_body,
+                delivery_id=delivery_id,
+                payload=payload,
+            )
+            prefix = (
+                "Queued edited PR top-level comment"
+                if action == "edited"
+                else "Queued PR top-level comment"
+            )
+            return _queued_pr_comment_action(
+                prompt=f"{prefix} on #{number} by {user}",
+                repo=repo,
+                pr_number=number,
+                comment_type="issues",
+                comment_id=comment_id,
+                html_url=comment.get("html_url", ""),
+                author=user,
+                is_bot=is_bot,
+                context={
+                    "comment_body": comment_body,
+                    "delivery_id": delivery_id,
+                    "pr_title": issue.get("title", ""),
+                    "pr_body": issue.get("body", "") or "",
+                },
+            )
+
+        if event == "check_run" and action == "completed":
+            check = payload["check_run"]
+            conclusion = check["conclusion"]
+            if conclusion not in ("failure", "timed_out"):
+                log.debug("check_run completed with %s — ignoring", conclusion)
+                return None
+            name = check["name"]
+            prs = check["pull_requests"]
+            pr_nums = [pr["number"] for pr in prs]
+            log.info("CI failure: %s (%s) on PRs %s", name, conclusion, pr_nums)
+            _ci_conclusion = (
+                wct_oracle.CIFailure()
+                if conclusion == "failure"
+                else wct_oracle.CITimedOut()
+            )
+            wev = wct_oracle.EvtCIFailure(1, name, _ci_conclusion, pr_nums)
+            cmd = wct_oracle.translate(wev)
+            assert isinstance(cmd, wct_oracle.CmdCIFailure), "translate_total"
+            pr_str = ", ".join(f"#{n}" for n in pr_nums) if pr_nums else "unknown PR"
+            return Action(
+                prompt=f"CI failure on {pr_str}: {name} ({conclusion})",
+                preempts_worker=True,
+            )
+
+        if event == "pull_request" and action == "closed":
+            pr = payload["pull_request"]
+            number = pr["number"]
+            removed = FidoStore(repo_cfg.work_dir).clear_pr_comment_queue(
+                repo=repo,
+                pr_number=int(number),
+            )
+            if removed:
+                log.info(
+                    "cleared %d queued comment(s) for closed PR #%s", removed, number
+                )
+            if not pr["merged"]:
+                log.debug("PR #%s closed without merge — ignoring", number)
+                return None
+            log.info("PR #%s merged", number)
+            wev = wct_oracle.EvtPRMerged(1, number)
+            cmd = wct_oracle.translate(wev)
+            assert isinstance(cmd, wct_oracle.CmdPRMerged), "translate_total"
+            return Action(prompt=f"PR #{number} merged — cleanup")
+
+        log.debug("ignored event: %s (action=%s)", event, action)
+        return None
+
+    def backfill_missed_pr_comments(
+        self,
+        repo_cfg: RepoConfig,
+        pr_number: int,
+        *,
+        gh_user: str,
+    ) -> int:
+        """Replay ``issue_comment`` webhooks we may have missed while fido was
+        down (fix for #794).  Returns the number of comments inspected.
+
+        Scope is narrow by design: only **top-level PR comments** are replayed.
+        Inline review comments and review threads are already scanned each
+        iteration by ``Worker.handle_threads``, so the worker loop backfills
+        those on its own — only issue-comments are invisible to the loop.
+
+        Idempotent: comments with a completed SQLite claim are skipped — Fido
+        already replied to them.  Comments handled with a task (ACT/DO) are
+        additionally deduped by :func:`create_task` via ``comment_id`` in
+        ``tasks.json``.  This method is intended to run **once per
+        WorkerThread lifetime** (at startup) — not every iteration.
+        """
+        assert self._gh is not None, "gh required for backfill_missed_pr_comments"
+        log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
+        comments = self._gh.get_issue_comments(repo_cfg.name, pr_number)
+        for c in comments:
+            user = (c.get("user") or {}).get("login", "")
+            if not user:
+                continue
+            if user.lower() == gh_user.lower():
+                continue
+            if user.lower() in ("fidocancode", "fido-can-code"):
+                continue
+            if not _is_allowed(user, repo_cfg, self._config):
+                continue
+            comment_id = c.get("id")
+            if comment_id is None:
+                continue
+            # Skip comments Fido already claimed or completed in the SQLite store.
+            if FidoStore(repo_cfg.work_dir).is_claimed_or_completed(int(comment_id)):
+                log.info("backfill: comment %s already claimed — skipping", comment_id)
+                continue
+            body = c.get("body", "") or ""
+            is_bot = user.endswith("[bot]")
+            thread = {
+                "repo": repo_cfg.name,
+                "pr": pr_number,
+                "comment_id": comment_id,
+                "url": c.get("html_url", ""),
+                "author": user,
+                "comment_type": "issues",
+            }
+            prompt = (
+                f"PR top-level comment on #{pr_number} by {user} "
+                f"({'bot' if is_bot else 'human/owner'}):\n\n{body}"
+            )
+            create_task(prompt, self._config, repo_cfg, self._gh, thread=thread)
+        log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
+        return len(comments)
+
+    def launch_sync(self, repo_cfg: RepoConfig) -> None:
+        """Sync tasks.json → PR body in a background thread."""
+        assert self._gh is not None, "gh required for launch_sync"
+        from fido.tasks import sync_tasks_background
+
+        sync_tasks_background(repo_cfg.work_dir, self._gh)
+        log.info("sync-tasks launched")
+
+
 def dispatch(
     event: str,
     payload: dict[str, Any],
@@ -1108,240 +1445,14 @@ def dispatch(
     delivery_id: str | None = None,
     oracle: WebhookIngressOracle | None = None,
 ) -> Action | None:
-    """Map a GitHub webhook event to an action. Returns None if ignored.
+    """Thin compatibility shim — delegates to :class:`Dispatcher`.
 
-    When *delivery_id* and *oracle* are provided the
-    :class:`WebhookIngressOracle` is consulted before any routing logic runs.
-    Duplicate deliveries (same delivery ID arriving a second time) and
-    ``pull_request_review / submitted`` events with ``review.state ==
-    "commented"`` are suppressed by returning ``None`` before any side
-    effects execute.  Decisive review states (``approved``,
-    ``changes_requested``, ``dismissed``) are dispatched normally so the
-    worker wakes up without waiting for the next poll cycle.
+    Use :meth:`Dispatcher.dispatch` directly; this free function is kept
+    only until all callers have migrated.
     """
-    action = payload.get("action")
-    repo = repo_cfg.name  # validated at routing time
-
-    # Oracle check — deduplicate at the ingress boundary.
-    if delivery_id is not None and oracle is not None:
-        review_state = payload.get("review", {}).get("state", "")
-        collapse_review = (
-            event == "pull_request_review"
-            and action == "submitted"
-            and review_state == "commented"
-        )
-        ingress_result = oracle.check_dispatch(
-            repo_cfg.name,
-            delivery_id,
-            collapse_review=collapse_review,
-        )
-        if ingress_result is None:
-            return None
-
-    if event == "ping":
-        log.info("ping received — hook_id=%s", payload.get("hook_id"))
-        return None
-
-    if event == "issues" and action == "assigned":
-        assignee = payload["assignee"]["login"]
-        issue = payload["issue"]
-        number = issue["number"]
-        title = issue["title"]
-        if not number:
-            return None
-        log.info("issue #%s assigned to %s: %s", number, assignee, title)
-        wev = wct_oracle.EvtIssueAssigned(1, number, assignee)
-        cmd = wct_oracle.translate(wev)
-        assert isinstance(cmd, wct_oracle.CmdIssueAssigned), "translate_total"
-        return Action(prompt=f"New issue #{number} assigned to {assignee}: {title}")
-
-    if event == "pull_request_review" and action == "submitted":
-        review = payload["review"]
-        pr = payload["pull_request"]
-        number = pr.get("number")
-        state = review["state"]
-        user = review["user"]["login"]
-        review_id = review.get("id")
-        if not number:
-            return None
-        if not _is_allowed(user, repo_cfg, config):
-            log.debug("ignoring review on PR #%s by %s (not allowed)", number, user)
-            return None
-        log.info("review on PR #%s: %s by %s", number, state, user)
-        if review_id is not None:
-            wev = wct_oracle.EvtReviewSubmitted(1, number, review_id, user)
-            cmd = wct_oracle.translate(wev)
-            assert isinstance(cmd, wct_oracle.CmdReviewSubmitted), "translate_total"
-        return Action(
-            prompt=f"Review on PR #{number}: {state} by {user}",
-            review_comments={"repo": repo, "pr": number, "review_id": review_id}
-            if review_id
-            else None,
-        )
-
-    if event == "pull_request_review_comment" and action in {"created", "edited"}:
-        comment = payload["comment"]
-        pr = payload["pull_request"]
-        number = pr.get("number")
-        user = comment["user"]["login"]
-        comment_id = comment["id"]
-        if user.lower() in ("fidocancode", "fido-can-code"):
-            log.debug("ignoring own comment on PR #%s", number)
-            return None
-        if not number:
-            return None
-        if not _is_allowed(user, repo_cfg, config):
-            log.debug("ignoring comment on PR #%s by %s (not allowed)", number, user)
-            return None
-        comment_body = comment.get("body", "") or ""
-        log.info("comment on PR #%s by %s: %s", number, user, comment_body[:80])
-        is_bot = user.endswith("[bot]")
-        comment_id = int(comment_id)
-        wev = wct_oracle.EvtReviewComment(1, number, comment_id, user, is_bot)
-        cmd = wct_oracle.translate(wev)
-        assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
-        assert isinstance(cmd.cmd_kind, wct_oracle.ReviewLine), "translate_total"
-        _enqueue_pr_comment_webhook(
-            repo_cfg=repo_cfg,
-            repo=repo,
-            pr_number=number,
-            comment_type="pulls",
-            comment=comment,
-            author=user,
-            is_bot=is_bot,
-            body=comment_body,
-            delivery_id=delivery_id,
-            payload=payload,
-        )
-        prefix = (
-            "Queued edited review comment"
-            if action == "edited"
-            else "Queued review comment"
-        )
-        return _queued_pr_comment_action(
-            prompt=(
-                f"{prefix} on PR #{number} by {user}"
-                f" ({'bot' if is_bot else 'human/owner'})"
-            ),
-            repo=repo,
-            pr_number=number,
-            comment_type="pulls",
-            comment_id=comment_id,
-            html_url=comment.get("html_url", ""),
-            author=user,
-            is_bot=is_bot,
-            context={
-                "comment_body": comment_body,
-                "delivery_id": delivery_id,
-                "pr_title": pr.get("title", ""),
-                "pr_body": pr.get("body", "") or "",
-                "file": comment.get("path", ""),
-                "line": comment.get("line"),
-                "diff_hunk": comment.get("diff_hunk", ""),
-            },
-        )
-
-    if event == "issue_comment" and action in {"created", "edited"}:
-        comment = payload["comment"]
-        issue = payload["issue"]
-        user = comment["user"]["login"]
-        pr = issue.get("pull_request")
-        if not pr:
-            log.debug("issue_comment on non-PR issue — ignoring")
-            return None
-        if user.lower() in ("fidocancode", "fido-can-code"):
-            log.debug("ignoring own comment on PR")
-            return None
-        if not _is_allowed(user, repo_cfg, config):
-            log.debug("ignoring comment by %s (not allowed)", user)
-            return None
-        number = issue["number"]
-        comment_body = comment.get("body", "") or ""
-        comment_id = int(comment["id"])
-        is_bot = user.endswith("[bot]")
-        log.info("PR comment on #%s by %s: %s", number, user, comment_body[:80])
-        wev = wct_oracle.EvtIssueComment(1, number, comment_id, user, is_bot)
-        cmd = wct_oracle.translate(wev)
-        assert isinstance(cmd, wct_oracle.CmdComment), "translate_total"
-        assert isinstance(cmd.cmd_kind, wct_oracle.TopLevelPR), "translate_total"
-        _enqueue_pr_comment_webhook(
-            repo_cfg=repo_cfg,
-            repo=repo,
-            pr_number=number,
-            comment_type="issues",
-            comment=comment,
-            author=user,
-            is_bot=is_bot,
-            body=comment_body,
-            delivery_id=delivery_id,
-            payload=payload,
-        )
-        prefix = (
-            "Queued edited PR top-level comment"
-            if action == "edited"
-            else "Queued PR top-level comment"
-        )
-        return _queued_pr_comment_action(
-            prompt=f"{prefix} on #{number} by {user}",
-            repo=repo,
-            pr_number=number,
-            comment_type="issues",
-            comment_id=comment_id,
-            html_url=comment.get("html_url", ""),
-            author=user,
-            is_bot=is_bot,
-            context={
-                "comment_body": comment_body,
-                "delivery_id": delivery_id,
-                "pr_title": issue.get("title", ""),
-                "pr_body": issue.get("body", "") or "",
-            },
-        )
-
-    if event == "check_run" and action == "completed":
-        check = payload["check_run"]
-        conclusion = check["conclusion"]
-        if conclusion not in ("failure", "timed_out"):
-            log.debug("check_run completed with %s — ignoring", conclusion)
-            return None
-        name = check["name"]
-        prs = check["pull_requests"]
-        pr_nums = [pr["number"] for pr in prs]
-        log.info("CI failure: %s (%s) on PRs %s", name, conclusion, pr_nums)
-        _ci_conclusion = (
-            wct_oracle.CIFailure()
-            if conclusion == "failure"
-            else wct_oracle.CITimedOut()
-        )
-        wev = wct_oracle.EvtCIFailure(1, name, _ci_conclusion, pr_nums)
-        cmd = wct_oracle.translate(wev)
-        assert isinstance(cmd, wct_oracle.CmdCIFailure), "translate_total"
-        pr_str = ", ".join(f"#{n}" for n in pr_nums) if pr_nums else "unknown PR"
-        return Action(
-            prompt=f"CI failure on {pr_str}: {name} ({conclusion})",
-            preempts_worker=True,
-        )
-
-    if event == "pull_request" and action == "closed":
-        pr = payload["pull_request"]
-        number = pr["number"]
-        removed = FidoStore(repo_cfg.work_dir).clear_pr_comment_queue(
-            repo=repo,
-            pr_number=int(number),
-        )
-        if removed:
-            log.info("cleared %d queued comment(s) for closed PR #%s", removed, number)
-        if not pr["merged"]:
-            log.debug("PR #%s closed without merge — ignoring", number)
-            return None
-        log.info("PR #%s merged", number)
-        wev = wct_oracle.EvtPRMerged(1, number)
-        cmd = wct_oracle.translate(wev)
-        assert isinstance(cmd, wct_oracle.CmdPRMerged), "translate_total"
-        return Action(prompt=f"PR #{number} merged — cleanup")
-
-    log.debug("ignored event: %s (action=%s)", event, action)
-    return None
+    return Dispatcher(config).dispatch(
+        event, payload, repo_cfg, delivery_id=delivery_id, oracle=oracle
+    )
 
 
 def _load_persona(config: Config) -> str:
@@ -2580,125 +2691,26 @@ def backfill_missed_pr_comments(
     *,
     gh_user: str,
 ) -> int:
-    """Replay ``issue_comment`` webhooks we may have missed while fido was
-    down (fix for #794).  Returns the number of comments inspected.
+    """Thin compatibility shim — delegates to :class:`Dispatcher`.
 
-    Scope is narrow by design: only **top-level PR comments** are replayed.
-    Inline review comments and review threads are already scanned each
-    iteration by ``Worker.handle_threads``, so the worker loop backfills
-    those on its own — only issue-comments are invisible to the loop.
-
-    Idempotent: comments with a completed SQLite claim are skipped — Fido
-    already replied to them.  Comments handled with a task (ACT/DO) are additionally
-    deduped by :func:`create_task` via ``comment_id`` in ``tasks.json``.
-    This function is intended to run **once per WorkerThread lifetime** (at
-    startup) — not every iteration.
+    Use :meth:`Dispatcher.backfill_missed_pr_comments` directly; this free
+    function is kept only until all callers have migrated.
     """
-    log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
-    comments = gh.get_issue_comments(repo_cfg.name, pr_number)
-    for c in comments:
-        user = (c.get("user") or {}).get("login", "")
-        if not user:
-            continue
-        if user.lower() == gh_user.lower():
-            continue
-        if user.lower() in ("fidocancode", "fido-can-code"):
-            continue
-        if not _is_allowed(user, repo_cfg, config):
-            continue
-        comment_id = c.get("id")
-        if comment_id is None:
-            continue
-        # Skip comments Fido already claimed or completed in the SQLite store.
-        if FidoStore(repo_cfg.work_dir).is_claimed_or_completed(int(comment_id)):
-            log.info("backfill: comment %s already claimed — skipping", comment_id)
-            continue
-        body = c.get("body", "") or ""
-        is_bot = user.endswith("[bot]")
-        thread = {
-            "repo": repo_cfg.name,
-            "pr": pr_number,
-            "comment_id": comment_id,
-            "url": c.get("html_url", ""),
-            "author": user,
-            "comment_type": "issues",
-        }
-        prompt = (
-            f"PR top-level comment on #{pr_number} by {user} "
-            f"({'bot' if is_bot else 'human/owner'}):\n\n{body}"
-        )
-        create_task(prompt, config, repo_cfg, gh, thread=thread)
-    log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
-    return len(comments)
+    return Dispatcher(config, gh).backfill_missed_pr_comments(
+        repo_cfg, pr_number, gh_user=gh_user
+    )
 
 
 def launch_sync(config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
-    """Sync tasks.json → PR body in a background thread."""
-    from fido.tasks import sync_tasks_background
+    """Thin compatibility shim — delegates to :class:`Dispatcher`.
 
-    sync_tasks_background(repo_cfg.work_dir, gh)
-    log.info("sync-tasks launched")
+    Use :meth:`Dispatcher.launch_sync` directly; this free function is kept
+    only until all callers have migrated.
+    """
+    Dispatcher(config, gh).launch_sync(repo_cfg)
 
 
 def launch_worker(repo_cfg: RepoConfig, registry: WorkerRegistry) -> None:
     """Wake the per-repo WorkerThread via the registry."""
     log.info("waking worker thread for %s", repo_cfg.name)
     registry.wake(repo_cfg.name)
-
-
-class Dispatcher:
-    """Typed collaborator that owns :func:`dispatch`, :func:`backfill_missed_pr_comments`,
-    and :func:`launch_sync`.
-
-    Accepts ``config`` and ``gh`` at construction time — these are stable
-    across requests.  ``repo_cfg`` is passed at call time because it is
-    resolved per-webhook from the incoming repository name.
-
-    This is the replacement for the ``_fn_dispatch`` callable-slot pattern on
-    :class:`~fido.server.WebhookHandler`.  Callers construct one instance and
-    hold it as a proper collaborator rather than reaching into a class-level
-    function slot.
-    """
-
-    def __init__(self, config: Config, gh: GitHub) -> None:
-        self._config = config
-        self._gh = gh
-
-    def dispatch(
-        self,
-        event: str,
-        payload: dict[str, Any],
-        repo_cfg: RepoConfig,
-        *,
-        delivery_id: str | None = None,
-        oracle: WebhookIngressOracle | None = None,
-    ) -> Action | None:
-        """Delegate to the module-level :func:`dispatch` free function."""
-        return dispatch(
-            event,
-            payload,
-            self._config,
-            repo_cfg,
-            delivery_id=delivery_id,
-            oracle=oracle,
-        )
-
-    def backfill_missed_pr_comments(
-        self,
-        repo_cfg: RepoConfig,
-        pr_number: int,
-        *,
-        gh_user: str,
-    ) -> int:
-        """Delegate to the module-level :func:`backfill_missed_pr_comments`."""
-        return backfill_missed_pr_comments(
-            self._config,
-            repo_cfg,
-            self._gh,
-            pr_number,
-            gh_user=gh_user,
-        )
-
-    def launch_sync(self, repo_cfg: RepoConfig) -> None:
-        """Delegate to the module-level :func:`launch_sync`."""
-        launch_sync(self._config, repo_cfg, self._gh)

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1426,7 +1426,9 @@ class Dispatcher:
                 f"PR top-level comment on #{pr_number} by {user} "
                 f"({'bot' if is_bot else 'human/owner'}):\n\n{body}"
             )
-            create_task(prompt, self._config, repo_cfg, self._gh, thread=thread)
+            create_task(
+                prompt, self._config, repo_cfg, self._gh, thread=thread, dispatcher=self
+            )
         log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
         return len(comments)
 
@@ -1437,25 +1439,6 @@ class Dispatcher:
 
         sync_tasks_background(self._repo_cfg.work_dir, self._gh)
         log.info("sync-tasks launched")
-
-
-def dispatch(
-    event: str,
-    payload: dict[str, Any],
-    config: Config,
-    repo_cfg: RepoConfig,
-    *,
-    delivery_id: str | None = None,
-    oracle: WebhookIngressOracle | None = None,
-) -> Action | None:
-    """Thin compatibility shim — delegates to :class:`Dispatcher`.
-
-    Use :meth:`Dispatcher.dispatch` directly; this free function is kept
-    only until all callers have migrated.
-    """
-    return Dispatcher(config, repo_cfg).dispatch(
-        event, payload, delivery_id=delivery_id, oracle=oracle
-    )
 
 
 def _load_persona(config: Config) -> str:
@@ -2658,8 +2641,6 @@ def create_task(
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
     if dispatcher is not None:
         dispatcher.launch_sync()
-    else:
-        launch_sync(config, repo_cfg, gh)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
         if registry is not None and _reorder_background_fn is _reorder_tasks_background:
@@ -2684,33 +2665,6 @@ def create_task(
     if registry is not None:
         _maybe_abort_for_new_task(repo_cfg, new_task, registry)
     return new_task
-
-
-def backfill_missed_pr_comments(
-    config: Config,
-    repo_cfg: RepoConfig,
-    gh: GitHub,
-    pr_number: int,
-    *,
-    gh_user: str,
-) -> int:
-    """Thin compatibility shim — delegates to :class:`Dispatcher`.
-
-    Use :meth:`Dispatcher.backfill_missed_pr_comments` directly; this free
-    function is kept only until all callers have migrated.
-    """
-    return Dispatcher(config, repo_cfg, gh).backfill_missed_pr_comments(
-        pr_number, gh_user=gh_user
-    )
-
-
-def launch_sync(config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
-    """Thin compatibility shim — delegates to :class:`Dispatcher`.
-
-    Use :meth:`Dispatcher.launch_sync` directly; this free function is kept
-    only until all callers have migrated.
-    """
-    Dispatcher(config, repo_cfg, gh).launch_sync()
 
 
 def launch_worker(repo_cfg: RepoConfig, registry: WorkerRegistry) -> None:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -846,7 +846,7 @@ def queue_reply_tasks(
     is_bot: bool = False,
     registry: Any = None,  # noqa: ANN401  # WorkerRegistry-or-ActivityReporter; either works
     create_task_fn: Callable[..., object] | None = None,
-    dispatcher: "Dispatcher | None" = None,
+    dispatcher: "Dispatcher",
 ) -> int:
     """Create any tasks implied by a reply outcome.
 
@@ -879,6 +879,7 @@ def _apply_reply_result(
     gh: GitHub,
     thread: dict[str, Any] | None,
     registry: ActivityReporter,
+    dispatcher: "Dispatcher",
 ) -> None:
     """Apply task side effects from a recovered reply."""
     queue_reply_tasks(
@@ -889,6 +890,7 @@ def _apply_reply_result(
         gh,
         thread=thread,
         registry=registry,
+        dispatcher=dispatcher,
     )
 
 
@@ -911,6 +913,7 @@ def recover_reply_promises(
     gh: GitHub,
     pr_number: int,
     registry: ActivityReporter,
+    dispatcher: "Dispatcher",
     *,
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
@@ -1016,6 +1019,7 @@ def recover_reply_promises(
             gh,
             action.thread,
             registry,
+            dispatcher,
         )
         _ack_promises(store, (promise_id for promise_id, _ in group))
         processed_any = True
@@ -1084,6 +1088,7 @@ def recover_reply_promises(
             gh,
             thread=action.reply_to,
             registry=registry,
+            dispatcher=dispatcher,
         )
         _ack_promises(store, (group_promise_id for group_promise_id, _ in group))
         processed_any = True
@@ -1112,14 +1117,12 @@ class Dispatcher:
     repo and hold them in a ``dict[str, Dispatcher]`` collaborator rather than
     reaching into a class-level function slot.
 
-    ``gh`` is optional because :meth:`dispatch` does not use it.  Pass ``gh``
-    when constructing a ``Dispatcher`` that will call
-    :meth:`backfill_missed_pr_comments` or :meth:`launch_sync`.
+    ``gh`` is required because :meth:`backfill_missed_pr_comments` and
+    :meth:`launch_sync` both use it.  The composition root always has a real
+    ``GitHub`` instance, so there is no production case where ``gh`` is absent.
     """
 
-    def __init__(
-        self, config: Config, repo_cfg: RepoConfig, gh: GitHub | None = None
-    ) -> None:
+    def __init__(self, config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
         self._config = config
         self._repo_cfg = repo_cfg
         self._gh = gh
@@ -1392,7 +1395,6 @@ class Dispatcher:
         ``tasks.json``.  This method is intended to run **once per
         WorkerThread lifetime** (at startup) — not every iteration.
         """
-        assert self._gh is not None, "gh required for backfill_missed_pr_comments"
         repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
         comments = self._gh.get_issue_comments(repo_cfg.name, pr_number)
@@ -1435,7 +1437,6 @@ class Dispatcher:
 
     def launch_sync(self) -> None:
         """Sync tasks.json → PR body in a background thread."""
-        assert self._gh is not None, "gh required for launch_sync"
         from fido.tasks import sync_tasks_background
 
         sync_tasks_background(self._repo_cfg.work_dir, self._gh)
@@ -2557,7 +2558,7 @@ def create_task(
     thread: dict[str, Any] | None = None,
     registry: ActivityReporter | None = None,
     *,
-    dispatcher: "Dispatcher | None" = None,
+    dispatcher: "Dispatcher",
     _get_commit_summary_fn: Callable[[Path], str] = _get_commit_summary,
     _reorder_background_fn: Callable[..., None] = _reorder_tasks_background,
     _tasks: Tasks | None = None,
@@ -2630,8 +2631,7 @@ def create_task(
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
-    if dispatcher is not None:
-        dispatcher.launch_sync()
+    dispatcher.launch_sync()
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
         if _reorder_background_fn is _reorder_tasks_background:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -846,6 +846,7 @@ def queue_reply_tasks(
     is_bot: bool = False,
     registry: Any = None,  # noqa: ANN401  # WorkerRegistry-or-ActivityReporter; either works
     create_task_fn: Callable[..., object] | None = None,
+    dispatcher: "Dispatcher | None" = None,
 ) -> int:
     """Create any tasks implied by a reply outcome.
 
@@ -863,6 +864,7 @@ def queue_reply_tasks(
             gh,
             thread=thread,
             registry=registry,
+            dispatcher=dispatcher,
         )
         if not (isinstance(task, dict) and task.get("status") == "skipped_resolved"):
             created += 1
@@ -2467,6 +2469,7 @@ def create_task(
     thread: dict[str, Any] | None = None,
     registry: WorkerRegistry | None = None,
     *,
+    dispatcher: "Dispatcher | None" = None,
     _get_commit_summary_fn: Callable[[Path], str] = _get_commit_summary,
     _reorder_background_fn: Callable[..., None] = _reorder_tasks_background,
     _tasks: Tasks | None = None,
@@ -2539,7 +2542,10 @@ def create_task(
     task_type = TaskType.THREAD if thread else TaskType.SPEC
     log.info("creating task: %s", prompt[:100])
     new_task = _tasks.add(title=prompt, task_type=task_type, thread=thread)
-    launch_sync(config, repo_cfg, gh)
+    if dispatcher is not None:
+        dispatcher.launch_sync(repo_cfg)
+    else:
+        launch_sync(config, repo_cfg, gh)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
         if registry is not None and _reorder_background_fn is _reorder_tasks_background:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -739,7 +739,7 @@ def _make_thread(
     provider: Provider | None = None,
     session_issue: int | None = None,
     config: Config | None = None,
-    dispatcher: "Dispatcher | None" = None,
+    dispatchers: "dict[str, Dispatcher] | None" = None,
     _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client.
@@ -758,7 +758,7 @@ def _make_thread(
         session_issue=session_issue,
         config=config,
         repo_cfg=repo_cfg,
-        dispatcher=dispatcher,
+        dispatcher=dispatchers.get(repo_cfg.name) if dispatchers is not None else None,
         issue_cache=registry.get_issue_cache(repo_cfg.name),
     )
 
@@ -767,7 +767,7 @@ def make_registry(
     repos: dict[str, RepoConfig],
     gh: GitHub,
     config: Config | None = None,
-    dispatcher: "Dispatcher | None" = None,
+    dispatchers: "dict[str, Dispatcher] | None" = None,
     *,
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
@@ -791,7 +791,7 @@ def make_registry(
             provider=provider,
             session_issue=session_issue,
             config=config,
-            dispatcher=dispatcher,
+            dispatchers=dispatchers,
         )
 
     registry = WorkerRegistry(factory)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
@@ -14,6 +15,9 @@ from fido.provider import PromptSession, Provider
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
 from fido.worker import WorkerThread
+
+if TYPE_CHECKING:
+    from fido.events import Dispatcher
 
 log = logging.getLogger(__name__)
 
@@ -735,6 +739,7 @@ def _make_thread(
     provider: Provider | None = None,
     session_issue: int | None = None,
     config: Config | None = None,
+    dispatcher: "Dispatcher | None" = None,
     _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client.
@@ -753,6 +758,7 @@ def _make_thread(
         session_issue=session_issue,
         config=config,
         repo_cfg=repo_cfg,
+        dispatcher=dispatcher,
         issue_cache=registry.get_issue_cache(repo_cfg.name),
     )
 
@@ -761,6 +767,7 @@ def make_registry(
     repos: dict[str, RepoConfig],
     gh: GitHub,
     config: Config | None = None,
+    dispatcher: "Dispatcher | None" = None,
     *,
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
@@ -784,6 +791,7 @@ def make_registry(
             provider=provider,
             session_issue=session_issue,
             config=config,
+            dispatcher=dispatcher,
         )
 
     registry = WorkerRegistry(factory)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -745,7 +745,7 @@ def _make_thread(
     provider: Provider | None = None,
     session_issue: int | None = None,
     config: Config | None = None,
-    dispatchers: "dict[str, Dispatcher] | None" = None,
+    dispatchers: "dict[str, Dispatcher]",
     _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client.
@@ -764,7 +764,7 @@ def _make_thread(
         session_issue=session_issue,
         config=config,
         repo_cfg=repo_cfg,
-        dispatcher=dispatchers.get(repo_cfg.name) if dispatchers is not None else None,
+        dispatcher=dispatchers[repo_cfg.name],
         issue_cache=registry.get_issue_cache(repo_cfg.name),
     )
 
@@ -773,8 +773,8 @@ def make_registry(
     repos: dict[str, RepoConfig],
     gh: GitHub,
     config: Config | None = None,
-    dispatchers: "dict[str, Dispatcher] | None" = None,
     *,
+    dispatchers: "dict[str, Dispatcher]",
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
     """Create a :class:`WorkerRegistry` and start threads for all repos.

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -622,7 +622,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
-    dispatcher: Dispatcher | None = None
+    dispatchers: dict[str, Dispatcher] = {}
     # Infrastructure ports — set by server.run() composition root.
     infra: Infra = real_infra()
     static_files: StaticFiles | None = None
@@ -761,12 +761,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         # Dispatch BEFORE acknowledging — if dispatch raises, return 500 so
         # GitHub retries instead of treating the event as successfully handled.
-        assert self.dispatcher is not None, "dispatcher not wired — call run() first"
+        dispatcher = self.dispatchers.get(repo_name)
+        assert dispatcher is not None, "dispatcher not wired — call run() first"
         try:
-            action = self.dispatcher.dispatch(
+            action = dispatcher.dispatch(
                 event,
                 payload,
-                repo_cfg,
                 delivery_id=delivery,
                 oracle=type(self).ingress_oracle,
             )
@@ -1085,7 +1085,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         is_bot=action.is_bot,
                         registry=self.registry,
                         create_task_fn=type(self)._fn_create_task,
-                        dispatcher=self.dispatcher,
+                        dispatcher=self.dispatchers.get(repo_cfg.name),
                     )
 
             if action.review_comments:
@@ -1130,7 +1130,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     is_bot=action.is_bot,
                     registry=self.registry,
                     create_task_fn=type(self)._fn_create_task,
-                    dispatcher=self.dispatcher,
+                    dispatcher=self.dispatchers.get(repo_cfg.name),
                 )
 
             log.info(
@@ -1529,15 +1529,18 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = gh
-    dispatcher = Dispatcher(config, gh)
-    WebhookHandler.dispatcher = dispatcher
+    dispatchers = {
+        name: Dispatcher(config, repo_cfg, gh)
+        for name, repo_cfg in config.repos.items()
+    }
+    WebhookHandler.dispatchers = dispatchers
     WebhookHandler.static_files = StaticFiles(
         Path(__file__).resolve().parent / "static"
     )
     WebhookHandler.provider_factory = DefaultProviderFactory(
         session_system_file=config.sub_dir / "persona.md"
     )
-    registry = _make_registry(config.repos, gh, config, dispatcher=dispatcher)
+    registry = _make_registry(config.repos, gh, config, dispatchers=dispatchers)
     WebhookHandler.registry = registry
     # Bootstrap issue caches eagerly so the picker has populated data immediately —
     # even for repos whose worker resumes on an existing issue and never calls

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -761,8 +761,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         # Dispatch BEFORE acknowledging — if dispatch raises, return 500 so
         # GitHub retries instead of treating the event as successfully handled.
-        dispatcher = self.dispatchers.get(repo_name)
-        assert dispatcher is not None, "dispatcher not wired — call run() first"
+        dispatcher = self.dispatchers[repo_name]
         try:
             action = dispatcher.dispatch(
                 event,
@@ -1085,7 +1084,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         is_bot=action.is_bot,
                         registry=self.registry,
                         create_task_fn=type(self)._fn_create_task,
-                        dispatcher=self.dispatchers.get(repo_cfg.name),
+                        dispatcher=self.dispatchers[repo_cfg.name],
                     )
 
             if action.review_comments:
@@ -1130,7 +1129,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     is_bot=action.is_bot,
                     registry=self.registry,
                     create_task_fn=type(self)._fn_create_task,
-                    dispatcher=self.dispatchers.get(repo_cfg.name),
+                    dispatcher=self.dispatchers[repo_cfg.name],
                 )
 
             log.info(

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1085,6 +1085,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         is_bot=action.is_bot,
                         registry=self.registry,
                         create_task_fn=type(self)._fn_create_task,
+                        dispatcher=self.dispatcher,
                     )
 
             if action.review_comments:
@@ -1129,6 +1130,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     is_bot=action.is_bot,
                     registry=self.registry,
                     create_task_fn=type(self)._fn_create_task,
+                    dispatcher=self.dispatcher,
                 )
 
             log.info(

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1529,14 +1529,15 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = gh
-    WebhookHandler.dispatcher = Dispatcher(config, gh)
+    dispatcher = Dispatcher(config, gh)
+    WebhookHandler.dispatcher = dispatcher
     WebhookHandler.static_files = StaticFiles(
         Path(__file__).resolve().parent / "static"
     )
     WebhookHandler.provider_factory = DefaultProviderFactory(
         session_system_file=config.sub_dir / "persona.md"
     )
-    registry = _make_registry(config.repos, gh, config)
+    registry = _make_registry(config.repos, gh, config, dispatcher=dispatcher)
     WebhookHandler.registry = registry
     # Bootstrap issue caches eagerly so the picker has populated data immediately —
     # even for repos whose worker resumes on an existing issue and never calls

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -26,9 +26,9 @@ from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.events import (
     Action,
+    Dispatcher,
     WebhookIngressOracle,
     create_task,
-    dispatch,
     launch_worker,
     queue_reply_tasks,
     reply_outcome_creates_tasks,
@@ -622,10 +622,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
     # Injectable collaborators — set as class attributes so HTTP-driven tests
     # can replace them without patching module-level names.
     gh: GitHub | None = None
+    dispatcher: Dispatcher | None = None
     # Infrastructure ports — set by server.run() composition root.
     infra: Infra = real_infra()
     static_files: StaticFiles | None = None
-    _fn_dispatch = staticmethod(dispatch)
     _fn_reply_to_comment = staticmethod(reply_to_comment)
     _fn_reply_to_review = staticmethod(reply_to_review)
     _fn_reply_to_issue_comment = staticmethod(reply_to_issue_comment)
@@ -761,11 +761,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
         # Dispatch BEFORE acknowledging — if dispatch raises, return 500 so
         # GitHub retries instead of treating the event as successfully handled.
+        assert self.dispatcher is not None, "dispatcher not wired — call run() first"
         try:
-            action = type(self)._fn_dispatch(
+            action = self.dispatcher.dispatch(
                 event,
                 payload,
-                self.config,
                 repo_cfg,
                 delivery_id=delivery,
                 oracle=type(self).ingress_oracle,
@@ -1527,6 +1527,7 @@ def run(
 
     WebhookHandler.config = config
     WebhookHandler.gh = gh
+    WebhookHandler.dispatcher = Dispatcher(config, gh)
     WebhookHandler.static_files = StaticFiles(
         Path(__file__).resolve().parent / "static"
     )

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4026,7 +4026,6 @@ class Worker:
                 # comment_id so re-tasking already-handled comments is a no-op.
                 if self._dispatcher is not None:
                     self._dispatcher.backfill_missed_pr_comments(
-                        recovery_repo_cfg,
                         pr_number,
                         gh_user=repo_ctx.gh_user,
                     )

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4030,16 +4030,6 @@ class Worker:
                         pr_number,
                         gh_user=repo_ctx.gh_user,
                     )
-                else:
-                    from fido.events import backfill_missed_pr_comments
-
-                    backfill_missed_pr_comments(
-                        recovery_config,
-                        recovery_repo_cfg,
-                        self.gh,
-                        pr_number,
-                        gh_user=repo_ctx.gh_user,
-                    )
                 self._first_iteration = False
             if pr_is_fresh:
                 log.info("fresh PR — skipping CI/thread/rescope checks")

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from fido.events import Action
+    from fido.events import Action, Dispatcher
 
 import requests as _requests
 
@@ -1154,6 +1154,7 @@ class Worker:
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
+        dispatcher: "Dispatcher | None" = None,
         first_iteration: bool = False,
         *,
         issue_cache: IssueTreeCache,
@@ -1179,6 +1180,7 @@ class Worker:
         self._prompts = prompts
         self._config = config
         self._repo_cfg = repo_cfg
+        self._dispatcher = dispatcher
         self._provider_factory = (
             DefaultProviderFactory(session_system_file=_sub_dir() / "persona.md")
             if provider_factory is None
@@ -4022,15 +4024,22 @@ class Worker:
                 # Runs only on the first iteration per WorkerThread lifetime so
                 # the steady-state loop stays fast; create_task dedups on
                 # comment_id so re-tasking already-handled comments is a no-op.
-                from fido.events import backfill_missed_pr_comments
+                if self._dispatcher is not None:
+                    self._dispatcher.backfill_missed_pr_comments(
+                        recovery_repo_cfg,
+                        pr_number,
+                        gh_user=repo_ctx.gh_user,
+                    )
+                else:
+                    from fido.events import backfill_missed_pr_comments
 
-                backfill_missed_pr_comments(
-                    recovery_config,
-                    recovery_repo_cfg,
-                    self.gh,
-                    pr_number,
-                    gh_user=repo_ctx.gh_user,
-                )
+                    backfill_missed_pr_comments(
+                        recovery_config,
+                        recovery_repo_cfg,
+                        self.gh,
+                        pr_number,
+                        gh_user=repo_ctx.gh_user,
+                    )
                 self._first_iteration = False
             if pr_is_fresh:
                 log.info("fresh PR — skipping CI/thread/rescope checks")
@@ -4121,6 +4130,7 @@ class WorkerThread(threading.Thread):
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
+        dispatcher: "Dispatcher | None" = None,
         *,
         issue_cache: IssueTreeCache,
     ) -> None:
@@ -4167,6 +4177,7 @@ class WorkerThread(threading.Thread):
         self._session_issue: int | None = session_issue
         self._config = config
         self._repo_cfg = repo_cfg
+        self._dispatcher = dispatcher
         self._bootstrap_session: PromptSession | None = session
         # True until the first ``Worker.run()`` returns — flipped after that so
         # the one-shot startup backfill (fix #794) only fires once per thread.
@@ -4445,6 +4456,7 @@ class WorkerThread(threading.Thread):
                     config=self._config,
                     repo_cfg=self._repo_cfg,
                     provider_factory=self._provider_factory,
+                    dispatcher=self._dispatcher,
                     first_iteration=self._is_first_iteration,
                     issue_cache=self._issue_cache,
                 )

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1172,9 +1172,9 @@ class Worker:
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
-        dispatcher: "Dispatcher | None" = None,
         first_iteration: bool = False,
         *,
+        dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
     ) -> None:
         self.work_dir = work_dir
@@ -2431,6 +2431,7 @@ class Worker:
                 thread=action.reply_to,
                 is_bot=action.is_bot,
                 registry=self._registry,
+                dispatcher=self._dispatcher,
             )
         log.info("threads done")
         tasks.sync_tasks_background(self.work_dir, self.gh)
@@ -2510,6 +2511,7 @@ class Worker:
                 else action.thread,
                 is_bot=action.is_bot,
                 registry=self._registry,
+                dispatcher=self._dispatcher,
             )
             store.ack_promise(promise.promise_id)
         except Exception as exc:
@@ -4064,6 +4066,7 @@ class Worker:
                 self.gh,
                 pr_number,
                 self._registry,
+                self._dispatcher,
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
             )
@@ -4073,11 +4076,10 @@ class Worker:
                 # Runs only on the first iteration per WorkerThread lifetime so
                 # the steady-state loop stays fast; create_task dedups on
                 # comment_id so re-tasking already-handled comments is a no-op.
-                if self._dispatcher is not None:
-                    self._dispatcher.backfill_missed_pr_comments(
-                        pr_number,
-                        gh_user=repo_ctx.gh_user,
-                    )
+                self._dispatcher.backfill_missed_pr_comments(
+                    pr_number,
+                    gh_user=repo_ctx.gh_user,
+                )
                 self._first_iteration = False
             if pr_is_fresh:
                 log.info("fresh PR — skipping CI/thread/rescope checks")
@@ -4168,8 +4170,8 @@ class WorkerThread(threading.Thread):
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
-        dispatcher: "Dispatcher | None" = None,
         *,
+        dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
     ) -> None:
         super().__init__(name=f"worker-{work_dir.name}", daemon=True)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,62 @@
+"""Hand-rolled test fakes shared across the Fido test suite."""
+
+from collections.abc import Callable
+
+
+class _FakeDispatcher:
+    """Hand-rolled fake for :class:`fido.events.Dispatcher`.
+
+    Records calls with typed fields so tests can assert on sequencing,
+    call counts, and arguments without MagicMock.  Configurable return
+    values and side-effects cover the three usage patterns across the
+    test suite:
+
+    - ``dispatch_return`` / ``dispatch_side_effect`` for server tests
+    - ``backfill_return`` / ``backfill_side_effect`` for worker tests
+    - bare construction for ``create_task`` tests that only need
+      ``launch_sync()`` to be callable
+    """
+
+    def __init__(
+        self,
+        *,
+        dispatch_return: object = None,
+        dispatch_side_effect: Callable[..., object] | BaseException | None = None,
+        backfill_return: int = 0,
+        backfill_side_effect: (Callable[..., int] | BaseException | None) = None,
+    ) -> None:
+        self.dispatch_calls: list[tuple] = []
+        self.backfill_calls: list[dict[str, object]] = []
+        self.launch_sync_calls: int = 0
+        self._dispatch_return = dispatch_return
+        self._dispatch_side_effect = dispatch_side_effect
+        self._backfill_return = backfill_return
+        self._backfill_side_effect = backfill_side_effect
+
+    def dispatch(
+        self,
+        event: str,
+        payload: dict,
+        *,
+        delivery_id: str | None = None,
+        oracle: object = None,
+    ) -> object:
+        self.dispatch_calls.append((event, payload, delivery_id, oracle))
+        if callable(self._dispatch_side_effect):
+            return self._dispatch_side_effect(
+                event, payload, delivery_id=delivery_id, oracle=oracle
+            )
+        if isinstance(self._dispatch_side_effect, BaseException):
+            raise self._dispatch_side_effect
+        return self._dispatch_return
+
+    def backfill_missed_pr_comments(self, pr_number: int, *, gh_user: str) -> int:
+        self.backfill_calls.append({"pr_number": pr_number, "gh_user": gh_user})
+        if callable(self._backfill_side_effect):
+            return self._backfill_side_effect(pr_number, gh_user=gh_user)
+        if isinstance(self._backfill_side_effect, BaseException):
+            raise self._backfill_side_effect
+        return self._backfill_return
+
+    def launch_sync(self) -> None:
+        self.launch_sync_calls += 1

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -27,6 +27,7 @@ from fido.tasks import (
     _thread_task_for_auto_resolve_oracle,
     review_thread_for_auto_resolve_oracle,
 )
+from tests.fakes import _FakeDispatcher
 
 # ---------------------------------------------------------------------------
 # provider_factory.py — fallback ValueError branches
@@ -1847,7 +1848,7 @@ class TestEventsCreateTaskExitUntriaged:
                     gh,
                     thread=thread,
                     registry=registry,
-                    dispatcher=MagicMock(),
+                    dispatcher=_FakeDispatcher(),
                     _reorder_background_fn=boom,
                     _get_commit_summary_fn=lambda wd: "summary",
                     _tasks=tasks,

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -1839,19 +1839,19 @@ class TestEventsCreateTaskExitUntriaged:
             raise RuntimeError("explode")
 
         with patch.object(events, "_reorder_tasks_background", new=boom):
-            with patch.object(events, "launch_sync"):
-                with pytest.raises(RuntimeError, match="explode"):
-                    events.create_task(
-                        "prompt",
-                        config,
-                        repo_cfg,
-                        gh,
-                        thread=thread,
-                        registry=registry,
-                        _reorder_background_fn=boom,
-                        _get_commit_summary_fn=lambda wd: "summary",
-                        _tasks=tasks,
-                    )
+            with pytest.raises(RuntimeError, match="explode"):
+                events.create_task(
+                    "prompt",
+                    config,
+                    repo_cfg,
+                    gh,
+                    thread=thread,
+                    registry=registry,
+                    dispatcher=MagicMock(),
+                    _reorder_background_fn=boom,
+                    _get_commit_summary_fn=lambda wd: "summary",
+                    _tasks=tasks,
+                )
         registry.enter_untriaged.assert_called_once_with("test/repo")
         registry.exit_untriaged.assert_called_once_with("test/repo")
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7117,50 +7117,41 @@ class TestGitHubInsightFiler:
 class TestDispatcher:
     """Unit tests for the :class:`~fido.events.Dispatcher` collaborator."""
 
-    def test_dispatch_delegates_to_free_function(self, tmp_path: Path) -> None:
+    def test_dispatch_routes_ping_to_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        mock_gh = MagicMock()
         repo_cfg = _repo_cfg(tmp_path)
-        oracle = WebhookIngressOracle()
-        payload = {**_payload(), "action": "opened"}
-        with patch("fido.events.dispatch") as mock_dispatch:
-            mock_dispatch.return_value = None
-            d = Dispatcher(cfg, mock_gh)
-            result = d.dispatch(
-                "issues", payload, repo_cfg, delivery_id="abc", oracle=oracle
-            )
-        mock_dispatch.assert_called_once_with(
-            "issues", payload, cfg, repo_cfg, delivery_id="abc", oracle=oracle
-        )
+        d = Dispatcher(cfg)
+        result = d.dispatch("ping", {"hook_id": 1}, repo_cfg)
         assert result is None
 
-    def test_dispatch_returns_action(self, tmp_path: Path) -> None:
+    def test_dispatch_returns_action_for_issue_assigned(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        mock_gh = MagicMock()
         repo_cfg = _repo_cfg(tmp_path)
-        action = Action(prompt="hello")
-        with patch("fido.events.dispatch", return_value=action):
-            d = Dispatcher(cfg, mock_gh)
-            result = d.dispatch("ping", {}, repo_cfg)
-        assert result is action
+        payload = {
+            "action": "assigned",
+            "assignee": {"login": "rhencke"},
+            "issue": {"number": 7, "title": "Do the thing"},
+        }
+        d = Dispatcher(cfg)
+        result = d.dispatch("issues", payload, repo_cfg)
+        assert isinstance(result, Action)
+        assert "7" in result.prompt
 
-    def test_backfill_delegates_to_free_function(self, tmp_path: Path) -> None:
+    def test_backfill_returns_count(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = []
         repo_cfg = _repo_cfg(tmp_path)
-        with patch(
-            "fido.events.backfill_missed_pr_comments", return_value=3
-        ) as mock_bf:
-            d = Dispatcher(cfg, mock_gh)
-            count = d.backfill_missed_pr_comments(repo_cfg, 42, gh_user="fido")
-        mock_bf.assert_called_once_with(cfg, repo_cfg, mock_gh, 42, gh_user="fido")
-        assert count == 3
+        d = Dispatcher(cfg, mock_gh)
+        count = d.backfill_missed_pr_comments(repo_cfg, 42, gh_user="fido")
+        mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
+        assert count == 0
 
-    def test_launch_sync_delegates_to_free_function(self, tmp_path: Path) -> None:
+    def test_launch_sync_calls_background(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         mock_gh = MagicMock()
         repo_cfg = _repo_cfg(tmp_path)
-        with patch("fido.events.launch_sync") as mock_sync:
+        with patch("fido.tasks.sync_tasks_background") as mock_sync:
             d = Dispatcher(cfg, mock_gh)
             d.launch_sync(repo_cfg)
-        mock_sync.assert_called_once_with(cfg, repo_cfg, mock_gh)
+        mock_sync.assert_called_once_with(repo_cfg.work_dir, mock_gh)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3250,7 +3250,7 @@ class TestCreateTask:
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=None
         )
-        mock_dispatcher.launch_sync.assert_called_once_with(repo_cfg)
+        mock_dispatcher.launch_sync.assert_called_once_with()
 
     def test_passes_thread(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -7120,8 +7120,8 @@ class TestDispatcher:
     def test_dispatch_routes_ping_to_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         repo_cfg = _repo_cfg(tmp_path)
-        d = Dispatcher(cfg)
-        result = d.dispatch("ping", {"hook_id": 1}, repo_cfg)
+        d = Dispatcher(cfg, repo_cfg)
+        result = d.dispatch("ping", {"hook_id": 1})
         assert result is None
 
     def test_dispatch_returns_action_for_issue_assigned(self, tmp_path: Path) -> None:
@@ -7132,8 +7132,8 @@ class TestDispatcher:
             "assignee": {"login": "rhencke"},
             "issue": {"number": 7, "title": "Do the thing"},
         }
-        d = Dispatcher(cfg)
-        result = d.dispatch("issues", payload, repo_cfg)
+        d = Dispatcher(cfg, repo_cfg)
+        result = d.dispatch("issues", payload)
         assert isinstance(result, Action)
         assert "7" in result.prompt
 
@@ -7142,8 +7142,8 @@ class TestDispatcher:
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = []
         repo_cfg = _repo_cfg(tmp_path)
-        d = Dispatcher(cfg, mock_gh)
-        count = d.backfill_missed_pr_comments(repo_cfg, 42, gh_user="fido")
+        d = Dispatcher(cfg, repo_cfg, mock_gh)
+        count = d.backfill_missed_pr_comments(42, gh_user="fido")
         mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
         assert count == 0
 
@@ -7152,6 +7152,6 @@ class TestDispatcher:
         mock_gh = MagicMock()
         repo_cfg = _repo_cfg(tmp_path)
         with patch("fido.tasks.sync_tasks_background") as mock_sync:
-            d = Dispatcher(cfg, mock_gh)
-            d.launch_sync(repo_cfg)
+            d = Dispatcher(cfg, repo_cfg, mock_gh)
+            d.launch_sync()
         mock_sync.assert_called_once_with(repo_cfg.work_dir, mock_gh)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -11,6 +11,7 @@ from fido.events import (
     _INSIGHT_LABEL,
     _INSIGHT_REPO,
     Action,
+    Dispatcher,
     WebhookIngressOracle,
     _apply_reply_result,
     _BackgroundRescopeTrigger,
@@ -7096,3 +7097,55 @@ class TestGitHubInsightFiler:
 
         body = gh.create_issue.call_args.args[2]
         assert "https://github.com/org/proj/pull/10#discussion_r555" in body
+
+
+class TestDispatcher:
+    """Unit tests for the :class:`~fido.events.Dispatcher` collaborator."""
+
+    def test_dispatch_delegates_to_free_function(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        mock_gh = MagicMock()
+        repo_cfg = _repo_cfg(tmp_path)
+        oracle = WebhookIngressOracle()
+        payload = {**_payload(), "action": "opened"}
+        with patch("fido.events.dispatch") as mock_dispatch:
+            mock_dispatch.return_value = None
+            d = Dispatcher(cfg, mock_gh)
+            result = d.dispatch(
+                "issues", payload, repo_cfg, delivery_id="abc", oracle=oracle
+            )
+        mock_dispatch.assert_called_once_with(
+            "issues", payload, cfg, repo_cfg, delivery_id="abc", oracle=oracle
+        )
+        assert result is None
+
+    def test_dispatch_returns_action(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        mock_gh = MagicMock()
+        repo_cfg = _repo_cfg(tmp_path)
+        action = Action(prompt="hello")
+        with patch("fido.events.dispatch", return_value=action):
+            d = Dispatcher(cfg, mock_gh)
+            result = d.dispatch("ping", {}, repo_cfg)
+        assert result is action
+
+    def test_backfill_delegates_to_free_function(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        mock_gh = MagicMock()
+        repo_cfg = _repo_cfg(tmp_path)
+        with patch(
+            "fido.events.backfill_missed_pr_comments", return_value=3
+        ) as mock_bf:
+            d = Dispatcher(cfg, mock_gh)
+            count = d.backfill_missed_pr_comments(repo_cfg, 42, gh_user="fido")
+        mock_bf.assert_called_once_with(cfg, repo_cfg, mock_gh, 42, gh_user="fido")
+        assert count == 3
+
+    def test_launch_sync_delegates_to_free_function(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path)
+        mock_gh = MagicMock()
+        repo_cfg = _repo_cfg(tmp_path)
+        with patch("fido.events.launch_sync") as mock_sync:
+            d = Dispatcher(cfg, mock_gh)
+            d.launch_sync(repo_cfg)
+        mock_sync.assert_called_once_with(cfg, repo_cfg, mock_gh)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -51,6 +51,7 @@ from fido.synthesis_call import SynthesisExhaustedError
 from fido.synthesis_executor import CommentTarget
 from fido.types import ActiveIssue, ActivePR, RescopeIntent
 from fido.worker import ActivityReporter
+from tests.fakes import _FakeDispatcher
 
 
 def _synthesis_response(
@@ -277,6 +278,7 @@ class TestRecoverReplyPromises:
             MagicMock(),
             7,
             registry=MagicMock(spec=ActivityReporter),
+            dispatcher=_FakeDispatcher(),
         )
 
     def test_recovers_issue_comment_promise(self, tmp_path: Path) -> None:
@@ -305,6 +307,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert result is True
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "acked"
@@ -350,6 +353,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
         assert store.promise(promise.promise_id).state == "acked"
@@ -382,6 +386,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
         assert store.promise(promise.promise_id).state == "acked"
@@ -404,6 +409,7 @@ class TestRecoverReplyPromises:
             gh,
             7,
             registry=MagicMock(spec=ActivityReporter),
+            dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
         self._assert_recovery_matches_oracle(
@@ -425,6 +431,7 @@ class TestRecoverReplyPromises:
             gh,
             7,
             registry=MagicMock(spec=ActivityReporter),
+            dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
         self._assert_recovery_matches_oracle(
@@ -452,6 +459,7 @@ class TestRecoverReplyPromises:
             gh,
             7,
             registry=MagicMock(spec=ActivityReporter),
+            dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
         assert [
@@ -482,6 +490,7 @@ class TestRecoverReplyPromises:
             gh,
             7,
             registry=MagicMock(spec=ActivityReporter),
+            dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
         assert [
@@ -516,6 +525,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
         assert [
@@ -550,6 +560,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert FidoStore(tmp_path).claim_state(302) == "retryable_failed"
         assert FidoStore(tmp_path).recoverable_promises()[0].state == "failed"
@@ -582,6 +593,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
         assert [
@@ -617,6 +629,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert FidoStore(tmp_path).claim_state(205) == "retryable_failed"
         assert FidoStore(tmp_path).recoverable_promises()[0].state == "failed"
@@ -652,6 +665,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert result is True
         mock_create_task.assert_not_called()
@@ -691,6 +705,7 @@ class TestRecoverReplyPromises:
                     gh,
                     7,
                     registry=MagicMock(spec=ActivityReporter),
+                    dispatcher=_FakeDispatcher(),
                 )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
 
@@ -744,6 +759,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert result is True
         assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
@@ -805,6 +821,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert result is True
         assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
@@ -867,6 +884,7 @@ class TestRecoverReplyPromises:
                 7,
                 agent=_client(),
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
 
         store = FidoStore(tmp_path)
@@ -936,6 +954,7 @@ class TestRecoverReplyPromises:
                     gh,
                     7,
                     registry=MagicMock(spec=ActivityReporter),
+                    dispatcher=_FakeDispatcher(),
                 )
         store = FidoStore(tmp_path)
         assert store.promise(first.promise_id).state == "prepared"
@@ -1001,6 +1020,7 @@ class TestRecoverReplyPromises:
                 7,
                 agent=_client(),
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
 
         store = FidoStore(tmp_path)
@@ -1087,6 +1107,7 @@ class TestRecoverReplyPromises:
                     gh,
                     7,
                     registry=MagicMock(spec=ActivityReporter),
+                    dispatcher=_FakeDispatcher(),
                 )
         assert mock_reply.call_count == 0
         mock_create_task.assert_not_called()
@@ -1151,6 +1172,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 registry=MagicMock(spec=ActivityReporter),
+                dispatcher=_FakeDispatcher(),
             )
         assert result is True
         assert mock_reply.call_count == 2
@@ -1387,7 +1409,7 @@ class TestReplyPromiseHelpers:
 class TestDispatchPing:
     def test_returns_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "ping", {"hook_id": 123, **_payload()}
         )
         assert result is None
@@ -1402,7 +1424,9 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 1, "title": "test issue"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issues", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issues", payload
+        )
         assert result is not None
         assert "#1" in result.prompt
 
@@ -1414,7 +1438,9 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 0, "title": "test"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issues", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issues", payload
+        )
         assert result is None
 
 
@@ -1435,7 +1461,7 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "pr title", "body": "pr body"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review_comment", payload
         )
         assert result is not None
@@ -1463,7 +1489,7 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review_comment", payload
         )
         assert result is not None
@@ -1490,7 +1516,7 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        result = Dispatcher(cfg, repo_cfg).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-125",
@@ -1530,12 +1556,12 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        Dispatcher(cfg, repo_cfg).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-126-a",
         )
-        Dispatcher(cfg, repo_cfg).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-126-b",
@@ -1563,7 +1589,7 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        Dispatcher(cfg, repo_cfg).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-127-a",
@@ -1577,7 +1603,7 @@ class TestDispatchReviewComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = Dispatcher(cfg, repo_cfg).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "pull_request_review_comment",
             edited_payload,
             delivery_id="delivery-review-127-b",
@@ -1598,7 +1624,7 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "done", "user": {"login": "FidoCanCode"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review_comment", payload
         )
         assert result is None
@@ -1611,7 +1637,7 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "rando"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review_comment", payload
         )
         assert result is None
@@ -1629,7 +1655,9 @@ class TestDispatchCheckRun:
                 "pull_requests": [{"number": 3}],
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "check_run", payload
+        )
         assert result is not None
         assert "CI failure" in result.prompt
         assert result.preempts_worker is True
@@ -1641,7 +1669,9 @@ class TestDispatchCheckRun:
             "action": "completed",
             "check_run": {"conclusion": "success", "name": "lint", "pull_requests": []},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "check_run", payload
+        )
         assert result is None
 
 
@@ -1664,7 +1694,9 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": True},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("pull_request", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "pull_request", payload
+        )
         assert result is not None
         assert "merged" in result.prompt
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
@@ -1687,7 +1719,9 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": False},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("pull_request", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "pull_request", payload
+        )
         assert result is None
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
 
@@ -1711,7 +1745,9 @@ class TestDispatchIssueComment:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issue_comment", payload
+        )
         assert result is not None
         assert result.comment_body is None
         assert result.preempts_worker is True
@@ -1746,7 +1782,7 @@ class TestDispatchIssueComment:
             },
         }
 
-        result = Dispatcher(cfg, repo_cfg).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "issue_comment",
             payload,
             delivery_id="delivery-issue-457",
@@ -1785,7 +1821,7 @@ class TestDispatchIssueComment:
             },
         }
 
-        Dispatcher(cfg, repo_cfg).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "issue_comment", payload, delivery_id="delivery-a"
         )
         edited_payload = {
@@ -1797,7 +1833,7 @@ class TestDispatchIssueComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = Dispatcher(cfg, repo_cfg).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
             "issue_comment", edited_payload, delivery_id="delivery-b"
         )
 
@@ -1816,14 +1852,16 @@ class TestDispatchIssueComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "owner"}},
             "issue": {"number": 10, "title": "issue"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issue_comment", payload
+        )
         assert result is None
 
 
 class TestDispatchUnknown:
     def test_unknown_event(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "unknown_event",
             {**_payload(), "action": "whatever"},
         )
@@ -2096,6 +2134,7 @@ class TestReplyToComment:
                 MagicMock(),
                 thread=None,
                 registry=None,
+                dispatcher=_FakeDispatcher(),
             )
         mock_create_task.assert_not_called()
 
@@ -2122,6 +2161,7 @@ class TestReplyToComment:
                 MagicMock(),
                 thread=thread,
                 registry=None,
+                dispatcher=_FakeDispatcher(),
             )
         mock_create_task.assert_called_once()
         _, kwargs = mock_create_task.call_args
@@ -3402,6 +3442,7 @@ class TestCreateTask:
                 mock_gh,
                 thread=thread,
                 _tasks=mock_tasks,
+                dispatcher=_FakeDispatcher(),
                 _get_commit_summary_fn=lambda wd: "",
             )
         warns = [
@@ -3414,7 +3455,7 @@ class TestCreateTask:
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         mock_gh = MagicMock()
         mock_tasks = self._mock_tasks()
-        mock_dispatcher = MagicMock()
+        mock_dispatcher = _FakeDispatcher()
         create_task(
             "do something",
             cfg,
@@ -3426,7 +3467,7 @@ class TestCreateTask:
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=None
         )
-        mock_dispatcher.launch_sync.assert_called_once_with()
+        assert mock_dispatcher.launch_sync_calls == 1
 
     def test_passes_thread(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -3442,7 +3483,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3465,7 +3506,7 @@ class TestCreateTask:
             thread=thread,
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
@@ -3495,7 +3536,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3525,7 +3566,7 @@ class TestCreateTask:
             thread=thread,
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
@@ -3554,7 +3595,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
@@ -3584,7 +3625,7 @@ class TestCreateTask:
             thread=thread,
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
@@ -3607,7 +3648,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         mock_tasks.add.assert_called_once()
 
@@ -3627,7 +3668,7 @@ class TestCreateTask:
             repo_cfg,
             MagicMock(),
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         assert result == fake_task
 
@@ -3650,6 +3691,7 @@ class TestCreateTask:
                 MagicMock(),
                 thread=thread,
                 create_task_fn=fake_create,
+                dispatcher=_FakeDispatcher(),
             )
             == 1
         )
@@ -3692,7 +3734,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )  # no registry
         registry.abort_task.assert_not_called()
 
@@ -3730,7 +3772,7 @@ class TestCreateTask:
             MagicMock(),
             registry=registry,
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )  # no thread
         registry.abort_task.assert_not_called()
 
@@ -3763,7 +3805,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -3810,7 +3852,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -3838,7 +3880,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -3870,7 +3912,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -3902,7 +3944,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -3958,7 +4000,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # ABORT_KEEP: current task stays in tasks.json
@@ -3990,7 +4032,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # task should still be in tasks.json (ABORT_KEEP)
@@ -4021,7 +4063,7 @@ class TestCreateTask:
             _tasks=mock_tasks,
             _reorder_background_fn=MagicMock(),
             _get_commit_summary_fn=lambda wd: "",
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -4040,7 +4082,7 @@ class TestCreateTask:
             MagicMock(),
             registry=registry,
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
@@ -4061,7 +4103,7 @@ class TestCreateTask:
             MagicMock(),
             registry=registry,
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
@@ -4086,7 +4128,7 @@ class TestCreateTask:
             MagicMock(),
             registry=registry,
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         registry.abort_task.assert_not_called()
 
@@ -4115,7 +4157,7 @@ class TestCreateTask:
                 reorder_called.append((wd, cs, cfg, gh, rc, reg))
             ),
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         assert len(reorder_called) == 1
         assert reorder_called[0][0] == tmp_path
@@ -4143,7 +4185,7 @@ class TestCreateTask:
             MagicMock(),
             _reorder_background_fn=lambda *a: reorder_called.append(a),
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         assert reorder_called == []
 
@@ -4154,7 +4196,7 @@ class TestCreateTask:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         mock_tasks = self._mock_tasks()
-        mock_dispatcher = MagicMock()
+        mock_dispatcher = _FakeDispatcher()
         with patch("fido.events._rewrite_pr_description") as mock_rewrite:
             create_task(
                 "Spec task",
@@ -4192,7 +4234,7 @@ class TestCreateTask:
                 cs
             ),
             _tasks=mock_tasks,
-            dispatcher=MagicMock(),
+            dispatcher=_FakeDispatcher(),
         )
         assert summaries == ["custom summary"]
 
@@ -4201,7 +4243,7 @@ class TestCreateTask:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         result = create_task(
-            "do a thing", cfg, repo_cfg, MagicMock(), dispatcher=MagicMock()
+            "do a thing", cfg, repo_cfg, MagicMock(), dispatcher=_FakeDispatcher()
         )
         assert result["title"] == "do a thing"
 
@@ -5607,7 +5649,7 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review", payload
         )
         assert result is not None
@@ -5622,7 +5664,7 @@ class TestDispatchPullRequestReview:
             "review": {"state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review", payload
         )
         assert result is not None
@@ -5636,7 +5678,7 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review", payload
         )
         assert result is None
@@ -5649,7 +5691,7 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "stranger"}},
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review", payload
         )
         assert result is None
@@ -5666,7 +5708,7 @@ class TestDispatchPullRequestReview:
             "review": {"id": 77, "state": "commented", "user": {"login": "owner"}},
             "pull_request": {"number": 4},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-commented-1",
@@ -5685,7 +5727,7 @@ class TestDispatchPullRequestReview:
             "review": {"id": 78, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-approved-1",
@@ -5708,7 +5750,7 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 6},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-changes-requested-1",
@@ -5727,7 +5769,7 @@ class TestDispatchPullRequestReview:
             "review": {"id": 80, "state": "dismissed", "user": {"login": "owner"}},
             "pull_request": {"number": 7},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-dismissed-1",
@@ -5748,7 +5790,9 @@ class TestDispatchCheckRunNoPrs:
                 "pull_requests": [],
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "check_run", payload
+        )
         assert result is not None
         assert "unknown PR" in result.prompt
 
@@ -5766,7 +5810,9 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issue_comment", payload
+        )
         assert result is None
 
     def test_unallowed_user_ignored(self, tmp_path: Path) -> None:
@@ -5781,7 +5827,9 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+            "issue_comment", payload
+        )
         assert result is None
 
 
@@ -5800,7 +5848,7 @@ class TestDispatchReviewCommentNoNumber:
             },
             "pull_request": {},  # no number
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
             "pull_request_review_comment", payload
         )
         assert result is None
@@ -7245,7 +7293,7 @@ class TestDispatcher:
     def test_dispatch_routes_ping_to_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         repo_cfg = _repo_cfg(tmp_path)
-        d = Dispatcher(cfg, repo_cfg)
+        d = Dispatcher(cfg, repo_cfg, MagicMock())
         result = d.dispatch("ping", {"hook_id": 1})
         assert result is None
 
@@ -7257,7 +7305,7 @@ class TestDispatcher:
             "assignee": {"login": "rhencke"},
             "issue": {"number": 7, "title": "Do the thing"},
         }
-        d = Dispatcher(cfg, repo_cfg)
+        d = Dispatcher(cfg, repo_cfg, MagicMock())
         result = d.dispatch("issues", payload)
         assert isinstance(result, Action)
         assert "7" in result.prompt

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -33,8 +33,6 @@ from fido.events import (
     _task_snapshot,
     build_review_comment_action,
     create_task,
-    dispatch,
-    launch_sync,
     launch_worker,
     needs_more_context,
     queue_reply_tasks,
@@ -1367,8 +1365,8 @@ class TestReplyPromiseHelpers:
 class TestDispatchPing:
     def test_returns_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = dispatch(
-            "ping", {"hook_id": 123, **_payload()}, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "ping", {"hook_id": 123, **_payload()}
         )
         assert result is None
 
@@ -1382,7 +1380,7 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 1, "title": "test issue"},
         }
-        result = dispatch("issues", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issues", payload)
         assert result is not None
         assert "#1" in result.prompt
 
@@ -1394,7 +1392,7 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 0, "title": "test"},
         }
-        result = dispatch("issues", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issues", payload)
         assert result is None
 
 
@@ -1415,8 +1413,8 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "pr title", "body": "pr body"},
         }
-        result = dispatch(
-            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review_comment", payload
         )
         assert result is not None
         assert result.reply_to is None
@@ -1443,8 +1441,8 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
-        result = dispatch(
-            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review_comment", payload
         )
         assert result is not None
         assert result.thread is not None
@@ -1470,11 +1468,9 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        result = dispatch(
+        result = Dispatcher(cfg, repo_cfg).dispatch(
             "pull_request_review_comment",
             payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-review-125",
         )
 
@@ -1512,18 +1508,14 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        dispatch(
+        Dispatcher(cfg, repo_cfg).dispatch(
             "pull_request_review_comment",
             payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-review-126-a",
         )
-        dispatch(
+        Dispatcher(cfg, repo_cfg).dispatch(
             "pull_request_review_comment",
             payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-review-126-b",
         )
 
@@ -1549,11 +1541,9 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        dispatch(
+        Dispatcher(cfg, repo_cfg).dispatch(
             "pull_request_review_comment",
             payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-review-127-a",
         )
         edited_payload = {
@@ -1565,11 +1555,9 @@ class TestDispatchReviewComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = dispatch(
+        result = Dispatcher(cfg, repo_cfg).dispatch(
             "pull_request_review_comment",
             edited_payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-review-127-b",
         )
 
@@ -1588,8 +1576,8 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "done", "user": {"login": "FidoCanCode"}},
             "pull_request": {"number": 5},
         }
-        result = dispatch(
-            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review_comment", payload
         )
         assert result is None
 
@@ -1601,8 +1589,8 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "rando"}},
             "pull_request": {"number": 5},
         }
-        result = dispatch(
-            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review_comment", payload
         )
         assert result is None
 
@@ -1619,7 +1607,7 @@ class TestDispatchCheckRun:
                 "pull_requests": [{"number": 3}],
             },
         }
-        result = dispatch("check_run", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
         assert result is not None
         assert "CI failure" in result.prompt
         assert result.preempts_worker is True
@@ -1631,7 +1619,7 @@ class TestDispatchCheckRun:
             "action": "completed",
             "check_run": {"conclusion": "success", "name": "lint", "pull_requests": []},
         }
-        result = dispatch("check_run", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
         assert result is None
 
 
@@ -1654,7 +1642,7 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": True},
         }
-        result = dispatch("pull_request", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("pull_request", payload)
         assert result is not None
         assert "merged" in result.prompt
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
@@ -1677,7 +1665,7 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": False},
         }
-        result = dispatch("pull_request", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("pull_request", payload)
         assert result is None
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
 
@@ -1701,7 +1689,7 @@ class TestDispatchIssueComment:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = dispatch("issue_comment", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
         assert result is not None
         assert result.comment_body is None
         assert result.preempts_worker is True
@@ -1736,11 +1724,9 @@ class TestDispatchIssueComment:
             },
         }
 
-        result = dispatch(
+        result = Dispatcher(cfg, repo_cfg).dispatch(
             "issue_comment",
             payload,
-            cfg,
-            repo_cfg,
             delivery_id="delivery-issue-457",
         )
 
@@ -1777,7 +1763,9 @@ class TestDispatchIssueComment:
             },
         }
 
-        dispatch("issue_comment", payload, cfg, repo_cfg, delivery_id="delivery-a")
+        Dispatcher(cfg, repo_cfg).dispatch(
+            "issue_comment", payload, delivery_id="delivery-a"
+        )
         edited_payload = {
             **payload,
             "action": "edited",
@@ -1787,8 +1775,8 @@ class TestDispatchIssueComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = dispatch(
-            "issue_comment", edited_payload, cfg, repo_cfg, delivery_id="delivery-b"
+        result = Dispatcher(cfg, repo_cfg).dispatch(
+            "issue_comment", edited_payload, delivery_id="delivery-b"
         )
 
         assert result is not None
@@ -1806,18 +1794,16 @@ class TestDispatchIssueComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "owner"}},
             "issue": {"number": 10, "title": "issue"},
         }
-        result = dispatch("issue_comment", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
         assert result is None
 
 
 class TestDispatchUnknown:
     def test_unknown_event(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
             "unknown_event",
             {**_payload(), "action": "whatever"},
-            cfg,
-            _repo_cfg(tmp_path),
         )
         assert result is None
 
@@ -5234,16 +5220,14 @@ class TestBackfillMissedPrComments:
     def test_creates_task_for_allowed_collaborator_comment(
         self, tmp_path: Path
     ) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [self._comment(100)]
         mock_gh.is_thread_resolved_for_comment.return_value = False
         cfg = self._cfg(tmp_path)
         repo_cfg = self._repo_cfg(tmp_path)
         with patch("fido.events.create_task") as mock_create:
-            count = backfill_missed_pr_comments(
-                cfg, repo_cfg, mock_gh, 1, gh_user="fidocancode"
+            count = Dispatcher(cfg, repo_cfg, mock_gh).backfill_missed_pr_comments(
+                1, gh_user="fidocancode"
             )
         assert count == 1
         mock_create.assert_called_once()
@@ -5253,37 +5237,25 @@ class TestBackfillMissedPrComments:
         assert kwargs["thread"]["author"] == "rhencke"
 
     def test_skips_fido_own_comments(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="fidocancode", body="my own reply")
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="FidoCanCode",
-            )
+            Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="FidoCanCode")
         mock_create.assert_not_called()
 
     def test_skips_by_gh_user_case_insensitive(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="Alice", body="mine")
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="alice",
-            )
+            Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="alice")
         mock_create.assert_not_called()
 
     def test_skips_fido_literal_name_even_if_gh_user_mismatch(
@@ -5291,81 +5263,61 @@ class TestBackfillMissedPrComments:
     ) -> None:
         """Defense in depth: even if ``gh_user`` is misconfigured, comments
         from the literal fido account must never trigger a backfill task."""
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="fido-can-code", body="my reply")
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="mis-configured-bot",
-            )
+            Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="mis-configured-bot")
         mock_create.assert_not_called()
 
     def test_skips_non_allowed_users(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="random-stranger")
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
+            Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path, collaborators=frozenset({"rhencke"})),
                 mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         mock_create.assert_not_called()
 
     def test_allows_configured_bots(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="dependabot[bot]", body="bump dep")
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
+            Dispatcher(
                 self._cfg(tmp_path, allowed_bots=frozenset({"dependabot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         assert mock_create.call_count == 1
         _, kwargs = mock_create.call_args
         assert "bot" in kwargs["thread"]["author"]
 
     def test_prompt_marks_bot_vs_human(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, user="rhencke", body="human msg"),
             self._comment(101, user="bot[bot]", body="bot msg"),
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
+            Dispatcher(
                 self._cfg(tmp_path, allowed_bots=frozenset({"bot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         prompts = [c.args[0] for c in mock_create.call_args_list]
         assert any("human/owner" in p for p in prompts)
         assert any("(bot)" in p for p in prompts)
 
     def test_skips_empty_login_and_missing_id(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             {"id": 1, "user": {"login": ""}, "body": "x"},
@@ -5373,28 +5325,18 @@ class TestBackfillMissedPrComments:
             {"id": 2, "user": None, "body": "x"},
         ]
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         mock_create.assert_not_called()
 
     def test_empty_comment_list_is_noop(self, tmp_path: Path) -> None:
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = []
         with patch("fido.events.create_task") as mock_create:
-            count = backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            count = Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         assert count == 0
         mock_create.assert_not_called()
 
@@ -5404,8 +5346,6 @@ class TestBackfillMissedPrComments:
         reply_to_issue_comment completes comment ids in SQLite after posting;
         backfill must honour that durable claim and skip re-queueing.
         """
-        from fido.events import backfill_missed_pr_comments
-
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = [
             self._comment(100, body="already answered"),
@@ -5419,13 +5359,9 @@ class TestBackfillMissedPrComments:
         FidoStore(tmp_path).ack_promise(promise.promise_id)
 
         with patch("fido.events.create_task") as mock_create:
-            backfill_missed_pr_comments(
-                self._cfg(tmp_path),
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                1,
-                gh_user="fidocancode",
-            )
+            Dispatcher(
+                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
 
         # Only comment 200 (unclaimed) should be queued.
         assert mock_create.call_count == 1
@@ -5451,15 +5387,15 @@ class TestLaunchSync:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         with patch("fido.tasks.sync_tasks_background") as mock_sync:
-            launch_sync(cfg, self._repo_cfg(tmp_path), mock_gh)
+            Dispatcher(cfg, self._repo_cfg(tmp_path), mock_gh).launch_sync()
         mock_sync.assert_called_once_with(tmp_path, mock_gh)
 
     def test_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         with patch("fido.tasks.sync_tasks_background"):
-            launch_sync(
+            Dispatcher(
                 cfg, self._repo_cfg(tmp_path), _make_mock_gh()
-            )  # should not raise
+            ).launch_sync()  # should not raise
 
 
 class TestLaunchWorker:
@@ -5485,7 +5421,9 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 3},
         }
-        result = dispatch("pull_request_review", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review", payload
+        )
         assert result is not None
         assert result.review_comments is not None
         assert result.review_comments["review_id"] == 55
@@ -5498,7 +5436,9 @@ class TestDispatchPullRequestReview:
             "review": {"state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 3},
         }
-        result = dispatch("pull_request_review", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review", payload
+        )
         assert result is not None
         assert result.review_comments is None
 
@@ -5510,7 +5450,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {},
         }
-        result = dispatch("pull_request_review", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review", payload
+        )
         assert result is None
 
     def test_not_allowed_user_ignored(self, tmp_path: Path) -> None:
@@ -5521,7 +5463,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "stranger"}},
             "pull_request": {"number": 3},
         }
-        result = dispatch("pull_request_review", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review", payload
+        )
         assert result is None
 
     def test_commented_review_collapsed_by_oracle(self, tmp_path: Path) -> None:
@@ -5536,11 +5480,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 77, "state": "commented", "user": {"login": "owner"}},
             "pull_request": {"number": 4},
         }
-        result = dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
             "pull_request_review",
             payload,
-            cfg,
-            _repo_cfg(tmp_path),
             delivery_id="delivery-commented-1",
             oracle=oracle,
         )
@@ -5557,11 +5499,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 78, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 5},
         }
-        result = dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
             "pull_request_review",
             payload,
-            cfg,
-            _repo_cfg(tmp_path),
             delivery_id="delivery-approved-1",
             oracle=oracle,
         )
@@ -5582,11 +5522,9 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 6},
         }
-        result = dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
             "pull_request_review",
             payload,
-            cfg,
-            _repo_cfg(tmp_path),
             delivery_id="delivery-changes-requested-1",
             oracle=oracle,
         )
@@ -5603,11 +5541,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 80, "state": "dismissed", "user": {"login": "owner"}},
             "pull_request": {"number": 7},
         }
-        result = dispatch(
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
             "pull_request_review",
             payload,
-            cfg,
-            _repo_cfg(tmp_path),
             delivery_id="delivery-dismissed-1",
             oracle=oracle,
         )
@@ -5626,7 +5562,7 @@ class TestDispatchCheckRunNoPrs:
                 "pull_requests": [],
             },
         }
-        result = dispatch("check_run", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("check_run", payload)
         assert result is not None
         assert "unknown PR" in result.prompt
 
@@ -5644,7 +5580,7 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = dispatch("issue_comment", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
         assert result is None
 
     def test_unallowed_user_ignored(self, tmp_path: Path) -> None:
@@ -5659,7 +5595,7 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = dispatch("issue_comment", payload, cfg, _repo_cfg(tmp_path))
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch("issue_comment", payload)
         assert result is None
 
 
@@ -5678,8 +5614,8 @@ class TestDispatchReviewCommentNoNumber:
             },
             "pull_request": {},  # no number
         }
-        result = dispatch(
-            "pull_request_review_comment", payload, cfg, _repo_cfg(tmp_path)
+        result = Dispatcher(cfg, _repo_cfg(tmp_path)).dispatch(
+            "pull_request_review_comment", payload
         )
         assert result is None
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3238,29 +3238,36 @@ class TestCreateTask:
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         mock_gh = MagicMock()
         mock_tasks = self._mock_tasks()
-        with patch("fido.events.launch_sync") as mock_sync:
-            create_task("do something", cfg, repo_cfg, mock_gh, _tasks=mock_tasks)
+        mock_dispatcher = MagicMock()
+        create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            _tasks=mock_tasks,
+            dispatcher=mock_dispatcher,
+        )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=None
         )
-        mock_sync.assert_called_once_with(cfg, repo_cfg, mock_gh)
+        mock_dispatcher.launch_sync.assert_called_once_with(repo_cfg)
 
     def test_passes_thread(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         thread = {"repo": "a/b", "pr": 1, "comment_id": 5}
         mock_tasks = self._mock_tasks()
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
         )
@@ -3274,16 +3281,16 @@ class TestCreateTask:
         mock_tasks = self._mock_tasks()
         mock_gh = MagicMock()
         mock_gh.is_thread_resolved_for_comment.return_value = True
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
 
@@ -3303,17 +3310,17 @@ class TestCreateTask:
             {"id": 1002, "author": "owner", "body": "actually queue it"},
             {"id": 1003, "author": "FidoCanCode", "body": "will do"},
         ]
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
         )
@@ -3334,16 +3341,16 @@ class TestCreateTask:
             {"id": 1001, "author": "FidoCanCode", "body": "fixed"},
             {"id": 1002, "author": "owner", "body": "new follow-up"},
         ]
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
 
@@ -3362,17 +3369,17 @@ class TestCreateTask:
             {"id": 1001, "author": "FidoCanCode", "body": "fixed"},
             {"id": 1002, "author": "copilot[bot]", "body": "suggestion"},
         ]
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_called_once_with(
             title="do something", task_type=ANY, thread=thread
         )
@@ -3393,16 +3400,16 @@ class TestCreateTask:
             {"id": 1001, "author": "FidoCanCode", "body": "fixed"},
             {"id": 1002, "author": "drive-by", "body": "noise"},
         ]
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_not_called()
         assert result["status"] == "skipped_resolved"
 
@@ -3415,17 +3422,17 @@ class TestCreateTask:
         mock_tasks = self._mock_tasks()
         mock_gh = MagicMock()
         mock_gh.is_thread_resolved_for_comment.side_effect = RuntimeError("api down")
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "do something",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         mock_tasks.add.assert_called_once()
 
     def test_returns_created_task(self, tmp_path: Path) -> None:
@@ -3438,10 +3445,14 @@ class TestCreateTask:
             "type": "spec",
         }
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            result = create_task(
-                "do something", cfg, repo_cfg, MagicMock(), _tasks=mock_tasks
-            )
+        result = create_task(
+            "do something",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         assert result == fake_task
 
     def test_queue_reply_tasks_counts_only_created_tasks(self, tmp_path: Path) -> None:
@@ -3496,17 +3507,17 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )  # no registry
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )  # no registry
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_new_task_has_no_thread(self, tmp_path: Path) -> None:
@@ -3536,15 +3547,15 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Another plain task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                registry=registry,
-                _tasks=mock_tasks,
-            )  # no thread
+        create_task(
+            "Another plain task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            registry=registry,
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )  # no thread
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_no_current_task_in_state(self, tmp_path: Path) -> None:
@@ -3566,18 +3577,18 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_current_task_has_thread(self, tmp_path: Path) -> None:
@@ -3613,18 +3624,18 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "New thread task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=new_thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "New thread task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=new_thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_state_file_absent(self, tmp_path: Path) -> None:
@@ -3641,18 +3652,18 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_current_task_not_in_tasks_json(self, tmp_path: Path) -> None:
@@ -3673,18 +3684,18 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_no_abort_when_state_has_no_current_task(self, tmp_path: Path) -> None:
@@ -3705,18 +3716,18 @@ class TestCreateTask:
         }
         registry = MagicMock()
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def _setup_abort_scenario(
@@ -3761,18 +3772,18 @@ class TestCreateTask:
             "thread": thread,
         }
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # ABORT_KEEP: current task stays in tasks.json
         remaining = json.loads((fido_dir / "tasks.json").read_text())
@@ -3793,18 +3804,18 @@ class TestCreateTask:
             "thread": thread,
         }
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         # task should still be in tasks.json (ABORT_KEEP)
         remaining = json.loads((fido_dir / "tasks.json").read_text())
@@ -3824,18 +3835,18 @@ class TestCreateTask:
             "thread": thread,
         }
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                registry=registry,
-                _tasks=mock_tasks,
-                _reorder_background_fn=MagicMock(),
-                _get_commit_summary_fn=lambda wd: "",
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            registry=registry,
+            _tasks=mock_tasks,
+            _reorder_background_fn=MagicMock(),
+            _get_commit_summary_fn=lambda wd: "",
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_ci_preempts_thread(self, tmp_path: Path) -> None:
@@ -3846,15 +3857,15 @@ class TestCreateTask:
         registry, fido_dir = self._setup_abort_scenario(tmp_path, "thread")
         fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "CI fix",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                registry=registry,
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "CI fix",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            registry=registry,
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -3867,15 +3878,15 @@ class TestCreateTask:
         registry, fido_dir = self._setup_abort_scenario(tmp_path, "spec")
         fake_task = {"id": "t-ci", "title": "CI fix", "status": "pending", "type": "ci"}
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "CI fix",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                registry=registry,
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "CI fix",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            registry=registry,
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_called_once_with("owner/repo", task_id="t-current")
         remaining = json.loads((fido_dir / "tasks.json").read_text())
         assert any(t["id"] == "t-current" for t in remaining)
@@ -3892,15 +3903,15 @@ class TestCreateTask:
             "type": "spec",
         }
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "New spec task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                registry=registry,
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "New spec task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            registry=registry,
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         registry.abort_task.assert_not_called()
 
     def test_thread_task_triggers_reorder_background(self, tmp_path: Path) -> None:
@@ -3917,19 +3928,19 @@ class TestCreateTask:
         mock_gh = MagicMock()
         reorder_called: list[tuple] = []
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Comment task",
-                cfg,
-                repo_cfg,
-                mock_gh,
-                thread=thread,
-                _get_commit_summary_fn=lambda wd: "abc1234 add thing",
-                _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: (
-                    reorder_called.append((wd, cs, cfg, gh, rc, reg))
-                ),
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "Comment task",
+            cfg,
+            repo_cfg,
+            mock_gh,
+            thread=thread,
+            _get_commit_summary_fn=lambda wd: "abc1234 add thing",
+            _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: (
+                reorder_called.append((wd, cs, cfg, gh, rc, reg))
+            ),
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         assert len(reorder_called) == 1
         assert reorder_called[0][0] == tmp_path
         assert reorder_called[0][1] == "abc1234 add thing"
@@ -3949,15 +3960,15 @@ class TestCreateTask:
         }
         reorder_called: list = []
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "Spec task",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                _reorder_background_fn=lambda *a: reorder_called.append(a),
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "Spec task",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            _reorder_background_fn=lambda *a: reorder_called.append(a),
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         assert reorder_called == []
 
     def test_spec_task_does_not_call_rewrite_pr_description(
@@ -3967,12 +3978,15 @@ class TestCreateTask:
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
         mock_tasks = self._mock_tasks()
-        with (
-            patch("fido.events.launch_sync"),
-            patch("fido.events._rewrite_pr_description") as mock_rewrite,
-        ):
+        mock_dispatcher = MagicMock()
+        with patch("fido.events._rewrite_pr_description") as mock_rewrite:
             create_task(
-                "Spec task", cfg, repo_cfg, MagicMock(), _tasks=mock_tasks
+                "Spec task",
+                cfg,
+                repo_cfg,
+                MagicMock(),
+                _tasks=mock_tasks,
+                dispatcher=mock_dispatcher,
             )  # thread=None
         mock_rewrite.assert_not_called()
 
@@ -3991,27 +4005,28 @@ class TestCreateTask:
         }
         summaries: list[str] = []
         mock_tasks = self._mock_tasks(fake_task)
-        with patch("fido.events.launch_sync"):
-            create_task(
-                "t",
-                cfg,
-                repo_cfg,
-                MagicMock(),
-                thread=thread,
-                _get_commit_summary_fn=lambda wd: "custom summary",
-                _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: (
-                    summaries.append(cs)
-                ),
-                _tasks=mock_tasks,
-            )
+        create_task(
+            "t",
+            cfg,
+            repo_cfg,
+            MagicMock(),
+            thread=thread,
+            _get_commit_summary_fn=lambda wd: "custom summary",
+            _reorder_background_fn=lambda wd, cs, cfg, gh, rc, reg: summaries.append(
+                cs
+            ),
+            _tasks=mock_tasks,
+            dispatcher=MagicMock(),
+        )
         assert summaries == ["custom summary"]
 
     def test_default_tasks_creates_task_in_file(self, tmp_path: Path) -> None:
         """When _tasks is not passed, create_task constructs Tasks(work_dir) itself."""
         cfg = self._cfg(tmp_path)
         repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
-        with patch("fido.events.launch_sync"):
-            result = create_task("do a thing", cfg, repo_cfg, MagicMock())
+        result = create_task(
+            "do a thing", cfg, repo_cfg, MagicMock(), dispatcher=MagicMock()
+        )
         assert result["title"] == "do a thing"
 
         from fido.tasks import Tasks

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -17,6 +17,7 @@ from fido.registry import (
     make_registry,
 )
 from fido.rocq import worker_registry_crash as registry_fsm
+from tests.fakes import _FakeDispatcher
 
 
 class RepoConfig(_RepoConfig):
@@ -632,7 +633,14 @@ class TestMakeThread:
         mock_registry = MagicMock()
         mock_gh = MagicMock()
         mock_wt_cls = MagicMock()
-        result = _make_thread(cfg, mock_registry, gh=mock_gh, _WorkerThread=mock_wt_cls)
+        fake_dispatcher = _FakeDispatcher()
+        result = _make_thread(
+            cfg,
+            mock_registry,
+            gh=mock_gh,
+            dispatchers={"foo/bar": fake_dispatcher},
+            _WorkerThread=mock_wt_cls,
+        )
         from fido.config import RepoMembership
 
         mock_wt_cls.assert_called_once_with(
@@ -645,7 +653,7 @@ class TestMakeThread:
             session_issue=None,
             config=None,
             repo_cfg=cfg,
-            dispatcher=None,
+            dispatcher=fake_dispatcher,
             issue_cache=mock_registry.get_issue_cache.return_value,
         )
         mock_registry.get_issue_cache.assert_called_once_with("foo/bar")
@@ -656,7 +664,13 @@ class TestMakeThread:
         work_dir.mkdir()
         cfg = _repo("foo/bar", work_dir)
         mock_wt_cls = MagicMock()
-        _make_thread(cfg, MagicMock(), gh=MagicMock(), _WorkerThread=mock_wt_cls)
+        _make_thread(
+            cfg,
+            MagicMock(),
+            gh=MagicMock(),
+            dispatchers={"foo/bar": _FakeDispatcher()},
+            _WorkerThread=mock_wt_cls,
+        )
         assert mock_wt_cls.call_args[0][0] == work_dir
 
     def test_config_forwarded_to_worker_thread(self, tmp_path: Path) -> None:
@@ -673,14 +687,25 @@ class TestMakeThread:
         )
         mock_wt_cls = MagicMock()
         _make_thread(
-            cfg, MagicMock(), gh=MagicMock(), config=config, _WorkerThread=mock_wt_cls
+            cfg,
+            MagicMock(),
+            gh=MagicMock(),
+            config=config,
+            dispatchers={"foo/bar": _FakeDispatcher()},
+            _WorkerThread=mock_wt_cls,
         )
         assert mock_wt_cls.call_args.kwargs["config"] is config
 
     def test_repo_cfg_forwarded_to_worker_thread(self, tmp_path: Path) -> None:
         cfg = _repo("foo/bar", tmp_path)
         mock_wt_cls = MagicMock()
-        _make_thread(cfg, MagicMock(), gh=MagicMock(), _WorkerThread=mock_wt_cls)
+        _make_thread(
+            cfg,
+            MagicMock(),
+            gh=MagicMock(),
+            dispatchers={"foo/bar": _FakeDispatcher()},
+            _WorkerThread=mock_wt_cls,
+        )
         assert mock_wt_cls.call_args.kwargs["repo_cfg"] is cfg
 
 
@@ -691,6 +716,7 @@ class TestMakeRegistry:
         result = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
+            dispatchers={},
             _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert isinstance(result, WorkerRegistry)
@@ -703,13 +729,14 @@ class TestMakeRegistry:
         make_registry(
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
+            dispatchers={},
             _thread_factory=mock_factory,
         )
         assert mock_factory.call_count == 2
         assert mock_thread.start.call_count == 2
 
     def test_empty_repos_returns_empty_registry(self) -> None:
-        result = make_registry({}, MagicMock())
+        result = make_registry({}, MagicMock(), dispatchers={})
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
 
@@ -720,6 +747,7 @@ class TestMakeRegistry:
         reg = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
+            dispatchers={},
             _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert reg.is_alive("foo/bar") is True
@@ -738,7 +766,11 @@ class TestMakeRegistry:
         )
         mock_factory = MagicMock(return_value=MagicMock())
         make_registry(
-            {"foo/bar": cfg}, MagicMock(), config, _thread_factory=mock_factory
+            {"foo/bar": cfg},
+            MagicMock(),
+            config,
+            dispatchers={},
+            _thread_factory=mock_factory,
         )
         assert mock_factory.call_args.kwargs["config"] is config
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -645,6 +645,7 @@ class TestMakeThread:
             session_issue=None,
             config=None,
             repo_cfg=cfg,
+            dispatcher=None,
             issue_cache=mock_registry.get_issue_cache.return_value,
         )
         mock_registry.get_issue_cache.assert_called_once_with("foo/bar")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,7 +113,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 def _restore_handler_fns() -> object:
     saved = {
         "gh": WebhookHandler.gh,
-        "dispatcher": WebhookHandler.dispatcher,
+        "dispatchers": WebhookHandler.dispatchers,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
@@ -154,9 +154,10 @@ def _stub_provider_statuses() -> object:
 @pytest.fixture()
 def server(tmp_path: Path) -> object:
     cfg = _config(tmp_path)
+    repo_cfg = cfg.repos["owner/repo"]
     WebhookHandler.config = cfg
     WebhookHandler.registry = MagicMock()
-    WebhookHandler.dispatcher = Dispatcher(cfg, MagicMock())
+    WebhookHandler.dispatchers = {"owner/repo": Dispatcher(cfg, repo_cfg, MagicMock())}
     WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
     port = srv.server_address[1]
@@ -2174,7 +2175,7 @@ class TestProcessAction:
         payload = {**_payload(), "action": "created"}
         mock_dispatcher = MagicMock()
         mock_dispatcher.dispatch.side_effect = RuntimeError("boom")
-        WebhookHandler.dispatcher = mock_dispatcher
+        WebhookHandler.dispatchers = {"owner/repo": mock_dispatcher}
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert exc_info.value.code == 500
@@ -2211,7 +2212,7 @@ class TestProcessAction:
         mock_dispatcher.dispatch.side_effect = lambda *_a, **_kw: call_order.append(
             "dispatch"
         )
-        WebhookHandler.dispatcher = mock_dispatcher
+        WebhookHandler.dispatchers = {"owner/repo": mock_dispatcher}
         WebhookHandler._respond = fake_respond  # type: ignore[method-assign]
         try:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
@@ -4506,10 +4507,13 @@ class TestSelfRestart:
 
     def _make_server(self, tmp_path: Path) -> object:
         cfg = _self_restart_cfg(tmp_path)
+        repo_cfg = cfg.repos["owner/fido"]
         mock_registry = MagicMock()
         WebhookHandler.config = cfg
         WebhookHandler.registry = mock_registry
-        WebhookHandler.dispatcher = Dispatcher(cfg, MagicMock())
+        WebhookHandler.dispatchers = {
+            "owner/fido": Dispatcher(cfg, repo_cfg, MagicMock())
+        }
         srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
         port = srv.server_address[1]
         t = threading.Thread(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,7 @@ from fido.config import Config
 from fido.config import RepoConfig as _RepoConfig
 from fido.events import (
     Action,
+    Dispatcher,
     WebhookIngressOracle,
 )
 from fido.infra import Infra
@@ -112,7 +113,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 def _restore_handler_fns() -> object:
     saved = {
         "gh": WebhookHandler.gh,
-        "_fn_dispatch": WebhookHandler._fn_dispatch,
+        "dispatcher": WebhookHandler.dispatcher,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
         "_fn_reply_to_issue_comment": WebhookHandler._fn_reply_to_issue_comment,
@@ -155,6 +156,7 @@ def server(tmp_path: Path) -> object:
     cfg = _config(tmp_path)
     WebhookHandler.config = cfg
     WebhookHandler.registry = MagicMock()
+    WebhookHandler.dispatcher = Dispatcher(cfg, MagicMock())
     WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
     port = srv.server_address[1]
@@ -2170,7 +2172,9 @@ class TestProcessAction:
         """When dispatch raises, return 500 so GitHub retries the delivery."""
         url, cfg = server
         payload = {**_payload(), "action": "created"}
-        WebhookHandler._fn_dispatch = MagicMock(side_effect=RuntimeError("boom"))
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.dispatch.side_effect = RuntimeError("boom")
+        WebhookHandler.dispatcher = mock_dispatcher
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
         assert exc_info.value.code == 500
@@ -2203,7 +2207,11 @@ class TestProcessAction:
             call_order.append(f"respond_{code}")
             original_respond(self, code, msg)
 
-        WebhookHandler._fn_dispatch = fake_dispatch
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.dispatch.side_effect = lambda *_a, **_kw: call_order.append(
+            "dispatch"
+        )
+        WebhookHandler.dispatcher = mock_dispatcher
         WebhookHandler._respond = fake_respond  # type: ignore[method-assign]
         try:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
@@ -4501,6 +4509,7 @@ class TestSelfRestart:
         mock_registry = MagicMock()
         WebhookHandler.config = cfg
         WebhookHandler.registry = mock_registry
+        WebhookHandler.dispatcher = Dispatcher(cfg, MagicMock())
         srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
         port = srv.server_address[1]
         t = threading.Thread(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,6 +30,7 @@ from fido.server import FidoHTTPServer, PreflightError, WebhookHandler, _repo_st
 from fido.store import FidoStore
 from fido.tasks import Tasks
 from fido.types import TaskStatus, TaskType
+from tests.fakes import _FakeDispatcher
 
 
 class RepoConfig(_RepoConfig):
@@ -2133,6 +2134,7 @@ class TestProcessAction:
         handler.config = cfg
         handler.registry = WorkerRegistry(MagicMock())
         handler.gh = MagicMock()
+        handler.dispatchers = {"owner/repo": _FakeDispatcher()}
         phases: list[str] = []
 
         def reply_to_issue_comment(*args: object) -> tuple[str, list[str]]:
@@ -2173,8 +2175,7 @@ class TestProcessAction:
         """When dispatch raises, return 500 so GitHub retries the delivery."""
         url, cfg = server
         payload = {**_payload(), "action": "created"}
-        mock_dispatcher = MagicMock()
-        mock_dispatcher.dispatch.side_effect = RuntimeError("boom")
+        mock_dispatcher = _FakeDispatcher(dispatch_side_effect=RuntimeError("boom"))
         WebhookHandler.dispatchers = {"owner/repo": mock_dispatcher}
         with pytest.raises(urllib.error.HTTPError) as exc_info:
             _post_webhook(url, cfg, "pull_request_review_comment", payload)
@@ -2208,9 +2209,8 @@ class TestProcessAction:
             call_order.append(f"respond_{code}")
             original_respond(self, code, msg)
 
-        mock_dispatcher = MagicMock()
-        mock_dispatcher.dispatch.side_effect = lambda *_a, **_kw: call_order.append(
-            "dispatch"
+        mock_dispatcher = _FakeDispatcher(
+            dispatch_side_effect=lambda *_a, **_kw: call_order.append("dispatch")
         )
         WebhookHandler.dispatchers = {"owner/repo": mock_dispatcher}
         WebhookHandler._respond = fake_respond  # type: ignore[method-assign]
@@ -2394,6 +2394,7 @@ class TestProcessActionInner:
         handler.config = cfg
         handler.gh = MagicMock()
         handler.registry = MagicMock()
+        handler.dispatchers = {"owner/repo": _FakeDispatcher()}
         return handler
 
     def _activity(self) -> MagicMock:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5913,7 +5913,13 @@ class TestRunSeedTasksIntegration:
             return 0
 
         def _run_once(first: bool) -> None:
-            worker = Worker(tmp_path, gh, first_iteration=first)
+            from fido.events import Dispatcher
+
+            mock_dispatcher = MagicMock(spec=Dispatcher)
+            mock_dispatcher.backfill_missed_pr_comments.side_effect = _backfill
+            worker = Worker(
+                tmp_path, gh, first_iteration=first, dispatcher=mock_dispatcher
+            )
             with (
                 patch.object(
                     worker, "create_context", return_value=self._make_mock_ctx(tmp_path)
@@ -5929,7 +5935,6 @@ class TestRunSeedTasksIntegration:
                 patch.object(worker, "seed_tasks_from_pr_body"),
                 patch.object(worker, "handle_ci", return_value=False),
                 patch.object(worker, "handle_threads", return_value=False),
-                patch("fido.events.backfill_missed_pr_comments", side_effect=_backfill),
             ):
                 worker.run()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -74,6 +74,7 @@ from fido.worker import (
 from fido.worker import (
     WorkerThread as _WorkerThreadBase,
 )
+from tests.fakes import _FakeDispatcher
 
 _MISSING = object()
 
@@ -124,6 +125,8 @@ class Worker(_WorkerBase):
             )
         if "issue_cache" not in kwargs:
             kwargs["issue_cache"] = IssueTreeCache(kwargs.get("repo_name", "test/repo"))
+        if "dispatcher" not in kwargs:
+            kwargs["dispatcher"] = _FakeDispatcher()
         super().__init__(work_dir, gh, *args, **kwargs)
 
     def assert_git_identity(self, *, phase: str) -> None:
@@ -152,6 +155,8 @@ class WorkerThread(_WorkerThreadBase):
             )
         if "issue_cache" not in kwargs:
             kwargs["issue_cache"] = IssueTreeCache(repo_name)
+        if "dispatcher" not in kwargs:
+            kwargs["dispatcher"] = _FakeDispatcher()
         super().__init__(work_dir, repo_name, gh, *args, **kwargs)
 
 
@@ -2416,7 +2421,12 @@ class TestAssertGitIdentity:
         gh = MagicMock()
         gh.get_authenticated_identity.return_value = self._EXPECTED
         return (
-            _WorkerBase(tmp_path, gh, issue_cache=IssueTreeCache("test/repo")),
+            _WorkerBase(
+                tmp_path,
+                gh,
+                dispatcher=_FakeDispatcher(),
+                issue_cache=IssueTreeCache("test/repo"),
+            ),
             gh,
         )
 
@@ -6160,10 +6170,7 @@ class TestRunSeedTasksIntegration:
             return 0
 
         def _run_once(first: bool) -> None:
-            from fido.events import Dispatcher
-
-            mock_dispatcher = MagicMock(spec=Dispatcher)
-            mock_dispatcher.backfill_missed_pr_comments.side_effect = _backfill
+            mock_dispatcher = _FakeDispatcher(backfill_side_effect=_backfill)
             worker = Worker(
                 tmp_path,
                 gh,
@@ -6213,10 +6220,7 @@ class TestRunSeedTasksIntegration:
 
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        from fido.events import Dispatcher
-
-        mock_dispatcher = MagicMock(spec=Dispatcher)
-        mock_dispatcher.backfill_missed_pr_comments.return_value = 0
+        mock_dispatcher = _FakeDispatcher(backfill_return=0)
         worker = Worker(
             tmp_path,
             gh,
@@ -6258,9 +6262,7 @@ class TestRunSeedTasksIntegration:
         avoid one superfluous API round-trip."""
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        from fido.events import Dispatcher
-
-        mock_dispatcher = MagicMock(spec=Dispatcher)
+        mock_dispatcher = _FakeDispatcher()
         worker = Worker(
             tmp_path,
             gh,
@@ -6284,7 +6286,7 @@ class TestRunSeedTasksIntegration:
             patch.object(worker, "seed_tasks_from_pr_body"),
         ):
             worker.run()
-        mock_dispatcher.backfill_missed_pr_comments.assert_not_called()
+        assert mock_dispatcher.backfill_calls == []
 
     def test_seed_not_called_when_find_or_create_pr_raises(
         self, tmp_path: Path

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5957,7 +5957,11 @@ class TestRunSeedTasksIntegration:
 
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, first_iteration=True)
+        from fido.events import Dispatcher
+
+        mock_dispatcher = MagicMock(spec=Dispatcher)
+        mock_dispatcher.backfill_missed_pr_comments.return_value = 0
+        worker = Worker(tmp_path, gh, first_iteration=True, dispatcher=mock_dispatcher)
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(
@@ -5975,7 +5979,6 @@ class TestRunSeedTasksIntegration:
             patch.object(worker, "handle_ci", return_value=False),
             patch.object(worker, "handle_queued_comments", return_value=False),
             patch.object(worker, "handle_threads", return_value=False),
-            patch("fido.events.backfill_missed_pr_comments", return_value=0),
             caplog.at_level(logging.WARNING, logger="fido"),
         ):
             worker.run()
@@ -5993,7 +5996,10 @@ class TestRunSeedTasksIntegration:
         avoid one superfluous API round-trip."""
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, first_iteration=True)
+        from fido.events import Dispatcher
+
+        mock_dispatcher = MagicMock(spec=Dispatcher)
+        worker = Worker(tmp_path, gh, first_iteration=True, dispatcher=mock_dispatcher)
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(
@@ -6008,10 +6014,9 @@ class TestRunSeedTasksIntegration:
                 worker, "find_or_create_pr", return_value=(42, "fix-bug", True)
             ),
             patch.object(worker, "seed_tasks_from_pr_body"),
-            patch("fido.events.backfill_missed_pr_comments") as mock_backfill,
         ):
             worker.run()
-        mock_backfill.assert_not_called()
+        mock_dispatcher.backfill_missed_pr_comments.assert_not_called()
 
     def test_seed_not_called_when_find_or_create_pr_raises(
         self, tmp_path: Path
@@ -14407,10 +14412,11 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
+            dispatcher: object = None,
             first_iteration: bool = False,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -14514,10 +14520,11 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
+            dispatcher: object = None,
             first_iteration: bool = False,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -14568,10 +14575,11 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
+            dispatcher: object = None,
             first_iteration: bool = False,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -14956,10 +14964,11 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
+            dispatcher: object = None,
             first_iteration: bool = False,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task

--- a/tests/test_worker_commit_leftovers.py
+++ b/tests/test_worker_commit_leftovers.py
@@ -9,6 +9,7 @@ import pytest
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
 from fido.worker import Worker
+from tests.fakes import _FakeDispatcher
 
 
 def _init_repo(tmp_path: Path) -> None:
@@ -26,7 +27,12 @@ def _init_repo(tmp_path: Path) -> None:
 
 def _worker(tmp_path: Path) -> Worker:
     gh = MagicMock(spec=GitHub)
-    return Worker(tmp_path, gh, issue_cache=IssueTreeCache("test/repo"))
+    return Worker(
+        tmp_path,
+        gh,
+        dispatcher=_FakeDispatcher(),
+        issue_cache=IssueTreeCache("test/repo"),
+    )
 
 
 def _head(tmp_path: Path) -> str:

--- a/tests/test_worker_persist_session_id.py
+++ b/tests/test_worker_persist_session_id.py
@@ -11,11 +11,13 @@ import pytest
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
 from fido.worker import WorkerThread
+from tests.fakes import _FakeDispatcher
 
 
 def _make_thread(tmp_path: Path, **kwargs: object) -> WorkerThread:
     gh = MagicMock(spec=GitHub)
     kwargs.setdefault("issue_cache", IssueTreeCache("owner/repo"))
+    kwargs.setdefault("dispatcher", _FakeDispatcher())
     return WorkerThread(
         tmp_path,
         "owner/repo",


### PR DESCRIPTION
Fixes #1310.

Extracts a typed `Dispatcher` collaborator from the `_fn_dispatch`, `_fn_backfill_missed_pr_comments`, and `_fn_launch_sync` callable-slot pattern on `WebhookHandler`. One `Dispatcher` per repo is constructed at startup with `config`, `repo_cfg`, and `gh` baked in — both `gh` and `dispatcher` are required everywhere, not Optional — so a forgotten wiring is a loud error instead of a silent no-op. All test sites use a hand-rolled `_FakeDispatcher` with typed recording fields instead of `MagicMock`.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (14)</summary>

- [x] File follow-up issue: DispatcherProtocol + tighter _FakeDispatcher recording types <!-- type:spec -->
- [x] [Replace all MagicMock(spec=Dispatcher) and dispatcher=MagicMock() usages across test_events.py, test_server.py, test_worker.py, and test_coverage_fills.py with a hand-rolled _FakeDispatcher class that records dispatch/backfill_missed_pr_comments/launch_sync calls. The fake should have typed fields (not generic mock attributes) so tests assert on real structure.](https://github.com/FidoCanCode/home/pull/1328#issuecomment-4371338003) <!-- type:thread -->
- [x] Replace MagicMock(spec=Dispatcher) with hand-rolled _FakeDispatcher <!-- type:spec -->
- [x] Thread Dispatcher into create_task for launch_sync calls <!-- type:spec -->
- [x] Inject Dispatcher into worker for backfill_missed_pr_comments <!-- type:spec -->
- [x] Replace patch-based dispatch tests with injected fake Dispatcher <!-- type:spec -->
- [x] [Move the actual logic from the free functions (dispatch, backfill_missed_pr_comments, launch_sync) into the Dispatcher methods. If the free functions need to survive the migration period, they should delegate to a Dispatcher — not the other way around.](https://github.com/FidoCanCode/home/pull/1328#discussion_r3178931619) <!-- type:thread -->
- [x] Delete free functions dispatch, backfill_missed_pr_comments, launch_sync <!-- type:spec -->
- [x] [Move repo_cfg from a per-call parameter on all three Dispatcher methods into the Dispatcher constructor. Create one Dispatcher per repo at startup in the composition root. The webhook handler should look up the correct Dispatcher by repo name rather than passing repo_cfg at each call site.](https://github.com/FidoCanCode/home/pull/1328#discussion_r3178991522) <!-- type:thread -->
- [x] Wire Dispatcher into WebhookHandler, replace _fn_dispatch slot <!-- type:spec -->
- [x] Extract Dispatcher class wrapping dispatch, backfill, and launch_sync <!-- type:spec -->
- [x] Flip delegation: move logic into Dispatcher, free functions delegate to it <!-- type:spec -->
- [x] Move repo_cfg into Dispatcher constructor, create per-repo dispatchers <!-- type:spec -->
- [x] [PR top-level comment on #1328 by rhencke (human/owner): Drop the assert dispatcher is not None, "dispatcher not wired — call run() first" in _do_post_inner — startup preconditions belong at startup, not on every webhook. After fixing (2)/(3), use self.dispatchers[repo_name] and let a missing key raise — that's a real coordination bug, not a hot-path concern.](https://github.com/FidoCanCode/home/pull/1328#issuecomment-4372565526) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->