### PR TITLE
Bug: handler-preemption FSM/count mismatch causes worker crash loop (closes #1330)

### DIFF
--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -547,7 +547,14 @@ class WorkerRegistry:
         with self._untriaged_lock:
             old = self._untriaged.get(repo_name, 0)
             self._untriaged[repo_name] = old + 1
-            self._preemption_fsm_transition(repo_name, preemption_fsm.WebhookArrives())
+            if old == 0:
+                # Boolean abstraction in handler_preemption.v: legacy demand
+                # is NonEmpty iff *any* handler is in flight.  Fire the FSM
+                # transition only on the 0→1 edge so the FSM agrees with the
+                # Python count by construction.
+                self._preemption_fsm_transition(
+                    repo_name, preemption_fsm.WebhookArrives()
+                )
             ev = self._untriaged_drained.get(repo_name)
             if ev is None:
                 ev = threading.Event()
@@ -575,19 +582,11 @@ class WorkerRegistry:
                 return
             new = old - 1
             self._untriaged[repo_name] = new
-            new_state = self._preemption_fsm_transition(
-                repo_name, preemption_fsm.HandlerDone()
-            )
-            if new > 0:
-                self._preemption_fsm_states[repo_name] = preemption_fsm.with_legacy(
-                    new_state, preemption_fsm.LegacyNonEmpty()
-                )
-                log.debug(
-                    "preemption[%s]: FSM legacy remains non-empty (count is %d)",
-                    repo_name,
-                    new,
-                )
-            else:
+            if new == 0:
+                # Boolean abstraction: fire HandlerDone only on the 1→0 edge.
+                # The FSM agrees with the Python count by construction, so no
+                # post-transition with_legacy override is needed.
+                self._preemption_fsm_transition(repo_name, preemption_fsm.HandlerDone())
                 ev = self._untriaged_drained.get(repo_name)
                 if ev is not None:
                     ev.set()
@@ -663,6 +662,13 @@ class WorkerRegistry:
             if cleared <= 0:
                 return 0
             self._untriaged[repo_name] = 0
+            # The FSM is on the boolean abstraction: legacy is NonEmpty iff
+            # any handler is in flight.  When count > 0, FSM legacy is
+            # NonEmpty by construction (enter_untriaged fired WebhookArrives
+            # on the 0→1 edge), so HandlerDone is the valid drain event.
+            # Without this transition, the FSM stays at LegacyNonEmpty after
+            # force-clear and the next assert_worker_turn_ok crashes (#1330).
+            self._preemption_fsm_transition(repo_name, preemption_fsm.HandlerDone())
             ev = self._untriaged_drained.get(repo_name)
             if ev is not None:
                 ev.set()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1083,6 +1083,21 @@ class TestUntriagedInbox:
         t.join(timeout=2.0)
         assert unblocked.is_set(), "force_clear should unblock waiter"
 
+    def test_force_clear_drains_fsm_legacy_demand(self) -> None:
+        """Regression for #1330: force_clear must take the FSM through the
+        modeled HandlerDone transition, not just zero the Python count.
+
+        Before the fix, force_clear left ``legacy_demand=LegacyNonEmpty`` while
+        the count said 0, so the next ``assert_worker_turn_ok`` fired the FSM
+        oracle and crashed the worker — repeatedly, in a watchdog-restart loop.
+        """
+        reg = self._reg()
+        reg.enter_untriaged("foo/bar")
+        reg.enter_untriaged("foo/bar")  # count=2; FSM is LegacyNonEmpty
+        reg.force_clear_untriaged("foo/bar")
+        # FSM must be back at LegacyEmpty so the worker can take its next turn.
+        reg.assert_worker_turn_ok("foo/bar")  # must not raise
+
 
 class TestPreemptionFsmOracle:
     """Tests for the handler_preemption FSM oracle wired into WorkerRegistry.
@@ -1168,6 +1183,37 @@ class TestPreemptionFsmOracle:
         reg.enter_untriaged("foo/bar")
         reg.exit_untriaged("foo/bar")
         reg.exit_untriaged("foo/bar")
+        reg.assert_worker_turn_ok("foo/bar")  # must not raise
+
+    def test_partial_exit_keeps_fsm_blocked_until_count_drains(self) -> None:
+        """Boolean-abstraction contract: the FSM agrees with the Python count
+        by construction.  Two enters then one exit must leave the FSM at
+        ``LegacyNonEmpty`` (count is still 1) — no spurious HandlerDone fires
+        on the intermediate edge.
+        """
+        reg = self._reg()
+        reg.enter_untriaged("foo/bar")
+        reg.enter_untriaged("foo/bar")
+        reg.exit_untriaged("foo/bar")  # count=1; FSM still LegacyNonEmpty
+
+        with pytest.raises(AssertionError, match="WorkerTurnStart rejected"):
+            reg.assert_worker_turn_ok("foo/bar")
+
+        reg.exit_untriaged("foo/bar")  # count=0; FSM transitions to Empty
+        reg.assert_worker_turn_ok("foo/bar")  # must not raise
+
+    def test_repeated_enter_is_fsm_idempotent(self) -> None:
+        """Multiple enters at the same repo must not crash the FSM oracle.
+
+        Under the boolean abstraction the FSM transition fires only on the
+        ``0 → 1`` count edge; subsequent enters are no-ops at the FSM level.
+        """
+        reg = self._reg()
+        for _ in range(5):
+            reg.enter_untriaged("foo/bar")
+        # Drain to zero — exactly one HandlerDone should fire on the 1→0 edge.
+        for _ in range(5):
+            reg.exit_untriaged("foo/bar")
         reg.assert_worker_turn_ok("foo/bar")  # must not raise
 
     # ── per-repo isolation ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #1330.

The handler-preemption FSM (`models/handler_preemption.v`) uses a **boolean** abstraction — `LegacyDemand` is `LegacyEmpty` or `LegacyNonEmpty`, with `HandlerDone` rejected when already empty. The Python in `registry.py` was treating `_untriaged` as a **counter** and patching the FSM to compensate:

- `exit_untriaged` fired `HandlerDone` on every exit, then forced `with_legacy(state, LegacyNonEmpty)` if the count was still > 0 — re-mutating the FSM outside the modeled transition.
- `force_clear_untriaged` skipped the FSM entirely. After a 5-min `wait_for_inbox_drain` timeout it zeroed the count but left `legacy=LegacyNonEmpty`, so the next `assert_worker_turn_ok` fired `WorkerTurnStart`, the FSM rejected it, and the worker crashed. Watchdog auto-restarted; FSM dict survived; loop.

Both bypasses are the same root cause: counter semantics layered on a boolean FSM, with hand-patching to align them.

## Fix

Make Python honor the FSM's boolean abstraction by firing transitions only on count-edge transitions:

- `enter_untriaged`: `WebhookArrives` only on `0 → 1`.
- `exit_untriaged`: `HandlerDone` only on `1 → 0`. Drop the `with_legacy` override.
- `force_clear_untriaged`: `HandlerDone` before zeroing (legacy is `NonEmpty` whenever count > 0, so the transition is valid).

After this, Python and the FSM agree by construction. The model is unchanged; the existing lemmas already prove the behavior. Both modeled-boundary violations on this surface go away in one diff.

## Test plan

- [x] `./fido ci` — 3864 passed, 100% coverage.
- [x] `force_clear_drains_fsm_legacy_demand` — direct regression for the crash.
- [x] `partial_exit_keeps_fsm_blocked_until_count_drains` — confirms count-edge semantics.
- [x] `repeated_enter_is_fsm_idempotent` — five enters, five exits, FSM Empty.
- [ ] Watch live for one webhook cycle on `FidoCanCode/home` after restart to confirm no crashes.