### PR TITLE
Bug: vet cycle triple — inbox-leak (#1336), rescope-dup-task (#1337), PR-body divider (#1335)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -8,9 +8,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
@@ -43,6 +42,9 @@ from fido.synthesis_executor import CommentTarget, SynthesisExecutor
 from fido.tasks import Tasks, thread_comment_author_for_auto_resolve_oracle
 from fido.types import ActiveIssue, ActivePR, RescopeIntent, TaskType
 
+if TYPE_CHECKING:
+    from fido.worker import ActivityReporter
+
 log = logging.getLogger(__name__)
 
 _FIDO_LOGINS = frozenset({"fidocancode", "fido-can-code"})
@@ -68,8 +70,8 @@ class _BackgroundRescopeTrigger:
         work_dir: Path,
         config: Config,
         gh: GitHub,
-        repo_cfg: RepoConfig | None = None,
-        registry: WorkerRegistry | None = None,
+        repo_cfg: RepoConfig,
+        registry: "ActivityReporter",
         agent: ProviderAgent | None = None,
         prompts: Prompts | None = None,
     ) -> None:
@@ -875,9 +877,8 @@ def _apply_reply_result(
     config: Config,
     repo_cfg: RepoConfig,
     gh: GitHub,
-    *,
     thread: dict[str, Any] | None,
-    registry: WorkerRegistry | None,
+    registry: "ActivityReporter",
 ) -> None:
     """Apply task side effects from a recovered reply."""
     queue_reply_tasks(
@@ -909,10 +910,10 @@ def recover_reply_promises(
     repo_cfg: RepoConfig,
     gh: GitHub,
     pr_number: int,
+    registry: "ActivityReporter",
     *,
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
-    registry: WorkerRegistry | None = None,
 ) -> bool:
     """Recover queued webhook replies for the current PR from SQLite promises."""
     store = FidoStore(repo_cfg.work_dir)
@@ -1013,8 +1014,8 @@ def recover_reply_promises(
             config,
             repo_cfg,
             gh,
-            thread=action.thread,
-            registry=registry,
+            action.thread,
+            registry,
         )
         _ack_promises(store, (promise_id for promise_id, _ in group))
         processed_any = True
@@ -1357,10 +1358,10 @@ def reply_to_comment(
     config: Config,
     repo_cfg: RepoConfig,
     gh: GitHub,
+    registry: "ActivityReporter",
     *,
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
-    registry: WorkerRegistry | None = None,
 ) -> tuple[str, list[str]]:
     """Handle a review comment via the synthesis LLM call, post reply.
 
@@ -1465,8 +1466,8 @@ def reply_to_comment(
         repo_cfg.work_dir,
         config,
         gh,
-        repo_cfg=repo_cfg,
-        registry=registry,
+        repo_cfg,
+        registry,
         agent=agent,
         prompts=prompts,
     )
@@ -1689,10 +1690,10 @@ def reply_to_issue_comment(
     config: Config,
     repo_cfg: RepoConfig,
     gh: GitHub,
+    registry: "ActivityReporter",
     *,
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
-    registry: WorkerRegistry | None = None,
 ) -> tuple[str, list[str]]:
     """Handle a top-level PR comment via the synthesis LLM call, post reply.
 
@@ -1778,8 +1779,8 @@ def reply_to_issue_comment(
         repo_cfg.work_dir,
         config,
         gh,
-        repo_cfg=repo_cfg,
-        registry=registry,
+        repo_cfg,
+        registry,
         agent=agent,
         prompts=prompts,
     )
@@ -1895,7 +1896,7 @@ _TYPE_PRIORITY = {TaskType.CI: 0, TaskType.THREAD: 1, TaskType.SPEC: 2}
 def _maybe_abort_for_new_task(
     repo_cfg: RepoConfig,
     new_task: dict[str, Any],
-    registry: WorkerRegistry,
+    registry: "ActivityReporter",
     *,
     _state: State | None = None,
     _tasks: Tasks | None = None,
@@ -2181,8 +2182,8 @@ def _load_active_context_for_rescope(
 def _make_reorder_kwargs(
     work_dir: Path,
     config: Config,
-    repo_cfg: RepoConfig | None,
-    registry: WorkerRegistry | None,
+    repo_cfg: RepoConfig,
+    registry: "ActivityReporter",
     gh: GitHub,
     agent: ProviderAgent,
     prompts: Prompts,
@@ -2210,30 +2211,25 @@ def _make_reorder_kwargs(
             _tasks=Tasks(work_dir),
         )
 
+    def on_inprogress_affected(task_id: str) -> None:
+        log.info(
+            "reorder_tasks_background: in-progress task affected — aborting %s",
+            repo_cfg.name,
+        )
+        registry.abort_task(repo_cfg.name, task_id=task_id)
+
     kwargs: dict[str, Any] = {
         "_on_changes": on_changes,
         "_on_done": on_done,
+        "_on_inprogress_affected": on_inprogress_affected,
         "agent": agent,
         "prompts": prompts,
     }
-    if registry is not None and repo_cfg is not None:
-
-        def on_inprogress_affected(task_id: str) -> None:
-            log.info(
-                "reorder_tasks_background: in-progress task affected — aborting %s",
-                repo_cfg.name,
-            )
-            registry.abort_task(repo_cfg.name, task_id=task_id)
-
-        kwargs["_on_inprogress_affected"] = on_inprogress_affected
-    if repo_cfg is not None:
-        issue_ctx, pr_ctx = _load_active_context_for_rescope(
-            work_dir, repo_cfg.name, gh
-        )
-        if issue_ctx is not None:
-            kwargs["issue"] = issue_ctx
-        if pr_ctx is not None:
-            kwargs["pr"] = pr_ctx
+    issue_ctx, pr_ctx = _load_active_context_for_rescope(work_dir, repo_cfg.name, gh)
+    if issue_ctx is not None:
+        kwargs["issue"] = issue_ctx
+    if pr_ctx is not None:
+        kwargs["pr"] = pr_ctx
     return kwargs
 
 
@@ -2242,8 +2238,8 @@ def _reorder_tasks_background(
     commit_summary: str,
     config: Config,
     gh: GitHub,
-    repo_cfg: RepoConfig | None = None,
-    registry: WorkerRegistry | None = None,
+    repo_cfg: RepoConfig,
+    registry: "ActivityReporter",
     *,
     intents: list[RescopeIntent] | None = None,
     _start: Callable[[threading.Thread], None] = threading.Thread.start,
@@ -2288,11 +2284,7 @@ def _reorder_tasks_background(
     rewrite_fn = _rewrite_fn if _rewrite_fn is not None else _rewrite_pr_description
     state = _coalesce_state if _coalesce_state is not None else _reorder_coalesce
     if agent is None:
-        agent = (
-            _configured_agent(config, repo_cfg)
-            if repo_cfg is not None
-            else ClaudeClient()
-        )
+        agent = _configured_agent(config, repo_cfg)
     if prompts is None:
         prompts = Prompts(_load_persona(config))
 
@@ -2339,10 +2331,8 @@ def _reorder_tasks_background(
         # inbox holds; otherwise the worker parks forever (#1280).
         try:
             set_thread_kind("webhook")
-            if repo_cfg is not None:
-                set_thread_repo(repo_cfg.name)
-            if registry is not None and repo_cfg is not None:
-                registry.set_rescoping(repo_cfg.name, True)
+            set_thread_repo(repo_cfg.name)
+            registry.set_rescoping(repo_cfg.name, True)
             log.info("rescope BG: starting (work_dir=%s)", work_dir)
             while True:
                 iteration += 1
@@ -2367,31 +2357,15 @@ def _reorder_tasks_background(
             # cleanup step (set_rescoping, set_thread_repo, set_thread_kind)
             # must not skip the exit_untriaged calls — losing them leaves the
             # worker permanently blocked on a non-empty inbox counter (#1280).
-            actually_released = 0
-            if registry is not None and repo_cfg is not None:
-                for _ in range(release_untriaged):
-                    registry.exit_untriaged(repo_cfg.name)
-                    actually_released += 1
-                registry.set_rescoping(repo_cfg.name, False)
-            elif release_untriaged > 0:
-                # Fail loud: the count was bumped (a coalesced caller called
-                # registry.enter_untriaged), but this rescope has no registry
-                # to call exit on — every accumulated hold is now leaked and
-                # the worker will park on the inbox forever.  See #1336 for
-                # the call-chain bug that produces this state.
-                log.error(
-                    "rescope BG: leaking %d untriaged hold(s) — "
-                    "registry=%s, repo_cfg=%s; worker WILL park (#1336)",
-                    release_untriaged,
-                    "set" if registry is not None else "None",
-                    "set" if repo_cfg is not None else "None",
-                )
-            if repo_cfg is not None:
-                set_thread_repo(None)
+            # registry and repo_cfg are required at construction time (#1336)
+            # so the release path is unconditional — no Optional guards.
+            for _ in range(release_untriaged):
+                registry.exit_untriaged(repo_cfg.name)
+            registry.set_rescoping(repo_cfg.name, False)
+            set_thread_repo(None)
             set_thread_kind(None)
             log.info(
-                "rescope BG: finally complete (released %d/%d untriaged hold(s))",
-                actually_released,
+                "rescope BG: finally complete (released %d untriaged hold(s))",
                 release_untriaged,
             )
 
@@ -2412,18 +2386,11 @@ def _reorder_tasks_background(
                 entry["running"] = False
                 entry["pending"] = None
         # Same ordering as run_loop's finally — release before set_rescoping.
-        if registry is not None and repo_cfg is not None:
-            for _ in range(release_untriaged):
-                registry.exit_untriaged(repo_cfg.name)
-            registry.set_rescoping(repo_cfg.name, False)
-        elif release_untriaged > 0:
-            log.error(
-                "rescope BG (start failure): leaking %d untriaged hold(s) — "
-                "registry=%s, repo_cfg=%s; worker WILL park (#1336)",
-                release_untriaged,
-                "set" if registry is not None else "None",
-                "set" if repo_cfg is not None else "None",
-            )
+        # registry and repo_cfg are required (#1336) so this path is
+        # unconditional.
+        for _ in range(release_untriaged):
+            registry.exit_untriaged(repo_cfg.name)
+        registry.set_rescoping(repo_cfg.name, False)
         raise
 
 
@@ -2491,7 +2458,7 @@ def create_task(
     repo_cfg: RepoConfig,
     gh: GitHub,
     thread: dict[str, Any] | None = None,
-    registry: WorkerRegistry | None = None,
+    registry: "ActivityReporter | None" = None,
     *,
     _get_commit_summary_fn: Callable[[Path], str] = _get_commit_summary,
     _reorder_background_fn: Callable[..., None] = _reorder_tasks_background,
@@ -2568,21 +2535,32 @@ def create_task(
     launch_sync(config, repo_cfg, gh)
     if thread:
         commit_summary = _get_commit_summary_fn(repo_cfg.work_dir)
-        if registry is not None and _reorder_background_fn is _reorder_tasks_background:
-            registry.enter_untriaged(repo_cfg.name)
-            try:
-                _reorder_background_fn(
-                    repo_cfg.work_dir,
-                    commit_summary,
-                    config,
-                    gh,
-                    repo_cfg,
-                    registry,
-                    _release_untriaged_on_finish=True,
+        if _reorder_background_fn is _reorder_tasks_background:
+            # Production path — _reorder_tasks_background requires a real
+            # registry to bookkeep the inbox.  Without one, skip the rescope
+            # entirely and log loudly (#1336): silently dropping the rescope
+            # is exactly the fail-soft pattern that produced the original
+            # bug.
+            if registry is None:
+                log.warning(
+                    "create_task: thread task created without registry — "
+                    "skipping background rescope (#1336)",
                 )
-            except Exception:
-                registry.exit_untriaged(repo_cfg.name)
-                raise
+            else:
+                registry.enter_untriaged(repo_cfg.name)
+                try:
+                    _reorder_background_fn(
+                        repo_cfg.work_dir,
+                        commit_summary,
+                        config,
+                        gh,
+                        repo_cfg,
+                        registry,
+                        _release_untriaged_on_finish=True,
+                    )
+                except Exception:
+                    registry.exit_untriaged(repo_cfg.name)
+                    raise
         else:
             _reorder_background_fn(
                 repo_cfg.work_dir, commit_summary, config, gh, repo_cfg, registry

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1002,6 +1002,7 @@ def recover_reply_promises(
                 gh,
                 agent=agent,
                 prompts=prompts,
+                registry=registry,
             )
         except Exception:
             _mark_promises_failed(store, (promise_id for promise_id, _ in group))
@@ -1067,6 +1068,7 @@ def recover_reply_promises(
                 gh,
                 agent=agent,
                 prompts=prompts,
+                registry=registry,
             )
         except Exception:
             _mark_promises_failed(
@@ -2365,15 +2367,31 @@ def _reorder_tasks_background(
             # cleanup step (set_rescoping, set_thread_repo, set_thread_kind)
             # must not skip the exit_untriaged calls — losing them leaves the
             # worker permanently blocked on a non-empty inbox counter (#1280).
+            actually_released = 0
             if registry is not None and repo_cfg is not None:
                 for _ in range(release_untriaged):
                     registry.exit_untriaged(repo_cfg.name)
+                    actually_released += 1
                 registry.set_rescoping(repo_cfg.name, False)
+            elif release_untriaged > 0:
+                # Fail loud: the count was bumped (a coalesced caller called
+                # registry.enter_untriaged), but this rescope has no registry
+                # to call exit on — every accumulated hold is now leaked and
+                # the worker will park on the inbox forever.  See #1336 for
+                # the call-chain bug that produces this state.
+                log.error(
+                    "rescope BG: leaking %d untriaged hold(s) — "
+                    "registry=%s, repo_cfg=%s; worker WILL park (#1336)",
+                    release_untriaged,
+                    "set" if registry is not None else "None",
+                    "set" if repo_cfg is not None else "None",
+                )
             if repo_cfg is not None:
                 set_thread_repo(None)
             set_thread_kind(None)
             log.info(
-                "rescope BG: finally complete (released %d untriaged hold(s))",
+                "rescope BG: finally complete (released %d/%d untriaged hold(s))",
+                actually_released,
                 release_untriaged,
             )
 
@@ -2398,6 +2416,14 @@ def _reorder_tasks_background(
             for _ in range(release_untriaged):
                 registry.exit_untriaged(repo_cfg.name)
             registry.set_rescoping(repo_cfg.name, False)
+        elif release_untriaged > 0:
+            log.error(
+                "rescope BG (start failure): leaking %d untriaged hold(s) — "
+                "registry=%s, repo_cfg=%s; worker WILL park (#1336)",
+                release_untriaged,
+                "set" if registry is not None else "None",
+                "set" if repo_cfg is not None else "None",
+            )
         raise
 
 

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -616,7 +616,12 @@ class Prompts:
             "4. If a task is already covered by a recent commit, omit it from the "
             "output — it will be marked done.\n"
             "5. Include only pending and in_progress tasks in the output — omit "
-            "completed.\n\n"
+            "completed.\n"
+            "6. If a pending task already exists for one of the change requests "
+            "above (matched by content or by its thread metadata), KEEP that "
+            "task and use its exact ID — do NOT emit a second entry with a "
+            'null "id" for the same change request, even if you are rewriting '
+            "its description.  One change request → one task (#1337).\n\n"
             'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
             'Each element: {"id": "..." or null, "title": "...", "description": "..."}.\n'
             "No other text before or after the JSON."

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1054,7 +1054,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     activity.set_description("triaging review comment")
                     try:
                         category, titles = type(self)._fn_reply_to_comment(
-                            action, self.config, repo_cfg, gh
+                            action, self.config, repo_cfg, gh, self.registry
                         )
                     except Exception:
                         self._fail_reply(repo_cfg, promise)
@@ -1101,7 +1101,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     activity.set_description("triaging PR comment")
                     try:
                         category, titles = type(self)._fn_reply_to_issue_comment(
-                            action, self.config, repo_cfg, gh
+                            action, self.config, repo_cfg, gh, self.registry
                         )
                     except Exception:
                         self._fail_reply(repo_cfg, promise)

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -697,6 +697,8 @@ def _parse_reorder_response(raw: str) -> list[dict[str, Any]] | None:
 def _make_new_tasks_from_opus(
     ordered_items: list[dict[str, Any]],
     snapshot_ids: frozenset[str],
+    current: list[dict[str, Any]] | None = None,
+    intents: list[RescopeIntent] | None = None,
 ) -> list[dict[str, Any]]:
     """Create fresh task dicts for items Opus returned with a null or absent id.
 
@@ -708,13 +710,42 @@ def _make_new_tasks_from_opus(
     Each new task receives a fresh timestamp-random ID, ``status: "pending"``,
     and ``type: "spec"`` unless Opus specified a different type.  Items with
     blank titles are silently skipped.
+
+    Dedup against post-snapshot thread tasks (#1337): when *current* and
+    *intents* are provided, any rescope intent whose ``comment_id`` is already
+    covered by a thread task added since the snapshot was taken is treated as
+    "already serviced" — the entry-boundary ``create_task`` path produced the
+    thread task while Opus was thinking, so any null-id item Opus emits for
+    the same intent is a duplicate.  We suppress one null-id item per covered
+    intent (in arrival order) to keep at most one task per intent.
     """
+    covered_intents = 0
+    if current is not None and intents:
+        post_snapshot_lineage: set[int] = set()
+        for task in current:
+            if task.get("id") in snapshot_ids:
+                continue
+            for cid in _thread_lineage_comment_ids(task.get("thread")):
+                post_snapshot_lineage.add(cid)
+        for intent in intents:
+            if intent.comment_id in post_snapshot_lineage:
+                covered_intents += 1
+
     new_tasks: list[dict[str, Any]] = []
+    skipped = 0
     for item in ordered_items:
         if "id" in item and item["id"] is not None:
             continue  # has an id — handled by oracle or ignored as unknown
         title = (item.get("title") or "").strip()
         if not title:
+            continue
+        if skipped < covered_intents:
+            log.info(
+                "rescope: dropping duplicate new task %r — already serviced "
+                "by a post-snapshot thread task (#1337)",
+                title[:80],
+            )
+            skipped += 1
             continue
         task: dict[str, Any] = {
             "id": f"{int(time.time() * 1000)}-{random.randint(0, 9999):04d}",
@@ -750,6 +781,7 @@ def _apply_reorder(
     current: list[dict[str, Any]],
     ordered_items: list[dict[str, Any]],
     original_ids: frozenset[str] = frozenset(),
+    intents: list[RescopeIntent] | None = None,
 ) -> list[dict[str, Any]]:
     """Apply Opus-synthesised items to the current task list.
 
@@ -776,7 +808,9 @@ def _apply_reorder(
     oracle_result = _apply_reorder_with_oracle(current, ordered_items, snapshot_ids)
     _assert_rescope_matches_oracle(current, ordered_items, snapshot_ids, oracle_result)
 
-    new_tasks = _make_new_tasks_from_opus(ordered_items, snapshot_ids)
+    new_tasks = _make_new_tasks_from_opus(
+        ordered_items, snapshot_ids, current=current, intents=intents
+    )
     if not new_tasks:
         return oracle_result
 
@@ -957,7 +991,7 @@ def reorder_tasks(
         inprogress = next(
             (t for t in current if t.get("status") == TaskStatus.IN_PROGRESS), None
         )
-        result = _apply_reorder(current, ordered_items, original_ids)
+        result = _apply_reorder(current, ordered_items, original_ids, intents=intents)
         if inprogress is not None:
             inprogress_in_result = next(
                 (t for t in result if t["id"] == inprogress["id"]), None

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1009,25 +1009,20 @@ def _write_pr_description(
     ``sync.lock`` that :func:`fido.tasks.sync_tasks` holds, preventing a
     description rewrite from overwriting a concurrent work-queue update.
 
-    Raises ``ValueError`` when the existing body has no ``---`` divider
-    (rewrite precondition).  Returns without writing when the agent returns
-    empty or un-parseable output — the existing body is kept as-is and a
-    warning is logged.
+    Self-heals when the existing body has no ``---`` divider: builds a fresh
+    work-queue section and treats the entire existing body as the description
+    seed.  Returns without writing when the agent returns empty or un-parseable
+    output — the existing body is kept as-is and a warning is logged.
     """
     if agent is None:
         raise ValueError("_write_pr_description requires agent")
 
     divider = "\n\n---\n\n"
 
-    # For a rewrite, only proceed when the divider is present so we know
-    # where the description section ends.  For initial write (empty body)
-    # skip this guard and build the rest section fresh.
-    if existing_body and divider not in existing_body:
-        raise ValueError(
-            f"_write_pr_description: no --- divider in PR #{pr_number} body"
-        )
-
-    # Preserve the existing rest section or build the work-queue from scratch.
+    # Preserve the existing rest section, or build the work-queue from scratch
+    # (covers both empty-body initial writes and divider-less legacy bodies —
+    # see #1335: PR #1328 was opened with no divider, every rescope's _on_done
+    # raised, and the inbox-leak bug surfaced as a side effect).
     if divider in existing_body:
         rest = existing_body.split(divider, 1)[1]
         # Re-apply the work queue from task_list so a stale PR body snapshot
@@ -1051,6 +1046,12 @@ def _write_pr_description(
         else:
             queue = "<!-- no tasks yet -->"
         rest = f"## Work queue\n\n<!-- WORK_QUEUE_START -->\n{queue}\n<!-- WORK_QUEUE_END -->"
+        if existing_body:
+            log.info(
+                "_write_pr_description: PR #%s body has no --- divider — "
+                "self-healing by appending a fresh work-queue section (#1335)",
+                pr_number,
+            )
 
     prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
     raw = safe_voice_turn(
@@ -2383,12 +2384,18 @@ class Worker:
                 "reply_promise_id": promise.promise_id,
             }
             try:
+                # registry= flows through to _BackgroundRescopeTrigger so the
+                # rescope BG run_loop's finally can exit_untriaged the holds
+                # it accumulates from coalesced create_task calls.  Without it,
+                # the worker parks on a leaked inbox hold after this reply
+                # path fires.  See #1336.
                 category, titles = events.reply_to_comment(
                     action,
                     config,
                     repo_cfg,
                     self.gh,
                     agent=self._provider_agent,
+                    registry=self._registry,  # type: ignore[arg-type]
                 )
             except Exception:
                 store.mark_failed(promise.promise_id)
@@ -2511,6 +2518,11 @@ class Worker:
     ) -> tuple[str, list[str]]:
         from fido import events
 
+        # Thread the registry through to events.reply_to_* — without this, the
+        # synthesis path constructs _BackgroundRescopeTrigger with registry=None,
+        # the rescope BG run_loop's finally has no registry to call
+        # exit_untriaged on, and the inbox count leaks.  Worker parks on the
+        # next provider turn.  See #1336.
         if queued.comment_type == "pulls":
             return events.reply_to_comment(
                 action,
@@ -2519,6 +2531,7 @@ class Worker:
                 self.gh,
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
+                registry=self._registry,  # type: ignore[arg-type]
             )
         return events.reply_to_issue_comment(
             action,
@@ -2527,6 +2540,7 @@ class Worker:
             self.gh,
             agent=self._provider_agent,
             prompts=self._get_prompts(),
+            registry=self._registry,  # type: ignore[arg-type]
         )
 
     def _queued_review_comment_action(

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -183,9 +183,18 @@ class RepoNameFilter(logging.Filter):
 class ActivityReporter(Protocol):
     """Structural protocol satisfied by WorkerRegistry.
 
-    Workers use this to report their activity and query the full registry
-    snapshot for status generation, without a direct import of WorkerRegistry
-    (which would create a circular dependency).
+    The Worker holds a reference to the registry as ``ActivityReporter`` and
+    threads it through to the reply / rescope chain in :mod:`fido.events`.
+    Methods cover both worker-side calls (``has_untriaged``,
+    ``wait_for_inbox_drain``, ``assert_worker_turn_ok``, ...) and the
+    ingress/rescope-side calls that ``reply_to_*`` and
+    ``_reorder_tasks_background`` make on the same reference
+    (``enter_untriaged``, ``exit_untriaged``, ``set_rescoping``,
+    ``abort_task``).  Keeping them on one Protocol lets us avoid a circular
+    ``WorkerRegistry`` import in :mod:`fido.events` while still threading a
+    real registry through every code path that needs to bookkeep the inbox
+    (#1336 — silently dropping the registry along the chain is what produced
+    the inbox-leak bug).
     """
 
     def report_activity(self, repo_name: str, what: str, busy: bool) -> None: ...
@@ -207,6 +216,14 @@ class ActivityReporter(Protocol):
     def assert_worker_turn_ok(self, repo_name: str) -> None: ...
 
     def force_clear_untriaged(self, repo_name: str) -> int: ...
+
+    def enter_untriaged(self, repo_name: str) -> None: ...
+
+    def exit_untriaged(self, repo_name: str) -> None: ...
+
+    def set_rescoping(self, repo_name: str, active: bool) -> None: ...
+
+    def abort_task(self, repo_name: str, *, task_id: str) -> None: ...
 
 
 class LockHeld(Exception):
@@ -2383,19 +2400,22 @@ class Worker:
                 **(action.context or {}),
                 "reply_promise_id": promise.promise_id,
             }
+            # registry flows through to _BackgroundRescopeTrigger so the
+            # rescope BG run_loop's finally can exit_untriaged the holds it
+            # accumulates from coalesced create_task calls.  Without it the
+            # worker parks on a leaked inbox hold after this reply path
+            # fires (#1336); the registry parameter is now required.
+            assert self._registry is not None, (
+                "Worker._registry is required for handle_threads reply path"
+            )
             try:
-                # registry= flows through to _BackgroundRescopeTrigger so the
-                # rescope BG run_loop's finally can exit_untriaged the holds
-                # it accumulates from coalesced create_task calls.  Without it,
-                # the worker parks on a leaked inbox hold after this reply
-                # path fires.  See #1336.
                 category, titles = events.reply_to_comment(
                     action,
                     config,
                     repo_cfg,
                     self.gh,
+                    self._registry,
                     agent=self._provider_agent,
-                    registry=self._registry,  # type: ignore[arg-type]
                 )
             except Exception:
                 store.mark_failed(promise.promise_id)
@@ -2518,29 +2538,31 @@ class Worker:
     ) -> tuple[str, list[str]]:
         from fido import events
 
-        # Thread the registry through to events.reply_to_* — without this, the
-        # synthesis path constructs _BackgroundRescopeTrigger with registry=None,
-        # the rescope BG run_loop's finally has no registry to call
-        # exit_untriaged on, and the inbox count leaks.  Worker parks on the
-        # next provider turn.  See #1336.
+        # registry is required (#1336): without it the synthesis path
+        # constructs _BackgroundRescopeTrigger with no registry, the rescope
+        # BG run_loop's finally cannot call exit_untriaged, and the inbox
+        # count leaks.  Worker parks on the next provider turn.
+        assert self._registry is not None, (
+            "Worker._registry is required when replying to queued comments"
+        )
         if queued.comment_type == "pulls":
             return events.reply_to_comment(
                 action,
                 config,
                 repo_cfg,
                 self.gh,
+                self._registry,
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
-                registry=self._registry,  # type: ignore[arg-type]
             )
         return events.reply_to_issue_comment(
             action,
             config,
             repo_cfg,
             self.gh,
+            self._registry,
             agent=self._provider_agent,
             prompts=self._get_prompts(),
-            registry=self._registry,  # type: ignore[arg-type]
         )
 
     def _queued_review_comment_action(
@@ -3835,11 +3857,20 @@ class Worker:
         from fido.tasks import reorder_tasks
 
         commit_summary = _get_commit_summary(self.work_dir)
+        # _make_reorder_kwargs always wires up on_inprogress_affected (#1336);
+        # at pick time there is no in-progress task so the callback won't fire,
+        # but the registry must be a real reference to keep the type contract.
+        assert self._registry is not None, (
+            "Worker._registry is required for rescope_before_pick"
+        )
+        assert self._repo_cfg is not None, (
+            "Worker._repo_cfg is required for rescope_before_pick"
+        )
         kwargs = _make_reorder_kwargs(
             self.work_dir,
             self._config,
             self._repo_cfg,
-            None,  # no _on_inprogress_affected: no running task to abort at pick time
+            self._registry,
             self.gh,
             self._provider_agent,
             self._get_prompts(),
@@ -4021,12 +4052,16 @@ class Worker:
             )
             from fido.events import recover_reply_promises
 
+            assert self._registry is not None, (
+                "Worker._registry is required for recover_reply_promises"
+            )
             recovered_promises = recover_reply_promises(
                 ctx.fido_dir,
                 recovery_config,
                 recovery_repo_cfg,
                 self.gh,
                 pr_number,
+                self._registry,
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
             )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -51,6 +51,7 @@ from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import SynthesisExhaustedError
 from fido.synthesis_executor import CommentTarget
 from fido.types import ActiveIssue, ActivePR, RescopeIntent
+from fido.worker import ActivityReporter
 
 
 def _synthesis_response(
@@ -276,6 +277,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             MagicMock(),
             7,
+            registry=MagicMock(spec=ActivityReporter),
         )
 
     def test_recovers_issue_comment_promise(self, tmp_path: Path) -> None:
@@ -303,6 +305,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert result is True
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "acked"
@@ -347,6 +350,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         mock_reply.assert_not_called()
         assert store.promise(promise.promise_id).state == "acked"
@@ -378,6 +382,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         mock_reply.assert_not_called()
         assert store.promise(promise.promise_id).state == "acked"
@@ -399,6 +404,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
         self._assert_recovery_matches_oracle(
@@ -419,6 +425,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
         self._assert_recovery_matches_oracle(
@@ -445,6 +452,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
         assert [
@@ -474,6 +482,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
         assert [
@@ -507,6 +516,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         mock_reply.assert_not_called()
         assert [
@@ -540,6 +550,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert FidoStore(tmp_path).claim_state(302) == "retryable_failed"
         assert FidoStore(tmp_path).recoverable_promises()[0].state == "failed"
@@ -571,6 +582,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         mock_reply.assert_not_called()
         assert [
@@ -605,6 +617,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert FidoStore(tmp_path).claim_state(205) == "retryable_failed"
         assert FidoStore(tmp_path).recoverable_promises()[0].state == "failed"
@@ -639,6 +652,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert result is True
         mock_create_task.assert_not_called()
@@ -677,6 +691,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
+                    registry=MagicMock(spec=ActivityReporter),
                 )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
 
@@ -729,6 +744,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert result is True
         assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
@@ -789,6 +805,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert result is True
         assert mock_reply.call_args.args[0].comment_body == "first\n\n---\n\nsecond"
@@ -850,6 +867,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         store = FidoStore(tmp_path)
@@ -918,6 +936,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
+                    registry=MagicMock(spec=ActivityReporter),
                 )
         store = FidoStore(tmp_path)
         assert store.promise(first.promise_id).state == "prepared"
@@ -982,6 +1001,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         store = FidoStore(tmp_path)
@@ -1067,6 +1087,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
+                    registry=MagicMock(spec=ActivityReporter),
                 )
         assert mock_reply.call_count == 0
         mock_create_task.assert_not_called()
@@ -1130,6 +1151,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert result is True
         assert mock_reply.call_count == 2
@@ -1854,7 +1876,11 @@ class TestReplyToComment:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="do stuff")
         cat, titles = reply_to_comment(
-            action, cfg, self._repo_cfg(tmp_path), _make_mock_gh()
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            _make_mock_gh(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert cat == "ACT"
 
@@ -1865,7 +1891,11 @@ class TestReplyToComment:
             reply_to={"repo": "a/b", "pr": 1, "comment_id": 5},
         )
         cat, titles = reply_to_comment(
-            action, cfg, self._repo_cfg(tmp_path), _make_mock_gh()
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            _make_mock_gh(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert cat == "ACT"
 
@@ -1905,6 +1935,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert "logging" in titles[0].lower()
@@ -1954,6 +1985,7 @@ class TestReplyToComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         effect = store.reply_outbox_effect(promise.promise_id)
@@ -2003,6 +2035,7 @@ class TestReplyToComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         mock_gh.reply_to_review_comment.assert_not_called()
@@ -2027,6 +2060,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
 
@@ -2057,6 +2091,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         gh.resolve_thread.assert_not_called()
 
@@ -2129,6 +2164,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -2157,6 +2193,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert titles == ["Cache results for performance"]
@@ -2185,6 +2222,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert "refactor" in titles[0].lower()
@@ -2211,6 +2249,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
 
@@ -2237,6 +2276,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 MagicMock(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
     def test_claim_race_returns_act_with_no_titles(self, tmp_path: Path) -> None:
@@ -2257,7 +2297,11 @@ class TestReplyToComment:
             is_bot=False,
         )
         cat, titles = reply_to_comment(
-            action, cfg, self._repo_cfg(tmp_path), _make_mock_gh()
+            action,
+            cfg,
+            self._repo_cfg(tmp_path),
+            _make_mock_gh(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert cat == "ACT"
         assert titles == []
@@ -2282,6 +2326,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 MagicMock(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
 
@@ -2310,6 +2355,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert titles == ["Add tests and update docs"]
@@ -2342,6 +2388,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert titles == ["Fix the parser"]
@@ -2388,6 +2435,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         # Human spoke last — must post a fresh reply, never edit the old one
@@ -2419,6 +2467,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         # Posted replies are immutable; answer replies also post a new artifact.
@@ -2458,6 +2507,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -2489,6 +2539,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -2594,6 +2645,7 @@ class TestReplyToCommentSynthesisFallback:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -2643,6 +2695,7 @@ class TestReplyToCommentSynthesisFallback:
                     self._repo_cfg(tmp_path),
                     mock_gh,
                     agent=_client(),
+                    registry=MagicMock(spec=ActivityReporter),
                 )
         mock_remove_eyes.assert_called_once()
 
@@ -2680,6 +2733,7 @@ class TestReplyToCommentSynthesisFallback:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         mock_fallback.assert_called_once()
@@ -2714,6 +2768,7 @@ class TestReplyToCommentSynthesisFallback:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         # Reply still posted despite eyes-add failure.
@@ -2767,6 +2822,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert titles == ["Fix the bug"]
@@ -2785,6 +2841,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
 
@@ -2802,6 +2859,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
 
@@ -2843,6 +2901,7 @@ class TestReplyToIssueComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         effect = store.reply_outbox_effect(promise.promise_id)
@@ -2864,6 +2923,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
 
@@ -2885,6 +2945,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         assert "refactor" in titles[0].lower()
@@ -2934,6 +2995,7 @@ class TestReplyToIssueComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         assert cat == "ANSWER"
@@ -2957,6 +3019,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
     def test_post_exception_propagates(self, tmp_path: Path) -> None:
@@ -2984,6 +3047,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
     def test_no_comment_id_skips_react(self, tmp_path: Path) -> None:
@@ -3007,6 +3071,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         mock_gh.add_reaction.assert_not_called()
@@ -3024,7 +3089,11 @@ class TestReplyToIssueComment:
         ):
             factory_cls.return_value.create_agent.return_value = _client()
             cat, titles = reply_to_issue_comment(
-                action, cfg, self._repo_cfg(tmp_path), self._mock_gh()
+                action,
+                cfg,
+                self._repo_cfg(tmp_path),
+                self._mock_gh(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         factory_cls.return_value.create_agent.assert_called_once_with(
             self._repo_cfg(tmp_path),
@@ -3057,6 +3126,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
         mock_gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
@@ -3086,6 +3156,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ACT"
 
@@ -3104,6 +3175,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert FidoStore(tmp_path).claim_state(4275080243) == "completed"
 
@@ -3120,6 +3192,7 @@ class TestReplyToIssueComment:
             self._repo_cfg(tmp_path),
             _make_mock_gh(),
             agent=_client("unused"),
+            registry=MagicMock(spec=ActivityReporter),
         )
 
         assert category == "ACT"
@@ -3145,6 +3218,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 self._mock_gh(),
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         claim_dir = tmp_path / ".git" / "fido" / "comments"
         assert not claim_dir.exists() or not list(claim_dir.iterdir()), (
@@ -3175,6 +3249,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -3200,6 +3275,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -3231,6 +3307,123 @@ class TestCreateTask:
             "type": "spec",
         }
         return t
+
+    def test_inbox_balanced_through_create_task_coalesce_and_finally(
+        self, tmp_path: Path
+    ) -> None:
+        """Integration test for #1336: simulate the exact race that produced
+        the bug — rescope-A is running when create_task fires, coalesces a
+        rescope-B (calling enter_untriaged + bumping untriaged_holds), and
+        the BG's finally must call exit_untriaged for the bumped holds.
+
+        Before the fix: registry threaded through reply_to_* as None, so
+        run_loop's closure had registry=None and the finally skipped
+        exit_untriaged.  Inbox stayed at 1 forever.
+
+        After the fix: registry is required throughout, so the finally
+        unconditionally calls exit_untriaged once per untriaged_holds
+        increment, returning the inbox to 0."""
+
+        # Real-ish registry recording enter/exit so we can assert balance.
+        class _CountingRegistry:
+            def __init__(self) -> None:
+                self.count = 0
+                self.events: list[str] = []
+
+            def enter_untriaged(self, repo_name: str) -> None:
+                _ = repo_name
+                self.count += 1
+                self.events.append("enter")
+
+            def exit_untriaged(self, repo_name: str) -> None:
+                _ = repo_name
+                self.count -= 1
+                self.events.append("exit")
+
+            def set_rescoping(self, repo_name: str, active: bool) -> None:
+                _ = (repo_name, active)
+
+            def abort_task(self, repo_name: str, *, task_id: str) -> None:
+                _ = (repo_name, task_id)
+
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        registry = _CountingRegistry()
+        coalesce_state: dict = {}
+        started: list = []
+
+        def mock_reorder(work_dir: Path, commit_summary: str, **kwargs: object) -> None:
+            _ = (work_dir, commit_summary, kwargs)
+
+        # rescope-A: simulates the entry-boundary trigger that runs first
+        # (e.g. _BackgroundRescopeTrigger fired from reply_to_*).  No
+        # _release_untriaged_on_finish here — it doesn't bump untriaged_holds
+        # itself.
+        _reorder_tasks_background(
+            tmp_path,
+            "rescope-A",
+            cfg,
+            MagicMock(),
+            repo_cfg,
+            registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=coalesce_state,
+        )
+        # rescope-B: simulates create_task's call. enter_untriaged bumps the
+        # real count to 1, _release_untriaged_on_finish=True bumps
+        # untriaged_holds to 1, and the call coalesces (rescope-A is running).
+        registry.enter_untriaged(repo_cfg.name)
+        _reorder_tasks_background(
+            tmp_path,
+            "rescope-B",
+            cfg,
+            MagicMock(),
+            repo_cfg,
+            registry,
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=coalesce_state,
+            _release_untriaged_on_finish=True,
+        )
+        assert registry.count == 1, "enter must have bumped the count"
+        # Now run the BG to completion.  Its finally must call exit_untriaged
+        # once for each untriaged_holds increment, draining the count.
+        started[0]._target()  # noqa: SLF001
+        assert registry.count == 0, (
+            f"inbox leak (#1336): registry.count={registry.count} after "
+            f"BG finally; events={registry.events}"
+        )
+
+    def test_thread_task_without_registry_warns_and_skips_rescope(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Regression #1336: a thread task created without a registry must
+        log loudly and skip the background rescope (rather than silently
+        firing _reorder_tasks_background with registry=None — the silent
+        fail-soft path that produced the inbox-leak bug)."""
+        cfg = self._cfg(tmp_path)
+        repo_cfg = RepoConfig(name="owner/repo", work_dir=tmp_path)
+        mock_gh = MagicMock()
+        mock_tasks = self._mock_tasks()
+        thread = {"repo": "owner/repo", "pr": 1, "comment_id": 99}
+        with (
+            patch("fido.events.launch_sync"),
+            caplog.at_level("WARNING", logger="fido.events"),
+        ):
+            create_task(
+                "do something",
+                cfg,
+                repo_cfg,
+                mock_gh,
+                thread=thread,
+                _tasks=mock_tasks,
+                _get_commit_summary_fn=lambda wd: "",
+            )
+        warns = [
+            r for r in caplog.records if "skipping background rescope" in r.message
+        ]
+        assert warns, "expected a WARNING when thread task has no registry"
 
     def test_calls_add_task_and_launch_sync(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
@@ -4139,6 +4332,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1
         t = started[0]
@@ -4155,6 +4350,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert tmp_path.name in started[0].name
 
@@ -4171,6 +4368,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         assert len(calls) == 1
@@ -4189,6 +4388,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         on_changes = calls[0][2]["_on_changes"]
@@ -4286,39 +4487,6 @@ class TestReorderTasksBackground:
 
         registry.set_rescoping.assert_called_once_with("owner/repo", False)
         registry.exit_untriaged.assert_called_once_with("owner/repo")
-
-    def test_logs_error_on_thread_start_failure_when_holds_leak_with_no_registry(
-        self,
-        tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Regression for #1336: start-failure path must also log loudly
-        when registry/repo_cfg are unwired but holds were already accumulated."""
-        coalesce_state: dict = {
-            "running": True,
-            "pending": None,
-            "untriaged_holds": 1,
-        }
-
-        def fail_start(_thread: object) -> Never:
-            raise RuntimeError("cannot start")
-
-        with caplog.at_level("ERROR", logger="fido.events"):
-            with pytest.raises(RuntimeError, match="cannot start"):
-                _reorder_tasks_background(
-                    tmp_path,
-                    "commits",
-                    self._cfg(tmp_path),
-                    MagicMock(),
-                    _start=fail_start,
-                    _reorder_fn=MagicMock(),
-                    _coalesce_state=coalesce_state,
-                    _release_untriaged_on_finish=True,
-                )
-
-        leak_records = [r for r in caplog.records if "start failure" in r.message]
-        assert leak_records, "expected a loud ERROR on start-failure leak (#1336)"
-        assert leak_records[0].levelname == "ERROR"
 
     def test_release_runs_before_set_rescoping_in_finally(self, tmp_path: Path) -> None:
         """Release must fire BEFORE set_rescoping so a failure in the latter
@@ -4420,23 +4588,6 @@ class TestReorderTasksBackground:
         set_false_idx = registry.calls.index(("set_rescoping", "owner/repo", False))
         assert exit_idx < set_false_idx
 
-    def test_on_inprogress_affected_not_in_kwargs_when_no_registry(
-        self, tmp_path: Path
-    ) -> None:
-        started: list = []
-        calls, mock_reorder = self._capture_reorder_calls()
-        _reorder_tasks_background(
-            tmp_path,
-            "commits",
-            self._cfg(tmp_path),
-            MagicMock(),
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state={},
-        )
-        self._run_thread(started)
-        assert "_on_inprogress_affected" not in calls[0][2]
-
     def test_on_done_kwarg_calls_rewrite_fn(self, tmp_path: Path) -> None:
         started: list = []
         rewrite_calls: list = []
@@ -4459,6 +4610,8 @@ class TestReorderTasksBackground:
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
@@ -4488,6 +4641,8 @@ class TestReorderTasksBackground:
             agent=fake_client,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
@@ -4515,6 +4670,8 @@ class TestReorderTasksBackground:
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
@@ -4536,6 +4693,8 @@ class TestReorderTasksBackground:
             _rewrite_fn=lambda *a, **kw: None,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         on_done = calls[0][2]["_on_done"]
@@ -4558,6 +4717,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1
         assert state[str(tmp_path)]["running"] is True
@@ -4571,6 +4732,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1  # no second thread spawned
         assert state[str(tmp_path)]["pending"] is not None
@@ -4590,6 +4753,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Simulate a second trigger arriving before the thread runs
         _reorder_tasks_background(
@@ -4600,6 +4765,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Run the single thread — should execute reorder twice (cs1 then cs2)
         self._run_thread(started)
@@ -4624,6 +4791,8 @@ class TestReorderTasksBackground:
                 _start=lambda t: started.append(t),
                 _reorder_fn=mock_reorder,
                 _coalesce_state=state,
+                registry=MagicMock(spec=ActivityReporter),
+                repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
             )
         # Only one thread spawned; pending holds cs4 (the latest)
         assert len(started) == 1
@@ -4654,6 +4823,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Second call — coalesces, adds intent2
         _reorder_tasks_background(
@@ -4665,6 +4836,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Third call — coalesces, adds intent3
         _reorder_tasks_background(
@@ -4676,6 +4849,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Only one thread spawned; pending holds all three intents
         assert len(started) == 1
@@ -4703,6 +4878,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         assert state[str(tmp_path)]["running"] is False
@@ -4723,6 +4900,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)  # first thread completes
 
@@ -4734,6 +4913,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 2  # new thread spawned
 
@@ -4753,6 +4934,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         _reorder_tasks_background(
             dir_b,
@@ -4762,6 +4945,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 2  # each dir gets its own thread
 
@@ -4838,69 +5023,6 @@ class TestReorderTasksBackground:
         last_call = registry.set_rescoping.call_args_list[-1]
         assert last_call[0] == ("owner/repo", False)
 
-    def test_logs_error_when_holds_leak_with_no_registry(
-        self,
-        tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Regression for #1336: when a coalesced caller bumped
-        ``untriaged_holds`` but the running BG has no registry to call
-        ``exit_untriaged`` on, the finally must log a loud ERROR (not
-        silently misreport the release count)."""
-        started: list = []
-        _, mock_reorder = self._capture_reorder_calls()
-        coalesce_state: dict = {}
-        # First call: starts the BG with registry=None (the original bug
-        # scenario — _BackgroundRescopeTrigger constructed with registry=None
-        # because the worker reply path forgot to thread it through).
-        _reorder_tasks_background(
-            tmp_path,
-            "cs",
-            self._cfg(tmp_path),
-            MagicMock(),
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state=coalesce_state,
-        )
-        # Second call coalesces with _release_untriaged_on_finish=True,
-        # bumping untriaged_holds (a real create_task path would have called
-        # registry.enter_untriaged() too, leaking a hold the BG cannot release).
-        _reorder_tasks_background(
-            tmp_path,
-            "cs",
-            self._cfg(tmp_path),
-            MagicMock(),
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state=coalesce_state,
-            _release_untriaged_on_finish=True,
-        )
-        with caplog.at_level("ERROR", logger="fido.events"):
-            self._run_thread(started)
-        leak_records = [
-            r
-            for r in caplog.records
-            if "leaking" in r.message and "untriaged hold" in r.message
-        ]
-        assert leak_records, "expected a loud ERROR when holds leak (#1336)"
-        assert leak_records[0].levelname == "ERROR"
-
-    def test_no_rescoping_calls_when_no_registry(self, tmp_path: Path) -> None:
-        """When registry is None, set_rescoping is not called."""
-        started: list = []
-        _, mock_reorder = self._capture_reorder_calls()
-        _reorder_tasks_background(
-            tmp_path,
-            "cs",
-            self._cfg(tmp_path),
-            MagicMock(),
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state={},
-        )
-        self._run_thread(started)
-        # No registry provided — must not raise and must complete normally
-
     def test_sets_thread_local_repo_name_during_reorder(self, tmp_path: Path) -> None:
         """Thread-local repo_name is set to repo_cfg.name when reorder runs."""
         from fido.provider import current_repo
@@ -4921,6 +5043,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
         )
         self._run_thread(started)
         assert seen == ["owner/repo"]
@@ -4943,6 +5066,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
         )
         self._run_thread(started)
         assert current_repo() is None
@@ -4968,32 +5092,11 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=boom,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
         )
         with pytest.raises(RuntimeError, match="reorder exploded"):
             self._run_thread(started)
         assert current_repo() is None
-
-    def test_no_thread_local_set_when_no_repo_cfg(self, tmp_path: Path) -> None:
-        """When repo_cfg is None, set_thread_repo is not called (no crash)."""
-        from fido.provider import current_repo
-
-        started: list = []
-        seen: list = []
-
-        def mock_reorder(work_dir: Path, commit_summary: str, **kwargs: object) -> None:
-            seen.append(current_repo())
-
-        _reorder_tasks_background(
-            tmp_path,
-            "cs",
-            self._cfg(tmp_path),
-            MagicMock(),
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state={},
-        )
-        self._run_thread(started)
-        assert seen == [None]
 
     def test_sets_thread_kind_webhook_during_reorder(self, tmp_path: Path) -> None:
         """Thread kind is set to 'webhook' while the reorder loop runs (#955).
@@ -5017,6 +5120,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         assert seen == ["webhook"]
@@ -5037,6 +5142,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
         # run_loop must clear kind in its finally block so the caller's
@@ -5060,6 +5167,8 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=boom,
             _coalesce_state={},
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         with pytest.raises(RuntimeError, match="reorder exploded"):
             self._run_thread(started)
@@ -5789,6 +5898,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
+            registry=MagicMock(spec=ActivityReporter),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -5812,6 +5922,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
+            registry=MagicMock(spec=ActivityReporter),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -5831,6 +5942,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
+            registry=MagicMock(spec=ActivityReporter),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -5880,6 +5992,7 @@ class TestReplyToCommentElseBranch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -5910,6 +6023,7 @@ class TestReplyToCommentElseBranch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
     def test_skips_review_reply_when_artifact_already_recorded(
@@ -5956,6 +6070,7 @@ class TestReplyToCommentElseBranch:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         assert cat == "ACT"
@@ -6008,6 +6123,7 @@ class TestReplyToCommentEyesReaction:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Eyes reaction must come before synthesis
@@ -6041,6 +6157,7 @@ class TestReplyToCommentEyesReaction:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # First add_reaction call should be the eyes reaction
@@ -6076,6 +6193,7 @@ class TestReplyToCommentEyesReaction:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Reply still posted despite reaction failure
@@ -6106,6 +6224,7 @@ class TestReplyToCommentEyesReaction:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         mock_gh.add_reaction.assert_not_called()
@@ -6161,6 +6280,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Must be called exactly twice: initial context fetch + pre-post re-fetch
@@ -6215,6 +6335,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Re-fetch shows human is last → post new reply, not edit
@@ -6275,6 +6396,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Fresh data shows human is last speaker → post new reply, never edit
@@ -6316,6 +6438,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Falls back to initial snapshot (no Fido reply) → posts new reply
@@ -6374,6 +6497,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Concurrent handler already replied — neither post nor edit is called
@@ -6434,6 +6558,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Sibling-comment reply must NOT skip our post — we still reply.
@@ -6474,6 +6599,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Posted replies are immutable; Fido posts a new reply instead.
@@ -6526,6 +6652,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
+                registry=MagicMock(spec=ActivityReporter),
             )
 
         # Concurrent Fido reply detected (via fido-can-code) — skip
@@ -6955,7 +7082,7 @@ class TestMakeReorderKwargsActiveContext:
             tmp_path,
             self._cfg(tmp_path),
             self._repo_cfg(tmp_path),
-            None,
+            MagicMock(),
             gh,
             MagicMock(),
             MagicMock(),
@@ -6973,7 +7100,7 @@ class TestMakeReorderKwargsActiveContext:
             tmp_path,
             self._cfg(tmp_path),
             self._repo_cfg(tmp_path),
-            None,
+            MagicMock(),
             gh,
             MagicMock(),
             MagicMock(),
@@ -6996,7 +7123,7 @@ class TestMakeReorderKwargsActiveContext:
             tmp_path,
             self._cfg(tmp_path),
             self._repo_cfg(tmp_path),
-            None,
+            MagicMock(),
             gh,
             MagicMock(),
             MagicMock(),
@@ -7007,24 +7134,6 @@ class TestMakeReorderKwargsActiveContext:
         assert isinstance(pr, ActivePR)
         assert pr.number == 99
         assert pr.url == "https://github.com/owner/repo/pull/99"
-
-    def test_no_issue_or_pr_when_repo_cfg_is_none(self, tmp_path: Path) -> None:
-        fido_dir = self._fido_dir(tmp_path)
-        State(fido_dir).save({"issue": 5, "pr_number": 10})
-        gh = MagicMock()
-        kwargs = _make_reorder_kwargs(
-            tmp_path,
-            self._cfg(tmp_path),
-            None,  # no repo_cfg
-            None,
-            gh,
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-        )
-        assert "issue" not in kwargs
-        assert "pr" not in kwargs
-        gh.view_issue.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4287,6 +4287,39 @@ class TestReorderTasksBackground:
         registry.set_rescoping.assert_called_once_with("owner/repo", False)
         registry.exit_untriaged.assert_called_once_with("owner/repo")
 
+    def test_logs_error_on_thread_start_failure_when_holds_leak_with_no_registry(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Regression for #1336: start-failure path must also log loudly
+        when registry/repo_cfg are unwired but holds were already accumulated."""
+        coalesce_state: dict = {
+            "running": True,
+            "pending": None,
+            "untriaged_holds": 1,
+        }
+
+        def fail_start(_thread: object) -> Never:
+            raise RuntimeError("cannot start")
+
+        with caplog.at_level("ERROR", logger="fido.events"):
+            with pytest.raises(RuntimeError, match="cannot start"):
+                _reorder_tasks_background(
+                    tmp_path,
+                    "commits",
+                    self._cfg(tmp_path),
+                    MagicMock(),
+                    _start=fail_start,
+                    _reorder_fn=MagicMock(),
+                    _coalesce_state=coalesce_state,
+                    _release_untriaged_on_finish=True,
+                )
+
+        leak_records = [r for r in caplog.records if "start failure" in r.message]
+        assert leak_records, "expected a loud ERROR on start-failure leak (#1336)"
+        assert leak_records[0].levelname == "ERROR"
+
     def test_release_runs_before_set_rescoping_in_finally(self, tmp_path: Path) -> None:
         """Release must fire BEFORE set_rescoping so a failure in the latter
         cannot leave the inbox stuck (#1280).
@@ -4804,6 +4837,53 @@ class TestReorderTasksBackground:
             self._run_thread(started)
         last_call = registry.set_rescoping.call_args_list[-1]
         assert last_call[0] == ("owner/repo", False)
+
+    def test_logs_error_when_holds_leak_with_no_registry(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Regression for #1336: when a coalesced caller bumped
+        ``untriaged_holds`` but the running BG has no registry to call
+        ``exit_untriaged`` on, the finally must log a loud ERROR (not
+        silently misreport the release count)."""
+        started: list = []
+        _, mock_reorder = self._capture_reorder_calls()
+        coalesce_state: dict = {}
+        # First call: starts the BG with registry=None (the original bug
+        # scenario — _BackgroundRescopeTrigger constructed with registry=None
+        # because the worker reply path forgot to thread it through).
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=coalesce_state,
+        )
+        # Second call coalesces with _release_untriaged_on_finish=True,
+        # bumping untriaged_holds (a real create_task path would have called
+        # registry.enter_untriaged() too, leaking a hold the BG cannot release).
+        _reorder_tasks_background(
+            tmp_path,
+            "cs",
+            self._cfg(tmp_path),
+            MagicMock(),
+            _start=lambda t: started.append(t),
+            _reorder_fn=mock_reorder,
+            _coalesce_state=coalesce_state,
+            _release_untriaged_on_finish=True,
+        )
+        with caplog.at_level("ERROR", logger="fido.events"):
+            self._run_thread(started)
+        leak_records = [
+            r
+            for r in caplog.records
+            if "leaking" in r.message and "untriaged hold" in r.message
+        ]
+        assert leak_records, "expected a loud ERROR when holds leak (#1336)"
+        assert leak_records[0].levelname == "ERROR"
 
     def test_no_rescoping_calls_when_no_registry(self, tmp_path: Path) -> None:
         """When registry is None, set_rescoping is not called."""
@@ -6545,19 +6625,21 @@ class TestRewritePrDescription:
             )
         mock_gh.edit_pr_body.assert_not_called()
 
-    def test_raises_when_no_divider_in_body(self, tmp_path: Path) -> None:
+    def test_self_heals_when_no_divider_in_body(self, tmp_path: Path) -> None:
+        """#1335 regression: divider-less bodies must self-heal, not raise."""
         mock_gh = self._mock_gh(
             body="No divider here. <!-- WORK_QUEUE_START -->x<!-- WORK_QUEUE_END -->"
         )
-        with pytest.raises(ValueError, match="no --- divider"):
-            _rewrite_pr_description(
-                tmp_path,
-                mock_gh,
-                agent=_client(),
-                _state=self._mock_state(),
-                _tasks=self._mock_tasks(),
-            )
-        mock_gh.edit_pr_body.assert_not_called()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            agent=_client("<body>New desc.\n\nFixes #42.</body>"),
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
+        )
+        body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "\n\n---\n\n" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
 
     def test_raises_when_opus_returns_empty(self, tmp_path: Path) -> None:
         mock_gh = self._mock_gh()
@@ -6717,18 +6799,19 @@ class TestRewritePrDescription:
         )
         assert mock_gh.edit_pr_body.call_count == 3
 
-    def test_no_divider_raises_before_retry(self, tmp_path: Path) -> None:
-        """When the PR body has no --- divider, ValueError propagates immediately."""
+    def test_no_divider_self_heals(self, tmp_path: Path) -> None:
+        """#1335 regression: a body with no --- divider self-heals."""
         mock_gh = self._mock_gh(body="No divider here. Nothing.")
-        with pytest.raises(ValueError, match="no --- divider"):
-            _rewrite_pr_description(
-                tmp_path,
-                mock_gh,
-                agent=_client("<body>New desc.\n\nFixes #42.</body>"),
-                _state=self._mock_state(),
-                _tasks=self._mock_tasks(),
-            )
-        mock_gh.edit_pr_body.assert_not_called()
+        _rewrite_pr_description(
+            tmp_path,
+            mock_gh,
+            agent=_client("<body>New desc.\n\nFixes #42.</body>"),
+            _state=self._mock_state(),
+            _tasks=self._mock_tasks(),
+        )
+        body = mock_gh.edit_pr_body.call_args[0][2]
+        assert "\n\n---\n\n" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
 
     def test_refetches_pr_body_on_retry(self, tmp_path: Path) -> None:
         """PR body is re-fetched on each attempt so work-queue stays current."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -30,7 +30,7 @@ from fido.tasks import (
     reorder_tasks,
     review_thread_for_auto_resolve_oracle,
 )
-from fido.types import TaskStatus, TaskType
+from fido.types import RescopeIntent, TaskStatus, TaskType
 
 
 def _client(run_turn_return: str = "") -> MagicMock:
@@ -992,6 +992,72 @@ class TestMakeNewTasksFromOpus:
         result = _make_new_tasks_from_opus(items, frozenset({"1"}))
         assert len(result) == 1
         assert result[0]["title"] == "New"
+
+    def test_dedups_against_post_snapshot_thread_task(self) -> None:
+        """#1337 regression: when create_task added a thread task during the
+        Opus call (a new id appearing in current that's NOT in the snapshot
+        and whose lineage_comment_ids overlap a rescope intent), Opus's null-id
+        item for that same intent is a duplicate and must be dropped.
+        """
+        snapshot_ids = frozenset({"orig-1"})
+        current = [
+            {"id": "orig-1", "title": "Original", "status": "pending"},
+            {
+                "id": "post-snapshot-2",
+                "title": "Replace MagicMock with _FakeDispatcher",
+                "status": "in_progress",
+                "type": "thread",
+                "thread": {
+                    "comment_id": 4371338003,
+                    "lineage_comment_ids": [4371338003],
+                },
+            },
+        ]
+        intents = [
+            RescopeIntent(
+                comment_id=4371338003,
+                change_request="Replace MagicMock(spec=Dispatcher) with hand-rolled _FakeDispatcher",
+                timestamp="2026-05-04T13:15:44Z",
+            ),
+        ]
+        items = [
+            {"id": "orig-1", "title": "Original"},
+            {
+                "title": "Replace MagicMock(spec=Dispatcher) with _FakeDispatcher",
+                "description": "Step-by-step rewrite",
+            },
+        ]
+        result = _make_new_tasks_from_opus(
+            items, snapshot_ids, current=current, intents=intents
+        )
+        assert result == [], "covered intent must drop the duplicate (#1337)"
+
+    def test_does_not_dedup_when_lineage_does_not_match_intent(self) -> None:
+        """When no post-snapshot thread task covers the intent, Opus's null-id
+        item is genuinely new and must be kept."""
+        snapshot_ids = frozenset({"orig-1"})
+        current = [
+            {"id": "orig-1", "title": "Original", "status": "pending"},
+            {
+                "id": "post-2",
+                "title": "Some unrelated thread task",
+                "status": "pending",
+                "thread": {"comment_id": 999, "lineage_comment_ids": [999]},
+            },
+        ]
+        intents = [
+            RescopeIntent(
+                comment_id=4371338003,
+                change_request="other intent",
+                timestamp="2026-05-04T13:15:44Z",
+            ),
+        ]
+        items = [{"title": "Genuinely new spec", "description": ""}]
+        result = _make_new_tasks_from_opus(
+            items, snapshot_ids, current=current, intents=intents
+        )
+        assert len(result) == 1
+        assert result[0]["title"] == "Genuinely new spec"
 
 
 # ── _find_duplicate_titles ────────────────────────────────────────────────────

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4318,11 +4318,16 @@ class TestWritePrDescription:
         _, kwargs = mock_cc.run_turn.call_args
         assert kwargs.get("retry_on_preempt") is True
 
-    def test_raises_when_no_divider_in_existing_body(self) -> None:
+    def test_self_heals_when_no_divider_in_existing_body(self) -> None:
+        """#1335 regression: a divider-less body must self-heal, not raise."""
         gh = MagicMock()
-        with pytest.raises(ValueError, match="no --- divider"):
-            self._call(gh, existing_body="no divider here")
-        gh.edit_pr_body.assert_not_called()
+        self._call(gh, existing_body="no divider here")
+        body = gh.edit_pr_body.call_args[0][2]
+        # Self-heal must produce a well-formed body with both the divider and
+        # work-queue markers so the next rescope can find the rest section.
+        assert "\n\n---\n\n" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
+        assert "<!-- WORK_QUEUE_END -->" in body
 
     def test_initial_write_contains_work_queue_start_marker(self) -> None:
         gh = MagicMock()
@@ -4495,11 +4500,13 @@ class TestWritePrDescription:
         assert "<!-- WORK_QUEUE_START -->" in body
         assert "<!-- WORK_QUEUE_END -->" in body
 
-    def test_rewrite_raises_when_no_divider(self) -> None:
+    def test_rewrite_self_heals_when_no_divider(self) -> None:
+        """#1335 regression: rewrite path must self-heal a divider-less body."""
         gh = MagicMock()
-        with pytest.raises(ValueError, match="no --- divider"):
-            self._call(gh, existing_body="no divider here")
-        gh.edit_pr_body.assert_not_called()
+        self._call(gh, existing_body="no divider here")
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "\n\n---\n\n" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
 
     def test_requires_agent(self) -> None:
         gh = MagicMock()
@@ -8272,6 +8279,13 @@ class TestHandleQueuedComments:
 
         assert result is True
         mock_reply.assert_called_once()
+        # Regression #1336: registry must flow through to reply_to_issue_comment
+        # so _BackgroundRescopeTrigger gets a real registry to call
+        # exit_untriaged on.  Worker._registry is None in this fixture, but the
+        # kwarg must still be present and equal to whatever Worker is holding.
+        kwargs = mock_reply.call_args.kwargs
+        assert "registry" in kwargs, "registry must be passed to reply_to_*"
+        assert kwargs["registry"] is worker._registry  # noqa: SLF001
         mock_create_task.assert_called_once()
         mock_sync.assert_called()
         store = FidoStore(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -44,6 +44,7 @@ from fido.types import GitIdentity
 from fido.worker import (
     _RETRY_COMMENT_MARKER,
     AbortHandle,
+    ActivityReporter,
     GitIdentityError,
     LockHeld,
     RepoContext,
@@ -140,6 +141,8 @@ class WorkerThread(_WorkerThreadBase):
         *args: object,
         **kwargs: object,
     ) -> None:
+        if "registry" not in kwargs:
+            kwargs["registry"] = MagicMock(spec=ActivityReporter)
         repo_cfg = kwargs.get("repo_cfg", _MISSING)
         if repo_cfg is _MISSING and kwargs.get("provider") is None:
             kwargs["repo_cfg"] = _default_repo_cfg(
@@ -251,7 +254,7 @@ class TestRepoNameFilter:
 
 class TestResolveGitDir:
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def test_returns_path(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(stdout="/some/repo/.git\n"))
@@ -355,7 +358,9 @@ class TestCreateContext:
     def test_returns_worker_context(self, tmp_path: Path) -> None:
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
-        ctx = Worker(tmp_path, MagicMock()).create_context(_run=self._mock_run(git_dir))
+        ctx = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).create_context(_run=self._mock_run(git_dir))
         assert isinstance(ctx, WorkerContext)
         assert ctx.work_dir == tmp_path
         assert ctx.git_dir == git_dir
@@ -365,7 +370,9 @@ class TestCreateContext:
     def test_creates_fido_dir(self, tmp_path: Path) -> None:
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
-        ctx = Worker(tmp_path, MagicMock()).create_context(_run=self._mock_run(git_dir))
+        ctx = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).create_context(_run=self._mock_run(git_dir))
         assert ctx.fido_dir.is_dir()
         ctx.lock_fd.close()
 
@@ -376,9 +383,9 @@ class TestCreateContext:
         fd1 = acquire_lock(fido_dir)
         try:
             with pytest.raises(LockHeld):
-                Worker(tmp_path, MagicMock()).create_context(
-                    _run=self._mock_run(git_dir)
-                )
+                Worker(
+                    tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+                ).create_context(_run=self._mock_run(git_dir))
         finally:
             fd1.close()
 
@@ -441,7 +448,13 @@ class TestWorker:
             log_level="DEBUG",
             sub_dir=tmp_path,
         )
-        worker = Worker(tmp_path, MagicMock(), config=config, repo_cfg=None)
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            config=config,
+            repo_cfg=None,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert worker._config is config
 
     def test_repo_cfg_stored_when_passed(self, tmp_path: Path) -> None:
@@ -450,7 +463,12 @@ class TestWorker:
         cfg = RepoConfig(
             name="owner/repo", work_dir=tmp_path, provider=ProviderID.CLAUDE_CODE
         )
-        worker = Worker(tmp_path, MagicMock(), repo_cfg=cfg)
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=cfg,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert worker._repo_cfg is cfg
 
     def test_repo_cfg_provider_selects_copilot_provider(self, tmp_path: Path) -> None:
@@ -464,6 +482,7 @@ class TestWorker:
                 work_dir=tmp_path,
                 provider=ProviderID.COPILOT_CLI,
             ),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert worker._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
 
@@ -479,80 +498,116 @@ class TestWorker:
                 provider=ProviderID.CODEX,
             ),
             issue_cache=MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert worker._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
 
     def test_config_defaults_to_none(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         assert worker._config is None
 
     def test_repo_cfg_defaults_to_none(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock(), repo_cfg=None, provider=MagicMock())
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=None,
+            provider=MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert worker._repo_cfg is None
 
     # --- discover_repo_context ---
 
     def test_discover_returns_repo_context(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert isinstance(result, RepoContext)
 
     def test_discover_repo_field(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.repo == "alice/proj"
 
     def test_discover_owner_parsed(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.owner == "alice"
 
     def test_discover_repo_name_parsed(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.repo_name == "proj"
 
     def test_discover_gh_user(self, tmp_path: Path) -> None:
         gh = self._make_gh(user="fido")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.gh_user == "fido"
 
     def test_discover_default_branch(self, tmp_path: Path) -> None:
         gh = self._make_gh(branch="develop")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.default_branch == "develop"
 
     def test_discover_passes_cwd_to_get_repo_info(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(tmp_path, gh).discover_repo_context()
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         gh.get_repo_info.assert_called_once_with(cwd=tmp_path)
 
     def test_discover_passes_cwd_to_get_default_branch(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(tmp_path, gh).discover_repo_context()
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         gh.get_default_branch.assert_called_once_with(cwd=tmp_path)
 
     def test_discover_splits_on_first_slash_only(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="org/repo")
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.owner == "org"
         assert result.repo_name == "repo"
 
     def test_discover_uses_injected_membership(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         membership = RepoMembership(collaborators=frozenset({"alice", "bob"}))
-        result = Worker(tmp_path, gh, membership=membership).discover_repo_context()
+        result = Worker(
+            tmp_path,
+            gh,
+            membership=membership,
+            registry=MagicMock(spec=ActivityReporter),
+        ).discover_repo_context()
         assert result.membership is membership
         assert result.collaborators == frozenset({"alice", "bob"})
 
     def test_discover_default_membership_empty(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        result = Worker(tmp_path, gh).discover_repo_context()
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         assert result.collaborators == frozenset()
 
     def test_discover_does_not_call_get_collaborators(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(tmp_path, gh).discover_repo_context()
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).discover_repo_context()
         gh.get_collaborators.assert_not_called()
 
     # --- set_status ---
@@ -574,16 +629,22 @@ class TestWorker:
     def test_set_status_calls_set_user_status_on_success(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh, session=self._session(status="writing tests")).set_status(
-            "writing tests", _sub_dir_fn=lambda: tmp_path
-        )
+        Worker(
+            tmp_path,
+            gh,
+            session=self._session(status="writing tests"),
+            registry=MagicMock(spec=ActivityReporter),
+        ).set_status("writing tests", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with("writing tests", "🐕", busy=True)
 
     def test_set_status_busy_false_forwarded(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
-            tmp_path, gh, session=self._session(status="napping", emoji="😴")
+            tmp_path,
+            gh,
+            session=self._session(status="napping", emoji="😴"),
+            registry=MagicMock(spec=ActivityReporter),
         ).set_status("napping", busy=False, _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with("napping", "😴", busy=False)
 
@@ -593,7 +654,10 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
-            tmp_path, gh, session=self._session(status="", emoji=":dog:")
+            tmp_path,
+            gh,
+            session=self._session(status="", emoji=":dog:"),
+            registry=MagicMock(spec=ActivityReporter),
         ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         assert gh.set_user_status.call_args[0][0] == "idle"
 
@@ -601,7 +665,10 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
-            tmp_path, gh, session=self._session(status="Sniffing endpoints", emoji="")
+            tmp_path,
+            gh,
+            session=self._session(status="Sniffing endpoints", emoji=""),
+            registry=MagicMock(spec=ActivityReporter),
         ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with(
             "Sniffing endpoints", ":dog:", busy=True
@@ -611,9 +678,12 @@ class TestWorker:
         gh = self._make_gh()
         long_text = "x" * 100
         (tmp_path / "persona.md").write_text("I am Fido.")
-        Worker(tmp_path, gh, session=self._session(status=long_text)).set_status(
-            "something", _sub_dir_fn=lambda: tmp_path
-        )
+        Worker(
+            tmp_path,
+            gh,
+            session=self._session(status=long_text),
+            registry=MagicMock(spec=ActivityReporter),
+        ).set_status("something", _sub_dir_fn=lambda: tmp_path)
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
 
@@ -625,9 +695,9 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.INFO, logger="fido"):
-            Worker(tmp_path, gh, session=None).set_status(
-                "idle", _sub_dir_fn=lambda: tmp_path
-            )
+            Worker(
+                tmp_path, gh, session=None, registry=MagicMock(spec=ActivityReporter)
+            ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_not_called()
         assert "no session available" in caplog.text
 
@@ -640,7 +710,10 @@ class TestWorker:
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.WARNING, logger="fido"):
             Worker(
-                tmp_path, gh, session=self._session(status="", emoji=":dog:")
+                tmp_path,
+                gh,
+                session=self._session(status="", emoji=":dog:"),
+                registry=MagicMock(spec=ActivityReporter),
             ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         assert "falling back" in caplog.text
 
@@ -652,9 +725,12 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.INFO, logger="fido"):
-            Worker(tmp_path, gh, session=self._session(status="fetching")).set_status(
-                "fetching", _sub_dir_fn=lambda: tmp_path
-            )
+            Worker(
+                tmp_path,
+                gh,
+                session=self._session(status="fetching"),
+                registry=MagicMock(spec=ActivityReporter),
+            ).set_status("fetching", _sub_dir_fn=lambda: tmp_path)
         assert "set_status" in caplog.text
 
     def test_set_status_falls_back_to_empty_persona_on_oserror(
@@ -673,9 +749,9 @@ class TestWorker:
         gh = self._make_gh()
         (tmp_path / "persona.md").write_text("I am Fido.")
         session = self._session(status="working")
-        Worker(tmp_path, gh, session=session).set_status(
-            "working", _sub_dir_fn=lambda: tmp_path
-        )
+        Worker(
+            tmp_path, gh, session=session, registry=MagicMock(spec=ActivityReporter)
+        ).set_status("working", _sub_dir_fn=lambda: tmp_path)
         assert session.prompt.call_args[1]["system_prompt"] is not None
 
     def test_set_status_reports_activity_to_registry(self, tmp_path: Path) -> None:
@@ -799,21 +875,33 @@ class TestWorker:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         gh = self._make_issue_gh()
-        assert Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo") is None
+        assert (
+            Worker(
+                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            ).get_current_issue(fido_dir, "owner/repo")
+            is None
+        )
 
     def test_get_issue_returns_issue_number_when_open(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
-        assert Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo") == 7
+        assert (
+            Worker(
+                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            ).get_current_issue(fido_dir, "owner/repo")
+            == 7
+        )
 
     def test_get_issue_returns_int_type(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
-        result = Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
+        result = Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).get_current_issue(fido_dir, "owner/repo")
         assert isinstance(result, int)
 
     def test_get_issue_returns_none_when_closed(self, tmp_path: Path) -> None:
@@ -821,14 +909,21 @@ class TestWorker:
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
-        assert Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo") is None
+        assert (
+            Worker(
+                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            ).get_current_issue(fido_dir, "owner/repo")
+            is None
+        )
 
     def test_get_issue_clears_state_when_closed(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
-        Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).get_current_issue(fido_dir, "owner/repo")
         assert State(fido_dir).load() == {}
 
     def test_get_issue_does_not_call_view_issue_when_no_state(
@@ -837,7 +932,9 @@ class TestWorker:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         gh = self._make_issue_gh()
-        Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).get_current_issue(fido_dir, "owner/repo")
         gh.view_issue.assert_not_called()
 
     def test_get_issue_calls_view_issue_with_correct_args(self, tmp_path: Path) -> None:
@@ -845,7 +942,9 @@ class TestWorker:
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 12})
         gh = self._make_issue_gh(state="OPEN")
-        Worker(tmp_path, gh).get_current_issue(fido_dir, "alice/proj")
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).get_current_issue(fido_dir, "alice/proj")
         gh.view_issue.assert_called_once_with("alice/proj", 12)
 
     def test_get_issue_logs_info_when_closed(
@@ -858,7 +957,9 @@ class TestWorker:
         State(fido_dir).save({"issue": 9})
         gh = self._make_issue_gh(state="CLOSED")
         with caplog.at_level(logging.INFO, logger="fido"):
-            Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
+            Worker(
+                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            ).get_current_issue(fido_dir, "owner/repo")
         assert "advancing" in caplog.text
 
     def test_get_issue_state_preserved_when_open(self, tmp_path: Path) -> None:
@@ -866,7 +967,9 @@ class TestWorker:
         fido_dir.mkdir()
         State(fido_dir).save({"issue": 5})
         gh = self._make_issue_gh(state="OPEN")
-        Worker(tmp_path, gh).get_current_issue(fido_dir, "owner/repo")
+        Worker(
+            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+        ).get_current_issue(fido_dir, "owner/repo")
         assert State(fido_dir).load() == {"issue": 5}
 
     # --- run ---
@@ -890,14 +993,18 @@ class TestWorker:
     def test_create_session_instantiates_claude_session(self, tmp_path: Path) -> None:
         from fido import claude
 
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker.create_session()
         claude.ClaudeSession.assert_called_once()
 
     def test_create_session_passes_work_dir(self, tmp_path: Path) -> None:
         from fido import claude
 
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker.create_session()
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("work_dir") == tmp_path
@@ -907,7 +1014,9 @@ class TestWorker:
 
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker.create_session()
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("model") == "claude-opus-4-6"
@@ -918,7 +1027,9 @@ class TestWorker:
 
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker.create_session()
         assert worker._provider.agent.session is mock_session  # pyright: ignore[reportPrivateUsage]
 
@@ -929,6 +1040,7 @@ class TestWorker:
             tmp_path,
             MagicMock(),
             repo_cfg=_default_repo_cfg(tmp_path, repo_name="owner/repo"),
+            registry=MagicMock(spec=ActivityReporter),
         )
         worker._provider = None  # pyright: ignore[reportPrivateUsage]
         agent = worker._provider_agent
@@ -936,7 +1048,12 @@ class TestWorker:
         assert agent is worker._provider.agent  # pyright: ignore[reportPrivateUsage]
 
     def test_ensure_provider_requires_repo_cfg(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock(), repo_cfg=None)
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=None,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with pytest.raises(
             RuntimeError, match="worker provider requires explicit repo_cfg"
         ):
@@ -950,32 +1067,44 @@ class TestWorker:
         provider.agent.attach_session.side_effect = lambda attached: setattr(
             provider.agent, "session", attached
         )
-        worker = Worker(tmp_path, MagicMock(), provider=provider, session=session)
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            provider=provider,
+            session=session,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         provider.agent.attach_session.assert_called_once_with(session)
         assert worker._provider.agent.session is session  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_calls_stop(self, tmp_path: Path) -> None:
         mock_session = MagicMock()
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker._provider.agent.attach_session(mock_session)  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
         mock_session.stop.assert_called_once()
 
     def test_stop_session_clears_session(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         worker._provider.agent.attach_session(MagicMock())  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
         assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_is_noop_when_none(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()  # must not raise
 
     def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_create = MagicMock()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -998,7 +1127,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         order: list[str] = []
 
         def mark_recover(*args: object, **kwargs: object) -> bool:
@@ -1048,7 +1177,13 @@ class TestWorker:
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
         mock_session = MagicMock()
         # same issue as last time — no boundary restart, no model switch
-        worker = Worker(tmp_path, gh, session=mock_session, session_issue=7)
+        worker = Worker(
+            tmp_path,
+            gh,
+            session=mock_session,
+            session_issue=7,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1078,7 +1213,13 @@ class TestWorker:
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
         mock_session = MagicMock()
         # session was working on issue 5; now issue 7 is picked — boundary
-        worker = Worker(tmp_path, gh, session=mock_session, session_issue=5)
+        worker = Worker(
+            tmp_path,
+            gh,
+            session=mock_session,
+            session_issue=5,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1105,7 +1246,13 @@ class TestWorker:
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
         mock_session = MagicMock()
-        worker = Worker(tmp_path, gh, session=mock_session, session_issue=7)
+        worker = Worker(
+            tmp_path,
+            gh,
+            session=mock_session,
+            session_issue=7,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1131,7 +1278,12 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         mock_session = MagicMock()
-        worker = Worker(tmp_path, gh, session=mock_session)
+        worker = Worker(
+            tmp_path,
+            gh,
+            session=mock_session,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1150,7 +1302,7 @@ class TestWorker:
 
     def test_run_returns_2_when_lock_held(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with patch.object(worker, "create_context", side_effect=LockHeld("held")):
             assert worker.run() == 2
 
@@ -1177,7 +1329,7 @@ class TestWorker:
     def test_run_returns_0_on_success(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1198,7 +1350,7 @@ class TestWorker:
         import logging
 
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with patch.object(worker, "create_context", side_effect=LockHeld("held")):
             with caplog.at_level(logging.WARNING, logger="fido"):
                 worker.run()
@@ -1211,7 +1363,7 @@ class TestWorker:
 
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1235,7 +1387,7 @@ class TestWorker:
 
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1257,7 +1409,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         mock_teardown = MagicMock()
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1277,7 +1429,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         mock_setup = MagicMock(return_value=("c", "s"))
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1294,7 +1446,7 @@ class TestWorker:
     def test_run_calls_get_current_issue(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_get_issue = MagicMock(return_value=None)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1312,7 +1464,7 @@ class TestWorker:
     def test_run_calls_find_next_issue_when_no_current(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_find = MagicMock(return_value=None)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1332,7 +1484,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix bug", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_find = MagicMock(return_value=None)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1356,7 +1508,7 @@ class TestWorker:
     def test_run_returns_0_when_no_issue(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1379,7 +1531,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_pickup = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1410,7 +1562,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_pickup = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1437,7 +1589,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1464,7 +1616,7 @@ class TestWorker:
             "body": "Issue body text",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_focp = MagicMock(return_value=(42, "my-branch", False))
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1493,7 +1645,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "New thing", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1527,7 +1679,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Old thing", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1560,7 +1712,7 @@ class TestWorker:
         """CI/thread/rescope checks are unreachable when no issue is selected."""
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1591,7 +1743,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         iteration = 0
 
         def focp_side_effect(*_a: object, **_kw: object) -> tuple[int, str, bool]:
@@ -1642,7 +1794,9 @@ class TestWorkerFindNextIssue:
         provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE
         )
-        return Worker(tmp_path, gh, provider=provider), gh
+        return Worker(
+            tmp_path, gh, provider=provider, registry=MagicMock(spec=ActivityReporter)
+        ), gh
 
     def _make_repo_ctx(
         self,
@@ -1701,7 +1855,13 @@ class TestWorkerFindNextIssue:
                 ),
             ),
         )
-        worker = Worker(tmp_path, gh, provider=provider, repo_name="owner/repo")
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider=provider,
+            repo_name="owner/repo",
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = self._fido_dir(tmp_path)
 
         result = worker.find_next_issue(fido_dir, self._make_repo_ctx())
@@ -1729,7 +1889,13 @@ class TestWorkerFindNextIssue:
                 ),
             ),
         )
-        worker = Worker(tmp_path, gh, provider=provider, repo_name="owner/repo")
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider=provider,
+            repo_name="owner/repo",
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = self._fido_dir(tmp_path)
 
         worker.find_next_issue(fido_dir, self._make_repo_ctx())
@@ -2179,7 +2345,9 @@ class TestIssueHasOpenSubIssues:
                 inventory,
                 snapshot_started_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
             )
-        return Worker(tmp_path, gh, issue_cache=cache)
+        return Worker(
+            tmp_path, gh, issue_cache=cache, registry=MagicMock(spec=ActivityReporter)
+        )
 
     def _issue(
         self,
@@ -2722,7 +2890,9 @@ class TestWorkerVerifyCachedIssueStillOpen:
         provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE
         )
-        return Worker(tmp_path, gh, provider=provider), gh
+        return Worker(
+            tmp_path, gh, provider=provider, registry=MagicMock(spec=ActivityReporter)
+        ), gh
 
     def test_returns_true_when_state_open(self, tmp_path: Path) -> None:
         worker, gh = self._worker(tmp_path)
@@ -2752,7 +2922,13 @@ class TestWorkerPickFromCache:
         provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE
         )
-        return Worker(tmp_path, gh, provider=provider, issue_cache=cache), gh
+        return Worker(
+            tmp_path,
+            gh,
+            provider=provider,
+            issue_cache=cache,
+            registry=MagicMock(spec=ActivityReporter),
+        ), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -2870,7 +3046,13 @@ class TestWorkerFindNextIssueCacheBranch:
         provider.api.get_limit_snapshot.return_value = ProviderLimitSnapshot(
             provider=ProviderID.CLAUDE_CODE
         )
-        worker = Worker(tmp_path, gh, provider=provider, issue_cache=cache)
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider=provider,
+            issue_cache=cache,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         repo_ctx = RepoContext(
@@ -2902,7 +3084,12 @@ class TestWorkerPostPickupComment:
         gh = MagicMock()
         gh.view_issue.return_value = {"created_at": "2024-01-01T00:00:00Z"}
         gh.get_issue_events.return_value = []
-        return Worker(tmp_path, gh, provider_agent=provider_agent), gh
+        return Worker(
+            tmp_path,
+            gh,
+            provider_agent=provider_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        ), gh
 
     def test_skips_when_pickup_marker_present(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
@@ -3103,7 +3290,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        compact_cmd, sync_cmd = Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        compact_cmd, sync_cmd = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         assert compact_cmd.startswith("bash ")
         assert "sync_tasks_cli" in sync_cmd
 
@@ -3111,14 +3300,18 @@ class TestSetupHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        compact_cmd, _ = Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        compact_cmd, _ = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         assert "compact.sh" in compact_cmd
 
     def test_sync_cmd_references_sync_script(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        _, sync_cmd = Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        _, sync_cmd = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         assert "python -m fido.sync_tasks_cli" in sync_cmd
         assert "uv run" not in sync_cmd
 
@@ -3126,14 +3319,18 @@ class TestSetupHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        _, sync_cmd = Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        _, sync_cmd = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         assert str(tmp_path) in sync_cmd
 
     def test_creates_compact_script(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         assert (fido_dir / "compact.sh").exists()
 
     def test_adds_hooks_to_settings(self, tmp_path: Path) -> None:
@@ -3142,7 +3339,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         settings = tmp_path / ".claude" / "settings.local.json"
         assert settings.exists()
         cfg = json.loads(settings.read_text())
@@ -3152,7 +3351,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(tmp_path, MagicMock()).setup_hooks(fido_dir)
+        Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).setup_hooks(fido_dir)
         exclude = tmp_path / ".git" / "info" / "exclude"
         assert ".claude/settings.local.json" in exclude.read_text()
 
@@ -3162,7 +3363,9 @@ class TestTeardownHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         compact_cmd, sync_cmd = worker.setup_hooks(fido_dir)
         worker.teardown_hooks(fido_dir, compact_cmd, sync_cmd)
         assert not (fido_dir / "compact.sh").exists()
@@ -3173,7 +3376,9 @@ class TestTeardownHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         compact_cmd, sync_cmd = worker.setup_hooks(fido_dir)
         worker.teardown_hooks(fido_dir, compact_cmd, sync_cmd)
         settings = tmp_path / ".claude" / "settings.local.json"
@@ -3184,17 +3389,17 @@ class TestTeardownHooks:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         # Should not raise even when compact.sh does not exist
-        Worker(tmp_path, MagicMock()).teardown_hooks(
-            fido_dir, "bash /x/compact.sh", "bash sync.sh &"
-        )
+        Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).teardown_hooks(fido_dir, "bash /x/compact.sh", "bash sync.sh &")
 
     def test_noop_when_settings_missing(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / "fido"
         fido_dir.mkdir()
         # No settings file created — should not raise
-        Worker(tmp_path, MagicMock()).teardown_hooks(
-            fido_dir, "bash /x/compact.sh", "bash sync.sh &"
-        )
+        Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        ).teardown_hooks(fido_dir, "bash /x/compact.sh", "bash sync.sh &")
 
 
 class TestLoadState:
@@ -3919,7 +4124,9 @@ class TestGit:
 
     def test_calls_subprocess_run_with_git_prefix(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock())._git(["status"], _run=mock_run)
+        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+            ["status"], _run=mock_run
+        )
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
         assert args[0] == "git"
@@ -3927,29 +4134,37 @@ class TestGit:
 
     def test_passes_work_dir_as_cwd(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock())._git(["status"], _run=mock_run)
+        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+            ["status"], _run=mock_run
+        )
         assert mock_run.call_args[1]["cwd"] == tmp_path
 
     def test_check_true_by_default(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock())._git(["status"], _run=mock_run)
+        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+            ["status"], _run=mock_run
+        )
         assert mock_run.call_args[1]["check"] is True
 
     def test_check_false_propagated(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=1))
-        Worker(tmp_path, MagicMock())._git(["status"], check=False, _run=mock_run)
+        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+            ["status"], check=False, _run=mock_run
+        )
         assert mock_run.call_args[1]["check"] is False
 
     def test_propagates_called_process_error(self, tmp_path: Path) -> None:
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, "git"))
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(tmp_path, MagicMock())._git(
-                ["checkout", "no-such-branch"], _run=mock_run
-            )
+            Worker(
+                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            )._git(["checkout", "no-such-branch"], _run=mock_run)
 
     def test_capture_output_and_text_set(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock())._git(["log"], _run=mock_run)
+        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+            ["log"], _run=mock_run
+        )
         assert mock_run.call_args[1]["capture_output"] is True
         assert mock_run.call_args[1]["text"] is True
 
@@ -3978,7 +4193,9 @@ class TestGit:
                 )
             return success
 
-        result = Worker(tmp_path, MagicMock())._git(["add", "-A"], _run=_run)
+        result = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )._git(["add", "-A"], _run=_run)
         assert result is success
         assert len(calls) == 2
         assert not lock.exists()
@@ -3999,7 +4216,9 @@ class TestGit:
             )
         )
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(tmp_path, MagicMock())._git(["add", "-A"], _run=mock_run)
+            Worker(
+                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            )._git(["add", "-A"], _run=mock_run)
         assert lock.exists()
         assert mock_run.call_count == 1
 
@@ -4011,7 +4230,9 @@ class TestGit:
             )
         )
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(tmp_path, MagicMock())._git(["status"], _run=mock_run)
+            Worker(
+                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            )._git(["status"], _run=mock_run)
         assert mock_run.call_count == 1
 
 
@@ -4084,7 +4305,7 @@ class TestLocalBranchExists:
     """Tests for Worker._local_branch_exists (closes #828)."""
 
     def _worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def test_returns_true_on_exit_zero(self, tmp_path: Path) -> None:
         worker = self._worker(tmp_path)
@@ -4126,7 +4347,7 @@ class TestGitClean:
     """Tests for Worker.git_clean."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def _git_result(self, stdout: str = "") -> MagicMock:
         r = MagicMock()
@@ -4526,7 +4747,12 @@ class TestFindOrCreatePr:
         # retry-acknowledgement comment on every test.
         gh.find_closed_unmerged_prs_for_issue.return_value = []
         gh.find_closed_prs_as_context.return_value = []
-        return Worker(tmp_path, gh, provider_agent=provider_agent), gh
+        return Worker(
+            tmp_path,
+            gh,
+            provider_agent=provider_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        ), gh
 
     def _make_repo_ctx(
         self,
@@ -5281,7 +5507,16 @@ class TestFinalizeSetupWithNoTasks:
         gh = MagicMock()
         gh.get_issue_comments.return_value = []
         agent = _client(return_value=comment_text)
-        return Worker(tmp_path, gh, provider_agent=agent), gh, agent
+        return (
+            Worker(
+                tmp_path,
+                gh,
+                provider_agent=agent,
+                registry=MagicMock(spec=ActivityReporter),
+            ),
+            gh,
+            agent,
+        )
 
     def _make_repo_ctx(
         self, *, collaborators: frozenset[str] = frozenset({"rhencke"})
@@ -5377,7 +5612,12 @@ class TestResetLocalWorkspaceAndRetryAck:
         self, tmp_path: Path, provider_agent: MagicMock | None = None
     ) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh, provider_agent=provider_agent), gh
+        return Worker(
+            tmp_path,
+            gh,
+            provider_agent=provider_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        ), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -5615,7 +5855,7 @@ class TestSeedTasksFromPrBody:
 
     def _make_worker(self, tmp_path: Path) -> tuple["Worker", MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def _pr_with_queue(self, *task_titles: str, task_type: str = "spec") -> dict:
         lines = "\n".join(f"- [ ] {t} <!-- type:{task_type} -->" for t in task_titles)
@@ -5886,7 +6126,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "My task", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_seed = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -5920,7 +6160,12 @@ class TestRunSeedTasksIntegration:
             return 0
 
         def _run_once(first: bool) -> None:
-            worker = Worker(tmp_path, gh, first_iteration=first)
+            worker = Worker(
+                tmp_path,
+                gh,
+                first_iteration=first,
+                registry=MagicMock(spec=ActivityReporter),
+            )
             with (
                 patch.object(
                     worker, "create_context", return_value=self._make_mock_ctx(tmp_path)
@@ -5964,7 +6209,12 @@ class TestRunSeedTasksIntegration:
 
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, first_iteration=True)
+        worker = Worker(
+            tmp_path,
+            gh,
+            first_iteration=True,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(
@@ -6000,7 +6250,12 @@ class TestRunSeedTasksIntegration:
         avoid one superfluous API round-trip."""
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, first_iteration=True)
+        worker = Worker(
+            tmp_path,
+            gh,
+            first_iteration=True,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(
@@ -6026,7 +6281,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Done", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_seed = MagicMock()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -6059,7 +6314,7 @@ class TestRunSeedTasksIntegration:
         fido_dir.mkdir(parents=True)
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         # Persist initial state naming #201 as active.
         (fido_dir / "state.json").write_text(
             '{"issue": 201, "issue_title": "Parent", '
@@ -6107,7 +6362,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Leaf", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -6134,7 +6389,7 @@ class TestExtractRunId:
     """Tests for Worker._extract_run_id."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def test_extracts_id_from_standard_url(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
@@ -6164,7 +6419,7 @@ class TestFilterCiThreads:
     """Tests for Worker._filter_ci_threads."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def _make_node(
         self,
@@ -6332,7 +6587,7 @@ class TestHandleMergeConflict:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         gh.get_pr.return_value = {"mergeStateStatus": "DIRTY"}
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -6485,7 +6740,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_handle_mc = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -6512,7 +6767,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -6536,7 +6791,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         mock_ci = MagicMock(return_value=False)
         with (
@@ -6560,7 +6815,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         mock_mc = MagicMock(return_value=False)
         with (
@@ -6588,7 +6843,7 @@ class TestHandleCi:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -7047,7 +7302,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_handle_ci = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -7074,7 +7329,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -7097,7 +7352,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -7123,7 +7378,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Done", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_handle_ci = MagicMock(return_value=False)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -7151,7 +7406,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         call_order: list[str] = []
 
@@ -7187,7 +7442,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         mock_handle_ci = MagicMock(return_value=True)
 
@@ -7215,7 +7470,7 @@ class TestFilterThreads:
     """Tests for Worker._filter_threads."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def _make_node(
         self,
@@ -7449,6 +7704,7 @@ class TestResolveAddressedThreads:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
+                registry=MagicMock(spec=ActivityReporter),
             ),
             gh,
         )
@@ -7676,6 +7932,7 @@ class TestHandleThreads:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
+                registry=MagicMock(spec=ActivityReporter),
             ),
             gh,
         )
@@ -8130,7 +8387,12 @@ class TestHandleThreads:
     def test_requires_explicit_config_and_repo_cfg(self, tmp_path: Path) -> None:
         gh = MagicMock()
         gh.get_review_threads.return_value = [self._open_thread_node()]
-        worker = Worker(tmp_path, gh, issue_cache=MagicMock())
+        worker = Worker(
+            tmp_path,
+            gh,
+            issue_cache=MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with pytest.raises(
             RuntimeError, match="thread handling requires explicit config and repo_cfg"
         ):
@@ -8216,6 +8478,7 @@ class TestHandleQueuedComments:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
+                registry=MagicMock(spec=ActivityReporter),
             ),
             gh,
         )
@@ -8281,11 +8544,10 @@ class TestHandleQueuedComments:
         mock_reply.assert_called_once()
         # Regression #1336: registry must flow through to reply_to_issue_comment
         # so _BackgroundRescopeTrigger gets a real registry to call
-        # exit_untriaged on.  Worker._registry is None in this fixture, but the
-        # kwarg must still be present and equal to whatever Worker is holding.
-        kwargs = mock_reply.call_args.kwargs
-        assert "registry" in kwargs, "registry must be passed to reply_to_*"
-        assert kwargs["registry"] is worker._registry  # noqa: SLF001
+        # exit_untriaged on.  registry is the 5th positional arg.
+        args = mock_reply.call_args.args
+        assert len(args) >= 5, "registry must be passed positionally (5th arg)"
+        assert args[4] is worker._registry  # noqa: SLF001
         mock_create_task.assert_called_once()
         mock_sync.assert_called()
         store = FidoStore(tmp_path)
@@ -8460,7 +8722,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_threads = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -8485,7 +8747,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -8509,7 +8771,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -8671,11 +8933,19 @@ class TestRescopeBeforePick:
             sub_dir=tmp_path,
         )
         if with_config:
-            return Worker(tmp_path, MagicMock(), config=config, repo_cfg=cfg)
-        return Worker(tmp_path, MagicMock())
+            return Worker(
+                tmp_path,
+                MagicMock(),
+                config=config,
+                repo_cfg=cfg,
+                registry=MagicMock(spec=ActivityReporter),
+            )
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def test_skips_when_config_is_none(self, tmp_path: Path) -> None:
-        worker = Worker(tmp_path, MagicMock())
+        worker = Worker(
+            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+        )
         mock_tasks = MagicMock()
         mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
         worker._tasks = mock_tasks
@@ -8694,7 +8964,13 @@ class TestRescopeBeforePick:
             log_level="DEBUG",
             sub_dir=tmp_path,
         )
-        worker = Worker(tmp_path, MagicMock(), config=config, repo_cfg=None)
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            config=config,
+            repo_cfg=None,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         mock_tasks = MagicMock()
         mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
         worker._tasks = mock_tasks
@@ -8772,8 +9048,8 @@ class TestRescopeBeforePick:
             worker.rescope_before_pick()
         assert mock_reorder.call_args[0][1] == "abc123 first commit"
 
-    def test_no_inprogress_affected_callback(self, tmp_path: Path) -> None:
-        """Registry is passed as None so _on_inprogress_affected is not registered."""
+    def test_passes_registry_to_make_reorder_kwargs(self, tmp_path: Path) -> None:
+        """Registry is threaded through to _make_reorder_kwargs (#1336)."""
         worker = self._make_worker(tmp_path)
         mock_tasks = MagicMock()
         mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
@@ -8790,7 +9066,7 @@ class TestRescopeBeforePick:
             ),
         ):
             worker.rescope_before_pick()
-        assert captured_registry == [None]
+        assert captured_registry == [worker._registry]  # noqa: SLF001
 
     def test_calls_reorder_with_three_or_more_pending_tasks(
         self, tmp_path: Path
@@ -8841,7 +9117,7 @@ class TestRunRescopeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         mock_rescope = MagicMock()
         with (
@@ -8868,7 +9144,7 @@ class TestRunRescopeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         call_order: list[str] = []
 
@@ -8904,7 +9180,7 @@ class TestEnsurePushed:
     """Tests for Worker.ensure_pushed."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def _git_result(
         self, returncode: int = 0, stdout: str = "", stderr: str = ""
@@ -9016,7 +9292,7 @@ class TestSquashWipCommit:
     """Tests for Worker._squash_wip_commit."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock())
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
 
     def _ok(self, stdout: str = "") -> MagicMock:
         r = MagicMock()
@@ -9293,7 +9569,7 @@ class TestExecuteTask:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         gh.find_closed_prs_as_context.return_value = []
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -9903,7 +10179,12 @@ class TestExecuteTask:
             "planning-only, so I am marking it done and keeping this PR intact."
         )
         gh = MagicMock()
-        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider_agent=mock_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1, "current_task_id": "t1"})
         task = self._pending_task("Already done task")
@@ -10075,7 +10356,12 @@ class TestExecuteTask:
         mock_agent.supports_no_commit_reset = False
         gh = MagicMock()
         gh.find_closed_prs_as_context.return_value = []
-        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider_agent=mock_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = self._fido_dir(tmp_path)
         (fido_dir / "prompt").write_text("initial prompt")
         task = self._pending_task("Port to Python 3")
@@ -10132,7 +10418,12 @@ class TestExecuteTask:
         )
         gh = MagicMock()
         gh.find_closed_prs_as_context.return_value = []
-        worker = Worker(tmp_path, gh, provider_agent=mock_agent)
+        worker = Worker(
+            tmp_path,
+            gh,
+            provider_agent=mock_agent,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         fido_dir = self._fido_dir(tmp_path)
         (fido_dir / "prompt").write_text("initial prompt")
         task = self._pending_task("Add type hints")
@@ -10969,7 +11260,12 @@ class TestYieldForUntriaged:
     def test_no_op_when_registry_is_none(self, tmp_path: Path) -> None:
         """_yield_for_untriaged must not crash when _registry is None."""
         gh = MagicMock()
-        worker = Worker(tmp_path, gh, repo_name="owner/repo")
+        worker = Worker(
+            tmp_path,
+            gh,
+            repo_name="owner/repo",
+            registry=MagicMock(spec=ActivityReporter),
+        )
         worker._yield_for_untriaged()  # pyright: ignore[reportPrivateUsage]
 
     def test_no_op_when_inbox_empty(self, tmp_path: Path) -> None:
@@ -11168,6 +11464,22 @@ class _FakeActivityReporter:
     def assert_worker_turn_ok(self, repo_name: str) -> None:
         self.assert_calls.append(repo_name)
 
+    def enter_untriaged(self, repo_name: str) -> None:  # pragma: no cover — unused
+        _ = repo_name
+
+    def exit_untriaged(self, repo_name: str) -> None:  # pragma: no cover — unused
+        _ = repo_name
+
+    def set_rescoping(  # pragma: no cover — unused
+        self, repo_name: str, active: bool
+    ) -> None:
+        _ = (repo_name, active)
+
+    def abort_task(  # pragma: no cover — unused
+        self, repo_name: str, *, task_id: str
+    ) -> None:
+        _ = (repo_name, task_id)
+
 
 class TestAdmitWorkerTurn:
     """Tests for Worker._admit_worker_turn — the pre-provider gate."""
@@ -11351,7 +11663,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_execute = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -11378,7 +11690,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -11403,7 +11715,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_execute = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -11605,7 +11917,7 @@ class TestHandlePromoteMerge:
 
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def _repo_ctx(self, owner: str = "rhencke") -> RepoContext:
         return RepoContext(
@@ -13415,7 +13727,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_hpm = MagicMock(return_value=0)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -13443,7 +13755,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -13470,7 +13782,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -13497,7 +13809,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh)
+        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
         mock_hpm = MagicMock(return_value=0)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -14183,7 +14495,12 @@ class TestSyncTasksBackground:
 
 class TestWorkerThread:
     def _make_thread(self, tmp_path: Path) -> WorkerThread:
-        return WorkerThread(tmp_path, "owner/repo", MagicMock())
+        return WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+        )
 
     # ── constructor / attributes ──────────────────────────────────────────
 
@@ -14387,7 +14704,12 @@ class TestWorkerThread:
 
     def test_run_sets_thread_local_repo_name(self, tmp_path: Path) -> None:
         """WorkerThread.run() sets _thread_repo.repo_name to the short name."""
-        wt = WorkerThread(tmp_path, "owner/myrepo", MagicMock())
+        wt = WorkerThread(
+            tmp_path,
+            "owner/myrepo",
+            MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+        )
         wt._wake = MagicMock()
         captured: list[str] = []
 
@@ -14667,7 +14989,12 @@ class TestWorkerThread:
         """Session passed to WorkerThread constructor is used as the initial session."""
         mock_session = MagicMock()
         wt = WorkerThread(
-            tmp_path, "owner/repo", MagicMock(), session=mock_session, session_issue=7
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            session=mock_session,
+            session_issue=7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert wt.current_provider().agent.session is mock_session
         assert wt._session_issue == 7
@@ -14684,6 +15011,7 @@ class TestWorkerThread:
             provider=provider,
             session=session,
             session_issue=7,
+            registry=MagicMock(spec=ActivityReporter),
         )
         provider.agent.attach_session.assert_called_once_with(session)
         assert wt.current_provider() is provider
@@ -14693,7 +15021,13 @@ class TestWorkerThread:
     def test_detach_provider_returns_and_clears(self, tmp_path: Path) -> None:
         provider = MagicMock()
         provider.agent = MagicMock(spec=ClaudeClient)
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.detach_provider() is provider
         assert wt.current_provider() is None
 
@@ -14707,7 +15041,13 @@ class TestWorkerThread:
     def test_recover_provider_delegates_to_provider_agent(self, tmp_path: Path) -> None:
         provider = MagicMock()
         provider.agent.recover_session.return_value = True
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.recover_provider() is True
         provider.agent.recover_session.assert_called_once_with()
 
@@ -14777,7 +15117,13 @@ class TestWorkerThread:
     ) -> None:
         provider = MagicMock()
         provider.agent.session_dropped_count = 4
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.session_dropped_count == 4
 
     def test_session_sent_count_defaults_to_zero(self, tmp_path: Path) -> None:
@@ -14789,7 +15135,13 @@ class TestWorkerThread:
     ) -> None:
         provider = MagicMock()
         provider.agent.session_sent_count = 42
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.session_sent_count == 42
 
     def test_session_received_count_defaults_to_zero(self, tmp_path: Path) -> None:
@@ -14801,7 +15153,13 @@ class TestWorkerThread:
     ) -> None:
         provider = MagicMock()
         provider.agent.session_received_count = 38
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), provider=provider)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.session_received_count == 38
 
     def test_context_overflow_calls_retire_and_loops(self, tmp_path: Path) -> None:
@@ -14866,7 +15224,13 @@ class TestWorkerThread:
             log_level="DEBUG",
             sub_dir=tmp_path,
         )
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), config=config)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            config=config,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt._config is config
 
     def test_repo_cfg_stored_when_passed(self, tmp_path: Path) -> None:
@@ -14875,7 +15239,13 @@ class TestWorkerThread:
         cfg = RepoConfig(
             name="owner/repo", work_dir=tmp_path, provider=ProviderID.CLAUDE_CODE
         )
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=cfg)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            repo_cfg=cfg,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt._repo_cfg is cfg
 
     def test_repo_cfg_provider_selects_copilot_provider(self, tmp_path: Path) -> None:
@@ -14890,6 +15260,7 @@ class TestWorkerThread:
                 work_dir=tmp_path,
                 provider=ProviderID.COPILOT_CLI,
             ),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert wt._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
@@ -14907,6 +15278,7 @@ class TestWorkerThread:
                 provider=ProviderID.CODEX,
             ),
             issue_cache=MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert wt._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
@@ -14917,19 +15289,36 @@ class TestWorkerThread:
 
     def test_repo_cfg_defaults_to_none(self, tmp_path: Path) -> None:
         wt = WorkerThread(
-            tmp_path, "owner/repo", MagicMock(), repo_cfg=None, provider=MagicMock()
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            repo_cfg=None,
+            provider=MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
         )
         assert wt._repo_cfg is None
 
     def test_provider_defaults_to_none_when_repo_cfg_is_none(
         self, tmp_path: Path
     ) -> None:
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=None)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            repo_cfg=None,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.current_provider() is None
         assert wt._bootstrap_session is None  # pyright: ignore[reportPrivateUsage]
 
     def test_ensure_provider_requires_repo_cfg(self, tmp_path: Path) -> None:
-        wt = WorkerThread(tmp_path, "owner/repo", MagicMock(), repo_cfg=None)
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            repo_cfg=None,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         with pytest.raises(
             RuntimeError, match="worker thread provider requires explicit repo_cfg"
         ):
@@ -14951,7 +15340,12 @@ class TestWorkerThread:
             sub_dir=tmp_path,
         )
         wt = WorkerThread(
-            tmp_path, "owner/repo", MagicMock(), config=config, repo_cfg=cfg
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            config=config,
+            repo_cfg=cfg,
+            registry=MagicMock(spec=ActivityReporter),
         )
         wt._wake = MagicMock()
         received_config: list = []
@@ -15037,7 +15431,7 @@ class TestLeakedCommentCleanup:
 
     def _worker_with_gh(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh), gh
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
 
     def test_snapshot_returns_only_fido_ids(self, tmp_path: Path) -> None:
         worker, gh = self._worker_with_gh(tmp_path)


### PR DESCRIPTION
Closes #1336, #1337, #1335.  Insight filed: #1339.

Three intertwined bugs from a single vet cycle, fixed together because they share a code path.  PR upgraded to A-grade with full registry-required contract through the rescope chain.

## Summary

- **#1336** — \`Worker._reply_to_queued_comment\` / \`Worker.handle_threads\` / \`recover_reply_promises\` did not thread \`registry=\` to \`events.reply_to_*\`.  \`None\` flowed through \`_BackgroundRescopeTrigger\` into \`_reorder_tasks_background\`'s \`run_loop\` closure.  When \`create_task\` later coalesced a rescope (correctly bumping \`untriaged_holds\` and calling \`enter_untriaged\`), the BG's finally had \`registry=None\` from its closure, the \`if registry is not None\` guard skipped the matching \`exit_untriaged\` calls, and the misleading \`released N untriaged hold(s)\` log fired anyway.  Inbox stayed at 1 forever; \`wait_for_inbox_drain\` parked the home worker for 14 hours.

- **#1335** — PR #1328's body had no \`---\` divider.  \`_write_pr_description\` required one and raised \`ValueError\`, killing the rescope's \`_on_done\` callback.

- **#1337** — When a \`thread\` task is added during an Opus call, Opus emits a null-id rewrite of the same intent → parser promotes it to a duplicate spec task.

## Fixes

- **#1336**: \`registry: ActivityReporter\` is now **required positionally** throughout the rescope chain.  No more Optional fail-soft — pyright catches a missing kwarg at the call site.  Caught two latent missing-arg bugs along the way in \`server.py\`.

- **#1335**: \`_write_pr_description\` self-heals divider-less bodies.

- **#1337**: \`prompts.py\` rescope_prompt adds rule #6 telling Opus to keep existing pending tasks; parser-side dedup remains as safety net.

## Test plan

- [x] \`./fido ci\` — 3864 passed, 100% coverage.
- [x] Integration test for #1336 simulates the actual race.
- [ ] Live verification on FidoCanCode/home after restart.

Insight: #1339 — Optional collaborator parameters chain into silent fail-soft.