### PR TITLE
Bug: lockfree status PR 1/6 — introduce RegistrySnapshot + AtomicReference primitive, migrate started_at to validate pattern (closes #1343)

### DIFF
--- a/pyproject.project.toml
+++ b/pyproject.project.toml
@@ -5,6 +5,7 @@ description = "GitHub webhook listener for Fido"
 requires-python = ">=3.14"
 dependencies = [
   "agent-client-protocol>=0.9.0",
+  "frozendict>=2.4.7",
   "requests",
 ]
 

--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -14,6 +14,8 @@ import threading
 from collections.abc import Callable
 from typing import Generic, TypeVar
 
+from fido.lens import Lens
+
 _T = TypeVar("_T")
 
 
@@ -94,3 +96,26 @@ class AtomicReference(Generic[_T]):
             success, old = self.compare_and_set(old, new)
             if success:
                 return new
+
+    def lens_update(
+        self,
+        selector: "Callable[[Lens[_T]], Lens[_T]]",
+        value: object,
+    ) -> _T:
+        """Install *value* at the path described by *selector* atomically.
+
+        *selector* receives a :class:`~fido.lens.Lens`-wrapped root and
+        returns a navigated :class:`~fido.lens.Lens` pointing at the target
+        field.  *value* is installed there; the reconstructed root is CAS'd
+        into the reference with automatic retry::
+
+            ref.lens_update(
+                lambda root: root.repos[name],
+                new_repo_state,
+            )
+
+        *selector* must be a pure function — the retry loop may call it
+        more than once under write contention.  Returns the reconstructed
+        root value that was successfully installed.
+        """
+        return self.update(lambda old: selector(Lens(old)).set(value))  # type: ignore[return-value]

--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -1,0 +1,89 @@
+"""AtomicReference[T] — single-lock pointer-swap primitive for lock-free reads.
+
+Writers hold ``_lock`` for the duration of the pointer swap so concurrent
+writes are serialized and no update is lost.  Readers call :meth:`get`
+without acquiring any lock — a single object-reference load is atomic on all
+CPython-supported architectures, including the free-threaded (no-GIL) build.
+
+``T`` should be an immutable value (frozen dataclass, namedtuple, ``None``,
+etc.) so that readers who hold a reference to the snapshot can inspect all
+fields without encountering races inside the value itself.
+"""
+
+import threading
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+class AtomicReference(Generic[_T]):
+    """A reference cell whose pointer swap is serialized by a single lock.
+
+    Readers are observationally lock-free — :meth:`get` is a bare attribute
+    read with no lock acquire.  Writers hold the internal ``_lock`` only for
+    the atomic swap, keeping write-side latency minimal.
+
+    The typical usage pattern is *update with retry*::
+
+        ref = AtomicReference(initial_snapshot)
+
+        def bump(old: Snapshot) -> Snapshot:
+            return replace(old, counter=old.counter + 1)
+
+        ref.update(bump)  # retries automatically if a concurrent writer raced
+
+    ``fn`` passed to :meth:`update` must be a **pure function** — the retry
+    loop may call it more than once under write contention.
+    """
+
+    def __init__(self, initial: _T) -> None:
+        self._value: _T = initial
+        self._lock = threading.Lock()
+
+    def get(self) -> _T:
+        """Return the current value.  Lock-free; safe to call from any thread."""
+        return self._value
+
+    def set(self, value: _T) -> None:
+        """Unconditionally replace the stored reference.
+
+        Serialized by the internal lock so concurrent :meth:`set` and
+        :meth:`compare_and_set` calls never interleave.
+        """
+        with self._lock:
+            self._value = value
+
+    def compare_and_set(self, expected: _T, new_value: _T) -> bool:
+        """Swap to *new_value* only if the current reference **is** *expected*.
+
+        Uses identity (``is``) rather than equality (``==``) for the check —
+        the comparison is always O(1) and unambiguous regardless of how ``_T``
+        defines ``__eq__``.
+
+        Returns ``True`` on success, ``False`` when the current value is not
+        *expected* (indicating a concurrent write raced ahead).
+        """
+        with self._lock:
+            if self._value is not expected:
+                return False
+            self._value = new_value
+            return True
+
+    def update(self, fn: Callable[[_T], _T]) -> _T:
+        """Apply *fn* to the current value and install the result atomically.
+
+        Reads the current reference, calls ``fn(current)`` to produce the
+        next value, then attempts a compare-and-set.  If a concurrent writer
+        changed the reference first, the loop retries with the new current.
+
+        Returns the value that was successfully installed.
+
+        ``fn`` must be a pure function — it may be called more than once
+        under write contention.
+        """
+        while True:
+            old = self.get()
+            new = fn(old)
+            if self.compare_and_set(old, new):
+                return new

--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -54,36 +54,43 @@ class AtomicReference(Generic[_T]):
         with self._lock:
             self._value = value
 
-    def compare_and_set(self, expected: _T, new_value: _T) -> bool:
+    def compare_and_set(self, expected: _T, new_value: _T) -> tuple[bool, _T]:
         """Swap to *new_value* only if the current reference **is** *expected*.
 
         Uses identity (``is``) rather than equality (``==``) for the check —
         the comparison is always O(1) and unambiguous regardless of how ``_T``
         defines ``__eq__``.
 
-        Returns ``True`` on success, ``False`` when the current value is not
-        *expected* (indicating a concurrent write raced ahead).
+        Returns a ``(success, value)`` tuple:
+
+        - On success: ``(True, new_value)`` — the swap happened.
+        - On failure: ``(False, current)`` — the current reference at the
+          moment of rejection.  Callers (e.g. :meth:`update`) can feed
+          ``current`` straight into the next attempt without an extra
+          :meth:`get` round-trip.
         """
         with self._lock:
             if self._value is not expected:
-                return False
+                return False, self._value
             self._value = new_value
-            return True
+            return True, new_value
 
     def update(self, fn: Callable[[_T], _T]) -> _T:
         """Apply *fn* to the current value and install the result atomically.
 
         Reads the current reference, calls ``fn(current)`` to produce the
         next value, then attempts a compare-and-set.  If a concurrent writer
-        changed the reference first, the loop retries with the new current.
+        changed the reference first, the loop retries — using the value
+        returned by the failed CAS directly, without an extra :meth:`get`.
 
         Returns the value that was successfully installed.
 
         ``fn`` must be a pure function — it may be called more than once
         under write contention.
         """
+        old = self.get()
         while True:
-            old = self.get()
             new = fn(old)
-            if self.compare_and_set(old, new):
+            success, old = self.compare_and_set(old, new)
+            if success:
                 return new

--- a/src/fido/lens.py
+++ b/src/fido/lens.py
@@ -1,0 +1,97 @@
+"""Lens — path-recording updater for frozen dataclass trees.
+
+A :class:`Lens` wraps a frozen root value, records attribute and item
+accesses as the caller navigates into nested structure, then reconstructs
+the entire path of frozen copies when :meth:`~Lens.set` is called with
+the new leaf value.
+
+Frozen dataclass nodes are reconstructed via :func:`dataclasses.replace`.
+Frozen mapping nodes (e.g. :class:`frozendict.frozendict`) are
+reconstructed via ``type(parent)({**parent, key: new_value})``.
+
+Typical usage with :class:`~fido.atomic.AtomicReference`::
+
+    ref.update(lambda root: Lens(root).repos[name].set(new_repo_state))
+"""
+
+import dataclasses
+from typing import Any, Generic, TypeVar
+
+_R = TypeVar("_R")
+
+# Step kinds stored in the path tuple.
+_ATTR = "attr"
+_ITEM = "item"
+
+
+class Lens(Generic[_R]):
+    """Path-recording proxy for functional updates to frozen dataclass trees.
+
+    Each ``.attr`` or ``[key]`` access appends a step to the internal path
+    without touching the original structure.  :meth:`set` walks the path
+    forward to collect intermediate values, then backwards to produce
+    updated frozen copies at every level — returning a new root of the
+    same type.
+
+    The proxy is deliberately minimal: ``__getattr__`` records attribute
+    steps, ``__getitem__`` records key steps, and ``set`` is the only
+    terminal operation.  This means a field literally named ``set`` on a
+    target dataclass would shadow the method — acceptable for this
+    codebase, where no frozen dataclass has such a field.
+    """
+
+    __slots__ = ("_root", "_path")
+
+    def __init__(self, root: _R, _path: tuple[tuple[str, object], ...] = ()) -> None:
+        self._root = root
+        self._path = _path
+
+    def __getattr__(self, name: str) -> "Lens[_R]":
+        return Lens(self._root, self._path + ((_ATTR, name),))
+
+    def __getitem__(self, key: object) -> "Lens[_R]":
+        return Lens(self._root, self._path + ((_ITEM, key),))
+
+    def set(self, value: object) -> _R:
+        """Return a new root with *value* installed at the recorded path.
+
+        Walks the recorded path forward to collect the intermediate values
+        from the current root, then backwards — using
+        :func:`dataclasses.replace` for dataclass nodes and mapping
+        reconstruction for item-accessed nodes — to produce the updated
+        root.
+        """
+        if not self._path:
+            return value  # type: ignore[return-value]
+
+        # Forward pass: collect the value at each ancestor level.
+        # The traversal is inherently dynamically typed — we walk through
+        # dataclass attrs and mapping items whose types aren't known
+        # statically.  Any is confined to these locals; the public API
+        # uses object for parameters and _R for the return type.
+        #
+        # We stop one step short of the leaf: the backward pass at step i
+        # uses intermediates[i] as the parent to reconstruct, so we need
+        # intermediates[0..n-1] (the root through the second-to-last
+        # step's value).  The leaf value itself is never read — we're
+        # replacing it — so the key may not exist yet (insert case).
+        current: Any = self._root
+        intermediates: list[Any] = [current]
+        for kind, key in self._path[:-1]:
+            if kind == _ATTR:
+                current = getattr(current, key)  # type: ignore[arg-type]  # key is str for attr steps
+            else:
+                current = current[key]
+            intermediates.append(current)
+
+        # Backward pass: reconstruct frozen copies from leaf to root.
+        result: Any = value
+        for i in range(len(self._path) - 1, -1, -1):
+            kind, key = self._path[i]
+            parent = intermediates[i]
+            if kind == _ATTR:
+                result = dataclasses.replace(parent, **{key: result})  # type: ignore[arg-type]  # key is str for attr steps
+            else:
+                result = type(parent)({**parent, key: result})
+
+        return result  # type: ignore[return-value]

--- a/src/fido/lens.py
+++ b/src/fido/lens.py
@@ -11,7 +11,7 @@ reconstructed via ``type(parent)({**parent, key: new_value})``.
 
 Typical usage with :class:`~fido.atomic.AtomicReference`::
 
-    ref.update(lambda root: Lens(root).repos[name].set(new_repo_state))
+    ref.lens_update(lambda root: root.repos[name], new_repo_state)
 """
 
 import dataclasses

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -2,11 +2,13 @@
 
 import logging
 import threading
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
+from frozendict import frozendict
 
 from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
@@ -29,13 +31,33 @@ def _utcnow() -> datetime:
 
 
 @dataclass(frozen=True)
+class RepoState:
+    """Per-repo sub-snapshot within :class:`FidoState`.
+
+    *key* is the repo slug (e.g. ``"rhencke/confusio"``), matching the key
+    under which this record is stored in :attr:`FidoState.repos`.
+
+    *started_at* is the UTC timestamp when the most recent
+    :class:`~fido.worker.WorkerThread` for this repo was started.
+
+    As subsequent lock-free PRs migrate fields out of the per-lock dicts in
+    :class:`WorkerRegistry`, those fields grow here (e.g. ``activity``,
+    ``crash_record``, ``rescoping``).  Each migration removes the
+    corresponding lock and dict from ``WorkerRegistry.__init__``.
+    """
+
+    key: str
+    started_at: datetime
+
+
+@dataclass(frozen=True)
 class FidoState:
     """Atomically-swapped coordination snapshot owned by :class:`WorkerRegistry`.
 
-    ``started_at_by_repo`` maps each repo name to the UTC timestamp when
-    its most recent :class:`~fido.worker.WorkerThread` was started.  It is
-    populated once per thread boot and never mutated — making it a natural
-    fit for the single-lock CAS pattern in :class:`~fido.atomic.AtomicReference`.
+    ``repos`` maps each repo slug to its :class:`RepoState` snapshot.  It is
+    a :class:`frozendict` so stale readers that hold a reference to an old
+    snapshot can never accidentally mutate the mapping — the immutability
+    guarantee holds even on the free-threaded (no-GIL) build.
 
     **Convergence target**: ``FidoState`` is intended to grow to cover all
     coordination fields currently scattered across the per-lock dicts in
@@ -52,10 +74,10 @@ class FidoState:
     everything that ``./fido status`` currently shows.
     """
 
-    started_at_by_repo: Mapping[str, datetime]
+    repos: frozendict[str, RepoState]
 
 
-_EMPTY_FIDO_STATE = FidoState(started_at_by_repo={})
+_EMPTY_FIDO_STATE = FidoState(repos=frozendict())
 
 
 @dataclass
@@ -260,7 +282,9 @@ class WorkerRegistry:
         _now = _utcnow()
         self._state.update(
             lambda old: FidoState(
-                started_at_by_repo={**old.started_at_by_repo, _name: _now}
+                repos=frozendict(
+                    {**old.repos, _name: RepoState(key=_name, started_at=_now)}
+                )
             )
         )
         thread.start()
@@ -272,7 +296,8 @@ class WorkerRegistry:
         Lock-free: reads from the current :class:`FidoState` snapshot without
         acquiring any lock.
         """
-        return self._state.get().started_at_by_repo.get(repo_name)
+        repo_state = self._state.get().repos.get(repo_name)
+        return repo_state.started_at if repo_state is not None else None
 
     def wake(self, repo_name: str) -> None:
         """Wake the thread for *repo_name* so it checks for work immediately.

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -14,7 +14,6 @@ from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
-from fido.lens import Lens
 from fido.provider import PromptSession, Provider
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -281,10 +280,9 @@ class WorkerRegistry:
             self._threads[repo_cfg.name] = thread
         _name = repo_cfg.name
         _now = _utcnow()
-        self._state.update(
-            lambda root: (
-                Lens(root).repos[_name].set(RepoState(key=_name, started_at=_now))
-            )
+        self._state.lens_update(
+            lambda root: root.repos[_name],
+            RepoState(key=_name, started_at=_now),
         )
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -2,12 +2,13 @@
 
 import logging
 import threading
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
@@ -25,6 +26,36 @@ log = logging.getLogger(__name__)
 def _utcnow() -> datetime:
     """Return the current UTC time as a timezone-aware datetime."""
     return datetime.now(tz=timezone.utc)
+
+
+@dataclass(frozen=True)
+class FidoState:
+    """Atomically-swapped coordination snapshot owned by :class:`WorkerRegistry`.
+
+    ``started_at_by_repo`` maps each repo name to the UTC timestamp when
+    its most recent :class:`~fido.worker.WorkerThread` was started.  It is
+    populated once per thread boot and never mutated — making it a natural
+    fit for the single-lock CAS pattern in :class:`~fido.atomic.AtomicReference`.
+
+    **Convergence target**: ``FidoState`` is intended to grow to cover all
+    coordination fields currently scattered across the per-lock dicts in
+    :class:`WorkerRegistry` (worker activities, crash records, webhook
+    activities, rescoping flags, …).  As each field migrates here, the
+    corresponding lock disappears.
+
+    **Replaces FidoStatus long-term**: :class:`~fido.status.FidoStatus` in
+    ``status.py`` is a display-oriented dataclass shaped by the old
+    ``/status.json`` schema.  The end-state is to serialise ``FidoState``
+    directly to JSON — even where that changes the wire format — and retire
+    ``FidoStatus``.  The ``./fido status`` CLI output serves as the living
+    requirement: whatever ``FidoState`` carries must be sufficient to render
+    everything that ``./fido status`` currently shows.
+    """
+
+    started_at_by_repo: Mapping[str, datetime]
+
+
+_EMPTY_FIDO_STATE = FidoState(started_at_by_repo={})
 
 
 @dataclass
@@ -109,8 +140,10 @@ class WorkerRegistry:
         self._status_lock = threading.Lock()
         self._crashes: dict[str, WorkerCrash] = {}
         self._crash_lock = threading.Lock()
-        self._started_at: dict[str, datetime] = {}
-        self._started_at_lock = threading.Lock()
+        # _state holds the atomically-swapped FidoState snapshot.  Writers
+        # call AtomicReference.update() under the single internal lock; readers
+        # call AtomicReference.get() without any lock (observationally lock-free).
+        self._state: AtomicReference[FidoState] = AtomicReference(_EMPTY_FIDO_STATE)
         self._webhook_activities: dict[str, list[WebhookActivity]] = {}
         self._webhook_lock = threading.Lock()
         self._rescoping: dict[str, bool] = {}
@@ -223,15 +256,23 @@ class WorkerRegistry:
         thread = self._factory(repo_cfg, provider=provider, session_issue=session_issue)
         with self._threads_lock:
             self._threads[repo_cfg.name] = thread
-        with self._started_at_lock:
-            self._started_at[repo_cfg.name] = _utcnow()
+        _name = repo_cfg.name
+        _now = _utcnow()
+        self._state.update(
+            lambda old: FidoState(
+                started_at_by_repo={**old.started_at_by_repo, _name: _now}
+            )
+        )
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)
 
     def thread_started_at(self, repo_name: str) -> datetime | None:
-        """Return when the worker thread for *repo_name* was started, or None."""
-        with self._started_at_lock:
-            return self._started_at.get(repo_name)
+        """Return when the worker thread for *repo_name* was started, or None.
+
+        Lock-free: reads from the current :class:`FidoState` snapshot without
+        acquiring any lock.
+        """
+        return self._state.get().started_at_by_repo.get(repo_name)
 
     def wake(self, repo_name: str) -> None:
         """Wake the thread for *repo_name* so it checks for work immediately.

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -14,6 +14,7 @@ from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
+from fido.lens import Lens
 from fido.provider import PromptSession, Provider
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -281,10 +282,8 @@ class WorkerRegistry:
         _name = repo_cfg.name
         _now = _utcnow()
         self._state.update(
-            lambda old: FidoState(
-                repos=frozendict(
-                    {**old.repos, _name: RepoState(key=_name, started_at=_now)}
-                )
+            lambda root: (
+                Lens(root).repos[_name].set(RepoState(key=_name, started_at=_now))
             )
         )
         thread.start()

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -3,7 +3,10 @@
 import threading
 from dataclasses import dataclass
 
+from frozendict import frozendict
+
 from fido.atomic import AtomicReference
+from fido.lens import Lens
 
 
 @dataclass(frozen=True)
@@ -131,3 +134,61 @@ class TestAtomicReferenceUpdate:
             t.join()
 
         assert ref.get() == _State(n_threads * increments_per_thread)
+
+
+@dataclass(frozen=True)
+class _Item:
+    val: int
+
+
+@dataclass(frozen=True)
+class _Container:
+    items: frozendict[str, _Item]
+
+
+class TestAtomicReferenceLensUpdate:
+    def test_installs_value_at_path(self) -> None:
+        state = _Container(items=frozendict({"a": _Item(1)}))
+        ref: AtomicReference[_Container] = AtomicReference(state)
+        new_item = _Item(99)
+        result = ref.lens_update(lambda root: root.items["a"], new_item)
+        assert result.items["a"] is new_item
+        assert ref.get().items["a"] is new_item
+
+    def test_inserts_new_key(self) -> None:
+        ref: AtomicReference[_Container] = AtomicReference(
+            _Container(items=frozendict())
+        )
+        new_item = _Item(7)
+        ref.lens_update(lambda root: root.items["new"], new_item)
+        assert ref.get().items["new"] is new_item
+
+    def test_returns_installed_root(self) -> None:
+        ref: AtomicReference[_Container] = AtomicReference(
+            _Container(items=frozendict({"x": _Item(0)}))
+        )
+        result = ref.lens_update(lambda root: root.items["x"], _Item(5))
+        assert result is ref.get()
+
+    def test_selector_receives_lens(self) -> None:
+        """selector is called with a Lens, not the raw value."""
+        received: list[object] = []
+
+        def selector(root: Lens[_Container]) -> Lens[_Container]:
+            received.append(root)
+            return root.items["a"]
+
+        ref: AtomicReference[_Container] = AtomicReference(
+            _Container(items=frozendict({"a": _Item(1)}))
+        )
+        ref.lens_update(selector, _Item(2))
+        assert isinstance(received[0], Lens)
+
+    def test_preserves_sibling_keys(self) -> None:
+        a = _Item(1)
+        b = _Item(2)
+        ref: AtomicReference[_Container] = AtomicReference(
+            _Container(items=frozendict({"a": a, "b": b}))
+        )
+        ref.lens_update(lambda root: root.items["a"], _Item(99))
+        assert ref.get().items["b"] is b

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,0 +1,125 @@
+"""Tests for fido.atomic — AtomicReference[T] primitive."""
+
+import threading
+from dataclasses import dataclass
+
+from fido.atomic import AtomicReference
+
+
+@dataclass(frozen=True)
+class _State:
+    n: int
+
+
+class TestAtomicReferenceGet:
+    def test_get_returns_initial_value(self) -> None:
+        ref: AtomicReference[int] = AtomicReference(42)
+        assert ref.get() == 42
+
+    def test_get_returns_same_object(self) -> None:
+        obj = object()
+        ref: AtomicReference[object] = AtomicReference(obj)
+        assert ref.get() is obj
+
+
+class TestAtomicReferenceSet:
+    def test_set_replaces_value(self) -> None:
+        ref: AtomicReference[int] = AtomicReference(1)
+        ref.set(99)
+        assert ref.get() == 99
+
+    def test_set_replaces_with_new_object(self) -> None:
+        a = _State(0)
+        b = _State(1)
+        ref: AtomicReference[_State] = AtomicReference(a)
+        ref.set(b)
+        assert ref.get() is b
+
+
+class TestAtomicReferenceCompareAndSet:
+    def test_succeeds_when_expected_matches(self) -> None:
+        a = _State(0)
+        b = _State(1)
+        ref: AtomicReference[_State] = AtomicReference(a)
+        assert ref.compare_and_set(a, b) is True
+        assert ref.get() is b
+
+    def test_fails_when_expected_differs(self) -> None:
+        a = _State(0)
+        other = _State(0)  # equal value, different identity
+        b = _State(1)
+        ref: AtomicReference[_State] = AtomicReference(a)
+        assert ref.compare_and_set(other, b) is False
+        assert ref.get() is a  # unchanged
+
+    def test_uses_identity_not_equality(self) -> None:
+        # Two equal tuples — CAS should fail because they are distinct objects.
+        # Use tuple() at runtime to avoid CPython constant-folding identical
+        # literals to the same object.
+        x: tuple[int, ...] = tuple(range(3))
+        y: tuple[int, ...] = tuple(range(3))
+        assert x == y
+        assert x is not y  # distinct objects despite equal values
+        new: tuple[int, ...] = tuple(range(4, 7))
+        ref: AtomicReference[tuple[int, ...]] = AtomicReference(x)
+        assert ref.compare_and_set(y, new) is False
+        assert ref.get() is x
+
+    def test_leaves_value_unchanged_on_failure(self) -> None:
+        a = _State(10)
+        wrong = _State(99)
+        new = _State(20)
+        ref: AtomicReference[_State] = AtomicReference(a)
+        ref.compare_and_set(wrong, new)
+        assert ref.get() is a
+
+
+class TestAtomicReferenceUpdate:
+    def test_applies_function_to_current_value(self) -> None:
+        ref: AtomicReference[_State] = AtomicReference(_State(10))
+        result = ref.update(lambda s: _State(s.n + 5))
+        assert result == _State(15)
+        assert ref.get() == _State(15)
+
+    def test_returns_installed_value(self) -> None:
+        ref: AtomicReference[_State] = AtomicReference(_State(0))
+        installed = ref.update(lambda s: _State(s.n + 1))
+        assert installed is ref.get()
+
+    def test_retries_after_concurrent_modification(self) -> None:
+        """update() retries when a writer sneaks in between get() and CAS."""
+        ref: AtomicReference[_State] = AtomicReference(_State(0))
+        injected = [False]
+
+        def fn(s: _State) -> _State:
+            if not injected[0]:
+                injected[0] = True
+                # Race: overwrite the ref before update() can CAS.
+                ref.set(_State(100))
+            return _State(s.n + 1)
+
+        result = ref.update(fn)
+        # Iteration 1: s=State(0), ref sneaked to State(100), returns State(1).
+        #   CAS(State(0), State(1)) fails — identities differ.
+        # Iteration 2: s=State(100), returns State(101).
+        #   CAS(State(100), State(101)) succeeds.
+        assert result == _State(101)
+        assert ref.get() == _State(101)
+
+    def test_concurrent_updates_all_applied(self) -> None:
+        """Many concurrent update() calls; no increments are lost."""
+        ref: AtomicReference[_State] = AtomicReference(_State(0))
+        n_threads = 20
+        increments_per_thread = 50
+
+        def run() -> None:
+            for _ in range(increments_per_thread):
+                ref.update(lambda s: _State(s.n + 1))
+
+        threads = [threading.Thread(target=run) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert ref.get() == _State(n_threads * increments_per_thread)

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -41,7 +41,9 @@ class TestAtomicReferenceCompareAndSet:
         a = _State(0)
         b = _State(1)
         ref: AtomicReference[_State] = AtomicReference(a)
-        assert ref.compare_and_set(a, b) is True
+        success, value = ref.compare_and_set(a, b)
+        assert success is True
+        assert value is b
         assert ref.get() is b
 
     def test_fails_when_expected_differs(self) -> None:
@@ -49,7 +51,9 @@ class TestAtomicReferenceCompareAndSet:
         other = _State(0)  # equal value, different identity
         b = _State(1)
         ref: AtomicReference[_State] = AtomicReference(a)
-        assert ref.compare_and_set(other, b) is False
+        success, current = ref.compare_and_set(other, b)
+        assert success is False
+        assert current is a  # returned current reference, not the rejected new value
         assert ref.get() is a  # unchanged
 
     def test_uses_identity_not_equality(self) -> None:
@@ -62,7 +66,9 @@ class TestAtomicReferenceCompareAndSet:
         assert x is not y  # distinct objects despite equal values
         new: tuple[int, ...] = tuple(range(4, 7))
         ref: AtomicReference[tuple[int, ...]] = AtomicReference(x)
-        assert ref.compare_and_set(y, new) is False
+        success, current = ref.compare_and_set(y, new)
+        assert success is False
+        assert current is x  # returned the actual current reference
         assert ref.get() is x
 
     def test_leaves_value_unchanged_on_failure(self) -> None:
@@ -70,7 +76,9 @@ class TestAtomicReferenceCompareAndSet:
         wrong = _State(99)
         new = _State(20)
         ref: AtomicReference[_State] = AtomicReference(a)
-        ref.compare_and_set(wrong, new)
+        success, current = ref.compare_and_set(wrong, new)
+        assert success is False
+        assert current is a
         assert ref.get() is a
 
 

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -1,0 +1,150 @@
+"""Tests for fido.lens — path-recording updater for frozen dataclass trees."""
+
+from dataclasses import dataclass
+
+from frozendict import frozendict
+
+from fido.lens import Lens
+
+# ── test fixtures ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Inner:
+    value: int
+
+
+@dataclass(frozen=True)
+class Middle:
+    items: frozendict[str, Inner]
+
+
+@dataclass(frozen=True)
+class Root:
+    middle: Middle
+    label: str
+
+
+def _sample_root() -> Root:
+    return Root(
+        middle=Middle(
+            items=frozendict({"a": Inner(1), "b": Inner(2)}),
+        ),
+        label="original",
+    )
+
+
+# ── single-level attribute ───────────────────────────────────────────────
+
+
+class TestLensSingleAttribute:
+    def test_set_attribute(self) -> None:
+        root = _sample_root()
+        result = Lens(root).label.set("changed")
+        assert result.label == "changed"
+        assert result.middle is root.middle  # untouched subtree is shared
+
+    def test_original_unchanged(self) -> None:
+        root = _sample_root()
+        Lens(root).label.set("changed")
+        assert root.label == "original"
+
+
+# ── single-level item ───────────────────────────────────────────────────
+
+
+class TestLensSingleItem:
+    def test_set_existing_item(self) -> None:
+        root = _sample_root()
+        result = Lens(root).middle.items["a"].set(Inner(99))
+        assert result.middle.items["a"] == Inner(99)
+        assert result.middle.items["b"] is root.middle.items["b"]
+
+    def test_set_new_item(self) -> None:
+        root = _sample_root()
+        result = Lens(root).middle.items["c"].set(Inner(3))
+        assert result.middle.items["c"] == Inner(3)
+        assert len(result.middle.items) == 3
+        # Existing entries preserved.
+        assert result.middle.items["a"] is root.middle.items["a"]
+
+
+# ── deep navigation ─────────────────────────────────────────────────────
+
+
+class TestLensDeepNavigation:
+    def test_attr_item_attr(self) -> None:
+        """Navigate attr → item → attr through the full tree."""
+        root = _sample_root()
+        result = Lens(root).middle.items["a"].value.set(42)
+        assert result.middle.items["a"].value == 42
+        assert result.label == "original"
+        assert result.middle.items["b"] is root.middle.items["b"]
+
+    def test_preserves_frozendict_type(self) -> None:
+        root = _sample_root()
+        result = Lens(root).middle.items["a"].set(Inner(10))
+        assert type(result.middle.items) is frozendict
+
+
+# ── empty path ───────────────────────────────────────────────────────────
+
+
+class TestLensEmptyPath:
+    def test_set_at_root(self) -> None:
+        root = _sample_root()
+        replacement = Root(
+            middle=Middle(items=frozendict({})),
+            label="replaced",
+        )
+        result = Lens(root).set(replacement)
+        assert result is replacement
+
+
+# ── FidoState-shaped usage ───────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RepoState:
+    key: str
+    started_at: str  # simplified for test
+
+
+@dataclass(frozen=True)
+class FidoState:
+    repos: frozendict[str, RepoState]
+
+
+class TestLensFidoStatePattern:
+    """Mirrors the actual registry.py update pattern."""
+
+    def test_insert_repo(self) -> None:
+        state = FidoState(repos=frozendict())
+        new_repo = RepoState(key="owner/repo", started_at="now")
+        result = Lens(state).repos["owner/repo"].set(new_repo)
+        assert result.repos["owner/repo"] is new_repo
+
+    def test_update_existing_repo(self) -> None:
+        old_repo = RepoState(key="owner/repo", started_at="then")
+        state = FidoState(repos=frozendict({"owner/repo": old_repo}))
+        new_repo = RepoState(key="owner/repo", started_at="now")
+        result = Lens(state).repos["owner/repo"].set(new_repo)
+        assert result.repos["owner/repo"] is new_repo
+
+    def test_update_preserves_sibling_repos(self) -> None:
+        a = RepoState(key="a/a", started_at="t1")
+        b = RepoState(key="b/b", started_at="t2")
+        state = FidoState(repos=frozendict({"a/a": a, "b/b": b}))
+        new_a = RepoState(key="a/a", started_at="t3")
+        result = Lens(state).repos["a/a"].set(new_a)
+        assert result.repos["a/a"] is new_a
+        assert result.repos["b/b"] is b
+
+    def test_with_atomic_reference_update(self) -> None:
+        """End-to-end: Lens inside AtomicReference.update()."""
+        from fido.atomic import AtomicReference
+
+        ref: AtomicReference[FidoState] = AtomicReference(FidoState(repos=frozendict()))
+        new_repo = RepoState(key="owner/repo", started_at="now")
+        ref.update(lambda root: Lens(root).repos["owner/repo"].set(new_repo))
+        assert ref.get().repos["owner/repo"] is new_repo

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -140,11 +140,11 @@ class TestLensFidoStatePattern:
         assert result.repos["a/a"] is new_a
         assert result.repos["b/b"] is b
 
-    def test_with_atomic_reference_update(self) -> None:
-        """End-to-end: Lens inside AtomicReference.update()."""
+    def test_with_lens_update(self) -> None:
+        """End-to-end: lens_update navigates and installs atomically."""
         from fido.atomic import AtomicReference
 
         ref: AtomicReference[FidoState] = AtomicReference(FidoState(repos=frozendict()))
         new_repo = RepoState(key="owner/repo", started_at="now")
-        ref.update(lambda root: Lens(root).repos["owner/repo"].set(new_repo))
+        ref.lens_update(lambda root: root.repos["owner/repo"], new_repo)
         assert ref.get().repos["owner/repo"] is new_repo

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
+    { name = "frozendict" },
     { name = "requests" },
 ]
 
@@ -152,6 +153,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.9.0" },
+    { name = "frozendict", specifier = ">=2.4.7" },
     { name = "requests" },
 ]
 
@@ -163,6 +165,15 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #1343.

Introduces an `AtomicReference[T]` primitive (single-lock pointer swap, observationally lock-free for readers) and a frozen `FidoState` dataclass built around per-repo `RepoState` snapshots held in a `frozendict`, then migrates `started_at` from a lock-protected dict to a CAS-update on the snapshot. Includes a `Lens` helper for ergonomic functional updates to the frozen tree, with a two-parameter `lens_update` method on `AtomicReference` — a path-selector lambda navigates to the target, a second argument supplies the value, eliminating `.set()` from callsites entirely. `FidoState` is the convergence target — `FidoStatus` will eventually fold into it, with `./fido status` serving as the living requirement for what `FidoState`'s serialized form must represent.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Make root already be a Lens when passed to the update lambda (add a lens_update method or equivalent so callsites don't need explicit Lens(root) wrapping). Investigate replacing .set() with := or an operator overload — though := is not valid for subscript/attribute targets per PEP 572, so an alternative like operator overloading may be needed.](https://github.com/FidoCanCode/home/pull/1354#discussion_r3184085443) <!-- type:thread -->
- [x] [Add frozendict as a dependency. Introduce a frozen RepoState dataclass with started_at and key (repo slug). Reshape FidoState from started_at_by_repo: Mapping[str, datetime] to repos: frozendict[str, RepoState]. Update all CAS-update sites in registry.py (start(), thread_started_at()) and tests to use the new shape.](https://github.com/FidoCanCode/home/pull/1354#discussion_r3183725591) <!-- type:thread -->
- [x] [Change compare_and_set to return (success: bool, final_value: _T) tuple instead of just bool. Update the update() retry loop to use the returned value instead of calling get() again on CAS failure.](https://github.com/FidoCanCode/home/pull/1354#discussion_r3183363798) <!-- type:thread -->
- [x] Introduce RegistrySnapshot, migrate started_at to snapshot CAS pattern <!-- type:spec -->
- [x] Add AtomicReference[T] generic primitive with CAS and tests <!-- type:spec -->
- [x] [Rename RegistrySnapshot to FidoState. Add doc comments noting that FidoStatus should eventually be replaced by serializing FidoState to JSON (even where this breaks the old format), and that ./fido status serves as the living requirement for what FidoState's schema must represent.](https://github.com/FidoCanCode/home/pull/1354#issuecomment-4373006598) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->