### PR TITLE
Bug: rescope no longer infers task completion or removal from omission/cascade (cases A+B of #1357)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -316,7 +316,14 @@ def _rescope_releases_for_oracle(
         oracle_id = ids_by_task_id[task_id]
         item = ordered_by_id.get(task_id)
         if item is None:
-            decision: rescope_oracle.RescopeOp = rescope_oracle.CompleteTask(oracle_id)
+            # Opus omitted this task from its rescope output.  Treat as
+            # "keep as-is", not "completed" (#1357 case A).  Completion is a
+            # decision a worker turn must explicitly signal — it is not
+            # something the rescope reducer is allowed to infer from
+            # omission.  Legitimate consolidation/dedup still happens via the
+            # explicit-completion path; omission here just means Opus didn't
+            # speak for this task on this iteration.
+            decision: rescope_oracle.RescopeOp = rescope_oracle.KeepTask(oracle_id)
         elif "description" in item and item["description"] != task.get(
             "description", ""
         ):
@@ -993,25 +1000,21 @@ def reorder_tasks(
         )
         result = _apply_reorder(current, ordered_items, original_ids, intents=intents)
         if inprogress is not None:
+            # The omission ⇒ completed branch is gone (#1357 case A): the
+            # rescope reducer now uses KeepTask for omitted snapshot tasks,
+            # so the in-progress task always survives the rescope at its
+            # current status.  The only remaining trigger for
+            # _on_inprogress_affected is an explicit modification of the
+            # task's title or description by Opus, which resets the task
+            # to pending so the worker re-picks it under the new scope.
             inprogress_in_result = next(
                 (t for t in result if t["id"] == inprogress["id"]), None
             )
-            if (
-                inprogress_in_result is None
-                or inprogress_in_result.get("status") == TaskStatus.COMPLETED
+            if inprogress_in_result is not None and (
+                inprogress_in_result.get("title") != inprogress.get("title")
+                or inprogress_in_result.get("description")
+                != inprogress.get("description")
             ):
-                # Opus omitted the in-progress task — marked completed.
-                inprogress_affected = True
-                log.info(
-                    "reorder_tasks: in-progress task marked completed by Opus: %s",
-                    inprogress.get("title", "")[:60],
-                )
-            elif inprogress_in_result.get("title") != inprogress.get(
-                "title"
-            ) or inprogress_in_result.get("description") != inprogress.get(
-                "description"
-            ):
-                # Opus modified the in-progress task — reset to pending.
                 inprogress_affected = True
                 inprogress_in_result["status"] = str(TaskStatus.PENDING)
                 log.info(
@@ -1226,6 +1229,23 @@ class Tasks(JsonFileStore):
                     if int((t.get("thread") or {}).get("comment_id", -1)) == cid:
                         return True
         return False
+
+    def reset_to_pending(self, task_id: str) -> bool:
+        """Reset a task's status to ``pending``. Returns True if found.
+
+        Used by the worker's abort cleanup so that an aborted in-progress
+        task survives in the queue and can be re-picked under whatever
+        scope the rescope cascade gave it (#1357 case B).
+        """
+        with _locked(self._data_path, write=True) as lock:
+            tasks = lock.read()
+            for t in tasks:
+                if t["id"] == task_id:
+                    if t.get("status") != str(TaskStatus.PENDING):
+                        t["status"] = str(TaskStatus.PENDING)
+                        lock.write(tasks)
+                    return True
+            return False
 
     def remove(self, task_id: str) -> bool:
         """Remove a task. Returns True if found."""

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2974,18 +2974,28 @@ class Worker:
     def _cleanup_aborted_task(
         self, fido_dir: Path, task_id: str, task_title: str
     ) -> None:
-        """Discard uncommitted changes and remove task after an abort signal.
+        """Reset task to pending and discard uncommitted changes after abort.
 
         Called when ``self._abort_task`` is *active for* this task —
-        i.e. an abort was requested with this ``task_id``
-        and ``execute_task`` observed it mid-execution.  Runs
-        ``git_clean`` to restore the working tree, removes the task from
-        the queue, clears ``current_task_id`` from state, clears the
-        abort handle, and syncs the PR work queue.
+        i.e. an abort was requested with this ``task_id`` and
+        ``execute_task`` observed it mid-execution.  Runs ``git_clean`` to
+        restore the working tree (the in-flight work was tied to a scope
+        that's no longer current), resets the task status to ``pending``
+        so the next iteration can re-pick it on its updated scope, clears
+        ``current_task_id`` from state, clears the abort handle, and syncs
+        the PR work queue.
+
+        Per #1357 case B, the task is NOT removed from the queue here —
+        only an explicit worker-turn outcome may delete tasks.  Aborts
+        triggered by rescope (modify-in-progress → reset-to-pending →
+        abort) used to silently drop the task from ``tasks.json``, which
+        meant directives the user posted disappeared without a trace
+        every time the rescope cascade fired.  The task survives the
+        abort; the worker re-picks it under its new scope.
         """
         log.info("task aborted: %s", task_title)
         self.git_clean()
-        self._tasks.remove(task_id)
+        self._tasks.reset_to_pending(task_id)
         with State(fido_dir).modify() as state:
             state.pop("current_task_id", None)
         self._abort_task.clear()

--- a/tests/test_task_queue_rescope.py
+++ b/tests/test_task_queue_rescope.py
@@ -86,7 +86,8 @@ def _rescope_ops(
         snapshot_order.append(task_id)
         item = ordered_by_id.get(task["id"])
         if item is None:
-            ops.append(oracle.CompleteTask(task_id))
+            # #1357: omission ⇒ keep-as-is, not completed.
+            ops.append(oracle.KeepTask(task_id))
             continue
         if item.get("title", task["title"]) != task["title"] or item.get(
             "description", task.get("description", "")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -237,7 +237,10 @@ class TestRescopeOracleAdapter:
             current, frozenset({"a", "b"}), ids_by_task_id
         ) == [1]
 
-    def test_releases_encode_completion_description_updates_and_keeps(self) -> None:
+    def test_releases_encode_description_updates_and_keeps(self) -> None:
+        """#1357: omitted tasks get KeepTask, not CompleteTask.  Completion
+        is a worker-turn decision; the rescope reducer can only Keep,
+        Rewrite, or KeepTask (for omitted)."""
         current = [
             {
                 "id": "a",
@@ -277,7 +280,7 @@ class TestRescopeOracleAdapter:
 
         assert [type(release.release_decision).__name__ for release in releases] == [
             "RewriteTask",
-            "CompleteTask",
+            "KeepTask",
             "KeepTask",
         ]
 
@@ -575,6 +578,27 @@ class TestRemoveTask:
         assert not Tasks(tmp_path).remove("nonexistent")
 
 
+class TestResetToPending:
+    """Tests for Tasks.reset_to_pending — the abort-cleanup helper added
+    for #1357 case B (aborted tasks must survive in the queue, not vanish)."""
+
+    def test_resets_in_progress_to_pending(self, tmp_path: Path) -> None:
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        Tasks(tmp_path).update(task["id"], TaskStatus.IN_PROGRESS)
+        assert Tasks(tmp_path).reset_to_pending(task["id"]) is True
+        assert Tasks(tmp_path).list()[0]["status"] == str(TaskStatus.PENDING)
+
+    def test_no_op_when_already_pending(self, tmp_path: Path) -> None:
+        task = Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        # Idempotent: returns True (found) without rewriting the file.
+        assert Tasks(tmp_path).reset_to_pending(task["id"]) is True
+        assert Tasks(tmp_path).list()[0]["status"] == str(TaskStatus.PENDING)
+
+    def test_returns_false_if_not_found(self, tmp_path: Path) -> None:
+        Tasks(tmp_path).add(title="t", task_type=TaskType.SPEC)
+        assert Tasks(tmp_path).reset_to_pending("nonexistent") is False
+
+
 class TestUnblockTasks:
     def test_unblocks_blocked_tasks(self, tmp_path: Path) -> None:
         t1 = Tasks(tmp_path).add(title="first", task_type=TaskType.SPEC)
@@ -742,17 +766,20 @@ class TestApplyReorder:
         assert result[0]["id"] == "2"
         assert result[1]["id"] == "1"
 
-    def test_in_progress_task_marked_completed_when_opus_excludes_it(self) -> None:
+    def test_in_progress_task_kept_when_opus_excludes_it(self) -> None:
+        """#1357: Opus-omitting an in-progress task must NOT mark it
+        completed.  The omission is treated as keep-as-is — only an
+        explicit worker-turn outcome may complete a task."""
         current = [
             self._t("1", "Active task", status="in_progress"),
             self._t("2", "Spec task"),
         ]
         original_ids = frozenset({"1", "2"})
-        # Opus omitted task "1" (in_progress) — marked completed; caller aborts worker
         items = [self._item("2", "Spec task")]
         result = _apply_reorder(current, items, original_ids)
         task1 = next(t for t in result if t["id"] == "1")
-        assert task1["status"] == "completed"
+        assert task1["status"] == "in_progress"
+        assert task1["title"] == "Active task"
 
     def test_completed_tasks_preserved_at_end(self) -> None:
         current = [
@@ -787,13 +814,17 @@ class TestApplyReorder:
         assert result[1]["title"] == "New arrival"
         assert result[1]["description"] == ""
 
-    def test_marks_pending_task_completed_when_opus_excludes_it(self) -> None:
-        current = [self._t("1", "Keep"), self._t("2", "No longer needed")]
+    def test_keeps_pending_task_when_opus_excludes_it(self) -> None:
+        """#1357: Opus-omitting a pending task must NOT mark it completed.
+        Completion is a worker-turn decision; the rescope reducer can't
+        infer it from omission."""
+        current = [self._t("1", "Keep"), self._t("2", "Still pending")]
         original_ids = frozenset({"1", "2"})
-        items = [self._item("1", "Keep")]  # Opus omitted "2"
+        items = [self._item("1", "Keep")]
         result = _apply_reorder(current, items, original_ids)
         task2 = next(t for t in result if t["id"] == "2")
-        assert task2["status"] == "completed"
+        assert task2["status"] == "pending"
+        assert task2["title"] == "Still pending"
 
     def test_empty_ordered_items_preserves_completed_and_new(self) -> None:
         current = [
@@ -1163,14 +1194,17 @@ class TestReorderTasks:
         reorder_tasks(tmp_path, "", agent=_client(raw))
         assert Tasks(tmp_path).list()[0]["title"] == "Old title"
 
-    def test_marks_completed_task_opus_excludes(self, tmp_path: Path) -> None:
+    def test_keeps_task_opus_excludes(self, tmp_path: Path) -> None:
+        """#1357: end-to-end — reorder_tasks must not mark a task completed
+        because Opus omitted it.  Status survives the rescope unchanged."""
         t1 = self._add(tmp_path, "Keep")
-        t2 = self._add(tmp_path, "No longer needed")
+        t2 = self._add(tmp_path, "Still pending")
         raw = self._response([{"id": t1["id"], "title": "Keep", "description": ""}])
         reorder_tasks(tmp_path, "", agent=_client(raw))
         result = Tasks(tmp_path).list()
         task2 = next(t for t in result if t["id"] == t2["id"])
-        assert task2["status"] == "completed"
+        assert task2["status"] == "pending"
+        assert task2["title"] == "Still pending"
 
     def test_preserves_completed_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Done")
@@ -1233,9 +1267,12 @@ class TestReorderTasks:
         assert new_task["title"] == "Arrived mid-reorder"
         assert new_task["description"] == ""
 
-    def test_on_changes_called_when_thread_task_completed_by_reorder(
+    def test_on_changes_not_fired_when_opus_omits_thread_task(
         self, tmp_path: Path
     ) -> None:
+        """#1357: omission ⇒ keep-as-is, so no thread-completion change to
+        report.  Opus omitting a thread task no longer counts as a
+        completion event."""
         thread = {
             "repo": "r/r",
             "pr": 1,
@@ -1256,9 +1293,9 @@ class TestReorderTasks:
             agent=_client(raw),
             _on_changes=lambda changes: received.extend(changes),
         )
-        assert len(received) == 1
-        assert received[0]["kind"] == "completed"
-        assert received[0]["task"]["id"] == t1["id"]
+        assert received == []
+        task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
+        assert task1["status"] == "pending"
 
     def test_on_changes_called_when_thread_task_modified(self, tmp_path: Path) -> None:
         thread = {
@@ -1304,21 +1341,27 @@ class TestReorderTasks:
         assert received == []
 
     def test_on_changes_none_does_not_error(self, tmp_path: Path) -> None:
+        """A None callback must not raise when the rescope rewrites a thread
+        task's description (the change-emitting path under #1357)."""
         thread = {"repo": "r/r", "pr": 1, "comment_id": 42, "url": "https://x.com"}
         t1 = Tasks(tmp_path).add(
             title="Thread task", task_type=TaskType.THREAD, thread=thread
         )
-        t2 = self._add(tmp_path, "Keep")
-        raw = self._response([{"id": t2["id"], "title": "Keep", "description": ""}])
-        # Should not raise even though t1 is completed and _on_changes is None
+        raw = self._response(
+            [{"id": t1["id"], "title": "Thread task", "description": "rewritten"}]
+        )
         reorder_tasks(tmp_path, "", agent=_client(raw), _on_changes=None)
-        # t1 should be marked completed
         task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
-        assert task1["status"] == "completed"
+        assert task1["description"] == "rewritten"
 
-    def test_on_inprogress_affected_called_when_inprogress_task_completed(
+    def test_on_inprogress_affected_not_called_when_opus_omits_inprogress_task(
         self, tmp_path: Path
     ) -> None:
+        """#1357: omitting an in-progress task no longer auto-completes it,
+        so the affected-callback no longer fires from omission.  The task
+        survives in the queue at in_progress; only an explicit modification
+        by Opus triggers _on_inprogress_affected (covered by the modify
+        test)."""
         t1 = self._add(tmp_path, "In-progress task")
         Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
         t2 = self._add(tmp_path, "Keep this")
@@ -1332,10 +1375,9 @@ class TestReorderTasks:
             agent=_client(raw),
             _on_inprogress_affected=lambda _task_id: affected.append(1),
         )
-        assert affected == [1]
-        # in-progress task is marked completed
+        assert affected == []
         task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
-        assert task1["status"] == "completed"
+        assert task1["status"] == "in_progress"
 
     def test_on_inprogress_affected_called_when_inprogress_task_modified(
         self, tmp_path: Path
@@ -1397,13 +1439,19 @@ class TestReorderTasks:
         assert affected == []
 
     def test_on_inprogress_affected_none_does_not_error(self, tmp_path: Path) -> None:
+        """A None callback must not raise when Opus modifies the
+        in-progress task — the reset-to-pending + abort path under #1357."""
         t1 = self._add(tmp_path, "In-progress task")
         Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
-        t2 = self._add(tmp_path, "Keep this")
         raw = self._response(
-            [{"id": t2["id"], "title": "Keep this", "description": ""}]
+            [
+                {
+                    "id": t1["id"],
+                    "title": "In-progress task",
+                    "description": "rewritten scope",
+                }
+            ]
         )
-        # Should not raise even though in-progress task is completed and callback is None
         reorder_tasks(
             tmp_path,
             "",
@@ -1411,7 +1459,8 @@ class TestReorderTasks:
             _on_inprogress_affected=None,
         )
         task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
-        assert task1["status"] == "completed"
+        assert task1["status"] == str(TaskStatus.PENDING)
+        assert task1["description"] == "rewritten scope"
 
     def test_on_done_called_after_successful_reorder(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "Task A")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10903,9 +10903,13 @@ class TestExecuteTask:
         # and remains scoped to t-prior-removed — not active for t-next.
         assert worker._abort_task.is_active_for("t-next") is False
 
-    def test_abort_after_initial_run_removes_task_and_returns_true(
+    def test_abort_after_initial_run_resets_task_to_pending_and_returns_true(
         self, tmp_path: Path
     ) -> None:
+        """#1357 case B: an aborted in-progress task must SURVIVE in
+        ``tasks.json`` (reset to pending), not be silently removed.  The
+        abort cascade used to drop the task entirely, which is how
+        comment-driven directives disappeared without a trace."""
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1, "current_task_id": "t-abort"})
@@ -10918,20 +10922,24 @@ class TestExecuteTask:
             patch("fido.worker.provider_run", return_value=("sid", "")),
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
+            patch("fido.tasks.Tasks.reset_to_pending") as mock_reset,
             patch("fido.tasks.Tasks.remove") as mock_remove,
             patch("fido.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
         mock_clean.assert_called_once()
-        mock_remove.assert_called_once_with("t-abort")
+        mock_reset.assert_called_once_with("t-abort")
+        mock_remove.assert_not_called()
         assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()
 
-    def test_abort_during_resume_loop_removes_task_and_returns_true(
+    def test_abort_during_resume_loop_resets_task_to_pending_and_returns_true(
         self, tmp_path: Path
     ) -> None:
+        """#1357 case B: same survival contract during the resume-loop
+        abort path."""
         worker, _ = self._make_worker(tmp_path)
         fido_dir = self._fido_dir(tmp_path)
         State(fido_dir).save({"issue": 1})
@@ -10952,13 +10960,15 @@ class TestExecuteTask:
             patch("fido.worker.provider_run", side_effect=set_abort_on_second),
             patch.object(worker, "_git", self._git_same_sha()),
             patch.object(worker, "git_clean") as mock_clean,
+            patch("fido.tasks.Tasks.reset_to_pending") as mock_reset,
             patch("fido.tasks.Tasks.remove") as mock_remove,
             patch("fido.tasks.sync_tasks") as mock_sync,
         ):
             result = worker.execute_task(fido_dir, self._repo_ctx(), 1, "br")
         assert result is True
         mock_clean.assert_called_once()
-        mock_remove.assert_called_once_with("t-resume-abort")
+        mock_reset.assert_called_once_with("t-resume-abort")
+        mock_remove.assert_not_called()
         assert "current_task_id" not in State(fido_dir).load()
         assert not worker._abort_task.is_set()
         mock_sync.assert_called()


### PR DESCRIPTION
Stops the bleed for #1357 cases A and B.  Does **not** implement the full \`turn_outcome\` JSON-sentinel + Python-owned-commit redesign — that stays open under #1357.

## What was lost on PR #1354

- **Case A** — \`_rescope_releases_for_oracle\` chose \`CompleteTask\` for any snapshot task Opus omitted.  Two preempts mid-commit on PR #1354 left task ids absent from a subsequent rescope output → reducer marked them completed → PR work-queue claimed two tasks done while the PR had zero file changes.
- **Case B** — when Opus rewrote an in-progress task's title/description, the reducer reset to pending and triggered \`_on_inprogress_affected\` → worker abort.  \`Worker._cleanup_aborted_task\` then called \`Tasks.remove(task_id)\`, **deleting the task from the queue entirely**.  Comment-driven directives ("add frozendict, introduce \`RepoState\`, reshape \`FidoState\`") vanished without a trace.  Reproduced deterministically — every re-ask hit the same cascade.

## Surgical fix

- \`tasks.py:_rescope_releases_for_oracle\`: omitted snapshot tasks now get \`KeepTask\` instead of \`CompleteTask\`.  The Rocq oracle (\`task_queue_rescope.v\`) already had \`KeepTask\` as a legitimate op; no model change needed.
- \`worker.py:_cleanup_aborted_task\`: replace \`self._tasks.remove(task_id)\` with \`self._tasks.reset_to_pending(task_id)\`.  Aborted task survives at pending; worker re-picks under the new scope.  \`git_clean()\` stays (in-flight tree was tied to a stale scope).
- New \`Tasks.reset_to_pending(task_id) -> bool\` helper, mirrors \`Tasks.remove\`'s shape.

Dead code removed: the "in-progress task marked completed by Opus" branch in \`reorder_tasks\` — unreachable now that omission ⇒ KeepTask.

## What's still under #1357

The full \`turn_outcome\` contract (LLM signals \`commit-task-complete\` / \`commit-task-in-progress\` / \`skip-task-with-reason\` on the final output line; Python owns the commit + pre-commit-hook retry loop) addresses the **third** failure mode #1357 calls out — staged-not-committed work evaporating on preempt.  This PR doesn't touch that.  #1357 stays open with that scope.

## Test plan

- [x] \`./fido ci\` green via the pre-commit hook on the merge commit.  3871 pass, 100% coverage.
- [x] New regression tests:
  - \`TestResetToPending\` — \`Tasks.reset_to_pending\` happy path, idempotent, returns False on unknown id.
  - \`test_abort_after_initial_run_resets_task_to_pending_and_returns_true\` — abort cleanup keeps the task in the queue (renamed from the old "removes_task" test).
  - \`test_abort_during_resume_loop_resets_task_to_pending_and_returns_true\` — same for the resume-loop path.
  - \`test_in_progress_task_kept_when_opus_excludes_it\` — omission ⇒ in_progress preserved.
  - \`test_keeps_pending_task_when_opus_excludes_it\` — omission ⇒ pending preserved.
  - \`test_keeps_task_opus_excludes\` (end-to-end \`reorder_tasks\`) — same.
  - \`test_on_changes_not_fired_when_opus_omits_thread_task\` — no spurious "completed" change events.
  - \`test_on_inprogress_affected_not_called_when_opus_omits_inprogress_task\` — no spurious abort callbacks.
  - Existing modify-path tests still validate \`_on_inprogress_affected\` for the legitimate trigger.
- [ ] Live verification: bring Fido back up on a fresh PR cycle, post a comment-driven directive, confirm the task survives the rescope cascade and produces a real commit.