### PR TITLE
Bug: handler-thread wedge leaks FSM lock — add ForceRelease + watchdog (#1377)

### DIFF
--- a/models/BUG_MINED_INVARIANTS.md
+++ b/models/BUG_MINED_INVARIANTS.md
@@ -448,6 +448,48 @@ three transition arms (`Free | OwnedByWorker | OwnedByHandler` →
 `Free`).  The new lemma set complements the original safety pair —
 sibling property of `no_dual_ownership`, not a replacement.
 
+**IO substrate.** `session_lock_io.v` — separate reference model
+(no Python extraction; OS provides the actual transitions).
+Captures the subprocess lifecycle (`Spawned | Killed | Reaped`) and
+couples it with the lock FSM via two composite events:
+
+- `WatchdogPreempt` — cooperative preemption.  Webhook fires
+  `_fire_worker_cancel`, worker drains its turn, lock transfers via
+  the existing `Preempt` event.  Subprocess stays alive — the new
+  holder uses it without a respawn.
+- `WatchdogEvict` — forcible eviction.  Watchdog fires both
+  `ForceRelease` on the lock and `IssueKill` on the subprocess.
+  Lock advances to `Free`, subprocess advances to `Killed`.  The
+  wedged holder's `select` returns EOF when the OS closes stdout
+  (`OsCloseStdout`).
+
+Headline theorems:
+
+- `kill_eof_chain_terminates`: from `Spawned`, `IssueKill` then
+  `StdoutEof` always reaches `Reaped`.  IO-side liveness analogue
+  of `force_release_to_free`.
+- `evict_releases_lock`: for any prior lock state and a `Spawned`
+  subprocess, `WatchdogEvict` lands the coupled state at
+  `(Free, Killed)`.  The full coordination handshake in one step.
+- `evict_then_eof_reaps`: `WatchdogEvict` followed by `OsCloseStdout`
+  reaches `(Free, Reaped)` — the *complete* recovery: lock available,
+  subprocess fully torn down, stdout closed, holder unblocked.
+- `preempt_does_not_kill_subprocess`: cooperative preemption
+  transfers ownership without touching the subprocess.
+- `evict_kills_subprocess` + `preempt_and_evict_distinct_outcomes`:
+  the two paths produce structurally different coupled states —
+  the model proves the cooperative-vs-forcible distinction at the
+  IO layer, not just in the docstring.
+
+This is the "Rocq IO" piece — formalises the chain (1) watchdog
+fires kill → (2) OS propagates EOF → (3) holder's `iter_events`
+sees EOF and breaks → (4) holder's `__exit__` runs → (5)
+`_evicted_tids` guard skips `_fsm_release` — at the substrate level.
+Steps (3)–(5) are runtime implementation guarded by unit + smoke
+tests; (1)–(2) are now first-class theorems.  The model also pins
+down that webhook preemption *honors* the worker thread by
+preserving subprocess state, separate from the eviction path.
+
 **Status.** Runtime implementation live: `OwnedSession.force_release`
 fires the modeled event through the existing oracle wrapper,
 `_evicted_tids` carries cross-thread eviction state so the wedged

--- a/models/BUG_MINED_INVARIANTS.md
+++ b/models/BUG_MINED_INVARIANTS.md
@@ -421,7 +421,15 @@ escape-hatch event is accepted in every state.
 
 Formally proved in `session_lock.v`:
 - `force_release_to_free`: ∀s, transition(s, ForceRelease) = Some Free.
-- `every_state_reaches_free`: ∀s, ∃ev, transition(s, ev) = Some Free.
+- `unconditional_liveness`: ∃ev, ∀s, transition(s, ev) = Some Free —
+  strong liveness, with `ForceRelease` as the witness.  The watchdog
+  fires that single event without first inspecting FSM state and is
+  guaranteed `Free` regardless of where the holder was.
+- `every_state_reaches_free`: ∀s, ∃ev, transition(s, ev) = Some Free —
+  weaker form, named to document the *primary* path: voluntary
+  release for owned states, ForceRelease only for `Free` (idempotent
+  self-loop) and the unhappy case.  Strictly weaker than
+  `unconditional_liveness`; both are kept for pedagogical clarity.
 - `owned_state_exit_paths` (worker + handler): the only events that
   produce `Some _` from an owned state are the corresponding
   voluntary `*Release`, `Preempt` (worker only), and `ForceRelease`.

--- a/models/BUG_MINED_INVARIANTS.md
+++ b/models/BUG_MINED_INVARIANTS.md
@@ -408,6 +408,57 @@ demand modeling and enqueue-time wiring are tracked by
 
 ---
 
+## R. Session-lock liveness — bounded hold time + force-release escape
+
+**Invariant.** No FSM lock acquire can wait forever for a holder that
+will never release.  The original `session_lock.v` model proved
+**safety** (`no_dual_ownership`, `release_only_by_owner`) but every
+transition out of an owned state required the holder to *voluntarily*
+fire its release event — a property no real-world IO substrate can
+guarantee.  Liveness adds the dual property: from every state, at
+least one event drives the FSM to `Free`, and the watchdog's
+escape-hatch event is accepted in every state.
+
+Formally proved in `session_lock.v`:
+- `force_release_to_free`: ∀s, transition(s, ForceRelease) = Some Free.
+- `every_state_reaches_free`: ∀s, ∃ev, transition(s, ev) = Some Free.
+- `owned_state_exit_paths` (worker + handler): the only events that
+  produce `Some _` from an owned state are the corresponding
+  voluntary `*Release`, `Preempt` (worker only), and `ForceRelease`.
+  Confirms adding `ForceRelease` did not open any other accidental
+  exit edges.
+
+**Bugs.** [#1377](https://github.com/FidoCanCode/home/issues/1377)
+(handler thread wedged inside `consume_until_result` on a
+streaming-forever subprocess; FSM lock leaked indefinitely; webhooks
+queued at HandlerAcquire positions 1, 2, … forever; no exception
+ever raised because `idle_timeout` kept getting reset by streamed
+events).
+
+**Model.** `session_lock.v` extended with `ForceRelease : Event` and
+three transition arms (`Free | OwnedByWorker | OwnedByHandler` →
+`Free`).  The new lemma set complements the original safety pair —
+sibling property of `no_dual_ownership`, not a replacement.
+
+**Status.** Runtime implementation live: `OwnedSession.force_release`
+fires the modeled event through the existing oracle wrapper,
+`_evicted_tids` carries cross-thread eviction state so the wedged
+holder's eventual `__exit__` skips the now-incorrect normal release,
+`ClaudeSession._on_force_release` kills the subprocess so the parked
+`select()` returns EOF and the holder escapes
+`consume_until_result`, and `SessionLockWatchdog` is the daemon that
+fires `force_release` when a holder has held past
+`hold_deadline_seconds` (default 900 s).  Started from `server.run`
+alongside the existing `Watchdog` and `ReconcileWatchdog`.
+
+The wiring deliberately models the queued-handler transfer as two
+oracle calls (`ForceRelease → Free` then `HandlerAcquire → OwnedByHandler`)
+rather than the single-step direct mutation that `_fsm_release` does
+for the same case — a small precedent toward closing that earlier
+shortcut.
+
+---
+
 ## Summary
 
 | Cluster | Invariant focus | Bugs | Already covered | Action |
@@ -429,6 +480,7 @@ demand modeling and enqueue-time wiring are tracked by
 | O | Build cache | 1 | (CI, not coordination) | standard fix |
 | P | Worker registry slot lifecycle + crash recovery | lockfile race, provider orphan | ✓ worker_registry_crash.v live (#1056) | — |
 | Q | Handler preemption — product demand admission | 1 (#1067) | ✓ handler_preemption.v live (#1134) | — |
+| R | Session-lock liveness — bounded hold + force release | 1 (#1377) | ✓ session_lock.v ForceRelease live | — |
 
 **New issues filed (as of this survey):**
 - [#1041](https://github.com/FidoCanCode/home/issues/1041) — claude_session.v model (cluster B, 4 bugs of motivation) — **closed** ([#1052](https://github.com/FidoCanCode/home/pull/1052))

--- a/models/dune
+++ b/models/dune
@@ -7,6 +7,7 @@
   preamble
   seed
   session_lock
+  session_lock_io
   payload_text
   retry_budget
   coord_index

--- a/models/session_lock.v
+++ b/models/session_lock.v
@@ -9,9 +9,25 @@
     functional step function extracted to Python and run as a
     runtime-asserted oracle on every real state change.
 
-    Two key invariants are proved by computation ([reflexivity]):
-      [no_dual_ownership]     — acquiring an already-owned session fails.
-      [release_only_by_owner] — releasing only succeeds for the owner.
+    Five invariants are proved by computation ([reflexivity]):
+      [no_dual_ownership]            — acquiring an already-owned session fails.
+      [release_only_by_owner]        — voluntary releases only succeed for the owner.
+      [force_release_to_free]        — [ForceRelease] always lands in [Free].
+      [every_state_reaches_free]     — every state has at least one event reaching [Free]
+                                       (liveness — the lock cannot be held indefinitely).
+      [owned_state_exit_paths]       — the only events that move out of an owned state
+                                       are the corresponding [*Release], [Preempt]
+                                       (worker only), and [ForceRelease].
+
+    Liveness is the property the model previously lacked: every transition
+    out of an owned state required the holder to *voluntarily* fire its
+    release event, with no escape hatch for "holder is wedged in IO and
+    will never fire that event".  [ForceRelease] is that escape hatch —
+    fired by a watchdog when a holder has held the lock past a deadline,
+    or when an out-of-band IO failure (subprocess crash, broken pipe,
+    runaway streaming) has prevented the normal release path from running.
+    The watchdog also closes the wedged subprocess so the parked holder
+    thread escapes [consume_until_result] cleanly via EOF (closes #1377).
 
     Divergence between [OwnedSession] and [transition] crashes loudly
     with the theorem name so the violated invariant is immediately
@@ -34,15 +50,20 @@ Inductive State :=
 (** * Event
 
     [WorkerAcquire] / [HandlerAcquire] — regular acquisition requests.
-    [WorkerRelease] / [HandlerRelease] — current owner relinquishes.
+    [WorkerRelease] / [HandlerRelease] — current owner voluntarily relinquishes.
     [Preempt] — handler forcibly takes the session from a running worker
-    (corresponds to [hold_for_handler preempt_worker=True]). *)
+    (corresponds to [hold_for_handler preempt_worker=True]); transfers
+    ownership directly to a known successor handler.
+    [ForceRelease] — watchdog evicts the current holder when the holder
+    has held the lock past a deadline, or when an IO failure prevented
+    voluntary release.  Lands in [Free]; no successor is assumed. *)
 Inductive Event :=
   | WorkerAcquire  : Event
   | HandlerAcquire : Event
   | WorkerRelease  : Event
   | HandlerRelease : Event
-  | Preempt        : Event.
+  | Preempt        : Event
+  | ForceRelease   : Event.
 
 (** * Transition function
 
@@ -51,24 +72,31 @@ Inductive Event :=
 
     Rejection is fail-closed: there is no silent clobbering.  A handler
     must send [Preempt] to take a session from a worker; a plain
-    [HandlerAcquire] against an occupied session is refused. *)
+    [HandlerAcquire] against an occupied session is refused.
+
+    [ForceRelease] is the only event accepted in every state — it is the
+    sanctioned escape hatch for a wedged or dead holder.  See the
+    [force_release_to_free] and [every_state_reaches_free] lemmas. *)
 Definition transition (current : State) (event : Event) : option State :=
   match current with
   | Free =>
       match event with
       | WorkerAcquire  => Some OwnedByWorker
       | HandlerAcquire => Some OwnedByHandler
+      | ForceRelease   => Some Free
       | _              => None
       end
   | OwnedByWorker =>
       match event with
       | WorkerRelease  => Some Free
       | Preempt        => Some OwnedByHandler
+      | ForceRelease   => Some Free
       | _              => None
       end
   | OwnedByHandler =>
       match event with
       | HandlerRelease => Some Free
+      | ForceRelease   => Some Free
       | _              => None
       end
   end.
@@ -77,9 +105,10 @@ Python Extraction transition.
 
 (** * Proved invariants
 
-    Both lemmas follow by computation ([reflexivity]): [transition]
-    reduces to [None] on each listed combination, and Rocq's kernel
-    verifies the equality by normalisation.  No induction is needed.
+    All lemmas follow by computation ([reflexivity]) or simple case
+    analysis: [transition] reduces to a determinate result on each
+    combination, and Rocq's kernel verifies the equality by
+    normalisation.  No induction is needed.
 
     These names surface in the runtime oracle: when [OwnedSession]
     diverges from [transition], the crash message includes the theorem
@@ -87,7 +116,10 @@ Python Extraction transition.
 
 (** [no_dual_ownership]: a second acquire is always rejected when the
     session is already owned.  Both roles are blocked — explicit
-    [Preempt] is the only sanctioned takeover path. *)
+    [Preempt] is the only sanctioned takeover path.  [ForceRelease]
+    does not weaken this: it lands in [Free], not in another owned
+    state, so a forced eviction is still followed by a fresh acquire
+    via the normal path. *)
 Lemma no_dual_ownership :
   transition OwnedByWorker  WorkerAcquire  = None /\
   transition OwnedByWorker  HandlerAcquire = None /\
@@ -97,10 +129,12 @@ Proof.
   repeat split; reflexivity.
 Qed.
 
-(** [release_only_by_owner]: a release succeeds only when the releasing
-    role is the current owner.  Cross-releases (handler releasing a
-    worker-held session, worker releasing a handler-held session) are
-    rejected, as are releases from the [Free] state. *)
+(** [release_only_by_owner]: a *voluntary* release succeeds only when
+    the releasing role is the current owner.  Cross-releases (handler
+    releasing a worker-held session, worker releasing a handler-held
+    session) are rejected, as are releases from the [Free] state.
+    [ForceRelease] is the only sanctioned cross-role release path —
+    see [force_release_to_free] below. *)
 Lemma release_only_by_owner :
   transition OwnedByHandler WorkerRelease  = None /\
   transition OwnedByWorker  HandlerRelease = None /\
@@ -108,4 +142,55 @@ Lemma release_only_by_owner :
   transition Free           HandlerRelease = None.
 Proof.
   repeat split; reflexivity.
+Qed.
+
+(** [force_release_to_free]: [ForceRelease] is accepted in every state
+    and always lands in [Free].  This is the post-condition the
+    watchdog relies on: after firing [ForceRelease], the lock is
+    guaranteed acquirable by the next [WorkerAcquire] or
+    [HandlerAcquire], regardless of the prior holder. *)
+Lemma force_release_to_free :
+  forall s, transition s ForceRelease = Some Free.
+Proof.
+  intros s; destruct s; reflexivity.
+Qed.
+
+(** [every_state_reaches_free]: liveness.  From every state there is at
+    least one event that drives the FSM to [Free].  Without
+    [ForceRelease], owned states could reach [Free] only via the
+    holder's voluntary release — which a wedged or dead holder will
+    never fire.  With [ForceRelease], the watchdog can always
+    progress the lock; the model proves the lock is never terminally
+    held. *)
+Lemma every_state_reaches_free :
+  forall s, exists ev, transition s ev = Some Free.
+Proof.
+  intros s; destruct s.
+  - exists ForceRelease;   reflexivity.
+  - exists WorkerRelease;  reflexivity.
+  - exists HandlerRelease; reflexivity.
+Qed.
+
+(** [owned_state_exit_paths]: structural exhaustiveness.  The *only*
+    events that move out of an owned state (i.e. that produce
+    [Some _]) are the corresponding voluntary [*Release], [Preempt]
+    (worker only), and [ForceRelease].  Pins down the design: adding
+    [ForceRelease] did not open any other accidental exit edges. *)
+Lemma owned_worker_exit_paths :
+  forall ev s',
+    transition OwnedByWorker ev = Some s' ->
+    (ev = WorkerRelease /\ s' = Free) \/
+    (ev = Preempt       /\ s' = OwnedByHandler) \/
+    (ev = ForceRelease  /\ s' = Free).
+Proof.
+  intros ev s' H; destruct ev; simpl in H; inversion H; auto.
+Qed.
+
+Lemma owned_handler_exit_paths :
+  forall ev s',
+    transition OwnedByHandler ev = Some s' ->
+    (ev = HandlerRelease /\ s' = Free) \/
+    (ev = ForceRelease   /\ s' = Free).
+Proof.
+  intros ev s' H; destruct ev; simpl in H; inversion H; auto.
 Qed.

--- a/models/session_lock.v
+++ b/models/session_lock.v
@@ -9,12 +9,19 @@
     functional step function extracted to Python and run as a
     runtime-asserted oracle on every real state change.
 
-    Five invariants are proved by computation ([reflexivity]):
+    Six invariants are proved by computation ([reflexivity]) or simple
+    case analysis:
       [no_dual_ownership]            — acquiring an already-owned session fails.
       [release_only_by_owner]        — voluntary releases only succeed for the owner.
       [force_release_to_free]        — [ForceRelease] always lands in [Free].
-      [every_state_reaches_free]     — every state has at least one event reaching [Free]
-                                       (liveness — the lock cannot be held indefinitely).
+      [unconditional_liveness]       — strong liveness: there exists a *single*
+                                       event ([ForceRelease]) that drives every
+                                       state to [Free].  The watchdog fires this
+                                       event without first inspecting FSM state.
+      [every_state_reaches_free]     — weak liveness: every state has at least
+                                       one event reaching [Free] — citing
+                                       voluntary releases for owned states to
+                                       document them as the primary path.
       [owned_state_exit_paths]       — the only events that move out of an owned state
                                        are the corresponding [*Release], [Preempt]
                                        (worker only), and [ForceRelease].
@@ -155,13 +162,32 @@ Proof.
   intros s; destruct s; reflexivity.
 Qed.
 
-(** [every_state_reaches_free]: liveness.  From every state there is at
-    least one event that drives the FSM to [Free].  Without
-    [ForceRelease], owned states could reach [Free] only via the
-    holder's voluntary release — which a wedged or dead holder will
-    never fire.  With [ForceRelease], the watchdog can always
-    progress the lock; the model proves the lock is never terminally
-    held. *)
+(** [unconditional_liveness]: strong liveness.  There exists a *single*
+    event that drives every state to [Free] — that event is
+    [ForceRelease].  The shape is [exists ev, forall s, ...], strictly
+    stronger than the [forall s, exists ev, ...] of
+    [every_state_reaches_free]: the latter leaves open the possibility
+    that no single event works universally and the watchdog would
+    have to inspect FSM state before choosing what to fire.
+
+    This is the property the watchdog actually relies on: it calls
+    [force_release] without first reading [_fsm_state], and the
+    Rocq-modeled transition is guaranteed to land in [Free]
+    regardless of where the holder was.  Proved trivially as a
+    corollary of [force_release_to_free]. *)
+Theorem unconditional_liveness :
+  exists ev, forall s, transition s ev = Some Free.
+Proof. exists ForceRelease; exact force_release_to_free. Qed.
+
+(** [every_state_reaches_free]: weak liveness.  From every state there
+    is at least one event that drives the FSM to [Free].  Strictly
+    weaker than [unconditional_liveness], which provides a single
+    universal event; this lemma instead names a *different* event per
+    state — voluntary releases for owned states — to document them as
+    the primary path that real holders take.  [ForceRelease] is the
+    safety net for [Free] (idempotent self-loop) and the only
+    available event in the unhappy case where the holder will never
+    fire its voluntary release. *)
 Lemma every_state_reaches_free :
   forall s, exists ev, transition s ev = Some Free.
 Proof.

--- a/models/session_lock.v
+++ b/models/session_lock.v
@@ -9,11 +9,12 @@
     functional step function extracted to Python and run as a
     runtime-asserted oracle on every real state change.
 
-    Six invariants are proved by computation ([reflexivity]) or simple
+    Seven invariants are proved by computation ([reflexivity]) or simple
     case analysis:
       [no_dual_ownership]            — acquiring an already-owned session fails.
       [release_only_by_owner]        — voluntary releases only succeed for the owner.
-      [force_release_to_free]        — [ForceRelease] always lands in [Free].
+      [force_release_to_free]        — [ForceRelease] always lands in [Free]
+                                       from any single state.
       [unconditional_liveness]       — strong liveness: there exists a *single*
                                        event ([ForceRelease]) that drives every
                                        state to [Free].  The watchdog fires this
@@ -25,6 +26,12 @@
       [owned_state_exit_paths]       — the only events that move out of an owned state
                                        are the corresponding [*Release], [Preempt]
                                        (worker only), and [ForceRelease].
+      [trace_force_release_to_free]  — trace-level: from *any* starting state,
+                                       after *any* sequence of prior events,
+                                       firing [ForceRelease] lands in [Free].
+                                       Matches the runtime: the watchdog fires
+                                       without inspecting either current state
+                                       or prior trace.
 
     Liveness is the property the model previously lacked: every transition
     out of an owned state required the holder to *voluntarily* fire its
@@ -41,6 +48,8 @@
     visible in the traceback. *)
 
 From FidoModels Require Import preamble.
+From Coq Require Import List.
+Import ListNotations.
 
 (** * State
 
@@ -219,4 +228,52 @@ Lemma owned_handler_exit_paths :
     (ev = ForceRelease   /\ s' = Free).
 Proof.
   intros ev s' H; destruct ev; simpl in H; inversion H; auto.
+Qed.
+
+(** * Trace-level liveness
+
+    The lemmas above all reason about a single transition step.  The
+    runtime watchdog, however, fires [ForceRelease] without first
+    reading the FSM state — and the state it fires *into* is whatever
+    the FSM has reached through some prior sequence of events
+    (acquires, releases, preempts, and even prior force-releases).
+
+    The trace-level theorem [trace_force_release_to_free] proves the
+    watchdog's runtime guarantee directly: regardless of which event
+    sequence got us here, [ForceRelease] lands in [Free].  Combined
+    with [force_release_to_free] (the single-step shape) and
+    [unconditional_liveness] (the existence shape), this completes
+    the safety-net story: no matter what the prior trace looked like,
+    no matter how many acquires/releases/preempts interleaved, the
+    next [ForceRelease] is guaranteed to recover. *)
+
+(** Step a state through a list of events, applying only the
+    successful transitions (skipping rejected events the way the
+    runtime FSM does — a rejected event is a no-op for state, the
+    runtime treats [None] as "stay where you are").  Pure helper, no
+    side effects, used as a fold-like driver in trace-level proofs. *)
+Fixpoint walk (s : State) (events : list Event) : State :=
+  match events with
+  | nil       => s
+  | ev :: rest =>
+      match transition s ev with
+      | Some s' => walk s' rest
+      | None    => walk s rest
+      end
+  end.
+
+(** [trace_force_release_to_free]: the strongest form of the watchdog
+    invariant.  Take any starting state, walk through any event
+    sequence, then fire [ForceRelease] — the result is always [Free].
+
+    This is what the runtime watchdog does in practice: it fires
+    [ForceRelease] without inspecting the FSM, so the prior trace is
+    arbitrary.  The proof composes [force_release_to_free] with the
+    closure property that [walk] only ever produces a valid state
+    (which [force_release_to_free] then handles for any state). *)
+Theorem trace_force_release_to_free :
+  forall s events,
+    transition (walk s events) ForceRelease = Some Free.
+Proof.
+  intros s events; apply force_release_to_free.
 Qed.

--- a/models/session_lock_io.v
+++ b/models/session_lock_io.v
@@ -1,0 +1,334 @@
+(** Session-lock IO substrate — subprocess lifecycle + coupling with the lock FSM.
+
+    [models/session_lock.v] proved that [ForceRelease] is accepted in
+    every FSM state and lands in [Free].  That is the *coordination*
+    layer — it answers "given the watchdog fired the event, the lock
+    advances".  It does *not* answer "given the watchdog fired the
+    event, the wedged holder thread will eventually escape its parked
+    IO call".
+
+    The wedge in [#1377] depended on a chain that runs *outside* the
+    coordination FSM:
+
+      1. Watchdog calls [_proc.kill()].
+      2. OS kills the subprocess; stdout closes.
+      3. Holder's [select] returns ready with EOF on the closed pipe.
+      4. [iter_events] readline returns ``""``; the EOF branch breaks
+         the loop.
+      5. [consume_until_result] returns the (empty) result.
+      6. [with self:] runs [__exit__]; the [_evicted_tids] guard
+         skips [_fsm_release].
+
+    Steps 1-3 are the IO substrate: subprocess lifecycle.  This model
+    formalises that substrate as its own small FSM, then couples it
+    with [session_lock.v] so the headline runtime invariant can be
+    stated as a single theorem rather than an unmodeled chain.
+
+    The model also distinguishes two runtime paths the watchdog can
+    take when a worker holds the lock:
+
+    - [WatchdogPreempt] — cooperative preemption.  Webhook fires
+      [_fire_worker_cancel], the worker drains its turn cleanly, the
+      lock transfers via [Preempt].  The subprocess stays alive so
+      the new holder can use it without a respawn.
+    - [WatchdogEvict]   — forcible eviction.  Watchdog fires
+      [ForceRelease] on the lock and [IssueKill] on the subprocess.
+      Lock advances to [Free], subprocess advances to [Killed].
+      The wedged holder's [select] eventually returns EOF when the
+      OS closes stdout ([OsCloseStdout]).
+
+    Pinning down [preempt_does_not_kill_subprocess] vs
+    [evict_kills_subprocess] at the model layer is what "honors
+    preemption on the worker thread" means formally — preemption is
+    a separate coupled event that does not touch the IO substrate.
+
+    This is the [missing-Rocq-IO] piece flagged in cluster R of
+    [models/BUG_MINED_INVARIANTS.md].  Reference model only — no
+    [Python Extraction] directive: the OS provides the actual
+    transitions, so there is no Python target to oracle against.  The
+    purpose is to *state* the invariants formally so future code can
+    cite them rather than restate them in prose. *)
+
+From FidoModels Require Import preamble.
+From FidoModels Require Import session_lock.
+
+(** * Subprocess lifecycle
+
+    The minimal three-state lifecycle that captures the wedge ⇒
+    recovery dynamics.  Real subprocesses have many more transient
+    states (zombie reaping, signal queueing, file-descriptor
+    teardown), but for the coordination property we care about, three
+    states suffice:
+
+    [Spawned]  — subprocess is alive, stdout is open and the holder
+                 thread can park in [select] on it.
+    [Killed]   — [_proc.kill()] has been issued, but the OS has not
+                 yet propagated the close to stdout.  The holder is
+                 still parked; it will see EOF on the next OS tick.
+    [Reaped]   — stdout has been closed by the OS.  The next
+                 [readline] returns ``""``, [iter_events] breaks the
+                 loop on EOF, and the holder escapes
+                 [consume_until_result]. *)
+Inductive ProcState : Type :=
+  | Spawned : ProcState
+  | Killed  : ProcState
+  | Reaped  : ProcState.
+
+(** [IssueKill]   — the watchdog (or self) calls [_proc.kill()].
+    [StdoutEof]   — the OS has closed stdout following kill; subsequent
+                    [readline] returns ``""``.  In real time this is
+                    asynchronous — kill returns immediately, the OS
+                    closes the pipe later — so we model it as a separate
+                    event rather than folding it into [IssueKill]. *)
+Inductive ProcEvent : Type :=
+  | IssueKill : ProcEvent
+  | StdoutEof : ProcEvent.
+
+Definition proc_step (s : ProcState) (e : ProcEvent) : option ProcState :=
+  match s, e with
+  | Spawned, IssueKill  => Some Killed
+  | Killed,  StdoutEof  => Some Reaped
+  | _,       _          => None
+  end.
+
+(** ** Subprocess invariants *)
+
+(** [kill_progresses_spawned]: from a running subprocess, [IssueKill]
+    always succeeds and lands in [Killed].  No "kill might fail
+    silently" case in the substrate model. *)
+Lemma kill_progresses_spawned :
+  proc_step Spawned IssueKill = Some Killed.
+Proof. reflexivity. Qed.
+
+(** [eof_progresses_killed]: once kill has been issued, the OS
+    eventually closes stdout — modeled as a deterministic next step. *)
+Lemma eof_progresses_killed :
+  proc_step Killed StdoutEof = Some Reaped.
+Proof. reflexivity. Qed.
+
+(** [kill_eof_chain_terminates]: the two-step chain from [Spawned]
+    via [IssueKill] then [StdoutEof] always reaches [Reaped].  This is
+    the IO-side liveness analogue of [force_release_to_free]: once the
+    runtime issues kill and the OS does its work, the holder's stdout
+    *will* close. *)
+Theorem kill_eof_chain_terminates :
+  exists s1,
+    proc_step Spawned IssueKill = Some s1 /\
+    proc_step s1     StdoutEof  = Some Reaped.
+Proof.
+  exists Killed; split; reflexivity.
+Qed.
+
+(** [reaped_is_terminal]: no event makes progress from [Reaped].  The
+    subprocess has been torn down; the only useful action left is to
+    spawn a new one (which is a fresh [Spawned] state, modeled
+    elsewhere). *)
+Lemma reaped_is_terminal :
+  proc_step Reaped IssueKill = None /\
+  proc_step Reaped StdoutEof = None.
+Proof. split; reflexivity. Qed.
+
+(** [killed_does_not_accept_kill]: re-issuing [IssueKill] from
+    [Killed] is a no-op (rejected) — calling [_proc.kill()] twice
+    while the first kill is still propagating does not produce a new
+    state.  Mirrors the [ProcessLookupError] tolerance in
+    [ClaudeSession._on_force_release]. *)
+Lemma killed_does_not_accept_kill :
+  proc_step Killed IssueKill = None.
+Proof. reflexivity. Qed.
+
+(** * Coupled state — session lock × subprocess lifecycle
+
+    The runtime invariant we care about — "watchdog fires
+    ForceRelease and kill ⇒ lock reaches Free and holder will
+    eventually escape" — lives at the *combined* level.  Capture
+    that explicitly. *)
+
+Record CoupledState : Type := {
+  lock : State;
+  proc : ProcState;
+}.
+
+(** [CoupledEvent] enumerates the events that can advance the
+    coupled (lock × subprocess) state.
+
+    [WatchdogPreempt] is the *cooperative* preemption path — webhook
+    fires [_fire_worker_cancel], the worker drains its turn cleanly,
+    and the FSM transfers ownership via the modeled [Preempt] event.
+    The subprocess stays alive throughout: only ownership of the
+    lock changes hands.  Models the worker-thread-cooperates path.
+
+    [WatchdogEvict] is the *forcible* recovery path — the watchdog
+    has detected a wedged holder and fires both [ForceRelease] on the
+    lock and [IssueKill] on the subprocess.  The subprocess is torn
+    down so the wedged holder's parked [select] returns EOF.  Models
+    the worker-thread-doesn't-cooperate path.
+
+    [OsCloseStdout] is the asynchronous follow-up after [IssueKill]
+    has been issued: the operating system closes stdout, satisfying
+    the holder's [readline → ""] expectation.
+
+    Distinguishing [WatchdogPreempt] from [WatchdogEvict] is what
+    "honors preemption on the worker thread" means at the model
+    level: preemption transfers ownership without killing the IO
+    substrate, while eviction tears the substrate down. *)
+Inductive CoupledEvent : Type :=
+  | WatchdogPreempt : CoupledEvent  (* cooperative — Preempt only *)
+  | WatchdogEvict   : CoupledEvent  (* forcible — ForceRelease + IssueKill *)
+  | OsCloseStdout   : CoupledEvent. (* asynchronous OS event *)
+
+Definition coupled_step (s : CoupledState) (e : CoupledEvent) : option CoupledState :=
+  match e with
+  | WatchdogPreempt =>
+      match transition s.(lock) Preempt with
+      | Some lock' => Some {| lock := lock'; proc := s.(proc) |}
+      | None       => None
+      end
+  | WatchdogEvict =>
+      match transition s.(lock) ForceRelease, proc_step s.(proc) IssueKill with
+      | Some lock', Some proc' => Some {| lock := lock'; proc := proc' |}
+      | _, _                   => None
+      end
+  | OsCloseStdout =>
+      match proc_step s.(proc) StdoutEof with
+      | Some proc' => Some {| lock := s.(lock); proc := proc' |}
+      | None       => None
+      end
+  end.
+
+(** ** Coupled invariants *)
+
+(** [evict_releases_lock]: when the watchdog fires [WatchdogEvict] on
+    a state where the subprocess is [Spawned] (the wedge condition),
+    the resulting state has [lock = Free] and [proc = Killed].  This
+    is the headline composite property: the *modeled* runtime
+    invariant for the recovery handshake. *)
+Theorem evict_releases_lock :
+  forall lock0,
+    exists lock',
+      coupled_step {| lock := lock0; proc := Spawned |} WatchdogEvict
+      = Some {| lock := lock'; proc := Killed |}
+      /\ lock' = Free.
+Proof.
+  intro lock0.
+  exists Free.
+  unfold coupled_step; cbn.
+  rewrite (force_release_to_free lock0); cbn.
+  split; reflexivity.
+Qed.
+
+(** [evict_then_eof_reaps]: after the watchdog evicts, an
+    [OsCloseStdout] event progresses the subprocess to [Reaped] —
+    completing the holder-escape chain.  Combined with
+    [evict_releases_lock], this proves that the watchdog's eviction
+    plus one OS event recovers both the lock (to [Free]) and the
+    subprocess (to [Reaped]).  The holder's stdout is now closed,
+    [iter_events] sees EOF and breaks, and the wedge is over. *)
+Theorem evict_then_eof_reaps :
+  forall lock0,
+    exists s1 s2,
+      coupled_step {| lock := lock0; proc := Spawned |} WatchdogEvict = Some s1
+      /\ s1.(lock) = Free
+      /\ s1.(proc) = Killed
+      /\ coupled_step s1 OsCloseStdout = Some s2
+      /\ s2.(lock) = Free
+      /\ s2.(proc) = Reaped.
+Proof.
+  intro lock0.
+  exists {| lock := Free; proc := Killed |}.
+  exists {| lock := Free; proc := Reaped |}.
+  unfold coupled_step; cbn.
+  rewrite (force_release_to_free lock0).
+  cbn.
+  repeat split.
+Qed.
+
+(** [evict_lock_is_unconditional_on_lock_state]: even if the watchdog
+    evicts from a state where the lock is already [Free] (a race
+    against a holder that just released voluntarily), the post-state
+    is still consistent: lock stays [Free] (idempotent
+    [ForceRelease]) and the subprocess advances to [Killed].  The
+    runtime ``force_release`` returns ``False`` from this branch
+    ([already-Free no-op]) and skips the subclass kill hook; this
+    theorem documents the *modeled* counterpart — that even in the
+    race case, the FSM is well-defined. *)
+Theorem evict_from_free_is_well_defined :
+  exists lock' proc',
+    coupled_step {| lock := Free; proc := Spawned |} WatchdogEvict
+    = Some {| lock := lock'; proc := proc' |}
+    /\ lock' = Free
+    /\ proc' = Killed.
+Proof.
+  exists Free; exists Killed.
+  unfold coupled_step; cbn.
+  split; [ reflexivity | split; reflexivity ].
+Qed.
+
+(** ** Preemption vs eviction — distinguished IO behaviours
+
+    The cooperative-preemption and forcible-eviction paths must
+    differ at the substrate level.  Preempt transfers ownership but
+    leaves the subprocess running for the new holder to use; Evict
+    tears the subprocess down so the wedged holder can escape its
+    parked IO.  These two theorems pin down that distinction at the
+    model layer.  Together they answer the runtime question:
+    "does the watchdog honor preemption on the worker thread?" —
+    yes, because preemption is a *separate* coupled event that does
+    not touch the subprocess. *)
+
+(** [preempt_does_not_kill_subprocess]: cooperative preemption
+    transfers ownership from worker to handler with no IO-side
+    effect.  The subprocess stays in the same state so the new
+    handler holder can immediately use it without a respawn.  This
+    is the property that makes webhook-side preemption efficient:
+    the handler does not pay for a fresh subprocess boot. *)
+Theorem preempt_does_not_kill_subprocess :
+  forall p,
+    coupled_step {| lock := OwnedByWorker; proc := p |} WatchdogPreempt
+    = Some {| lock := OwnedByHandler; proc := p |}.
+Proof.
+  intro p.
+  unfold coupled_step; cbn.
+  reflexivity.
+Qed.
+
+(** [evict_kills_subprocess]: forcible eviction does kill the
+    subprocess.  Direct contrast to [preempt_does_not_kill_subprocess]:
+    evicting a worker-held session lands at [Killed], not at the
+    original [proc] state. *)
+Theorem evict_kills_subprocess :
+  coupled_step {| lock := OwnedByWorker; proc := Spawned |} WatchdogEvict
+  = Some {| lock := Free; proc := Killed |}.
+Proof.
+  unfold coupled_step; cbn.
+  reflexivity.
+Qed.
+
+(** [preempt_only_valid_from_owned_worker]: the cooperative
+    preemption path is rejected from [Free] and from [OwnedByHandler]
+    in the coupled model exactly the way it is in [session_lock.v]
+    alone.  Confirms the IO substrate did not relax the
+    handler-takes-over-only-from-worker invariant. *)
+Lemma preempt_only_valid_from_owned_worker :
+  forall p,
+    coupled_step {| lock := Free;           proc := p |} WatchdogPreempt = None /\
+    coupled_step {| lock := OwnedByHandler; proc := p |} WatchdogPreempt = None.
+Proof.
+  intro p.
+  unfold coupled_step; cbn.
+  split; reflexivity.
+Qed.
+
+(** [preempt_and_evict_distinct_outcomes]: from the worker-held
+    state with a live subprocess, the two paths produce visibly
+    different coupled states — the model proves the runtime
+    distinction directly.  Useful as a sanity property: if these
+    two outcomes ever collapse to one, the IO substrate has lost
+    the cooperative-vs-forcible distinction. *)
+Theorem preempt_and_evict_distinct_outcomes :
+  let s := {| lock := OwnedByWorker; proc := Spawned |} in
+  coupled_step s WatchdogPreempt <> coupled_step s WatchdogEvict.
+Proof.
+  unfold coupled_step; cbn.
+  discriminate.
+Qed.

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1009,6 +1009,46 @@ class ClaudeSession(OwnedSession):
         self._cancel.set()
         self._wake()
 
+    def _on_force_release(self, *, reason: str) -> None:
+        """Knock a wedged holder out of its parked IO call by killing the
+        subprocess.
+
+        :meth:`OwnedSession.force_release` has already fired the
+        ``ForceRelease`` FSM event and (if any handler is queued)
+        transferred ownership.  All that is left is to escape the
+        wedged thread from its blocking call inside
+        :meth:`consume_until_result`: closing the subprocess's stdout
+        makes the parked ``select()`` return ready with EOF, the
+        ``iter_events`` loop hits the EOF branch and returns,
+        :meth:`prompt`'s ``with self:`` runs ``__exit__``, and the
+        ``_evicted_tids`` guard in :meth:`OwnedSession._fsm_release`
+        skips the now-incorrect ``WorkerRelease`` / ``HandlerRelease``.
+
+        The kill is best-effort: if the subprocess has already exited
+        (race with idle timeout, normal shutdown, or another recovery
+        path), :meth:`subprocess.Popen.kill` raises
+        :class:`ProcessLookupError` which is caught and ignored.
+        """
+        log.warning(
+            "ClaudeSession[%s]: force_release killing pid=%s (reason=%r)",
+            self._repo_name or "?",
+            self._proc.pid,
+            reason,
+        )
+        try:
+            self._proc.kill()
+        except (ProcessLookupError, OSError) as exc:
+            log.debug(
+                "ClaudeSession[%s]: force_release kill: %s",
+                self._repo_name or "?",
+                exc,
+            )
+        # Reset the stream FSM so the next acquire's first turn does not
+        # inherit a stale Sending/AwaitingReply state from the killed
+        # subprocess.  Mirrors the cleanup in :meth:`_drain_to_boundary`
+        # after a cancel-drain timeout.
+        self._stream_reset()
+
     def _send_control_interrupt(self) -> str:
         """Write a stream-json ``control_request`` interrupt to subprocess
         stdin and return the request_id so the caller can assert the

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -614,6 +614,14 @@ class OwnedSession:
     _fsm_cond: threading.Condition
     _fsm_state: fsm.State
     _handler_queue: list[threading.Event]
+    # Tids that were evicted by :meth:`force_release` while still inside
+    # ``with self:``.  When the evicted holder eventually escapes
+    # ``consume_until_result`` (via the subprocess kill closing stdout) and
+    # runs ``__exit__``, the depth==0 cleanup consults this set: if its tid
+    # is present, it skips the normal :meth:`_fsm_release` (which would
+    # otherwise crash on ``release_only_by_owner`` because the FSM has
+    # already moved past the holder's state).  Guarded by ``_fsm_cond``.
+    _evicted_tids: set[int]
     # Allowed-tools value passed to :meth:`switch_tools` on handler entry.
     # ``None`` means no restriction (default for CopilotCLISession whose
     # switch_tools is a no-op; ClaudeSession sets this to
@@ -635,6 +643,10 @@ class OwnedSession:
         # not acquire immediately.  _fsm_release pops from the front and sets
         # the event to hand ownership to the next handler.
         self._handler_queue: list[threading.Event] = []
+        # Holders evicted by :meth:`force_release`; their eventual ``__exit__``
+        # consults this set under ``_fsm_cond`` and skips the normal
+        # ``_fsm_release`` so the double-release does not raise.
+        self._evicted_tids: set[int] = set()
         # Tool restriction applied on handler entry via switch_tools().
         # ClaudeSession overrides to HANDLER_ALLOWED_TOOLS in its constructor.
         self._handler_tools: str | None = None
@@ -752,12 +764,27 @@ class OwnedSession:
         :attr:`_fsm_state` transitions to :class:`~fido.rocq.transition.Free`
         and worker threads waiting on :attr:`_fsm_cond` are notified.
 
+        Skips the release entirely if the calling thread's tid is in
+        :attr:`_evicted_tids` — the watchdog already advanced the FSM
+        via :meth:`force_release` while this thread was wedged in IO,
+        so firing a normal ``*Release`` here would crash on the
+        ``release_only_by_owner`` invariant.
+
         Raises :class:`RuntimeError` if the current state is
-        :class:`~fido.rocq.transition.Free` (``release_only_by_owner``
-        invariant).
+        :class:`~fido.rocq.transition.Free` and the caller was not
+        evicted (``release_only_by_owner`` invariant).
         """
         tid = threading.get_ident()
         with self._fsm_cond:
+            if tid in self._evicted_tids:
+                self._evicted_tids.discard(tid)
+                log.debug(
+                    "fsm[%s]: WorkerRelease/HandlerRelease skipped "
+                    "(tid=%d previously evicted by ForceRelease)",
+                    self._repo_name or "?",
+                    tid,
+                )
+                return
             ev = (
                 fsm.WorkerRelease()
                 if isinstance(self._fsm_state, fsm.OwnedByWorker)
@@ -792,6 +819,124 @@ class OwnedSession:
                     type(ev).__name__,
                     tid,
                 )
+
+    def force_release(self, *, reason: str) -> bool:
+        """Evict the current FSM lock holder, advancing the lock to a
+        usable state.
+
+        The watchdog calls this when it detects a holder that has held
+        the lock past its deadline (typical cause: a thread parked
+        inside :meth:`PromptSession.prompt` on a subprocess that
+        streams forever and never produces ``type=result``, so
+        ``consume_until_result`` blocks indefinitely and the holder's
+        normal ``__exit__`` never runs).
+
+        Fires the ``ForceRelease`` FSM event through the oracle —
+        :func:`fido.rocq.transition.transition` accepts it in every
+        state and lands in :class:`~fido.rocq.transition.Free`
+        (proved by ``force_release_to_free``).  If a handler is queued
+        in :attr:`_handler_queue`, ownership is then transferred to
+        that handler with a second oracle call
+        (``Free + HandlerAcquire → OwnedByHandler``); otherwise the
+        FSM stays at ``Free`` and waiters on :attr:`_fsm_cond` are
+        notified.
+
+        The evicted holder's tid is recorded in :attr:`_evicted_tids`
+        so its eventual ``__exit__`` skips the normal
+        :meth:`_fsm_release` (which would crash on the
+        ``release_only_by_owner`` invariant — the FSM has moved past
+        the holder's state).  The evicted holder's
+        :class:`SessionTalker` is unregistered here too, so the next
+        :meth:`register_talker` from a fresh acquire does not collide
+        on a stale entry and raise :class:`SessionLeakError`.
+
+        After the FSM transition is committed, calls
+        :meth:`_on_force_release` so the subclass can knock the
+        holder thread out of its parked IO call (typically
+        ``self._proc.kill()`` — closing stdout makes the parked
+        ``select()`` return ready with EOF, ``iter_events`` breaks on
+        EOF, and the holder cleanly exits ``consume_until_result``).
+
+        Returns ``True`` when an owned state was evicted, ``False``
+        when the FSM was already :class:`~fido.rocq.transition.Free`
+        (the watchdog can race with a holder that just released
+        voluntarily; treat as a no-op).
+        """
+        with self._fsm_cond:
+            if isinstance(self._fsm_state, fsm.Free):
+                log.debug(
+                    "fsm[%s]: ForceRelease no-op — already Free (reason=%r)",
+                    self._repo_name or "?",
+                    reason,
+                )
+                return False
+            # Capture the evicted holder's identity before mutating any
+            # state.  ``_repo_name`` may be None on test stubs; in that
+            # case there is no global talker to consult and we fall back
+            # to the FSM state alone.
+            evicted_tid: int | None = None
+            if self._repo_name is not None:
+                talker = get_talker(self._repo_name)
+                if talker is not None:
+                    evicted_tid = talker.thread_id
+            prev_state_name = type(self._fsm_state).__name__
+            new_state = fsm.transition(self._fsm_state, fsm.ForceRelease())
+            if new_state is None:  # pragma: no cover — force_release_to_free
+                raise RuntimeError(
+                    "session-lock FSM: force_release_to_free violated — "
+                    f"ForceRelease rejected in state {prev_state_name}"
+                )
+            self._fsm_state = new_state  # → Free
+            if evicted_tid is not None:
+                self._evicted_tids.add(evicted_tid)
+                if self._repo_name is not None:
+                    unregister_talker(self._repo_name, evicted_tid)
+            if self._handler_queue:
+                # Transfer ownership directly to the next queued handler
+                # via the modeled HandlerAcquire transition (Free →
+                # OwnedByHandler).
+                handover = fsm.transition(self._fsm_state, fsm.HandlerAcquire())
+                if handover is None:  # pragma: no cover — proved unreachable
+                    raise RuntimeError(
+                        "session-lock FSM: HandlerAcquire from Free rejected"
+                    )
+                waiter = self._handler_queue.pop(0)
+                self._fsm_state = handover  # → OwnedByHandler
+                waiter.set()
+                log.warning(
+                    "fsm[%s]: ForceRelease %s → OwnedByHandler "
+                    "(evicted_tid=%s, queue=%d remaining, reason=%r)",
+                    self._repo_name or "?",
+                    prev_state_name,
+                    evicted_tid,
+                    len(self._handler_queue),
+                    reason,
+                )
+            else:
+                self._fsm_cond.notify_all()
+                log.warning(
+                    "fsm[%s]: ForceRelease %s → Free (evicted_tid=%s, reason=%r)",
+                    self._repo_name or "?",
+                    prev_state_name,
+                    evicted_tid,
+                    reason,
+                )
+        # Subclass hook fires *outside* the FSM lock so a slow
+        # subprocess kill doesn't block other threads waiting on
+        # ``_fsm_cond``.
+        self._on_force_release(reason=reason)
+        return True
+
+    def _on_force_release(self, *, reason: str) -> None:
+        """Subclass hook fired after :meth:`force_release` commits the
+        FSM transition.  Subclasses that wrap a long-lived IO resource
+        (e.g. :class:`~fido.claude.ClaudeSession`) override this to
+        knock the wedged holder thread out of its parked IO call —
+        typically by killing the subprocess so the parked ``select()``
+        returns EOF and the holder escapes ``consume_until_result``
+        cleanly.  Default is a no-op for subclasses with no such
+        coupling (e.g. CopilotCLISession)."""
+        del reason  # default base hook ignores the reason
 
     def _fire_worker_cancel(self) -> None:
         """Abort the current lock-holder's turn.  Subclasses override

--- a/src/fido/rocq/transition.py
+++ b/src/fido/rocq/transition.py
@@ -74,7 +74,20 @@ class Preempt(Event):
     pass
 
 
-EventT = WorkerAcquire | HandlerAcquire | WorkerRelease | HandlerRelease | Preempt
+@final
+@dataclass(frozen=True)
+class ForceRelease(Event):
+    pass
+
+
+EventT = (
+    WorkerAcquire
+    | HandlerAcquire
+    | WorkerRelease
+    | HandlerRelease
+    | Preempt
+    | ForceRelease
+)
 
 
 def transition(
@@ -94,6 +107,8 @@ def transition(
                     return None
                 case Preempt():
                     return None
+                case ForceRelease():
+                    return Free()
                 case __impossible:
                     assert_never(__impossible)
         case OwnedByWorker():
@@ -108,6 +123,8 @@ def transition(
                     return None
                 case Preempt():
                     return OwnedByHandler()
+                case ForceRelease():
+                    return Free()
                 case __impossible:
                     assert_never(__impossible)
         case OwnedByHandler():
@@ -122,6 +139,8 @@ def transition(
                     return Free()
                 case Preempt():
                     return None
+                case ForceRelease():
+                    return Free()
                 case __impossible:
                     assert_never(__impossible)
         case __impossible:

--- a/src/fido/rocq/transition.pymap
+++ b/src/fido/rocq/transition.pymap
@@ -1,2 +1,2 @@
 stability,python_start_line,python_start_col,python_end_line,python_end_col,source_file,source_start_line,source_start_col,source_end_line,source_end_col,kind,symbol,python_symbol
-open,93,0,95,18,session_lock.v,80,11,80,21,extraction,transition,transition
+open,93,0,95,18,session_lock.v,87,11,87,21,extraction,transition,transition

--- a/src/fido/rocq/transition.pymap
+++ b/src/fido/rocq/transition.pymap
@@ -1,2 +1,2 @@
 stability,python_start_line,python_start_col,python_end_line,python_end_col,source_file,source_start_line,source_start_col,source_end_line,source_end_col,kind,symbol,python_symbol
-open,93,0,95,18,session_lock.v,87,11,87,21,extraction,transition,transition
+open,93,0,95,18,session_lock.v,96,11,96,21,extraction,transition,transition

--- a/src/fido/rocq/transition.pymap
+++ b/src/fido/rocq/transition.pymap
@@ -1,2 +1,2 @@
 stability,python_start_line,python_start_col,python_end_line,python_end_col,source_file,source_start_line,source_start_col,source_end_line,source_end_col,kind,symbol,python_symbol
-open,80,0,82,18,session_lock.v,55,11,55,21,extraction,transition,transition
+open,93,0,95,18,session_lock.v,80,11,80,21,extraction,transition,transition

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -49,6 +49,7 @@ from fido.provider_factory import DefaultProviderFactory
 from fido.rate_limit import RateLimitMonitor, RateLimitWindow
 from fido.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from fido.rocq import self_restart as restart_fsm
+from fido.session_lock_watchdog import SessionLockWatchdog
 from fido.state import State
 from fido.static_files import StaticFiles
 from fido.status import provider_statuses_for_repo_configs
@@ -1470,6 +1471,7 @@ def run(
     _kill_active_children: Callable[..., None] = kill_active_children,
     _Watchdog: type[Watchdog] = Watchdog,
     _ReconcileWatchdog: type[ReconcileWatchdog] = ReconcileWatchdog,
+    _SessionLockWatchdog: type[SessionLockWatchdog] = SessionLockWatchdog,
     _RateLimitMonitor: type[RateLimitMonitor] = RateLimitMonitor,
     _preflight_repo_identity: Callable[..., None] = preflight_repo_identity,
     _preflight_tools: Callable[..., None] = preflight_tools,
@@ -1550,6 +1552,11 @@ def run(
     provider.set_session_resolver(registry.get_session)
     _Watchdog(registry, config.repos).start_thread()
     _ReconcileWatchdog(registry, config.repos, gh).start_thread()
+    # Session-lock watchdog evicts FSM lock holders that have parked past
+    # the deadline — without it, a holder wedged inside
+    # ``consume_until_result`` on a streaming-forever subprocess holds
+    # the lock indefinitely (closes #1377).
+    _SessionLockWatchdog(registry, config.repos).start_thread()
     rate_limit_monitor = _RateLimitMonitor(gh)
     rate_limit_monitor.start_thread()
     WebhookHandler.rate_limit_monitor = rate_limit_monitor

--- a/src/fido/session_lock_watchdog.py
+++ b/src/fido/session_lock_watchdog.py
@@ -1,0 +1,158 @@
+"""Session-lock watchdog — evict wedged FSM lock holders.
+
+The session-lock FSM (extracted from ``models/session_lock.v``) proves
+**safety** through ``no_dual_ownership`` and ``release_only_by_owner``,
+but in earlier model revisions the only path out of an owned state was
+the holder firing its voluntary ``WorkerRelease`` / ``HandlerRelease``
+event.  When a holder thread parked inside
+:meth:`~fido.claude.ClaudeSession.consume_until_result` on a subprocess
+that streamed events forever (so ``idle_timeout`` never tripped) and
+never produced ``type=result``, the holder never returned from
+``with self:``, ``__exit__`` never ran, ``_fsm_release`` never fired,
+and the FSM lock leaked indefinitely (closes #1377).
+
+The model now also proves **liveness** via ``force_release_to_free``
+and ``every_state_reaches_free``: ``ForceRelease`` is accepted in every
+state and always lands in :class:`~fido.rocq.transition.Free`.  This
+watchdog is the runtime driver that fires that event when a holder
+has held the lock past a deadline — guarding the property that no
+acquire can wait forever for a holder that will never release.
+
+Per repo, every :data:`_WATCHDOG_INTERVAL` seconds:
+
+1. Read the current :class:`~fido.provider.SessionTalker` snapshot.
+2. If a holder is registered and ``now - talker.started_at >
+   hold_deadline_seconds``, log a warning and call
+   :meth:`~fido.provider.OwnedSession.force_release` with a reason
+   string identifying the evicted tid and the elapsed hold time.
+3. The provider's :meth:`_on_force_release` subclass hook (e.g.
+   :meth:`~fido.claude.ClaudeSession._on_force_release`) knocks the
+   wedged thread out of its parked IO call by killing the subprocess.
+
+The watchdog itself never touches the FSM lock or the subprocess
+directly — every action goes through the modeled
+:meth:`force_release` API so the Rocq oracle catches any divergence.
+"""
+
+import logging
+import threading
+import time
+
+from fido.config import RepoConfig
+from fido.provider import OwnedSession, get_talker, talker_now
+from fido.registry import WorkerRegistry
+
+log = logging.getLogger(__name__)
+
+# Seconds between watchdog ticks.  Eviction granularity is therefore
+# ``_WATCHDOG_INTERVAL`` past the holder's deadline, in the worst case.
+_WATCHDOG_INTERVAL: float = 30.0
+
+# Default per-turn hold deadline.  A worker turn over this threshold is
+# already a code smell (typical legitimate turns finish in seconds to
+# a few minutes); past 15 minutes we assume the holder is wedged.
+# Configurable per session for tests and tightening over time.
+_DEFAULT_HOLD_DEADLINE_SECONDS: float = 900.0
+
+
+class SessionLockWatchdog:
+    """Per-repo poller that evicts FSM lock holders past a deadline.
+
+    Accepts *registry* and *repos* via the constructor so tests can
+    drive it directly with hand-rolled fakes (no MagicMock per
+    fido test conventions).  *hold_deadline_seconds* is configurable
+    per instance: tests use a tiny value so a single iteration triggers
+    eviction; production uses :data:`_DEFAULT_HOLD_DEADLINE_SECONDS`.
+    """
+
+    def __init__(
+        self,
+        registry: WorkerRegistry,
+        repos: dict[str, RepoConfig],
+        *,
+        hold_deadline_seconds: float = _DEFAULT_HOLD_DEADLINE_SECONDS,
+    ) -> None:
+        self.registry = registry
+        self.repos = repos
+        self.hold_deadline_seconds = hold_deadline_seconds
+
+    def run(self) -> int:
+        """Run one watchdog iteration. Returns 0.
+
+        For each configured repo with an attached session and an
+        active holder, compute the hold age via
+        :func:`~fido.provider.talker_now` and the talker's
+        ``started_at`` timestamp.  If the age exceeds
+        :attr:`hold_deadline_seconds`, fire
+        :meth:`~fido.provider.OwnedSession.force_release` on the
+        session.
+
+        Repos without a session (provider not yet initialised, or a
+        registry stub during boot) and repos with no current holder
+        (FSM is :class:`~fido.rocq.transition.Free`) are silently
+        skipped — both are normal idle states.
+        """
+        for repo_name in self.repos:
+            session = self._resolve_session(repo_name)
+            if session is None:
+                continue
+            talker = get_talker(repo_name)
+            if talker is None:
+                continue
+            held_for = (talker_now() - talker.started_at).total_seconds()
+            if held_for <= self.hold_deadline_seconds:
+                continue
+            reason = (
+                f"held > {self.hold_deadline_seconds:.0f}s "
+                f"by tid={talker.thread_id} kind={talker.kind} "
+                f"(actual {held_for:.0f}s, description={talker.description!r})"
+            )
+            log.warning(
+                "session-lock-watchdog[%s]: holder past deadline — %s",
+                repo_name,
+                reason,
+            )
+            session.force_release(reason=reason)
+        return 0
+
+    def _resolve_session(self, repo_name: str) -> OwnedSession | None:
+        """Return the :class:`OwnedSession` for *repo_name*, or ``None``.
+
+        :class:`~fido.registry.WorkerRegistry`'s
+        :meth:`~fido.registry.WorkerRegistry.get_session` returns the
+        provider session attached to the repo, or ``None`` when the
+        worker has not constructed one yet.  We also accept a
+        non-:class:`OwnedSession` return as ``None`` (defensive against
+        future provider types that may not extend the base) — the
+        watchdog then has nothing to do for that repo this tick.
+        """
+        session = self.registry.get_session(repo_name)
+        if isinstance(session, OwnedSession):
+            return session
+        return None
+
+    def start_thread(
+        self, *, _interval: float = _WATCHDOG_INTERVAL
+    ) -> threading.Thread:
+        """Start a daemon thread that runs :meth:`run` every *_interval* seconds."""
+
+        def _loop() -> None:
+            while True:
+                time.sleep(_interval)
+                self.run()
+
+        t = threading.Thread(target=_loop, daemon=True, name="session-lock-watchdog")
+        t.start()
+        return t
+
+
+def run(
+    registry: WorkerRegistry,
+    repos: dict[str, RepoConfig],
+    *,
+    hold_deadline_seconds: float = _DEFAULT_HOLD_DEADLINE_SECONDS,
+) -> int:
+    """Module-level entry point — create a watchdog and run one tick."""
+    return SessionLockWatchdog(
+        registry, repos, hold_deadline_seconds=hold_deadline_seconds
+    ).run()

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -575,3 +575,139 @@ def test_on_force_release_swallows_kill_oserror(tmp_path: Path) -> None:
 
     assert fake_proc.kill_calls == 1
     assert isinstance(session._stream_state, stream_fsm.Idle)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke: wedged holder is unblocked by force_release (#1377)
+# ---------------------------------------------------------------------------
+
+
+class _StreamingForeverProc:
+    """Hand-rolled subprocess that streams non-``result`` events forever.
+
+    Reproduces the wedge condition from #1377: ``iter_events`` keeps
+    receiving events, ``idle_timeout`` keeps getting reset, no
+    ``type=result`` ever arrives, the holder is parked in
+    ``consume_until_result`` indefinitely.
+
+    ``kill()`` flips an internal EOF flag so subsequent ``readline``
+    calls return ``""`` — that closes ``iter_events`` via its EOF
+    branch and the holder escapes ``consume_until_result``.
+    """
+
+    def __init__(self) -> None:
+        self.pid = 88888
+        self.returncode: int | None = None
+        self.stdin = MagicMock()
+        self.stdin.closed = False
+        self.kill_calls = 0
+        self._eof = threading.Event()
+        self._first_readline = threading.Event()
+        # Pretend stdout is the proc itself — the selector returns this
+        # object as "ready" and ``iter_events`` calls ``readline`` on it.
+        self.stdout = self
+        self.stderr = MagicMock()
+
+    def readline(self) -> str:
+        # Signal first readline so the test can synchronize on the
+        # holder being inside ``iter_events`` before firing the
+        # eviction.
+        self._first_readline.set()
+        if self._eof.is_set():
+            return ""
+        # Block briefly before returning the next event so the holder
+        # spends real time inside the loop — but stay responsive to
+        # eviction (kill flips _eof which we re-check).
+        if self._eof.wait(timeout=0.05):
+            return ""
+        return '{"type":"system","subtype":"streaming","session_id":"x"}\n'
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self._eof.set()
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return 0
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def test_force_release_unblocks_wedged_holder_end_to_end(tmp_path: Path) -> None:
+    """Full chain: a holder thread is parked in ``consume_until_result``
+    on a fake subprocess that streams events forever; the watchdog
+    fires ``force_release``; the kill propagates through
+    ``_on_force_release``; ``iter_events`` breaks on EOF; the holder's
+    ``__exit__`` runs and the ``_evicted_tids`` guard prevents the
+    double-release crash; the FSM lands in ``Free`` ready for a fresh
+    acquire — all within a generous 5 s budget.
+
+    This is the missing-Rocq-IO fix proved on real concurrency, not
+    just unit-by-unit: the holder thread is genuinely parked in
+    ``select()`` / ``readline``, the eviction comes from a different
+    thread, and the wedged thread escapes via the modeled chain.
+    """
+    from fido.rocq.transition import Free
+
+    session = _setup_session(tmp_path)
+    fake_proc = _StreamingForeverProc()
+    session._proc = fake_proc  # type: ignore[assignment]
+    # Selector: stdout always reported ready so iter_events keeps
+    # calling readline on the streaming proc.
+    session._selector = MagicMock(  # type: ignore[assignment]
+        return_value=([fake_proc.stdout], [], [])
+    )
+
+    holder_done = threading.Event()
+    holder_exception: list[BaseException] = []
+
+    def holder() -> None:
+        try:
+            with session:
+                session.consume_until_result()
+        except BaseException as exc:  # noqa: BLE001 — record everything
+            holder_exception.append(exc)
+        finally:
+            holder_done.set()
+
+    provider.set_thread_kind("worker")
+    try:
+        t = threading.Thread(target=holder, daemon=True)
+        t.start()
+        # Wait until the holder is genuinely inside ``iter_events`` —
+        # readline has been called at least once means the loop is hot.
+        assert fake_proc._first_readline.wait(timeout=5.0), (
+            "holder never entered iter_events readline"
+        )
+        # FSM must show the holder owning the lock at this point.
+        from fido.rocq.transition import OwnedByWorker
+
+        assert isinstance(session._fsm_state, OwnedByWorker)
+
+        # Watchdog (running on this main thread) evicts the wedged holder.
+        evicted = session.force_release(reason="end-to-end smoke")
+        assert evicted is True
+
+        # The holder must escape consume_until_result and finish its
+        # ``with`` block within a generous budget.
+        assert holder_done.wait(timeout=5.0), (
+            "wedged holder never escaped after force_release"
+        )
+
+        # No exception leaked from the holder thread — the
+        # ``_evicted_tids`` guard prevented the double-release crash.
+        assert holder_exception == [], (
+            f"holder thread raised unexpectedly: {holder_exception!r}"
+        )
+
+        # ``_on_force_release`` actually killed the subprocess.
+        assert fake_proc.kill_calls == 1
+        # Final FSM state is Free — ready for the next acquire with no
+        # stale holder slot.
+        assert isinstance(session._fsm_state, Free)
+    finally:
+        provider.set_thread_kind(None)
+        # Don't call session.stop — the proc is already in EOF state and
+        # ``stop`` would call wait/kill on the MagicMock'd default proc.
+        # Letting the daemon thread reap on process exit is sufficient.

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -472,3 +472,106 @@ def test_hold_reraises_leak_error_and_releases_lock(
         provider.set_thread_kind(None)
         provider.unregister_talker("owner/repo", 111_111)
         session.stop()
+
+
+# ---------------------------------------------------------------------------
+# ClaudeSession._on_force_release — kill subprocess so wedged holder escapes
+# (closes #1377)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingProc:
+    """Hand-rolled subprocess.Popen-shaped fake that records ``kill()`` calls.
+
+    Used in place of MagicMock so the test follows the project rule of
+    "hand-rolled typed fakes" for new tests; we only need ``pid``,
+    ``kill``, and the methods ``stop`` touches during cleanup.
+    """
+
+    def __init__(self, pid: int = 99999) -> None:
+        self.pid = pid
+        self.kill_calls = 0
+        self.kill_raises: BaseException | None = None
+        self.returncode: int | None = None
+        self.stdin = MagicMock()
+        self.stdin.closed = False
+        # ``stop()`` invokes wait/kill on shutdown — accept calls but no
+        # actual subprocess work to do.
+        self._wait_returncode = 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        if self.kill_raises is not None:
+            raise self.kill_raises
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self._wait_returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def test_on_force_release_kills_subprocess_and_resets_stream(
+    tmp_path: Path,
+) -> None:
+    """``_on_force_release`` knocks the wedged holder out of its parked IO
+    by killing the subprocess; the stream FSM is also reset so the next
+    acquire's first turn does not inherit stale ``Sending`` /
+    ``AwaitingReply`` state from the killed subprocess."""
+    from fido.claude import stream_fsm
+
+    session = _setup_session(tmp_path)
+    fake_proc = _RecordingProc(pid=12345)
+    session._proc = fake_proc  # type: ignore[assignment]
+    # Drive the stream FSM to AwaitingReply so we can observe the reset.
+    with session._stream_lock:
+        session._stream_state = stream_fsm.AwaitingReply()
+
+    session._on_force_release(reason="watchdog test eviction")
+
+    assert fake_proc.kill_calls == 1
+    assert isinstance(session._stream_state, stream_fsm.Idle)
+
+
+def test_on_force_release_swallows_already_dead_subprocess(
+    tmp_path: Path,
+) -> None:
+    """If the subprocess has already exited (race with idle timeout or
+    another recovery path), ``kill()`` raises :class:`ProcessLookupError`
+    or :class:`OSError` — the eviction must continue rather than
+    propagating that as a watchdog crash."""
+    from fido.claude import stream_fsm
+
+    session = _setup_session(tmp_path)
+    fake_proc = _RecordingProc()
+    fake_proc.kill_raises = ProcessLookupError("no such process")
+    session._proc = fake_proc  # type: ignore[assignment]
+    with session._stream_lock:
+        session._stream_state = stream_fsm.AwaitingReply()
+
+    # Must not raise.
+    session._on_force_release(reason="dead-subprocess test")
+
+    assert fake_proc.kill_calls == 1
+    # Stream FSM is still reset even when kill failed — defensive
+    # cleanup runs regardless of the kill outcome.
+    assert isinstance(session._stream_state, stream_fsm.Idle)
+
+
+def test_on_force_release_swallows_kill_oserror(tmp_path: Path) -> None:
+    """``OSError`` from ``kill`` (e.g. EPERM in restricted contexts) is
+    handled the same as ``ProcessLookupError``."""
+    from fido.claude import stream_fsm
+
+    session = _setup_session(tmp_path)
+    fake_proc = _RecordingProc()
+    fake_proc.kill_raises = OSError("permission denied")
+    session._proc = fake_proc  # type: ignore[assignment]
+    with session._stream_lock:
+        session._stream_state = stream_fsm.AwaitingReply()
+
+    session._on_force_release(reason="oserror test")
+
+    assert fake_proc.kill_calls == 1
+    assert isinstance(session._stream_state, stream_fsm.Idle)

--- a/tests/test_rocq_lsp.py
+++ b/tests/test_rocq_lsp.py
@@ -30,6 +30,16 @@ def _line_containing(path: Path, fragment: str) -> int:
     raise AssertionError(f"{fragment!r} not found in {path}")
 
 
+# Hard-coded line numbers in this file used to break every time
+# ``models/session_lock.v`` grew (for example when adding ``ForceRelease`` for
+# #1377).  Look the position up dynamically so the tests track the model
+# without manual editing.
+SESSION_LOCK_PATH = REPO / "models" / "session_lock.v"
+TRANSITION_LINE_0BASED = _line_containing(SESSION_LOCK_PATH, "Definition transition")
+TRANSITION_LINE_1BASED = TRANSITION_LINE_0BASED + 1
+TRANSITION_LINE_1BASED_STR = str(TRANSITION_LINE_1BASED)
+
+
 def test_location_and_diagnostic_json_shapes() -> None:
     location = Location(
         REPO / "models" / "session_lock.v",
@@ -54,7 +64,9 @@ def test_index_finds_transition_symbol_and_python_signature() -> None:
     index = RocqIndex(REPO)
     index.refresh()
 
-    symbol = index.symbol_at(REPO / "models" / "session_lock.v", 54, 11)
+    symbol = index.symbol_at(
+        REPO / "models" / "session_lock.v", TRANSITION_LINE_0BASED, 11
+    )
 
     assert symbol is not None
     assert symbol.name == "transition"
@@ -74,19 +86,31 @@ def test_index_finds_transition_symbol_and_python_signature() -> None:
 def test_service_hover_definition_references_symbols_and_diagnostics() -> None:
     service = RocqLanguageService(REPO)
 
-    hover = service.hover(Path("models/session_lock.v"), 54, 11)
-    definitions = service.definition(Path("models/session_lock.v"), 54, 11)
-    references = service.references(Path("models/session_lock.v"), 54, 11)
-    callers = service.callers(Path("models/session_lock.v"), 54, 11)
+    hover = service.hover(Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11)
+    definitions = service.definition(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
+    references = service.references(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
+    callers = service.callers(Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11)
     symbols = service.symbols(Path("models/session_lock.v"))
     tokens = service.semantic_tokens(Path("models/session_lock.v"))
     lenses = service.code_lens(Path("models/session_lock.v"))
     graph = service.dependency_graph()
-    signature = service.signature_help(Path("models/session_lock.v"), 54, 11)
-    completions = service.completion(Path("models/session_lock.v"), 54, 14)
-    explanation = service.explain(Path("models/session_lock.v"), 54, 11)
+    signature = service.signature_help(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
+    completions = service.completion(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 14
+    )
+    explanation = service.explain(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
     code_actions = service.code_actions(Path("models/session_lock.v"))
-    rename = service.rename(Path("models/session_lock.v"), 54, 11, "step")
+    rename = service.rename(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11, "step"
+    )
 
     assert hover is not None
     assert (
@@ -107,7 +131,7 @@ def test_service_hover_definition_references_symbols_and_diagnostics() -> None:
         }
     ]
     assert {
-        "line": 54,
+        "line": TRANSITION_LINE_0BASED,
         "start": 11,
         "length": 10,
         "type": "function",
@@ -143,15 +167,23 @@ def test_lsp_shapes() -> None:
     service = RocqLanguageService(REPO)
     uri = (REPO / "models" / "session_lock.v").resolve().as_uri()
 
-    definitions = service.lsp_definition(Path("models/session_lock.v"), 54, 11)
-    references = service.lsp_references(Path("models/session_lock.v"), 54, 11)
+    definitions = service.lsp_definition(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
+    references = service.lsp_references(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
     document_symbols = service.lsp_document_symbols(Path("models/session_lock.v"))
     workspace_symbols = service.lsp_workspace_symbols("trans")
     diagnostics = service.lsp_diagnostics(Path("models/session_lock.v"))
     semantic_tokens = service.lsp_semantic_tokens_full(Path("models/session_lock.v"))
     code_lens = service.lsp_code_lens(Path("models/session_lock.v"))
-    signature = service.lsp_signature_help(Path("models/session_lock.v"), 54, 11)
-    completions = service.lsp_completion(Path("models/session_lock.v"), 54, 14)
+    signature = service.lsp_signature_help(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 11
+    )
+    completions = service.lsp_completion(
+        Path("models/session_lock.v"), TRANSITION_LINE_0BASED, 14
+    )
     actions = service.lsp_code_actions(Path("models/session_lock.v"))
 
     assert definitions[0]["uri"] == uri
@@ -221,12 +253,20 @@ def test_index_maps_runtime_marker_symbols_to_runtime_python_methods() -> None:
 
 def test_cli_outputs_json_for_each_command() -> None:
     for argv in (
-        ["hover", "models/session_lock.v", "--line", "55", "--column", "12", "--json"],
+        [
+            "hover",
+            "models/session_lock.v",
+            "--line",
+            TRANSITION_LINE_1BASED_STR,
+            "--column",
+            "12",
+            "--json",
+        ],
         [
             "definition",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--json",
@@ -235,7 +275,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "references",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--json",
@@ -244,7 +284,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "callers",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--json",
@@ -253,7 +293,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "signature",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--json",
@@ -262,7 +302,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "completion",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "15",
             "--json",
@@ -271,7 +311,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "explain",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--json",
@@ -286,7 +326,7 @@ def test_cli_outputs_json_for_each_command() -> None:
             "rename",
             "models/session_lock.v",
             "--line",
-            "55",
+            TRANSITION_LINE_1BASED_STR,
             "--column",
             "12",
             "--new-name",
@@ -328,7 +368,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/hover",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
             },
         },
         {
@@ -337,7 +377,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/definition",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
             },
         },
         {
@@ -346,7 +386,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/references",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
             },
         },
         {
@@ -367,7 +407,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/signatureHelp",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
             },
         },
         {
@@ -376,7 +416,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/completion",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 14},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 14},
             },
         },
         {
@@ -403,7 +443,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/prepareRename",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
             },
         },
         {
@@ -412,7 +452,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
             "method": "textDocument/rename",
             "params": {
                 "textDocument": {"uri": uri},
-                "position": {"line": 54, "character": 11},
+                "position": {"line": TRANSITION_LINE_0BASED, "character": 11},
                 "newName": "step",
             },
         },
@@ -457,7 +497,7 @@ def test_lsp_server_handles_requests_notifications_errors_and_eof() -> None:
     assert responses[8]["result"][0]["title"] == "Refresh Rocq extraction"
     assert responses[9]["result"][0]["data"]["symbol"] == "transition"
     assert len(responses[10]["result"]["data"]) % 5 == 0
-    assert responses[11]["result"]["start"]["line"] == 54
+    assert responses[11]["result"]["start"]["line"] == TRANSITION_LINE_0BASED
     assert responses[12]["result"]["changes"]
     assert responses[14]["result"] is None
     assert responses[15]["error"]["code"] == -32603

--- a/tests/test_session_lock_hypothesis.py
+++ b/tests/test_session_lock_hypothesis.py
@@ -8,10 +8,17 @@ Python — not just for the specific cases enumerated in the unit tests,
 but for *every* input Hypothesis can construct.
 
 Proved invariants exercised:
-  ``no_dual_ownership``     — any acquire from an already-owned state → None
-  ``release_only_by_owner`` — cross-release or spurious release → None
+  ``no_dual_ownership``        — any acquire from an already-owned state → None
+  ``release_only_by_owner``    — cross-release or spurious release → None
+  ``force_release_to_free``    — ForceRelease always lands in Free regardless
+                                 of starting state (proved on every random
+                                 reachable state, not just the three roots)
+  ``unconditional_liveness``   — at the trace level: from any state reached
+                                 by an arbitrary event sequence, firing
+                                 ForceRelease lands in Free (the watchdog
+                                 needs no priors about state)
 
-A third "closure" property checks that every successful transition lands on
+A "closure" property checks that every successful transition lands on
 a valid state and that the FSM never silently returns garbage.
 """
 
@@ -19,6 +26,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from fido.rocq.transition import (
+    ForceRelease,
     Free,
     HandlerAcquire,
     HandlerRelease,
@@ -57,6 +65,7 @@ _all_events = st.one_of(
     _acquire_events,
     _release_events,
     st.just(Preempt()),
+    st.just(ForceRelease()),
 )
 
 
@@ -186,9 +195,111 @@ def test_preempt_is_only_worker_to_handler_path(event: object) -> None:
     All other events either keep the worker in the owned state (via
     WorkerRelease → Free, which is not OwnedByHandler) or are rejected.
     Confirms the model's exclusive-takeover design.
+
+    Note: ForceRelease is excluded from the strategy — it lands in
+    Free, not OwnedByHandler, so it does not violate the property
+    being asserted (and we test ForceRelease's target state explicitly
+    below).
     """
     result = transition(OwnedByWorker(), event)
     assert not isinstance(result, OwnedByHandler), (
         f"Unexpected OwnedByHandler from non-Preempt event "
         f"{type(event).__name__!r}: transition returned {result!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Property: force_release_to_free — ForceRelease always lands in Free
+# ---------------------------------------------------------------------------
+
+
+@given(state=_all_states)
+def test_force_release_always_lands_in_free(state: FsmState) -> None:
+    """Hypothesis mirror of ``force_release_to_free`` in the model.
+
+    Exhaustive over the three reachable FSM states; every one must
+    transition to Free under ForceRelease.  The watchdog's
+    post-condition is therefore unconditional on starting state.
+    """
+    result = transition(state, ForceRelease())
+    assert isinstance(result, Free), (
+        f"force_release_to_free violated: transition({type(state).__name__}, "
+        f"ForceRelease()) = {result!r}, expected Free()"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property: unconditional_liveness at the *trace* level
+# ---------------------------------------------------------------------------
+
+
+@given(events=st.lists(_all_events, min_size=0, max_size=50))
+def test_force_release_lands_in_free_after_arbitrary_trace(
+    events: list[object],
+) -> None:
+    """Trace-level mirror of ``unconditional_liveness``.
+
+    From the initial Free state, walk an arbitrary event sequence
+    (applying only successful transitions, mirroring the runtime).
+    Whatever state we end up in, firing ForceRelease must land us in
+    Free.
+
+    This is the strongest runtime form of the watchdog's guarantee:
+    no matter what interleaving of acquires, releases, preempts, and
+    even other ForceReleases happened first, the watchdog's next
+    ForceRelease unconditionally returns the FSM to a usable state.
+    """
+    current: FsmState = Free()
+    for ev in events:
+        result = transition(current, ev)
+        if result is not None:
+            current = result
+
+    final = transition(current, ForceRelease())
+    assert isinstance(final, Free), (
+        f"unconditional_liveness violated at trace level: "
+        f"after {len(events)} events ending in state "
+        f"{type(current).__name__!r}, transition(_, ForceRelease()) "
+        f"= {final!r}, expected Free()"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property: ForceRelease is the only event that succeeds in every state
+# ---------------------------------------------------------------------------
+
+
+@given(state=_all_states)
+def test_force_release_is_the_universal_release(state: FsmState) -> None:
+    """ForceRelease is the *only* event that succeeds in every state —
+    every other event is rejected from at least one state.
+
+    Mirrors the design intent of ``unconditional_liveness``:
+    ForceRelease is structurally distinguished from the voluntary
+    releases.  ``WorkerRelease`` is rejected from Free and
+    OwnedByHandler; ``HandlerRelease`` from Free and OwnedByWorker;
+    ``WorkerAcquire`` and ``HandlerAcquire`` from owned states;
+    ``Preempt`` from Free and OwnedByHandler.  Only ForceRelease
+    yields ``Some _`` for every state.
+    """
+    # ForceRelease succeeds.
+    assert transition(state, ForceRelease()) is not None
+
+    # No other event succeeds in *every* state.  We assert this by
+    # checking that for each non-ForceRelease event, at least one
+    # state rejects it — the witness varies by event but it always
+    # exists.
+    other_events = [
+        WorkerAcquire(),
+        HandlerAcquire(),
+        WorkerRelease(),
+        HandlerRelease(),
+        Preempt(),
+    ]
+    all_states = [Free(), OwnedByWorker(), OwnedByHandler()]
+    for ev in other_events:
+        rejected_somewhere = any(transition(s, ev) is None for s in all_states)
+        assert rejected_somewhere, (
+            f"event {type(ev).__name__!r} unexpectedly succeeds in every "
+            f"state — that would weaken ForceRelease's distinguishing role"
+        )

--- a/tests/test_session_lock_oracle.py
+++ b/tests/test_session_lock_oracle.py
@@ -12,7 +12,13 @@ Proved theorems being guarded:
   ``no_dual_ownership``        — acquisition rejected when session already owned
   ``release_only_by_owner``    — release rejected when wrong owner or Free
   ``force_release_to_free``    — ForceRelease always lands in Free
-  ``every_state_reaches_free`` — every state has at least one event reaching Free
+  ``unconditional_liveness``   — a *single* event (ForceRelease) drives every
+                                 state to Free (∃ev. ∀s. ...) — strong form
+                                 the watchdog relies on, fired without first
+                                 inspecting FSM state
+  ``every_state_reaches_free`` — weaker form (∀s. ∃ev. ...) — each state has
+                                 at least one event reaching Free, citing
+                                 voluntary releases for owned states
   ``owned_state_exit_paths``   — only WorkerRelease/Preempt/ForceRelease exit
                                  OwnedByWorker; only HandlerRelease/ForceRelease
                                  exit OwnedByHandler
@@ -447,3 +453,30 @@ def test_force_release_oracle_assertion_path_is_unreachable_in_practice() -> Non
             f"force_release_to_free violated: transition({s!r}, "
             f"ForceRelease()) = {result!r}"
         )
+
+
+def test_unconditional_liveness_witness_is_force_release() -> None:
+    """Runtime mirror of ``unconditional_liveness`` (``models/session_lock.v``).
+
+    The Rocq theorem says ``∃ev. ∀s. transition s ev = Some Free``.
+    ``ForceRelease`` is the witness — strictly stronger than
+    ``every_state_reaches_free`` (``∀s. ∃ev. …``), which would leave
+    open the possibility of no single event working universally.
+
+    This test pins down ForceRelease *as* that witness so the
+    watchdog's "fire ForceRelease without inspecting FSM state"
+    guarantee is asserted on the extracted Python and not just in
+    the model.  Mirroring the model proof keeps the runtime honest
+    about the strong form rather than the weak one.
+    """
+    from fido.rocq.transition import ForceRelease, transition
+
+    witness = ForceRelease()
+    # The witness works for *every* state — the strong ∃∀ shape.
+    assert all(
+        isinstance(transition(s, witness), Free)
+        for s in (Free(), OwnedByWorker(), OwnedByHandler())
+    ), (
+        "unconditional_liveness violated: ForceRelease should reach Free "
+        "from every state; the watchdog relies on this without state inspection."
+    )

--- a/tests/test_session_lock_oracle.py
+++ b/tests/test_session_lock_oracle.py
@@ -1,21 +1,35 @@
 """Tests for the FSM-driven lock coordination in OwnedSession.
 
 Covers the FSM coordination methods (``_fsm_acquire_worker`` /
-``_fsm_acquire_handler`` / ``_fsm_release``) — the authoritative
-lock coordinator extracted from ``models/session_lock.v``.  Workers
-block until Free with no queued handlers; handlers block until Free
-(FIFO queue for handler-on-handler ordering).
+``_fsm_acquire_handler`` / ``_fsm_release`` / ``force_release``) —
+the authoritative lock coordinator extracted from
+``models/session_lock.v``.  Workers block until Free with no queued
+handlers; handlers block until Free (FIFO queue for handler-on-handler
+ordering); ``force_release`` evicts a wedged holder regardless of
+state (liveness escape hatch added for #1377).
 
 Proved theorems being guarded:
-  ``no_dual_ownership``     — acquisition rejected when session already owned
-  ``release_only_by_owner`` — release rejected when wrong owner or Free
+  ``no_dual_ownership``        — acquisition rejected when session already owned
+  ``release_only_by_owner``    — release rejected when wrong owner or Free
+  ``force_release_to_free``    — ForceRelease always lands in Free
+  ``every_state_reaches_free`` — every state has at least one event reaching Free
+  ``owned_state_exit_paths``   — only WorkerRelease/Preempt/ForceRelease exit
+                                 OwnedByWorker; only HandlerRelease/ForceRelease
+                                 exit OwnedByHandler
 """
 
 import threading
 
 import pytest
 
-from fido.provider import OwnedSession
+from fido.provider import (
+    OwnedSession,
+    SessionTalker,
+    get_talker,
+    register_talker,
+    talker_now,
+    unregister_talker,
+)
 from fido.rocq.transition import (
     Free,
     OwnedByHandler,
@@ -256,3 +270,180 @@ def test_fsm_handler_fifo_order() -> None:
     # Final release clears to Free.
     session._fsm_release()
     assert isinstance(session._fsm_state, Free)
+
+
+# ---------------------------------------------------------------------------
+# FSM coordination: force_release (liveness escape — #1377)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingForceReleaseSession(_FakeSession):
+    """``_FakeSession`` that records every ``_on_force_release`` call.
+
+    Lets tests assert the subclass hook fired with the expected reason
+    after the FSM transition committed, mirroring the production
+    ``ClaudeSession._on_force_release`` override that kills the
+    subprocess.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.force_release_reasons: list[str] = []
+
+    def _on_force_release(self, *, reason: str) -> None:
+        self.force_release_reasons.append(reason)
+
+
+def test_force_release_from_free_is_noop() -> None:
+    """``force_release`` returns False when the FSM is already Free.
+
+    Watchdog can race a holder that just released voluntarily — the
+    eviction must be a no-op rather than corrupting state or raising.
+    """
+    session = _RecordingForceReleaseSession()
+    assert session.force_release(reason="watchdog tick") is False
+    assert isinstance(session._fsm_state, Free)
+    # Subclass hook is *not* fired on the no-op path — there is no
+    # holder to knock out of any blocking call.
+    assert session.force_release_reasons == []
+
+
+def test_force_release_from_owned_worker_lands_in_free() -> None:
+    """``force_release`` from OwnedByWorker → Free (force_release_to_free)."""
+    session = _RecordingForceReleaseSession()
+    session._fsm_acquire_worker()
+    assert isinstance(session._fsm_state, OwnedByWorker)
+
+    assert session.force_release(reason="worker wedge") is True
+
+    assert isinstance(session._fsm_state, Free)
+    assert session.force_release_reasons == ["worker wedge"]
+
+
+def test_force_release_from_owned_handler_lands_in_free() -> None:
+    """``force_release`` from OwnedByHandler → Free (force_release_to_free)."""
+    session = _RecordingForceReleaseSession()
+    session._fsm_acquire_handler()
+    assert isinstance(session._fsm_state, OwnedByHandler)
+
+    assert session.force_release(reason="handler wedge") is True
+
+    assert isinstance(session._fsm_state, Free)
+    assert session.force_release_reasons == ["handler wedge"]
+
+
+def test_force_release_with_queued_handler_transfers_ownership() -> None:
+    """``force_release`` with a queued handler hands ownership directly.
+
+    The first oracle call (ForceRelease) takes the FSM through Free;
+    the second (HandlerAcquire from Free) lands in OwnedByHandler.
+    The queued waiter's event is set so the parked handler thread
+    unblocks.
+    """
+    session = _RecordingForceReleaseSession()
+    session._fsm_acquire_worker()  # wedged worker holds the lock
+
+    fake_waiter = threading.Event()
+    with session._fsm_cond:
+        session._handler_queue.append(fake_waiter)
+
+    assert session.force_release(reason="worker wedge with queue") is True
+
+    assert fake_waiter.is_set(), "queued handler was not signalled"
+    assert isinstance(session._fsm_state, OwnedByHandler)
+    assert session._handler_queue == []
+    assert session.force_release_reasons == ["worker wedge with queue"]
+
+
+def test_evicted_holder_release_is_skipped() -> None:
+    """After ``force_release``, the evicted holder's ``_fsm_release`` is a no-op.
+
+    The evicted holder thread eventually escapes its wedged IO call
+    (typically because the subclass hook killed the subprocess and
+    its ``select()`` returned EOF).  Its ``__exit__`` calls
+    ``_fsm_release`` — without the ``_evicted_tids`` guard, that would
+    crash on ``release_only_by_owner`` because the FSM has already
+    moved past the holder's role.
+    """
+    session = _RecordingForceReleaseSession()
+    session._fsm_acquire_worker()
+    # Simulate the watchdog evicting *this* tid — there is no per-repo
+    # ``SessionTalker`` registered (``_FakeSession._repo_name = None``)
+    # so we mark the eviction directly the way ``force_release`` would
+    # for this thread's tid.
+    with session._fsm_cond:
+        session._evicted_tids.add(threading.get_ident())
+    # Advance the FSM the way ``force_release`` would.
+    session._fsm_state = Free()
+
+    # The evicted holder's eventual release: must NOT raise even though
+    # the FSM state is Free (the normal release_only_by_owner check
+    # would reject WorkerRelease/HandlerRelease here).
+    session._fsm_release()  # should be a silent no-op
+
+    # The eviction marker is consumed exactly once.
+    assert threading.get_ident() not in session._evicted_tids
+
+
+def test_force_release_unregisters_evicted_talker_and_records_tid() -> None:
+    """``force_release`` records the evicted holder's tid via the global
+    talker registry and unregisters the talker so the next acquire's
+    ``register_talker`` does not raise :class:`SessionLeakError` on a
+    stale entry.
+    """
+
+    class _ReposSession(_FakeSession):
+        _repo_name: str | None = "test/force-release-talker"
+
+    session = _ReposSession()
+    session._fsm_acquire_worker()
+
+    holder_tid = 424242
+    register_talker(
+        SessionTalker(
+            repo_name="test/force-release-talker",
+            thread_id=holder_tid,
+            kind="worker",
+            description="test holder",
+            claude_pid=1,
+            started_at=talker_now(),
+        )
+    )
+    try:
+        assert get_talker("test/force-release-talker") is not None, (
+            "talker setup failed"
+        )
+
+        assert session.force_release(reason="talker test") is True
+
+        assert isinstance(session._fsm_state, Free)
+        assert holder_tid in session._evicted_tids
+        assert get_talker("test/force-release-talker") is None, (
+            "stale talker should have been unregistered"
+        )
+    finally:
+        # Defensive cleanup: if the production path unregistered the
+        # talker (the assertion above), this is a no-op.  If the test
+        # failed before that point, this prevents the global registry
+        # from leaking into subsequent tests.
+        unregister_talker("test/force-release-talker", holder_tid)
+
+
+def test_force_release_oracle_assertion_path_is_unreachable_in_practice() -> None:
+    """``force_release_to_free`` proves ForceRelease is accepted in every
+    state; the runtime ``RuntimeError`` branch in ``force_release`` is
+    therefore unreachable through normal operation.
+
+    This test guards the *invariant statement*: from each of the three
+    states, ``transition(s, ForceRelease())`` returns Some Free.
+    Mirrors the proof in ``models/session_lock.v`` so a regression in
+    the extracted Python is caught at the test layer too.
+    """
+    from fido.rocq.transition import ForceRelease, transition
+
+    for s in (Free(), OwnedByWorker(), OwnedByHandler()):
+        result = transition(s, ForceRelease())
+        assert isinstance(result, Free), (
+            f"force_release_to_free violated: transition({s!r}, "
+            f"ForceRelease()) = {result!r}"
+        )

--- a/tests/test_session_lock_watchdog.py
+++ b/tests/test_session_lock_watchdog.py
@@ -1,0 +1,354 @@
+"""Tests for ``SessionLockWatchdog`` — the runtime driver that fires
+``ForceRelease`` on FSM lock holders that have held the lock past a
+deadline (closes #1377).
+
+The watchdog delegates the actual eviction to
+:meth:`~fido.provider.OwnedSession.force_release`, which is itself
+covered by ``test_session_lock_oracle.py``.  These tests exercise
+*just the watchdog's decision logic*: which repos it considers, what
+hold-age threshold triggers eviction, and how it behaves when no
+holder is present.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from fido import session_lock_watchdog
+from fido.config import RepoConfig
+from fido.provider import (
+    OwnedSession,
+    ProviderID,
+    SessionTalker,
+    register_talker,
+    unregister_talker,
+)
+from fido.session_lock_watchdog import SessionLockWatchdog
+
+
+class _RecordingSession(OwnedSession):
+    """OwnedSession stub that records every ``force_release`` call.
+
+    The watchdog calls :meth:`force_release` rather than poking FSM
+    state directly, so a stub that records the calls is enough to
+    assert "eviction fired with the expected reason" without spinning
+    up a real provider session.
+    """
+
+    _repo_name: str | None
+
+    def __init__(self, repo_name: str) -> None:
+        self._repo_name = repo_name
+        self._init_handler_reentry()
+        self.force_release_calls: list[str] = []
+
+    def _fire_worker_cancel(self) -> None:  # pragma: no cover — abstract hook
+        pass
+
+    def force_release(self, *, reason: str) -> bool:  # type: ignore[override]
+        self.force_release_calls.append(reason)
+        return True
+
+
+class _StubRegistry:
+    """Hand-rolled :class:`WorkerRegistry` substitute.
+
+    Exposes only :meth:`get_session` because that is the sole
+    registry method the watchdog touches — keeps the fake's surface
+    area minimal so it can't drift away from the production contract
+    silently.
+    """
+
+    def __init__(self, sessions: dict[str, OwnedSession | None]) -> None:
+        self._sessions = sessions
+
+    def get_session(self, repo_name: str) -> OwnedSession | None:
+        return self._sessions.get(repo_name)
+
+
+def _repo_config(name: str) -> RepoConfig:
+    """Minimal RepoConfig for watchdog tests — values don't matter,
+    only the dict key (the repo name) is consulted."""
+    return RepoConfig(
+        name=name,
+        work_dir=Path(f"/tmp/{name.replace('/', '-')}"),
+        provider=ProviderID.CLAUDE_CODE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-op paths: nothing to evict
+# ---------------------------------------------------------------------------
+
+
+def test_run_skips_repo_without_session() -> None:
+    """Repos whose registry has no session attached are silently skipped."""
+    registry = _StubRegistry({"FidoCanCode/home": None})
+    watchdog = SessionLockWatchdog(
+        registry,  # type: ignore[arg-type]
+        {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
+        hold_deadline_seconds=0.01,
+    )
+    assert watchdog.run() == 0
+
+
+def test_run_skips_repo_without_active_holder() -> None:
+    """A session with no registered talker (FSM Free) is left alone."""
+    session = _RecordingSession("FidoCanCode/home")
+    registry = _StubRegistry({"FidoCanCode/home": session})
+    watchdog = SessionLockWatchdog(
+        registry,  # type: ignore[arg-type]
+        {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
+        hold_deadline_seconds=0.01,
+    )
+    # No register_talker call → get_talker returns None.
+    watchdog.run()
+    assert session.force_release_calls == []
+
+
+def test_run_skips_holder_within_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Holders that have not exceeded the deadline are left alone."""
+    repo_name = "FidoCanCode/home"
+    session = _RecordingSession(repo_name)
+    registry = _StubRegistry({repo_name: session})
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    register_talker(
+        SessionTalker(
+            repo_name=repo_name,
+            thread_id=42,
+            kind="worker",
+            description="recent turn",
+            claude_pid=1,
+            started_at=started_at,
+        )
+    )
+    try:
+        # ``talker_now`` is the seam the watchdog uses to compute hold age.
+        # Set it to "5 seconds after started_at" so held_for = 5 s.
+        monkeypatch.setattr(
+            session_lock_watchdog,
+            "talker_now",
+            lambda: started_at + timedelta(seconds=5),
+        )
+        watchdog = SessionLockWatchdog(
+            registry,  # type: ignore[arg-type]
+            {repo_name: _repo_config(repo_name)},
+            hold_deadline_seconds=10.0,
+        )
+        watchdog.run()
+        assert session.force_release_calls == []
+    finally:
+        unregister_talker(repo_name, 42)
+
+
+# ---------------------------------------------------------------------------
+# Eviction path
+# ---------------------------------------------------------------------------
+
+
+def test_run_evicts_holder_past_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A holder whose age exceeds the deadline triggers ``force_release``.
+
+    The watchdog passes a reason string identifying the evicted tid
+    and the actual hold time so the production log makes the
+    eviction unambiguous in a postmortem.
+    """
+    repo_name = "FidoCanCode/home"
+    session = _RecordingSession(repo_name)
+    registry = _StubRegistry({repo_name: session})
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    register_talker(
+        SessionTalker(
+            repo_name=repo_name,
+            thread_id=99999,
+            kind="webhook",
+            description="wedged synthesis turn",
+            claude_pid=1,
+            started_at=started_at,
+        )
+    )
+    try:
+        monkeypatch.setattr(
+            session_lock_watchdog,
+            "talker_now",
+            lambda: started_at + timedelta(seconds=120),
+        )
+        watchdog = SessionLockWatchdog(
+            registry,  # type: ignore[arg-type]
+            {repo_name: _repo_config(repo_name)},
+            hold_deadline_seconds=60.0,
+        )
+        watchdog.run()
+    finally:
+        unregister_talker(repo_name, 99999)
+
+    assert len(session.force_release_calls) == 1
+    reason = session.force_release_calls[0]
+    assert "tid=99999" in reason
+    assert "kind=webhook" in reason
+    assert "wedged synthesis turn" in reason
+    # Reason carries both the threshold (60s) and the observed hold (120s)
+    # so a postmortem can tell what the watchdog actually saw.
+    assert "60s" in reason
+    assert "120s" in reason
+
+
+def test_run_handles_multiple_repos_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Watchdog evaluates each configured repo separately on the same tick."""
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    home = _RecordingSession("FidoCanCode/home")
+    confusio = _RecordingSession("rhencke/confusio")
+    registry = _StubRegistry({"FidoCanCode/home": home, "rhencke/confusio": confusio})
+
+    register_talker(
+        SessionTalker(
+            repo_name="FidoCanCode/home",
+            thread_id=1,
+            kind="webhook",
+            description="long",
+            claude_pid=1,
+            started_at=started_at,
+        )
+    )
+    register_talker(
+        SessionTalker(
+            repo_name="rhencke/confusio",
+            thread_id=2,
+            kind="worker",
+            description="short",
+            claude_pid=1,
+            started_at=started_at + timedelta(seconds=55),
+        )
+    )
+    try:
+        monkeypatch.setattr(
+            session_lock_watchdog,
+            "talker_now",
+            lambda: started_at + timedelta(seconds=60),
+        )
+        watchdog = SessionLockWatchdog(
+            registry,  # type: ignore[arg-type]
+            {
+                "FidoCanCode/home": _repo_config("FidoCanCode/home"),
+                "rhencke/confusio": _repo_config("rhencke/confusio"),
+            },
+            hold_deadline_seconds=10.0,
+        )
+        watchdog.run()
+    finally:
+        unregister_talker("FidoCanCode/home", 1)
+        unregister_talker("rhencke/confusio", 2)
+
+    # home's holder has been held 60 s (> 10 s) → evicted.
+    assert len(home.force_release_calls) == 1
+    # confusio's holder has only been held 5 s → spared.
+    assert confusio.force_release_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Session-type filtering
+# ---------------------------------------------------------------------------
+
+
+def test_run_skips_non_owned_session_returns() -> None:
+    """The defensive ``isinstance(session, OwnedSession)`` filter prevents
+    eviction attempts against a session type that does not implement
+    :meth:`force_release` — important for forward compatibility with
+    future provider sessions whose lifecycle differs from
+    :class:`OwnedSession`.
+    """
+
+    class _NotAnOwnedSession:
+        pass
+
+    registry = _StubRegistry({"FidoCanCode/home": _NotAnOwnedSession()})  # type: ignore[dict-item]
+    watchdog = SessionLockWatchdog(
+        registry,  # type: ignore[arg-type]
+        {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
+        hold_deadline_seconds=0.01,
+    )
+    assert watchdog.run() == 0
+
+
+# ---------------------------------------------------------------------------
+# Daemon thread
+# ---------------------------------------------------------------------------
+
+
+def test_start_thread_returns_running_daemon_that_invokes_run() -> None:
+    """``start_thread`` returns a daemon thread whose loop body invokes
+    :meth:`run` every *_interval* seconds.  Uses a tiny interval and an
+    event-recording ``run`` override so the test can confirm the loop
+    actually fires (covers the daemon's ``self.run()`` call site).
+    """
+    invoked = threading.Event()
+
+    class _SignalingWatchdog(SessionLockWatchdog):
+        def run(self) -> int:  # type: ignore[override]
+            invoked.set()
+            return 0
+
+    watchdog = _SignalingWatchdog(
+        _StubRegistry({}),  # type: ignore[arg-type]
+        {},
+        hold_deadline_seconds=999.0,
+    )
+    # Tiny interval so the daemon hits its first ``run`` quickly.  The
+    # thread is a daemon — no join needed; process exit will reap it.
+    t = watchdog.start_thread(_interval=0.01)
+    assert t.daemon is True
+    assert t.name == "session-lock-watchdog"
+    assert invoked.wait(timeout=2.0), "watchdog daemon never invoked run()"
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience entry point
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_run_evicts_past_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The module-level ``run`` helper composes ``SessionLockWatchdog`` and
+    runs one tick — convenience entry point parallels ``watchdog.run``.
+    """
+    from fido.session_lock_watchdog import run as run_watchdog
+
+    repo_name = "FidoCanCode/home"
+    session = _RecordingSession(repo_name)
+    registry = _StubRegistry({repo_name: session})
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    register_talker(
+        SessionTalker(
+            repo_name=repo_name,
+            thread_id=7,
+            kind="worker",
+            description="wedged",
+            claude_pid=1,
+            started_at=started_at,
+        )
+    )
+    try:
+        monkeypatch.setattr(
+            session_lock_watchdog,
+            "talker_now",
+            lambda: started_at + timedelta(seconds=2),
+        )
+        result = run_watchdog(
+            registry,  # type: ignore[arg-type]
+            {repo_name: _repo_config(repo_name)},
+            hold_deadline_seconds=1.0,
+        )
+    finally:
+        unregister_talker(repo_name, 7)
+
+    assert result == 0
+    assert len(session.force_release_calls) == 1


### PR DESCRIPTION
## Summary

- Add `ForceRelease` event to `models/session_lock.v` with three new
  lemmas (`force_release_to_free`, `every_state_reaches_free`,
  `owned_state_exit_paths`) — proves the FSM has a liveness escape
  hatch and no accidental exit edges were opened.
- Wire `OwnedSession.force_release()` + `_evicted_tids` set so the
  watchdog can evict a wedged holder without crashing the original
  holder's eventual `__exit__` on a double-release.
- New `SessionLockWatchdog` daemon that polls `get_talker()`
  snapshots; if a single thread holds the FSM lock past
  `hold_deadline_seconds` (default 900 s), fires `ForceRelease` and
  kills the wedged subprocess via the `_on_force_release()` subclass
  hook — the kill closes stdout, the parked `select()` returns EOF,
  the holder thread escapes `consume_until_result` cleanly.

Closes #1377.

## Why

The session-lock FSM had only voluntary release events. When a
handler thread wedged inside `consume_until_result` (subprocess
streamed forever, `idle_timeout` never fired because events kept
arriving), no exception ever propagated, no `__exit__` ran, and the
lock leaked indefinitely. New webhooks queued at `HandlerAcquire`
positions 1, 2, … forever; the untriaged inbox climbed; nothing
drained.

This is the missing-Rocq-IO class of bug: the model proved safety
under the modeled events but not liveness against external IO
failure. After this lands, *any* future cause of an unreleased lock
gets cleaned up the same way.

## Layered commits (incremental — push as each layer lands)

1. **session_lock model + extraction + LSP test patch** — landed.
2. **provider.py / claude.py force_release** — next.
3. **SessionLockWatchdog + server.py wire-up** — next.
4. **BUG_MINED_INVARIANTS.md cluster entry** — last.

## Test plan

- [ ] `./fido ci` green (lint + typecheck + 100% coverage + tests).
- [ ] Direct oracle assertions: `transition(s, ForceRelease())` →
      `Some Free` for every state.
- [ ] `OwnedSession.force_release()` evicts the holder; original
      holder's `__exit__` does not raise (evicted-tid skip).
- [ ] With a queued handler, `force_release` transfers ownership
      (FSM ends `OwnedByHandler`, waiter's event is set).
- [ ] `ClaudeSession._on_force_release()` actually `_proc.kill()`s
      the subprocess (fake popen test).
- [ ] `SessionLockWatchdog.run()` fires `force_release` exactly
      when `held_for > deadline`.
- [ ] End-to-end smoke: holder thread parked in fake-streaming-forever
      session; watchdog evicts; lock returns to `Free` within one
      tick; holder thread returns within ~1 s.