### PR TITLE
guarddog: stop monitor on re-invoke + recognize `down <reason>` maintenance args

### DIFF
--- a/.claude/skills/guarddog/SKILL.md
+++ b/.claude/skills/guarddog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guarddog
 description: Self-healing Fido loop — watch for problems, fix them when found, resume watching
-argument-hint: "[vet <description>]"
+argument-hint: "[vet <description> | down <reason>]"
 ---
 
 You are the guarddog. You watch Fido, and when something breaks, you fix it. One continuous loop: watch, detect, fix, watch.
@@ -10,11 +10,13 @@ You are the guarddog. You watch Fido, and when something breaks, you fix it. One
 
 When invoked, determine the current state automatically. Never ask — just detect and act.
 
-1. Run `./fido status` from `/home/rhencke/home-runner`
-2. Parse the output:
+1. **Always start by stopping any monitor task left running by a prior `/guarddog` invocation.** Use `TaskList` to find the previous guarddog monitor (the persistent one watching `./fido status` + journald) and `TaskStop` it. The new invocation gets a fresh decision.
+2. Check the invocation arguments first — they may signal explicit user intent that overrides state-based dispatch:
+   - Arguments describe a planned outage (e.g. `fido down to complete 1363`, `down <reason>`, `pause <reason>`) → **Maintenance pause**: do NOT start a monitor, do NOT investigate, do NOT escalate. Acknowledge briefly and exit. The user will re-invoke when ready.
+   - Arguments are `vet <description>` → go to **Vet mode** with that context
+3. Otherwise run `./fido status` from `/home/rhencke/home-runner` and parse:
    - "fido: DOWN" → go to **Investigate** (never blindly restart)
    - "fido: UP" → go to **Watch mode**
-   - Invoked with `vet <description>` → go to **Vet mode** with that context
 
 ## Watch mode
 


### PR DESCRIPTION
## Summary

Two fixes for the case where Fido is intentionally taken down (e.g. to merge a big PR by hand):

1. **Stop prior monitor on re-invoke** — every `/guarddog` invocation now starts by `TaskStop`ping any monitor task left running by a prior call. No more stacked watches.
2. **`down <reason>` / `pause <reason>` args trigger a maintenance pause** — explicit user signal that Fido is intentionally offline. Skill exits cleanly: no monitor, no investigate, no vet escalation. The user re-invokes when ready.

The state-based dispatch (`DOWN → Investigate`, `UP → Watch`) still applies when no maintenance args are passed, so unexpected crashes still escalate the way they always did.

## Why

During the #1363 merge, `/guarddog` was invoked twice with `fido down to complete 1363` while Fido was being shut down. The skill tried to enter Watch mode the first time (Fido was still UP) and would have tried to escalate to Vet mode the second time (Fido DOWN, no maintenance signal). Neither was wanted — Rob was just announcing intent.

## Test plan
- [x] Pre-commit (3981 tests, 100% coverage): green
- [ ] Re-invoke `/guarddog` with `fido down ...` args while Fido is DOWN → exits silently, no escalation
- [ ] Re-invoke `/guarddog` with no args while Fido is UP → starts watch as before, prior monitor stopped first