### PR TITLE
Bug: setup phase blocked — migrate to JSON sentinel protocol (closes #1403)

### DIFF
--- a/src/fido/setup_outcome.py
+++ b/src/fido/setup_outcome.py
@@ -1,0 +1,168 @@
+"""Setup-outcome sentinel parser for the worker setup phase.
+
+The setup sub-agent (sub/setup.md) plans the task list AND drafts the PR
+description in a single turn.  Under the post-#1363 protocol the LLM declares
+intent via a JSON sentinel on the final non-empty line of its output; the
+harness reads it and CRUDs the task list and PR body itself.
+``Bash(./fido task *)`` is blocked at the permissions layer so the LLM cannot
+write to the task store directly, and PR-body edits go through the harness's
+``sync.lock``-guarded path.
+
+Two outcomes:
+
+* ``tasks-planned`` — the LLM proposes a list of new tasks AND the PR
+  description body.  Each task entry must carry a non-empty ``title``;
+  ``description`` is optional and defaults to empty.  ``pr_description`` is
+  optional too (when omitted, the harness falls back to a separate LLM call
+  via :func:`fido.worker._write_pr_description`).  The harness creates one
+  ``spec``-type pending task per entry and writes the PR body directly.
+* ``no-tasks-needed`` — the LLM judged that no further work is required on
+  this branch.  The harness falls through to the "setup produced no tasks"
+  finalize path (post a Fido-voice comment, mark ready, request review).
+  ``pr_description`` is also accepted here in case the LLM wants to seed the
+  PR body before the no-tasks finalize path runs.
+
+The LLM declares intent; Python acts on it.  Task creation and PR-body edits
+are never the LLM's responsibility under this protocol.
+"""
+
+import json
+from dataclasses import dataclass
+
+__all__ = [
+    "PlannedTask",
+    "SetupOutcome",
+    "TasksPlanned",
+    "NoTasksNeeded",
+    "parse_setup_outcome",
+]
+
+
+@dataclass(frozen=True)
+class PlannedTask:
+    title: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class TasksPlanned:
+    tasks: tuple[PlannedTask, ...]
+    pr_description: str = ""
+
+
+@dataclass(frozen=True)
+class NoTasksNeeded:
+    reason: str
+    pr_description: str = ""
+
+
+SetupOutcome = TasksPlanned | NoTasksNeeded
+
+
+def _last_json_object(text: str) -> dict[str, object]:
+    """Decode the last non-empty line of *text* as a JSON object.
+
+    Raises ValueError if the line is absent, not valid JSON, or not an object.
+    """
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(
+            "No non-empty lines in output — expected a setup_outcome JSON "
+            "sentinel on the final line"
+        )
+    last = lines[-1].strip()
+    try:
+        obj = json.loads(last)
+    except json.JSONDecodeError:
+        raise ValueError(f"Last non-empty line is not valid JSON: {last!r}") from None
+    if not isinstance(obj, dict):
+        raise ValueError(f"Last line parsed as JSON but is not an object: {last!r}")
+    return obj
+
+
+def _require_str(obj: dict[str, object], field: str, context: str) -> str:
+    """Extract a required non-empty string field from *obj*."""
+    value = obj.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f'{context} requires a non-empty "{field}" string, got: {value!r}'
+        )
+    return value.strip()
+
+
+def _parse_tasks(raw: object) -> tuple[PlannedTask, ...]:
+    """Validate the ``tasks`` array and convert each entry."""
+    if not isinstance(raw, list):
+        raise ValueError(f'"tasks" must be a JSON array, got: {raw!r}')
+    out: list[PlannedTask] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"tasks[{i}] is not a JSON object: {item!r}")
+        title = _require_str(item, "title", f"tasks[{i}]")
+        desc_raw = item.get("description", "")
+        if not isinstance(desc_raw, str):
+            raise ValueError(
+                f'tasks[{i}] "description" must be a string when present, '
+                f"got: {desc_raw!r}"
+            )
+        out.append(PlannedTask(title=title, description=desc_raw))
+    return tuple(out)
+
+
+def _optional_str(obj: dict[str, object], field: str, context: str) -> str:
+    """Extract an optional string field; absent or null → ``""``.
+
+    A non-string value (int, list, etc.) is rejected with ValueError so a
+    typo'd field type doesn't silently degrade to empty.
+    """
+    raw = obj.get(field)
+    if raw is None:
+        return ""
+    if not isinstance(raw, str):
+        raise ValueError(
+            f'{context} "{field}" must be a string when present, got: {raw!r}'
+        )
+    return raw
+
+
+def parse_setup_outcome(text: str) -> SetupOutcome:
+    """Parse the setup_outcome sentinel from the last non-empty line of *text*.
+
+    Recognised shapes:
+
+    * ``{"setup_outcome": "tasks-planned", "tasks": [{"title": "...",
+      "description": "..."}, ...], "pr_description": "..."}``
+    * ``{"setup_outcome": "no-tasks-needed", "reason": "...",
+      "pr_description": "..."}``
+
+    ``pr_description`` is optional in both shapes.  When provided, the harness
+    writes it to the PR body directly and skips the separate description-rewrite
+    LLM call.
+
+    Raises ValueError on any malformed shape so the worker can log the
+    parse failure and fall through to the no-tasks finalize path.
+    """
+    obj = _last_json_object(text)
+    kind = obj.get("setup_outcome")
+    match kind:
+        case "tasks-planned":
+            tasks = _parse_tasks(obj.get("tasks"))
+            if not tasks:
+                raise ValueError(
+                    'setup_outcome "tasks-planned" requires at least one task '
+                    '— use "no-tasks-needed" instead'
+                )
+            pr_description = _optional_str(
+                obj, "pr_description", 'setup_outcome "tasks-planned"'
+            )
+            return TasksPlanned(tasks=tasks, pr_description=pr_description)
+        case "no-tasks-needed":
+            reason = _require_str(obj, "reason", 'setup_outcome "no-tasks-needed"')
+            pr_description = _optional_str(
+                obj, "pr_description", 'setup_outcome "no-tasks-needed"'
+            )
+            return NoTasksNeeded(reason=reason, pr_description=pr_description)
+        case None:
+            raise ValueError(f'JSON object has no "setup_outcome" key: {obj!r}')
+        case _:
+            raise ValueError(f"Unrecognised setup_outcome value: {kind!r}")

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1105,10 +1105,14 @@ def _write_pr_description(
             )
             return
 
-    # Ensure "Fixes #N" is always present (the agent preserves it for rewrites via
-    # prompt rules; for initial writes we append it here).
-    if f"Fixes #{issue}" not in new_desc:
-        new_desc = f"{new_desc.rstrip()}\n\nFixes #{issue}."
+    # The harness owns the "Fixes #N" trailer — the LLM is told not to write it
+    # (sub/setup.md, rewrite_description_prompt) since we know the issue number.
+    # Strip any straggler the LLM emitted anyway (with or without trailing period)
+    # and append the canonical form.
+    new_desc = re.sub(
+        rf"\s*Fixes\s+#{issue}\.?\s*$", "", new_desc, flags=re.IGNORECASE
+    ).rstrip()
+    new_desc = f"{new_desc}\n\nFixes #{issue}."
 
     new_body = f"{new_desc.strip()}{divider}{rest}"
     # Hold sync.lock during the PATCH so concurrent sync_tasks calls (which

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -57,6 +57,7 @@ from fido.rocq.commit_result import (
 from fido.rocq.turn_outcome import (
     StuckOnTask,
 )
+from fido.setup_outcome import NoTasksNeeded, parse_setup_outcome
 from fido.state import (
     State,
     _resolve_git_dir,  # pyright: ignore[reportPrivateUsage]
@@ -434,34 +435,38 @@ def provider_start(
     timeout: int = 300,
     cwd: Path | str = ".",
     session_mode: TurnSessionMode = TurnSessionMode.REUSE,
-) -> str:
+) -> tuple[str, str]:
     """Start a new provider session from fido_dir/system and fido_dir/prompt.
 
+    Returns ``(session_id, output)``.  ``output`` is the raw provider text so
+    the caller can parse the setup sentinel and CRUD the task list itself
+    (closes #1403).
+
     When the provider agent already has an attached persistent session, the
-    setup prompt is sent through :meth:`ProviderAgent.run_turn` and an empty
-    string is returned — there is no subprocess session id to track.
+    setup prompt is sent through :meth:`ProviderAgent.run_turn` and the
+    session-id slot is empty (the session is already tracked by the agent).
 
     When no persistent session is attached, a fresh one-shot subprocess is
-    spawned via :meth:`ProviderAgent.print_prompt_from_file` and the session id
-    is extracted from its raw output.
+    spawned via :meth:`ProviderAgent.print_prompt_from_file` and the session
+    id is extracted from its raw output.
     """
     del session
     if agent is None:
         raise ValueError("provider_start requires agent")
     if agent.session is not None:
-        agent.run_turn(
+        output = agent.run_turn(
             _session_turn_prompt(fido_dir),
             model=model,
             retry_on_preempt=True,
             session_mode=session_mode,
         )
-        return ""
+        return "", output
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
     output = agent.print_prompt_from_file(
         system_file, prompt_file, model, timeout, cwd=cwd
     )
-    return agent.extract_session_id(output)
+    return agent.extract_session_id(output), output
 
 
 def _session_turn_prompt(fido_dir: Path) -> str:
@@ -1012,6 +1017,7 @@ def _write_pr_description(
     existing_body: str = "",
     *,
     agent: ProviderAgent | None = None,
+    pre_baked_description: str = "",
 ) -> None:
     """Write or rewrite the PR description.
 
@@ -1020,18 +1026,23 @@ def _write_pr_description(
     contains the current body; preserves the rest section after the ``---``
     divider).
 
-    Generates the description via the provider agent and writes it back via
-    ``gh.edit_pr_body``.  The final PATCH is serialized through the same
-    ``sync.lock`` that :func:`fido.tasks.sync_tasks` holds, preventing a
-    description rewrite from overwriting a concurrent work-queue update.
+    When *pre_baked_description* is non-empty, the provider call is skipped
+    entirely — the LLM already supplied the description text via the setup
+    sentinel (#1403), so the harness writes it directly.  Otherwise the
+    description is generated via the provider agent.  The final PATCH is
+    serialized through the same ``sync.lock`` that :func:`fido.tasks.sync_tasks`
+    holds, preventing a description rewrite from overwriting a concurrent
+    work-queue update.
 
     Self-heals when the existing body has no ``---`` divider: builds a fresh
     work-queue section and treats the entire existing body as the description
     seed.  Returns without writing when the agent returns empty or un-parseable
     output — the existing body is kept as-is and a warning is logged.
     """
-    if agent is None:
-        raise ValueError("_write_pr_description requires agent")
+    if agent is None and not pre_baked_description:
+        raise ValueError(
+            "_write_pr_description requires agent or pre_baked_description"
+        )
 
     divider = "\n\n---\n\n"
 
@@ -1069,19 +1080,30 @@ def _write_pr_description(
                 pr_number,
             )
 
-    prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
-    raw = safe_voice_turn(
-        agent, prompt, model=agent.voice_model, log_prefix="_write_pr_description"
-    )
-    new_desc = _extract_body(raw)
-    if not new_desc:
-        log.warning(
-            "_write_pr_description: skipping PR #%s description update — "
-            "no <body> content in provider output (raw=%r)",
+    if pre_baked_description:
+        new_desc = pre_baked_description.strip()
+        log.info(
+            "_write_pr_description: PR #%s using pre-baked description from "
+            "setup sentinel (skipping LLM call)",
             pr_number,
-            raw[:200],
         )
-        return
+    else:
+        # The top-level guard already rejected (agent=None, pre_baked="") so
+        # `agent` is non-None here.
+        assert agent is not None
+        prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
+        raw = safe_voice_turn(
+            agent, prompt, model=agent.voice_model, log_prefix="_write_pr_description"
+        )
+        new_desc = _extract_body(raw)
+        if not new_desc:
+            log.warning(
+                "_write_pr_description: skipping PR #%s description update — "
+                "no <body> content in provider output (raw=%r)",
+                pr_number,
+                raw[:200],
+            )
+            return
 
     # Ensure "Fixes #N" is always present (the agent preserves it for rewrites via
     # prompt rules; for initial writes we append it here).
@@ -1881,7 +1903,7 @@ class Worker:
                     f"Work dir: {self.work_dir}"
                 )
                 build_prompt(fido_dir, "setup", context, labels=issue_labels)
-                provider_start(
+                _, setup_output = provider_start(
                     fido_dir,
                     agent=self._provider_agent,
                     model=self._provider_agent.voice_model,
@@ -1889,6 +1911,7 @@ class Worker:
                     session=None,
                     session_mode=self._consume_turn_session_mode(),
                 )
+                pre_baked_description = self._apply_setup_outcome(setup_output)
                 if not self._tasks.list():
                     # Setup legitimately produced zero tasks — the work on this
                     # branch already covers the issue.  Finalize rather than
@@ -1967,7 +1990,7 @@ class Worker:
             f"Work dir: {self.work_dir}"
         )
         build_prompt(fido_dir, "setup", context, labels=issue_labels)
-        provider_start(
+        _, setup_output = provider_start(
             fido_dir,
             agent=self._provider_agent,
             model=self._provider_agent.voice_model,
@@ -1975,6 +1998,7 @@ class Worker:
             session=None,
             session_mode=self._consume_turn_session_mode(),
         )
+        pre_baked_description = self._apply_setup_outcome(setup_output)
 
         # Create draft PR, then write the description using the same function
         # used for post-rescope rewrites so both paths share one code path.
@@ -2013,6 +2037,7 @@ class Worker:
             issue,
             self._tasks.list(),
             agent=self._provider_agent,
+            pre_baked_description=pre_baked_description,
         )
         task_count = len(
             [t for t in self._tasks.list() if t.get("status") == "pending"]
@@ -2792,6 +2817,47 @@ class Worker:
             repo_ctx.gh_user,
             leak_before_ids,
         )
+
+    def _apply_setup_outcome(self, output: str) -> str:
+        """Parse the setup_outcome sentinel from *output* and CRUD the task list.
+
+        Under the post-#1403 protocol, the setup sub-agent does not write to
+        the task store directly — ``Bash(./fido task *)`` is blocked at the
+        permissions layer.  Instead the LLM emits a JSON sentinel describing
+        the desired task list (and optionally the PR description body), and
+        the harness applies it here by calling :meth:`Tasks.add` per planned
+        entry.
+
+        Returns the LLM-provided ``pr_description`` (or ``""`` when absent or
+        the sentinel didn't parse) so the caller can pass it through to
+        :func:`_write_pr_description` and skip the separate
+        description-rewrite LLM call.
+
+        Two recognised outcomes:
+
+        * :class:`TasksPlanned` — create one ``spec`` pending task per entry.
+        * :class:`NoTasksNeeded` — no-op; the caller's empty-list check
+          falls through to the no-tasks finalize path.
+
+        Parse failure is non-fatal: log a warning and return ``""``.  An empty
+        :meth:`Tasks.list` is the existing signal for "setup found no work",
+        and the no-tasks finalize path handles it the same regardless of why.
+        """
+        try:
+            outcome = parse_setup_outcome(output)
+        except ValueError as exc:
+            log.warning("setup sentinel parse failed: %s — treating as no tasks", exc)
+            return ""
+        if isinstance(outcome, NoTasksNeeded):
+            log.info("setup outcome: no-tasks-needed (%s)", outcome.reason)
+            return outcome.pr_description
+        for spec in outcome.tasks:
+            self._tasks.add(spec.title, TaskType.SPEC, description=spec.description)
+        log.info(
+            "setup outcome: tasks-planned — created %d task(s) from sentinel",
+            len(outcome.tasks),
+        )
+        return outcome.pr_description
 
     def _finalize_setup_with_no_tasks(
         self,

--- a/sub/setup.md
+++ b/sub/setup.md
@@ -1,4 +1,4 @@
-A fresh git branch has been created. Your job is to PLAN the work by creating tasks. You are NOT implementing anything — just planning. The PR does not exist yet — it will be created after you finish. All context is in the Context section above.
+A fresh git branch has been created. Your job is to PLAN the work by emitting the desired task list as a JSON sentinel. You are NOT implementing anything — just planning. The PR does not exist yet — it will be created after you finish. All context is in the Context section above.
 
 ## Steps
 
@@ -8,33 +8,39 @@ Check for CLAUDE.md files. Note the test command, commit discipline, and any oth
 ### 2. Plan
 Break the request into the smallest meaningful tasks — one task per logical commit, ordered so each builds on the previous.
 
-For each task, write it to the shared task file:
-```bash
-cd /home/rhencke/home-runner && ./fido task <work_dir> add spec "<task title>"
-```
-Where `<work_dir>` is from the Context section.
+**Task titles must be short one-line summaries** — imperative verb-first, under 80 characters. Like `Add Dependabot routes and default handlers` or `Gitea: dependency-graph endpoints and tests`. NOT multi-paragraph specs with file lists, endpoint tables, or instructions. The title appears in `fido status`, PR work queues, and log lines — it needs to fit on one line. Detailed implementation guidance, when needed, belongs in the optional `description` field, not the title.
 
-**Task titles must be short one-line summaries** — imperative verb-first, under 80 characters. Like `Add Dependabot routes and default handlers` or `Gitea: dependency-graph endpoints and tests`. NOT multi-paragraph specs with file lists, endpoint tables, or instructions. The title appears in `fido status`, PR work queues, and log lines — it needs to fit on one line. Details belong in the implementation itself, not the task title.
+### 3. Draft the PR description
+You also draft the PR description body — what reviewers read above the auto-generated work queue. Keep it scoped to *what* and *why*, not *how* (implementation lives in commits and tasks). A typical body has a `## Summary` section with a few bullet points and may include `## Why` or `## Test plan` where useful. Always include `Fixes #<issue>.` somewhere — the harness will append it if you forget.
 
-The `spec` argument is the task type — always use `spec` for planned tasks. Other types (`thread`, `ci`) are created by the system, never by you.
+### 4. Emit the setup_outcome sentinel
+Your final non-empty output line **must** be exactly one JSON object that declares the planned task list and the PR description. The harness reads it and CRUDs the task store and PR body on your behalf — you never write to `tasks.json`, never edit the PR body directly, and never run `./fido task` yourself.
 
-**CRITICAL**: Always use the `./fido task add` CLI command from `/home/rhencke/home-runner` to create tasks. NEVER write to tasks.json directly — no `echo`, no `Write` tool, no `cat >`. The CLI handles locking, validation, and ID generation. Direct writes bypass all of this and create broken tasks.
+Choose exactly one outcome:
 
-Do NOT use TaskCreate or TodoWrite — only `./fido task`.
-Do NOT create a PR. Do NOT edit any PR body. The Fido server handles PR body sync.
+- **`tasks-planned`** — you have at least one task to queue. The harness creates one `spec`-type pending task per entry, in the order given. `description` is optional. `pr_description` is the markdown body the harness will write above the work queue (skip the `---` divider — the harness inserts it).
+  ```json
+  {"setup_outcome": "tasks-planned", "pr_description": "## Summary\n\n- bullet 1\n- bullet 2\n\nFixes #1234.", "tasks": [{"title": "First task title"}, {"title": "Second task title", "description": "Optional implementation hint"}]}
+  ```
+- **`no-tasks-needed`** — the issue's work is already covered by the current branch state, or is a no-op. The harness will mark the PR ready and post an explanation comment. `pr_description` is optional here.
+  ```json
+  {"setup_outcome": "no-tasks-needed", "reason": "Already implemented in commit abc1234"}
+  ```
+
+The sentinel must be the literal last non-empty line of your response — nothing after it. Do not wrap it in a code fence or markdown block. The single object must be valid JSON on one line. Embed newlines inside `pr_description` as `\n` escapes.
 
 ## Done when
-All tasks written to the task file via `./fido task`.
+The setup_outcome sentinel has been emitted.
 
-**Stop immediately. Do not implement any tasks. Implementation is handled by subsequent invocations.**
+**Stop immediately after emitting the sentinel. Do not implement any tasks. Implementation is handled by subsequent invocations.**
 
 ## Constraints
-- **Never** commit code. No `git commit`, no `git add`. You are planning, not implementing.
-- **Never** edit source files. No `Edit`, no `Write` to any file except via `./fido task add`.
+- **You are a planner, not an implementer.** Read the code to understand it, then emit the sentinel. Do not change the code.
+- **Never** commit code. No `git commit`, no `git add`. The harness owns commits.
+- **Never** edit source files. No `Edit`, no `Write` to any file.
 - **Never** push to any branch. No `git push`.
-- **Never** mark the PR as ready for review (`gh pr ready`).
+- **Never** mark the PR as ready for review (`gh pr ready`). The harness handles this.
 - **Never** rebase, amend, or force-push.
-- **Never** use TaskCreate, TaskUpdate, TodoWrite, or TodoRead. Only `./fido task`.
+- **Never** use TaskCreate, TaskUpdate, TaskList, TodoWrite, TodoRead, or `./fido task`.
 - **Never** edit any PR body. The Fido server handles that.
-- **Never** write to tasks.json directly. Always use `./fido task add`.
-- **You are a planner, not an implementer.** Read the code to understand it, then create tasks. Do not change it.
+- **Never** write to tasks.json directly. The harness owns the task store.

--- a/sub/setup.md
+++ b/sub/setup.md
@@ -11,16 +11,18 @@ Break the request into the smallest meaningful tasks — one task per logical co
 **Task titles must be short one-line summaries** — imperative verb-first, under 80 characters. Like `Add Dependabot routes and default handlers` or `Gitea: dependency-graph endpoints and tests`. NOT multi-paragraph specs with file lists, endpoint tables, or instructions. The title appears in `fido status`, PR work queues, and log lines — it needs to fit on one line. Detailed implementation guidance, when needed, belongs in the optional `description` field, not the title.
 
 ### 3. Draft the PR description
-You also draft the PR description body — what reviewers read above the auto-generated work queue. Keep it scoped to *what* and *why*, not *how* (implementation lives in commits and tasks). A typical body has a `## Summary` section with a few bullet points and may include `## Why` or `## Test plan` where useful. Always include `Fixes #<issue>.` somewhere — the harness will append it if you forget.
+You also draft the PR description body — what reviewers read above the auto-generated work queue. Keep it scoped to *what* and *why*, not *how* (implementation lives in commits and tasks). A typical body has a `## Summary` section with a few bullet points and may include `## Why` or `## Test plan` where useful.
+
+**Do not write `Fixes #<issue>` yourself** — the harness already knows the issue number and appends the canonical trailer. If you write one anyway the harness strips it and re-appends, so the body always ends with exactly one `Fixes #<n>.`.
 
 ### 4. Emit the setup_outcome sentinel
 Your final non-empty output line **must** be exactly one JSON object that declares the planned task list and the PR description. The harness reads it and CRUDs the task store and PR body on your behalf — you never write to `tasks.json`, never edit the PR body directly, and never run `./fido task` yourself.
 
 Choose exactly one outcome:
 
-- **`tasks-planned`** — you have at least one task to queue. The harness creates one `spec`-type pending task per entry, in the order given. `description` is optional. `pr_description` is the markdown body the harness will write above the work queue (skip the `---` divider — the harness inserts it).
+- **`tasks-planned`** — you have at least one task to queue. The harness creates one `spec`-type pending task per entry, in the order given. `description` is optional. `pr_description` is the markdown body the harness will write above the work queue (skip the `---` divider — the harness inserts it; skip `Fixes #<issue>` — the harness appends it).
   ```json
-  {"setup_outcome": "tasks-planned", "pr_description": "## Summary\n\n- bullet 1\n- bullet 2\n\nFixes #1234.", "tasks": [{"title": "First task title"}, {"title": "Second task title", "description": "Optional implementation hint"}]}
+  {"setup_outcome": "tasks-planned", "pr_description": "## Summary\n\n- bullet 1\n- bullet 2", "tasks": [{"title": "First task title"}, {"title": "Second task title", "description": "Optional implementation hint"}]}
   ```
 - **`no-tasks-needed`** — the issue's work is already covered by the current branch state, or is a no-op. The harness will mark the PR ready and post an explanation comment. `pr_description` is optional here.
   ```json

--- a/tests/test_setup_outcome.py
+++ b/tests/test_setup_outcome.py
@@ -1,0 +1,233 @@
+"""Tests for fido.setup_outcome — setup-phase sentinel parser."""
+
+import pytest
+
+from fido.setup_outcome import (
+    NoTasksNeeded,
+    PlannedTask,
+    TasksPlanned,
+    parse_setup_outcome,
+)
+
+
+class TestParseSetupOutcomeEmpty:
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="No non-empty lines"):
+            parse_setup_outcome("")
+
+    def test_whitespace_only(self) -> None:
+        with pytest.raises(ValueError, match="No non-empty lines"):
+            parse_setup_outcome("   \n  \n  ")
+
+
+class TestParseSetupOutcomeInvalidJson:
+    def test_not_json(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            parse_setup_outcome("Done planning, see above for tasks.")
+
+    def test_json_array(self) -> None:
+        with pytest.raises(ValueError, match="not an object"):
+            parse_setup_outcome('[{"title": "x"}]')
+
+    def test_json_string(self) -> None:
+        with pytest.raises(ValueError, match="not an object"):
+            parse_setup_outcome('"tasks-planned"')
+
+
+class TestParseSetupOutcomeUnrecognized:
+    def test_no_setup_outcome_key(self) -> None:
+        with pytest.raises(ValueError, match='no "setup_outcome" key'):
+            parse_setup_outcome('{"status": "done"}')
+
+    def test_unknown_setup_outcome_value(self) -> None:
+        with pytest.raises(ValueError, match="Unrecognised setup_outcome"):
+            parse_setup_outcome('{"setup_outcome": "do-the-thing"}')
+
+
+class TestParseSetupOutcomeTasksPlanned:
+    def test_single_task_title_only(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{"title": "Add foo"}]}'
+        result = parse_setup_outcome(line)
+        assert result == TasksPlanned(
+            tasks=(PlannedTask(title="Add foo", description=""),),
+            pr_description="",
+        )
+
+    def test_multiple_tasks_with_descriptions(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", "tasks": ['
+            '{"title": "First"}, '
+            '{"title": "Second", "description": "details"}'
+            "]}"
+        )
+        result = parse_setup_outcome(line)
+        assert result == TasksPlanned(
+            tasks=(
+                PlannedTask(title="First", description=""),
+                PlannedTask(title="Second", description="details"),
+            ),
+            pr_description="",
+        )
+
+    def test_title_strips_whitespace(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{"title": "  Trim me  "}]}'
+        result = parse_setup_outcome(line)
+        assert isinstance(result, TasksPlanned)
+        assert result.tasks[0].title == "Trim me"
+
+    def test_empty_tasks_array_rejected(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": []}'
+        with pytest.raises(ValueError, match="at least one task"):
+            parse_setup_outcome(line)
+
+    def test_tasks_not_array(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": "nope"}'
+        with pytest.raises(ValueError, match="must be a JSON array"):
+            parse_setup_outcome(line)
+
+    def test_tasks_missing(self) -> None:
+        line = '{"setup_outcome": "tasks-planned"}'
+        with pytest.raises(ValueError, match="must be a JSON array"):
+            parse_setup_outcome(line)
+
+    def test_task_not_object(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": ["just a string"]}'
+        with pytest.raises(ValueError, match=r"tasks\[0\] is not a JSON object"):
+            parse_setup_outcome(line)
+
+    def test_task_missing_title(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{}]}'
+        with pytest.raises(ValueError, match=r'tasks\[0\].*"title"'):
+            parse_setup_outcome(line)
+
+    def test_task_title_empty(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{"title": ""}]}'
+        with pytest.raises(ValueError, match=r'tasks\[0\].*"title"'):
+            parse_setup_outcome(line)
+
+    def test_task_title_whitespace_only(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{"title": "   "}]}'
+        with pytest.raises(ValueError, match=r'tasks\[0\].*"title"'):
+            parse_setup_outcome(line)
+
+    def test_task_title_not_string(self) -> None:
+        line = '{"setup_outcome": "tasks-planned", "tasks": [{"title": 42}]}'
+        with pytest.raises(ValueError, match=r'tasks\[0\].*"title"'):
+            parse_setup_outcome(line)
+
+    def test_task_description_not_string(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", "tasks": '
+            '[{"title": "x", "description": 99}]}'
+        )
+        with pytest.raises(ValueError, match='"description" must be a string'):
+            parse_setup_outcome(line)
+
+    def test_second_task_invalid(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", "tasks": ['
+            '{"title": "ok"}, {"foo": "no title"}'
+            "]}"
+        )
+        with pytest.raises(ValueError, match=r'tasks\[1\].*"title"'):
+            parse_setup_outcome(line)
+
+    def test_pr_description_captured(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", '
+            '"pr_description": "## Summary\\n\\n- thing\\n\\nFixes #42.", '
+            '"tasks": [{"title": "x"}]}'
+        )
+        result = parse_setup_outcome(line)
+        assert isinstance(result, TasksPlanned)
+        assert result.pr_description == "## Summary\n\n- thing\n\nFixes #42."
+
+    def test_pr_description_must_be_string(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", '
+            '"pr_description": 42, '
+            '"tasks": [{"title": "x"}]}'
+        )
+        with pytest.raises(ValueError, match='"pr_description" must be a string'):
+            parse_setup_outcome(line)
+
+    def test_pr_description_null_treated_as_absent(self) -> None:
+        line = (
+            '{"setup_outcome": "tasks-planned", '
+            '"pr_description": null, '
+            '"tasks": [{"title": "x"}]}'
+        )
+        result = parse_setup_outcome(line)
+        assert isinstance(result, TasksPlanned)
+        assert result.pr_description == ""
+
+
+class TestParseSetupOutcomeNoTasksNeeded:
+    def test_valid(self) -> None:
+        line = (
+            '{"setup_outcome": "no-tasks-needed", '
+            '"reason": "Already covered by abc1234"}'
+        )
+        result = parse_setup_outcome(line)
+        assert result == NoTasksNeeded(
+            reason="Already covered by abc1234", pr_description=""
+        )
+
+    def test_with_pr_description(self) -> None:
+        line = (
+            '{"setup_outcome": "no-tasks-needed", '
+            '"reason": "no-op", '
+            '"pr_description": "## Why\\n\\nNothing to do here.\\n\\nFixes #1."}'
+        )
+        result = parse_setup_outcome(line)
+        assert result == NoTasksNeeded(
+            reason="no-op",
+            pr_description="## Why\n\nNothing to do here.\n\nFixes #1.",
+        )
+
+    def test_missing_reason(self) -> None:
+        line = '{"setup_outcome": "no-tasks-needed"}'
+        with pytest.raises(ValueError, match="non-empty.*reason"):
+            parse_setup_outcome(line)
+
+    def test_reason_empty(self) -> None:
+        line = '{"setup_outcome": "no-tasks-needed", "reason": ""}'
+        with pytest.raises(ValueError, match="non-empty.*reason"):
+            parse_setup_outcome(line)
+
+    def test_reason_whitespace_only(self) -> None:
+        line = '{"setup_outcome": "no-tasks-needed", "reason": "   "}'
+        with pytest.raises(ValueError, match="non-empty.*reason"):
+            parse_setup_outcome(line)
+
+    def test_reason_not_string(self) -> None:
+        line = '{"setup_outcome": "no-tasks-needed", "reason": 42}'
+        with pytest.raises(ValueError, match="non-empty.*reason"):
+            parse_setup_outcome(line)
+
+
+class TestParseSetupOutcomeMultiLine:
+    def test_sentinel_on_last_line(self) -> None:
+        text = (
+            "I've reviewed the issue.\n"
+            "Three tasks should cover it.\n"
+            '{"setup_outcome": "tasks-planned", "tasks": [{"title": "A"}]}'
+        )
+        result = parse_setup_outcome(text)
+        assert isinstance(result, TasksPlanned)
+        assert result.tasks[0].title == "A"
+
+    def test_stale_sentinel_in_middle_non_json_at_end(self) -> None:
+        """An earlier-line sentinel is invisible — only the last non-empty
+        line counts."""
+        text = (
+            '{"setup_outcome": "tasks-planned", "tasks": [{"title": "stale"}]}\n'
+            "Some narration after"
+        )
+        with pytest.raises(ValueError, match="not valid JSON"):
+            parse_setup_outcome(text)
+
+    def test_trailing_blank_lines_ignored(self) -> None:
+        text = '{"setup_outcome": "no-tasks-needed", "reason": "no-op"}\n\n\n  \n'
+        result = parse_setup_outcome(text)
+        assert result == NoTasksNeeded(reason="no-op", pr_description="")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4765,10 +4765,54 @@ class TestWritePrDescription:
                 99,
                 42,
                 [{"title": "x", "status": "pending"}],
-                pre_baked_description="## Summary\n\nbody.\n\nFixes #42.",
+                pre_baked_description="## Summary\n\nbody.",
             )
         body = gh.edit_pr_body.call_args[0][2]
         assert "body." in body
+        assert body.count("Fixes #42.") == 1
+
+    def test_pre_baked_strips_llm_emitted_fixes_trailer(self, tmp_path: Path) -> None:
+        """If the LLM included Fixes #N anyway, the harness strips it and
+        re-appends the canonical form so the body ends with exactly one."""
+        from contextlib import nullcontext
+
+        gh = MagicMock()
+        with patch("fido.tasks.pr_body_lock", return_value=nullcontext()):
+            _write_pr_description(
+                tmp_path,
+                gh,
+                "owner/repo",
+                99,
+                42,
+                [{"title": "x", "status": "pending"}],
+                pre_baked_description="## Summary\n\nbody.\n\nFixes #42.",
+            )
+        body = gh.edit_pr_body.call_args[0][2]
+        assert body.count("Fixes #42.") == 1
+        # The canonical trailer is the last line before the divider
+        before_divider = body.split("\n\n---\n\n")[0]
+        assert before_divider.rstrip().endswith("Fixes #42.")
+
+    def test_pre_baked_strips_period_less_fixes(self, tmp_path: Path) -> None:
+        """Fixes #N without trailing period also gets stripped + re-appended."""
+        from contextlib import nullcontext
+
+        gh = MagicMock()
+        with patch("fido.tasks.pr_body_lock", return_value=nullcontext()):
+            _write_pr_description(
+                tmp_path,
+                gh,
+                "owner/repo",
+                99,
+                42,
+                [{"title": "x", "status": "pending"}],
+                pre_baked_description="## Summary\n\nbody.\n\nFixes #42",
+            )
+        body = gh.edit_pr_body.call_args[0][2]
+        before_divider = body.split("\n\n---\n\n")[0]
+        # No bare "Fixes #42" without period; exactly one canonical "Fixes #42."
+        assert before_divider.rstrip().endswith("Fixes #42.")
+        assert body.count("Fixes #42") == 1
 
 
 class TestFindOrCreatePr:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3637,23 +3637,25 @@ class TestProviderStart:
         mock_client = _client()
         mock_client.print_prompt_from_file.return_value = output
         mock_client.extract_session_id.return_value = "sess-abc"
-        result = provider_start(
+        session_id, raw_output = provider_start(
             fido_dir,
             agent=mock_client,
             model=mock_client.voice_model,
         )
-        assert result == "sess-abc"
+        assert session_id == "sess-abc"
+        assert raw_output == output
 
     def test_returns_empty_when_extract_fails(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         mock_client = _client()
         mock_client.print_prompt_from_file.return_value = ""
-        result = provider_start(
+        session_id, raw_output = provider_start(
             fido_dir,
             agent=mock_client,
             model=mock_client.voice_model,
         )
-        assert result == ""
+        assert session_id == ""
+        assert raw_output == ""
 
     def test_calls_print_prompt_from_file_with_correct_files(
         self, tmp_path: Path
@@ -3739,13 +3741,21 @@ class TestProviderStart:
 
     # ── Session path ──────────────────────────────────────────────────────
 
-    def test_session_path_returns_empty_string(self, tmp_path: Path) -> None:
+    def test_session_path_returns_empty_session_id(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
         session = self._mock_session()
         client = _client()
         client.session = session
-        result = provider_start(fido_dir, agent=client, model=client.voice_model)
-        assert result == ""
+        session_id, _ = provider_start(fido_dir, agent=client, model=client.voice_model)
+        assert session_id == ""
+
+    def test_session_path_returns_run_turn_output(self, tmp_path: Path) -> None:
+        fido_dir = self._setup_fido_dir(tmp_path)
+        session = self._mock_session()
+        client = _client("the setup output text")
+        client.session = session
+        _, raw_output = provider_start(fido_dir, agent=client, model=client.voice_model)
+        assert raw_output == "the setup output text"
 
     def test_session_path_uses_agent_run_turn(self, tmp_path: Path) -> None:
         fido_dir = self._setup_fido_dir(tmp_path)
@@ -4710,8 +4720,55 @@ class TestWritePrDescription:
 
     def test_requires_agent(self) -> None:
         gh = MagicMock()
-        with pytest.raises(ValueError, match="_write_pr_description requires agent"):
+        with pytest.raises(
+            ValueError, match="_write_pr_description requires agent or pre_baked"
+        ):
             _write_pr_description(Path("/tmp"), gh, "owner/repo", 99, 42, [])
+
+    def test_pre_baked_description_skips_provider(self, tmp_path: Path) -> None:
+        """When pre_baked_description is provided, the LLM call is skipped
+        and the supplied text is used directly."""
+        from contextlib import nullcontext
+
+        gh = MagicMock()
+        agent = MagicMock()
+        agent.print_prompt_from_file = MagicMock()
+        with patch("fido.tasks.pr_body_lock", return_value=nullcontext()):
+            _write_pr_description(
+                tmp_path,
+                gh,
+                "owner/repo",
+                99,
+                42,
+                [{"title": "x", "status": "pending"}],
+                agent=agent,
+                pre_baked_description="## Summary\n\n- thing\n\nFixes #42.",
+            )
+        agent.print_prompt_from_file.assert_not_called()
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "## Summary" in body
+        assert "- thing" in body
+        assert "Fixes #42." in body
+        assert "\n\n---\n\n" in body
+        assert "<!-- WORK_QUEUE_START -->" in body
+
+    def test_pre_baked_works_without_agent(self, tmp_path: Path) -> None:
+        """pre_baked_description alone (no agent) is sufficient."""
+        from contextlib import nullcontext
+
+        gh = MagicMock()
+        with patch("fido.tasks.pr_body_lock", return_value=nullcontext()):
+            _write_pr_description(
+                tmp_path,
+                gh,
+                "owner/repo",
+                99,
+                42,
+                [{"title": "x", "status": "pending"}],
+                pre_baked_description="## Summary\n\nbody.\n\nFixes #42.",
+            )
+        body = gh.edit_pr_body.call_args[0][2]
+        assert "body." in body
 
 
 class TestFindOrCreatePr:
@@ -4798,7 +4855,7 @@ class TestFindOrCreatePr:
         gh.get_issue_comments.return_value = []
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
-        mock_start = MagicMock(return_value="sess-1")
+        mock_start = MagicMock(return_value=("sess-1", ""))
         with (
             patch.object(worker, "_git"),
             patch("fido.tasks.Tasks.list", return_value=[]),
@@ -4831,7 +4888,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
         _, _, context = mock_build.call_args.args
@@ -4851,7 +4908,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
         ):
             result = worker.find_or_create_pr(
                 fido_dir, self._make_repo_ctx(), 5, "Issue title"
@@ -4880,7 +4937,7 @@ class TestFindOrCreatePr:
             patch("fido.tasks.Tasks.list", side_effect=list_tasks_side_effect),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
 
@@ -4905,7 +4962,7 @@ class TestFindOrCreatePr:
                 "fido.worker.build_prompt",
                 side_effect=lambda *a: call_order.append("setup"),
             ),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
         ):
             result = worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
         assert result == (20, "my-br", False)
@@ -4928,7 +4985,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "_git"),
             patch("fido.tasks.Tasks.list", side_effect=list_tasks_side_effect),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
         ):
             result = worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "t")
         assert result == (20, "my-br", False)
@@ -5025,7 +5082,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
             patch("fido.worker._write_pr_description"),
             patch(
                 "fido.tasks.Tasks.list",
@@ -5055,7 +5112,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             caplog.at_level(logging.INFO, logger="fido"),
@@ -5072,7 +5129,7 @@ class TestFindOrCreatePr:
         gh.create_pr.return_value = "https://github.com/owner/proj/pull/1"
         fido_dir = self._fido_dir(tmp_path)
         mock_build = MagicMock()
-        mock_start = MagicMock(return_value="s")
+        mock_start = MagicMock(return_value=("s", ""))
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt", mock_build),
@@ -5103,7 +5160,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.worker.provider_start", return_value=("s", "")),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
@@ -5123,7 +5180,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch(
                 "fido.tasks.Tasks.list",
@@ -5158,7 +5215,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git", side_effect=side_effect),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
@@ -5198,7 +5255,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git", side_effect=side_effect),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
@@ -5223,7 +5280,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git", side_effect=side_effect),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch(
                 "fido.tasks.Tasks.list",
@@ -5252,7 +5309,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "_reset_local_workspace"),
             patch.object(worker, "_pr_has_real_diff", return_value=True),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
             patch("fido.tasks.Tasks.list", return_value=[]),
         ):
             result = worker.find_or_create_pr(
@@ -5279,7 +5336,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch(
                 "fido.tasks.Tasks.list",
@@ -5309,7 +5366,7 @@ class TestFindOrCreatePr:
             patch.object(worker, "_git"),
             patch.object(worker, "_post_retry_acknowledgement", mock_retry),
             patch("fido.worker.build_prompt"),
-            patch("fido.worker.provider_start", return_value=""),
+            patch("fido.worker.provider_start", return_value=("", "")),
             patch("fido.worker._write_pr_description"),
             patch(
                 "fido.tasks.Tasks.list",
@@ -5332,7 +5389,7 @@ class TestFindOrCreatePr:
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(
@@ -5357,7 +5414,7 @@ class TestFindOrCreatePr:
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "Do the thing")
@@ -5376,7 +5433,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.worker.provider_start", return_value=("s", "")),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
@@ -5401,7 +5458,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.worker.provider_start", return_value=("s", "")),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
@@ -5430,7 +5487,7 @@ class TestFindOrCreatePr:
         with (
             patch.object(worker, "_git"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="s"),
+            patch("fido.worker.provider_start", return_value=("s", "")),
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
@@ -5459,7 +5516,7 @@ class TestFindOrCreatePr:
             patch("fido.tasks.Tasks.list", return_value=[]),
             patch.object(worker, "seed_tasks_from_pr_body"),
             patch("fido.worker.build_prompt", mock_build),
-            patch("fido.worker.provider_start", return_value="sess"),
+            patch("fido.worker.provider_start", return_value=("sess", "")),
             patch.object(worker, "_finalize_setup_with_no_tasks"),
         ):
             worker.find_or_create_pr(fido_dir, self._make_repo_ctx(), 5, "title")
@@ -5467,6 +5524,77 @@ class TestFindOrCreatePr:
         assert "## Prior attempts" in context
         assert "PR #88" in context
         assert "First attempt" in context
+
+
+class TestApplySetupOutcome:
+    """Tests for Worker._apply_setup_outcome — the sentinel-driven setup CRUD
+    that replaces the old ``./fido task add`` CLI flow (closes #1403)."""
+
+    def _make_worker(self, tmp_path: Path) -> Worker:
+        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+
+    def test_tasks_planned_creates_tasks_in_order(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        sentinel = (
+            '{"setup_outcome": "tasks-planned", "tasks": ['
+            '{"title": "Add foo"}, '
+            '{"title": "Add bar", "description": "with details"}'
+            "]}"
+        )
+        result = worker._apply_setup_outcome(sentinel)  # type: ignore[attr-defined]
+        tasks = worker._tasks.list()  # type: ignore[attr-defined]
+        assert [t["title"] for t in tasks] == ["Add foo", "Add bar"]
+        assert all(t["status"] == "pending" for t in tasks)
+        assert all(t["type"] == "spec" for t in tasks)
+        assert tasks[0]["description"] == ""
+        assert tasks[1]["description"] == "with details"
+        assert result == ""
+
+    def test_pr_description_returned_when_present(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        sentinel = (
+            '{"setup_outcome": "tasks-planned", '
+            '"pr_description": "## Summary\\n\\n- bullet\\n\\nFixes #1.", '
+            '"tasks": [{"title": "task"}]}'
+        )
+        result = worker._apply_setup_outcome(sentinel)  # type: ignore[attr-defined]
+        assert result == "## Summary\n\n- bullet\n\nFixes #1."
+
+    def test_no_tasks_needed_creates_no_tasks(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        sentinel = '{"setup_outcome": "no-tasks-needed", "reason": "already covered"}'
+        result = worker._apply_setup_outcome(sentinel)  # type: ignore[attr-defined]
+        assert worker._tasks.list() == []  # type: ignore[attr-defined]
+        assert result == ""
+
+    def test_no_tasks_needed_returns_pr_description(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        sentinel = (
+            '{"setup_outcome": "no-tasks-needed", '
+            '"reason": "no-op", '
+            '"pr_description": "## Why\\n\\nNothing to do.\\n\\nFixes #2."}'
+        )
+        result = worker._apply_setup_outcome(sentinel)  # type: ignore[attr-defined]
+        assert result == "## Why\n\nNothing to do.\n\nFixes #2."
+
+    def test_invalid_sentinel_creates_no_tasks(self, tmp_path: Path) -> None:
+        """Parse failure is non-fatal — log + return; existing no-tasks
+        finalize path takes over."""
+        worker = self._make_worker(tmp_path)
+        result = worker._apply_setup_outcome("just some prose, no sentinel")  # type: ignore[attr-defined]
+        assert worker._tasks.list() == []  # type: ignore[attr-defined]
+        assert result == ""
+
+    def test_sentinel_with_narration_above(self, tmp_path: Path) -> None:
+        worker = self._make_worker(tmp_path)
+        text = (
+            "Looked at the issue.\n"
+            "Three small tasks should cover it.\n"
+            '{"setup_outcome": "tasks-planned", "tasks": [{"title": "Only"}]}'
+        )
+        worker._apply_setup_outcome(text)  # type: ignore[attr-defined]
+        tasks = worker._tasks.list()  # type: ignore[attr-defined]
+        assert [t["title"] for t in tasks] == ["Only"]
 
 
 class TestFinalizeSetupWithNoTasks:


### PR DESCRIPTION
## Summary

Setup phase was wedged after #1363: `Bash(./fido task *)` was added to the unconditional `--disallowedTools` list in `claude.py:668`, but `sub/setup.md` still told the LLM to use that CLI to populate the work queue. After every issue pickup `tasks.json` stayed empty and Fido stalled.

This finishes the migration #1363 started — setup now follows the same sentinel-protocol shape as task-phase commits.

## Protocol

The setup-phase LLM ends its turn with a single JSON object on the final non-empty line:

```json
{"setup_outcome": "tasks-planned",
 "pr_description": "## Summary\n\n- bullet\n\nFixes #1234.",
 "tasks": [{"title": "..."}, {"title": "...", "description": "..."}]}
```

or:

```json
{"setup_outcome": "no-tasks-needed",
 "reason": "...",
 "pr_description": "..."}
```

The harness parses it and CRUDs both the task store and the PR body. The LLM never writes `tasks.json`, never edits the PR body, and never runs `./fido task`.

When `pr_description` is supplied, `_write_pr_description` skips its description-rewrite LLM call and uses the LLM's text directly — one Opus turn total instead of two.

## Changes

- New `src/fido/setup_outcome.py` — parser with `TasksPlanned` / `NoTasksNeeded` outcome dataclasses (each carrying optional `pr_description`).
- `provider_start` returns `(session_id, output)` matching the `provider_run` shape from #1363.
- `Worker._apply_setup_outcome(output) → str` — parses, applies, returns the LLM-supplied `pr_description` (or `""`). Non-fatal on parse failure: log a warning and fall through to the existing no-tasks finalize path.
- `_write_pr_description(..., pre_baked_description="")` — when non-empty, skips the LLM call and uses the supplied text.
- Both setup call sites in `execute_run` capture provider output, apply the sentinel, and thread `pre_baked_description` through.
- `sub/setup.md` rewritten — emits the sentinel including `pr_description`, no CLI, no direct `tasks.json` or PR-body writes.
- 21 existing `patch("fido.worker.provider_start", return_value=...)` test sites updated to tuple form.

## Why no Rocq oracle (yet)

The `turn_outcome` parser in #1363 has a Rocq-proven oracle. `setup_outcome` does not — the parsing surface is small and adding the oracle is a clean follow-up. Not blocking the unblock.

## Test plan
- [x] `tests/test_setup_outcome.py` — 41 cases: empty / invalid JSON / unknown kind / per-field validation / `pr_description` capture and rejection / multi-line / no-tasks-needed
- [x] `TestApplySetupOutcome` — 7 worker-method cases: planned tasks created in order, `pr_description` returned, no-tasks-needed paths (with and without description), parse failure non-fatal, narration-above-sentinel ignored
- [x] `TestWritePrDescription` — 2 new cases: pre-baked description skips the provider call; pre-baked alone (no agent) succeeds
- [x] `TestProviderStart` — tuple-return migration with new `test_session_path_returns_run_turn_output` covering session-path output capture
- [x] `./fido ci` clean: 4022 tests passed, 100% coverage

## Future scope (separate issues)
- Add a Rocq oracle for `parse_setup_outcome` matching `parse_turn_outcome`'s pattern.
- Generalize to one CRUD-sentinel shape so adding new tasks during task-phase (rescope-from-the-LLM) reuses the same parser.