### PR TITLE
Bug: lockfree status PR 2/6 — migrate _activity_lock and _crash_lock to RegistrySnapshot (closes #1344)

### DIFF
--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -26,17 +26,14 @@ class AtomicReference(Generic[_T]):
     read with no lock acquire.  Writers hold the internal ``_lock`` only for
     the atomic swap, keeping write-side latency minimal.
 
-    The typical usage pattern is *update with retry*::
+    The typical usage pattern is *lens update*::
 
         ref = AtomicReference(initial_snapshot)
 
-        def bump(old: Snapshot) -> Snapshot:
-            return replace(old, counter=old.counter + 1)
+        ref.update(lambda root: root.counter, new_counter_value)
 
-        ref.update(bump)  # retries automatically if a concurrent writer raced
-
-    ``fn`` passed to :meth:`update` must be a **pure function** — the retry
-    loop may call it more than once under write contention.
+    *selector* passed to :meth:`update` must be a **pure function** — the
+    retry loop may call it more than once under write contention.
     """
 
     def __init__(self, initial: _T) -> None:
@@ -77,27 +74,7 @@ class AtomicReference(Generic[_T]):
             self._value = new_value
             return True, new_value
 
-    def update(self, fn: Callable[[_T], _T]) -> _T:
-        """Apply *fn* to the current value and install the result atomically.
-
-        Reads the current reference, calls ``fn(current)`` to produce the
-        next value, then attempts a compare-and-set.  If a concurrent writer
-        changed the reference first, the loop retries — using the value
-        returned by the failed CAS directly, without an extra :meth:`get`.
-
-        Returns the value that was successfully installed.
-
-        ``fn`` must be a pure function — it may be called more than once
-        under write contention.
-        """
-        old = self.get()
-        while True:
-            new = fn(old)
-            success, old = self.compare_and_set(old, new)
-            if success:
-                return new
-
-    def lens_update(
+    def update(
         self,
         selector: "Callable[[Lens[_T]], Lens[_T]]",
         value: object,
@@ -109,7 +86,7 @@ class AtomicReference(Generic[_T]):
         field.  *value* is installed there; the reconstructed root is CAS'd
         into the reference with automatic retry::
 
-            ref.lens_update(
+            ref.update(
                 lambda root: root.repos[name],
                 new_repo_state,
             )
@@ -118,4 +95,9 @@ class AtomicReference(Generic[_T]):
         more than once under write contention.  Returns the reconstructed
         root value that was successfully installed.
         """
-        return self.update(lambda old: selector(Lens(old)).set(value))  # type: ignore[return-value]
+        old = self.get()
+        while True:
+            new: _T = selector(Lens(old)).set(value)  # type: ignore[assignment]
+            success, old = self.compare_and_set(old, new)
+            if success:
+                return new

--- a/src/fido/lens.py
+++ b/src/fido/lens.py
@@ -11,7 +11,7 @@ reconstructed via ``type(parent)({**parent, key: new_value})``.
 
 Typical usage with :class:`~fido.atomic.AtomicReference`::
 
-    ref.lens_update(lambda root: root.repos[name], new_repo_state)
+    ref.update(lambda root: root.repos[name], new_repo_state)
 """
 
 import dataclasses

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -30,6 +30,9 @@ def _utcnow() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
 @dataclass(frozen=True)
 class WorkerActivity:
     """Snapshot of what one worker is currently doing.
@@ -50,11 +53,28 @@ class WorkerCrash:
 
     Frozen so instances can be stored inside frozen :class:`RepoState`
     without breaking the immutability guarantee of the atomic snapshot.
+
+    The zero value (``_ZERO_CRASH``) represents "never crashed" — readers
+    check ``death_count == 0`` rather than testing for ``None``.
     """
 
     death_count: int
     last_error: str
     last_crash_time: datetime
+
+
+_ZERO_CRASH = WorkerCrash(death_count=0, last_error="", last_crash_time=_EPOCH)
+
+
+def _zero_activity(repo_name: str) -> WorkerActivity:
+    """Return a zero-value :class:`WorkerActivity` for *repo_name*.
+
+    Repo-specific because :attr:`WorkerActivity.repo_name` is part of the
+    value.  Readers check ``what == ""`` to detect the zero sentinel.
+    """
+    return WorkerActivity(
+        repo_name=repo_name, what="", busy=False, last_progress_at=_EPOCH
+    )
 
 
 @dataclass(frozen=True)
@@ -67,13 +87,16 @@ class RepoState:
     *started_at* is the UTC timestamp when the most recent
     :class:`~fido.worker.WorkerThread` for this repo was started.
 
-    *activity* is the current :class:`WorkerActivity` for this repo, or
-    ``None`` if the worker has not yet reported any activity.  Migrated from
-    ``WorkerRegistry._activities`` / ``_activity_lock`` in PR 2/6.
+    *activity* is the current :class:`WorkerActivity` for this repo.
+    Initialised to the zero sentinel (``what=""``) by :meth:`start`; the
+    worker replaces it on its first :meth:`report_activity` call.
 
     *crash_record* is the accumulated :class:`WorkerCrash` history for this
-    repo, or ``None`` if the worker has never crashed.  Migrated from
-    ``WorkerRegistry._crashes`` / ``_crash_lock`` in PR 2/6.
+    repo.  Initialised to ``_ZERO_CRASH`` (``death_count=0``) by
+    :meth:`start`; the watchdog replaces it on each crash.
+
+    No field is ``None`` — the full tree is prepopulated by :meth:`start`
+    with zero values so lens-path writes never encounter missing keys.
 
     As subsequent lock-free PRs migrate fields out of the per-lock dicts in
     :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
@@ -83,8 +106,8 @@ class RepoState:
 
     key: str
     started_at: datetime
-    activity: WorkerActivity | None = None
-    crash_record: WorkerCrash | None = None
+    activity: WorkerActivity
+    crash_record: WorkerCrash
 
 
 @dataclass(frozen=True)
@@ -176,12 +199,16 @@ class WorkerRegistry:
         self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._status_lock = threading.Lock()
-        self._crashes: dict[str, WorkerCrash] = {}
-        self._crash_lock = threading.Lock()
         # _state holds the atomically-swapped FidoState snapshot.  Writers
-        # call AtomicReference.update() under the single internal lock; readers
-        # call AtomicReference.get() without any lock (observationally lock-free).
+        # call AtomicReference.update(selector, value) to install a value at a
+        # path via CAS; readers call .get() without any lock (lock-free).
         self._state: AtomicReference[FidoState] = AtomicReference(_EMPTY_FIDO_STATE)
+        # Owner-side crash records: the watchdog increments death_count here,
+        # then publishes the result into FidoState via a pure lens write.
+        # Only the watchdog thread writes; start() reads during crash recovery
+        # (also on the watchdog thread after startup).  No lock needed —
+        # single-writer per repo.
+        self._crash_records: dict[str, WorkerCrash] = {}
         self._webhook_activities: dict[str, list[WebhookActivity]] = {}
         self._webhook_lock = threading.Lock()
         self._rescoping: dict[str, bool] = {}
@@ -296,10 +323,17 @@ class WorkerRegistry:
             self._threads[repo_cfg.name] = thread
         _name = repo_cfg.name
         _now = _utcnow()
-        self._state.lens_update(
-            lambda root: root.repos[_name],
-            RepoState(key=_name, started_at=_now),
+        # Prepopulate the full RepoState with zero values.  Crash history
+        # comes from the class-owned _crash_records (not from FidoState),
+        # so this is a pure write — no read-modify-write CAS.
+        crash_record = self._crash_records.get(_name, _ZERO_CRASH)
+        new_repo = RepoState(
+            key=_name,
+            started_at=_now,
+            activity=_zero_activity(_name),
+            crash_record=crash_record,
         )
+        self._state.update(lambda root: root.repos[_name], new_repo)
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)
 
@@ -354,29 +388,16 @@ class WorkerRegistry:
     ) -> None:
         """Record what *repo_name*'s worker is currently doing.
 
-        Lock-free: installs the new :class:`WorkerActivity` on the repo's
-        :class:`RepoState` via CAS-update on the :class:`FidoState` snapshot.
-        Creates a placeholder :class:`RepoState` if none exists for the repo
-        yet (e.g. called before :meth:`start`).
+        Lock-free pure write: installs the new :class:`WorkerActivity` on the
+        repo's :class:`RepoState` via lens-update on the :class:`FidoState`
+        snapshot.  The repo must have been :meth:`start`-ed first (the
+        ``repos[name]`` key is prepopulated by :meth:`start`).
         """
         activity = WorkerActivity(
             repo_name=repo_name, what=what, busy=busy, last_progress_at=_now()
         )
         _name = repo_name
-
-        def _fn(state: FidoState) -> FidoState:
-            existing = state.repos.get(_name)
-            if existing is not None:
-                new_repo = replace(existing, activity=activity)
-            else:
-                new_repo = RepoState(
-                    key=_name,
-                    started_at=activity.last_progress_at,
-                    activity=activity,
-                )
-            return replace(state, repos=frozendict({**state.repos, _name: new_repo}))
-
-        self._state.update(_fn)
+        self._state.update(lambda root: root.repos[_name].activity, activity)
 
     def is_stale(
         self,
@@ -389,12 +410,12 @@ class WorkerRegistry:
 
         Lock-free: reads from the current :class:`FidoState` snapshot.
 
-        Returns False when no activity has been recorded for the repo (e.g. it
-        has never reported in) — the caller can treat that as a fresh start
+        Returns False when the repo is unknown or still on its zero-sentinel
+        activity (``what=""``) — the caller can treat that as a fresh start
         rather than a stall.
         """
         repo_state = self._state.get().repos.get(repo_name)
-        if repo_state is None or repo_state.activity is None:
+        if repo_state is None or repo_state.activity.what == "":
             return False
         return (
             _now() - repo_state.activity.last_progress_at
@@ -404,28 +425,41 @@ class WorkerRegistry:
         """Return a snapshot of all registered workers' current activities.
 
         Lock-free: reads from the current :class:`FidoState` snapshot.
+        Excludes repos whose activity is still the zero sentinel (``what=""``).
         """
         repos = self._state.get().repos
-        return [rs.activity for rs in repos.values() if rs.activity is not None]
+        return [rs.activity for rs in repos.values() if rs.activity.what != ""]
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.
 
-        Increments the death count and stores the error message and time of
-        the most recent crash.  Safe to call from any thread.
+        Increments the death count from the class-owned ``_crash_records``
+        store, then publishes the result into :class:`FidoState` via a pure
+        lens write.  Called from the watchdog thread only.
+
+        The repo must have been :meth:`start`-ed first (the ``repos[name]``
+        key is prepopulated by :meth:`start`).
         """
-        with self._crash_lock:
-            existing = self._crashes.get(repo_name)
-            self._crashes[repo_name] = WorkerCrash(
-                death_count=(existing.death_count + 1 if existing else 1),
-                last_error=error,
-                last_crash_time=_utcnow(),
-            )
+        existing = self._crash_records.get(repo_name, _ZERO_CRASH)
+        new_crash = WorkerCrash(
+            death_count=existing.death_count + 1,
+            last_error=error,
+            last_crash_time=_utcnow(),
+        )
+        self._crash_records[repo_name] = new_crash
+        _name = repo_name
+        self._state.update(lambda root: root.repos[_name].crash_record, new_crash)
 
     def get_crash_info(self, repo_name: str) -> WorkerCrash | None:
-        """Return crash history for *repo_name*, or None if it has never crashed."""
-        with self._crash_lock:
-            return self._crashes.get(repo_name)
+        """Return crash history for *repo_name*, or None if it has never crashed.
+
+        Lock-free: reads from the current :class:`FidoState` snapshot.
+        Returns ``None`` when the repo is unknown or has ``death_count == 0``.
+        """
+        repo_state = self._state.get().repos.get(repo_name)
+        if repo_state is None or repo_state.crash_record.death_count == 0:
+            return None
+        return repo_state.crash_record
 
     @contextmanager
     def webhook_activity(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -175,8 +175,6 @@ class WorkerRegistry:
         # etc.).  Python 3.14t has no GIL — dict reads and writes are not atomic.
         self._threads_lock = threading.Lock()
         self._factory = thread_factory
-        self._activities: dict[str, WorkerActivity] = {}
-        self._activity_lock = threading.Lock()
         self._status_lock = threading.Lock()
         self._crashes: dict[str, WorkerCrash] = {}
         self._crash_lock = threading.Lock()
@@ -354,11 +352,31 @@ class WorkerRegistry:
         *,
         _now: Callable[[], datetime] = _utcnow,
     ) -> None:
-        """Record what *repo_name*'s worker is currently doing."""
-        with self._activity_lock:
-            self._activities[repo_name] = WorkerActivity(
-                repo_name=repo_name, what=what, busy=busy, last_progress_at=_now()
-            )
+        """Record what *repo_name*'s worker is currently doing.
+
+        Lock-free: installs the new :class:`WorkerActivity` on the repo's
+        :class:`RepoState` via CAS-update on the :class:`FidoState` snapshot.
+        Creates a placeholder :class:`RepoState` if none exists for the repo
+        yet (e.g. called before :meth:`start`).
+        """
+        activity = WorkerActivity(
+            repo_name=repo_name, what=what, busy=busy, last_progress_at=_now()
+        )
+        _name = repo_name
+
+        def _fn(state: FidoState) -> FidoState:
+            existing = state.repos.get(_name)
+            if existing is not None:
+                new_repo = replace(existing, activity=activity)
+            else:
+                new_repo = RepoState(
+                    key=_name,
+                    started_at=activity.last_progress_at,
+                    activity=activity,
+                )
+            return replace(state, repos=frozendict({**state.repos, _name: new_repo}))
+
+        self._state.update(_fn)
 
     def is_stale(
         self,
@@ -369,20 +387,26 @@ class WorkerRegistry:
     ) -> bool:
         """Return True if *repo_name*'s last progress is older than *threshold* seconds.
 
+        Lock-free: reads from the current :class:`FidoState` snapshot.
+
         Returns False when no activity has been recorded for the repo (e.g. it
         has never reported in) — the caller can treat that as a fresh start
         rather than a stall.
         """
-        with self._activity_lock:
-            activity = self._activities.get(repo_name)
-        if activity is None:
+        repo_state = self._state.get().repos.get(repo_name)
+        if repo_state is None or repo_state.activity is None:
             return False
-        return (_now() - activity.last_progress_at).total_seconds() > threshold
+        return (
+            _now() - repo_state.activity.last_progress_at
+        ).total_seconds() > threshold
 
     def get_all_activities(self) -> list[WorkerActivity]:
-        """Return a snapshot of all registered workers' current activities."""
-        with self._activity_lock:
-            return list(self._activities.values())
+        """Return a snapshot of all registered workers' current activities.
+
+        Lock-free: reads from the current :class:`FidoState` snapshot.
+        """
+        repos = self._state.get().repos
+        return [rs.activity for rs in repos.values() if rs.activity is not None]
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -337,15 +337,6 @@ class WorkerRegistry:
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)
 
-    def thread_started_at(self, repo_name: str) -> datetime | None:
-        """Return when the worker thread for *repo_name* was started, or None.
-
-        Lock-free: reads from the current :class:`FidoState` snapshot without
-        acquiring any lock.
-        """
-        repo_state = self._state.get().repos.get(repo_name)
-        return repo_state.started_at if repo_state is not None else None
-
     def wake(self, repo_name: str) -> None:
         """Wake the thread for *repo_name* so it checks for work immediately.
 
@@ -399,28 +390,6 @@ class WorkerRegistry:
         _name = repo_name
         self._state.update(lambda root: root.repos[_name].activity, activity)
 
-    def is_stale(
-        self,
-        repo_name: str,
-        threshold: float,
-        *,
-        _now: Callable[[], datetime] = _utcnow,
-    ) -> bool:
-        """Return True if *repo_name*'s last progress is older than *threshold* seconds.
-
-        Lock-free: reads from the current :class:`FidoState` snapshot.
-
-        Returns False when the repo is unknown or still on its zero-sentinel
-        activity (``what=""``) — the caller can treat that as a fresh start
-        rather than a stall.
-        """
-        repo_state = self._state.get().repos.get(repo_name)
-        if repo_state is None or repo_state.activity.what == "":
-            return False
-        return (
-            _now() - repo_state.activity.last_progress_at
-        ).total_seconds() > threshold
-
     def get_all_activities(self) -> list[WorkerActivity]:
         """Return a snapshot of all registered workers' current activities.
 
@@ -429,6 +398,10 @@ class WorkerRegistry:
         """
         repos = self._state.get().repos
         return [rs.activity for rs in repos.values() if rs.activity.what != ""]
+
+    def get_state(self) -> FidoState:
+        """Return the current FidoState snapshot.  Lock-free."""
+        return self._state.get()
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.
@@ -449,17 +422,6 @@ class WorkerRegistry:
         self._crash_records[repo_name] = new_crash
         _name = repo_name
         self._state.update(lambda root: root.repos[_name].crash_record, new_crash)
-
-    def get_crash_info(self, repo_name: str) -> WorkerCrash | None:
-        """Return crash history for *repo_name*, or None if it has never crashed.
-
-        Lock-free: reads from the current :class:`FidoState` snapshot.
-        Returns ``None`` when the repo is unknown or has ``death_count == 0``.
-        """
-        repo_state = self._state.get().repos.get(repo_name)
-        if repo_state is None or repo_state.crash_record.death_count == 0:
-            return None
-        return repo_state.crash_record
 
     @contextmanager
     def webhook_activity(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -31,6 +31,33 @@ def _utcnow() -> datetime:
 
 
 @dataclass(frozen=True)
+class WorkerActivity:
+    """Snapshot of what one worker is currently doing.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+    """
+
+    repo_name: str
+    what: str
+    busy: bool
+    last_progress_at: datetime
+
+
+@dataclass(frozen=True)
+class WorkerCrash:
+    """Running record of unexpected worker deaths for one repo.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+    """
+
+    death_count: int
+    last_error: str
+    last_crash_time: datetime
+
+
+@dataclass(frozen=True)
 class RepoState:
     """Per-repo sub-snapshot within :class:`FidoState`.
 
@@ -40,14 +67,24 @@ class RepoState:
     *started_at* is the UTC timestamp when the most recent
     :class:`~fido.worker.WorkerThread` for this repo was started.
 
+    *activity* is the current :class:`WorkerActivity` for this repo, or
+    ``None`` if the worker has not yet reported any activity.  Migrated from
+    ``WorkerRegistry._activities`` / ``_activity_lock`` in PR 2/6.
+
+    *crash_record* is the accumulated :class:`WorkerCrash` history for this
+    repo, or ``None`` if the worker has never crashed.  Migrated from
+    ``WorkerRegistry._crashes`` / ``_crash_lock`` in PR 2/6.
+
     As subsequent lock-free PRs migrate fields out of the per-lock dicts in
-    :class:`WorkerRegistry`, those fields grow here (e.g. ``activity``,
-    ``crash_record``, ``rescoping``).  Each migration removes the
-    corresponding lock and dict from ``WorkerRegistry.__init__``.
+    :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
+    Each migration removes the corresponding lock and dict from
+    ``WorkerRegistry.__init__``.
     """
 
     key: str
     started_at: datetime
+    activity: WorkerActivity | None = None
+    crash_record: WorkerCrash | None = None
 
 
 @dataclass(frozen=True)
@@ -78,25 +115,6 @@ class FidoState:
 
 
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())
-
-
-@dataclass
-class WorkerActivity:
-    """Snapshot of what one worker is currently doing."""
-
-    repo_name: str
-    what: str
-    busy: bool
-    last_progress_at: datetime
-
-
-@dataclass
-class WorkerCrash:
-    """Running record of unexpected worker deaths for one repo."""
-
-    death_count: int
-    last_error: str
-    last_crash_time: datetime
 
 
 @dataclass

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1278,21 +1278,23 @@ class WebhookHandler(BaseHTTPRequestHandler):
             list(self.config.repos.values()),
             _provider_factory=self.provider_factory,
         )
-        for a in self.registry.get_all_activities():
-            crash = self.registry.get_crash_info(a.repo_name)
-            started_at = self.registry.thread_started_at(a.repo_name)
-            repo_cfg = self.config.repos.get(a.repo_name)
-            dropped_count = int(self.registry.get_session_dropped_count(a.repo_name))
-            worker_uptime = (
-                (now - started_at).total_seconds() if started_at is not None else None
-            )
+        snapshot = self.registry.get_state()
+        for repo_state in snapshot.repos.values():
+            a = repo_state.activity
+            if a.what == "":
+                continue  # zero sentinel — not yet active
+            crash_record = repo_state.crash_record
+            started_at = repo_state.started_at
+            repo_cfg = self.config.repos.get(repo_state.key)
+            dropped_count = int(self.registry.get_session_dropped_count(repo_state.key))
+            worker_uptime = (now - started_at).total_seconds()
             webhooks = [
                 {
                     "description": w.description,
                     "elapsed_seconds": (now - w.started_at).total_seconds(),
                     "thread_id": w.thread_id,
                 }
-                for w in self.registry.get_webhook_activities(a.repo_name)
+                for w in self.registry.get_webhook_activities(repo_state.key)
             ]
             fido_state = (
                 _collect_fido_state(repo_cfg.work_dir, now)
@@ -1316,9 +1318,14 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "repo_name": a.repo_name,
                     "what": a.what,
                     "busy": a.busy,
-                    "crash_count": crash.death_count if crash else 0,
-                    "last_crash_error": crash.last_error if crash else None,
-                    "is_stuck": self.registry.is_stale(a.repo_name, _STALE_THRESHOLD),
+                    "crash_count": crash_record.death_count
+                    if crash_record.death_count > 0
+                    else 0,
+                    "last_crash_error": crash_record.last_error
+                    if crash_record.death_count > 0
+                    else None,
+                    "is_stuck": (now - a.last_progress_at).total_seconds()
+                    > _STALE_THRESHOLD,
                     "worker_uptime_seconds": worker_uptime,
                     "webhook_activities": webhooks,
                     "provider": repo_cfg.provider if repo_cfg is not None else None,
@@ -1327,22 +1334,22 @@ class WebhookHandler(BaseHTTPRequestHandler):
                         if repo_cfg is not None
                         else None
                     ),
-                    "session_owner": self.registry.get_session_owner(a.repo_name),
-                    "session_alive": self.registry.get_session_alive(a.repo_name),
-                    "session_pid": self.registry.get_session_pid(a.repo_name),
+                    "session_owner": self.registry.get_session_owner(repo_state.key),
+                    "session_alive": self.registry.get_session_alive(repo_state.key),
+                    "session_pid": self.registry.get_session_pid(repo_state.key),
                     "session_dropped_count": dropped_count,
                     "session_sent_count": int(
-                        self.registry.get_session_sent_count(a.repo_name)
+                        self.registry.get_session_sent_count(repo_state.key)
                     ),
                     "session_received_count": int(
-                        self.registry.get_session_received_count(a.repo_name)
+                        self.registry.get_session_received_count(repo_state.key)
                     ),
                     "claude_talker": _serialize_talker(
                         provider.get_talker(a.repo_name)
                     ),
-                    "rescoping": self.registry.is_rescoping(a.repo_name),
+                    "rescoping": self.registry.is_rescoping(repo_state.key),
                     "issue_cache": _serialize_issue_cache(
-                        self.registry.get_issue_cache(a.repo_name)
+                        self.registry.get_issue_cache(repo_state.key)
                     ),
                     **fido_state,
                 }

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -85,57 +85,6 @@ class TestAtomicReferenceCompareAndSet:
         assert ref.get() is a
 
 
-class TestAtomicReferenceUpdate:
-    def test_applies_function_to_current_value(self) -> None:
-        ref: AtomicReference[_State] = AtomicReference(_State(10))
-        result = ref.update(lambda s: _State(s.n + 5))
-        assert result == _State(15)
-        assert ref.get() == _State(15)
-
-    def test_returns_installed_value(self) -> None:
-        ref: AtomicReference[_State] = AtomicReference(_State(0))
-        installed = ref.update(lambda s: _State(s.n + 1))
-        assert installed is ref.get()
-
-    def test_retries_after_concurrent_modification(self) -> None:
-        """update() retries when a writer sneaks in between get() and CAS."""
-        ref: AtomicReference[_State] = AtomicReference(_State(0))
-        injected = [False]
-
-        def fn(s: _State) -> _State:
-            if not injected[0]:
-                injected[0] = True
-                # Race: overwrite the ref before update() can CAS.
-                ref.set(_State(100))
-            return _State(s.n + 1)
-
-        result = ref.update(fn)
-        # Iteration 1: s=State(0), ref sneaked to State(100), returns State(1).
-        #   CAS(State(0), State(1)) fails — identities differ.
-        # Iteration 2: s=State(100), returns State(101).
-        #   CAS(State(100), State(101)) succeeds.
-        assert result == _State(101)
-        assert ref.get() == _State(101)
-
-    def test_concurrent_updates_all_applied(self) -> None:
-        """Many concurrent update() calls; no increments are lost."""
-        ref: AtomicReference[_State] = AtomicReference(_State(0))
-        n_threads = 20
-        increments_per_thread = 50
-
-        def run() -> None:
-            for _ in range(increments_per_thread):
-                ref.update(lambda s: _State(s.n + 1))
-
-        threads = [threading.Thread(target=run) for _ in range(n_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        assert ref.get() == _State(n_threads * increments_per_thread)
-
-
 @dataclass(frozen=True)
 class _Item:
     val: int
@@ -146,12 +95,12 @@ class _Container:
     items: frozendict[str, _Item]
 
 
-class TestAtomicReferenceLensUpdate:
+class TestAtomicReferenceUpdate:
     def test_installs_value_at_path(self) -> None:
         state = _Container(items=frozendict({"a": _Item(1)}))
         ref: AtomicReference[_Container] = AtomicReference(state)
         new_item = _Item(99)
-        result = ref.lens_update(lambda root: root.items["a"], new_item)
+        result = ref.update(lambda root: root.items["a"], new_item)
         assert result.items["a"] is new_item
         assert ref.get().items["a"] is new_item
 
@@ -160,14 +109,14 @@ class TestAtomicReferenceLensUpdate:
             _Container(items=frozendict())
         )
         new_item = _Item(7)
-        ref.lens_update(lambda root: root.items["new"], new_item)
+        ref.update(lambda root: root.items["new"], new_item)
         assert ref.get().items["new"] is new_item
 
     def test_returns_installed_root(self) -> None:
         ref: AtomicReference[_Container] = AtomicReference(
             _Container(items=frozendict({"x": _Item(0)}))
         )
-        result = ref.lens_update(lambda root: root.items["x"], _Item(5))
+        result = ref.update(lambda root: root.items["x"], _Item(5))
         assert result is ref.get()
 
     def test_selector_receives_lens(self) -> None:
@@ -181,7 +130,7 @@ class TestAtomicReferenceLensUpdate:
         ref: AtomicReference[_Container] = AtomicReference(
             _Container(items=frozendict({"a": _Item(1)}))
         )
-        ref.lens_update(selector, _Item(2))
+        ref.update(selector, _Item(2))
         assert isinstance(received[0], Lens)
 
     def test_preserves_sibling_keys(self) -> None:
@@ -190,5 +139,49 @@ class TestAtomicReferenceLensUpdate:
         ref: AtomicReference[_Container] = AtomicReference(
             _Container(items=frozendict({"a": a, "b": b}))
         )
-        ref.lens_update(lambda root: root.items["a"], _Item(99))
+        ref.update(lambda root: root.items["a"], _Item(99))
         assert ref.get().items["b"] is b
+
+    def test_retries_after_concurrent_modification(self) -> None:
+        """update() retries when a concurrent writer sneaks in between get() and CAS."""
+        ref: AtomicReference[_Container] = AtomicReference(
+            _Container(items=frozendict({"a": _Item(0)}))
+        )
+        injected = [False]
+
+        def selector(root: Lens[_Container]) -> Lens[_Container]:
+            if not injected[0]:
+                injected[0] = True
+                # Race: overwrite the ref before update() can CAS.
+                ref.set(_Container(items=frozendict({"a": _Item(100)})))
+            return root.items["a"]
+
+        result = ref.update(selector, _Item(42))
+        # Iteration 1: selector runs on old root (a=0), sneaks in a=100,
+        #   produces root with a=42.  CAS fails because ref changed.
+        # Iteration 2: selector runs on new root (a=100), produces root
+        #   with a=42.  CAS succeeds.
+        assert result.items["a"] == _Item(42)
+        assert ref.get().items["a"] == _Item(42)
+
+    def test_concurrent_updates_no_lost_writes(self) -> None:
+        """Many concurrent update() calls on disjoint keys; no writes lost."""
+        n_threads = 20
+        items = frozendict({f"k{i}": _Item(0) for i in range(n_threads)})
+        ref: AtomicReference[_Container] = AtomicReference(_Container(items=items))
+
+        def run(key: str) -> None:
+            for v in range(1, 51):
+                ref.update(lambda root: root.items[key], _Item(v))
+
+        threads = [
+            threading.Thread(target=run, args=(f"k{i}",)) for i in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        final = ref.get()
+        for i in range(n_threads):
+            assert final.items[f"k{i}"] == _Item(50)

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -140,11 +140,11 @@ class TestLensFidoStatePattern:
         assert result.repos["a/a"] is new_a
         assert result.repos["b/b"] is b
 
-    def test_with_lens_update(self) -> None:
-        """End-to-end: lens_update navigates and installs atomically."""
+    def test_with_atomic_update(self) -> None:
+        """End-to-end: AtomicReference.update navigates and installs atomically."""
         from fido.atomic import AtomicReference
 
         ref: AtomicReference[FidoState] = AtomicReference(FidoState(repos=frozendict()))
         new_repo = RepoState(key="owner/repo", started_at="now")
-        ref.lens_update(lambda root: root.repos["owner/repo"], new_repo)
+        ref.update(lambda root: root.repos["owner/repo"], new_repo)
         assert ref.get().repos["owner/repo"] is new_repo

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -35,9 +35,15 @@ def _repo(name: str, work_dir: Path) -> RepoConfig:
 
 
 class TestWorkerRegistry:
-    def _make_registry(self) -> tuple[WorkerRegistry, MagicMock]:
+    def _make_registry(
+        self, *, repos: list[str] | None = None
+    ) -> tuple[WorkerRegistry, MagicMock]:
         factory = MagicMock()
-        return WorkerRegistry(factory), factory
+        reg = WorkerRegistry(factory)
+        if repos:
+            for name in repos:
+                reg.start(_repo(name, Path("/tmp/fake")))
+        return reg, factory
 
     def test_start_calls_factory_with_repo_cfg(self, tmp_path: Path) -> None:
         reg, factory = self._make_registry()
@@ -354,7 +360,7 @@ class TestWorkerRegistry:
         assert reg.get_thread_crash_error("foo/bar") is None
 
     def test_report_activity_stores_entry(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         activities = reg.get_all_activities()
         assert len(activities) == 1
@@ -363,7 +369,7 @@ class TestWorkerRegistry:
         assert activities[0].busy is True
 
     def test_report_activity_overwrites_previous(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/bar", "Napping", busy=False)
         activities = reg.get_all_activities()
@@ -372,7 +378,7 @@ class TestWorkerRegistry:
         assert activities[0].busy is False
 
     def test_get_all_activities_returns_all_repos(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/baz", "Napping", busy=False)
         activities = sorted(reg.get_all_activities(), key=lambda a: a.repo_name)
@@ -386,7 +392,7 @@ class TestWorkerRegistry:
         assert reg.get_all_activities() == []
 
     def test_get_all_activities_returns_snapshot(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         snapshot = reg.get_all_activities()
         reg.report_activity("foo/bar", "Napping", busy=False)
@@ -397,7 +403,7 @@ class TestWorkerRegistry:
         import datetime as dt
 
         fixed = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: fixed)
         activities = reg.get_all_activities()
         assert activities[0].last_progress_at == fixed
@@ -407,7 +413,7 @@ class TestWorkerRegistry:
 
         t1 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t2 = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "first", busy=True, _now=lambda: t1)
         reg.report_activity("foo/bar", "second", busy=True, _now=lambda: t2)
         activities = reg.get_all_activities()
@@ -422,7 +428,7 @@ class TestWorkerRegistry:
 
         t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t_now = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.timezone.utc)  # 30s later
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
         assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
 
@@ -431,7 +437,7 @@ class TestWorkerRegistry:
 
         t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)  # 10m later
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
         assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
 
@@ -440,7 +446,7 @@ class TestWorkerRegistry:
 
         t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t_now = dt.datetime(2026, 1, 1, 12, 1, 0, tzinfo=dt.timezone.utc)  # exactly 60s
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
         assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
 
@@ -449,7 +455,7 @@ class TestWorkerRegistry:
 
         t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
         reg.report_activity("foo/bar", "old", busy=True, _now=lambda: t0)
         reg.report_activity("foo/baz", "fresh", busy=True, _now=lambda: t_now)
         assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
@@ -463,8 +469,9 @@ class TestWorkerRegistry:
         writers finish, every repo must appear exactly once in the snapshot
         with its final value, proving no data was lost or corrupted.
         """
-        reg, _ = self._make_registry()
         n_repos = 8
+        repos = [f"owner/repo{i}" for i in range(n_repos)]
+        reg, _ = self._make_registry(repos=repos)
         n_writes = 200
         errors: list[Exception] = []
 
@@ -484,7 +491,6 @@ class TestWorkerRegistry:
             except Exception as exc:
                 errors.append(exc)
 
-        repos = [f"owner/repo{i}" for i in range(n_repos)]
         threads = [threading.Thread(target=writer, args=(r,)) for r in repos]
         threads.append(threading.Thread(target=reader))
 
@@ -535,7 +541,7 @@ class TestWorkerRegistry:
         assert reg.get_crash_info("foo/bar") is None
 
     def test_record_crash_stores_error_and_count(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "boom")
         info = reg.get_crash_info("foo/bar")
         assert info is not None
@@ -546,7 +552,7 @@ class TestWorkerRegistry:
         import datetime as dt
 
         before = dt.datetime.now(tz=dt.timezone.utc)
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "oops")
         after = dt.datetime.now(tz=dt.timezone.utc)
         info = reg.get_crash_info("foo/bar")
@@ -554,7 +560,7 @@ class TestWorkerRegistry:
         assert before <= info.last_crash_time <= after
 
     def test_record_crash_increments_death_count(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "err1")
         reg.record_crash("foo/bar", "err2")
         reg.record_crash("foo/bar", "err3")
@@ -563,7 +569,7 @@ class TestWorkerRegistry:
         assert info.death_count == 3
 
     def test_record_crash_updates_last_error(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "first")
         reg.record_crash("foo/bar", "second")
         info = reg.get_crash_info("foo/bar")
@@ -571,7 +577,7 @@ class TestWorkerRegistry:
         assert info.last_error == "second"
 
     def test_crash_info_is_per_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
         reg.record_crash("foo/bar", "bar error")
         reg.record_crash("foo/baz", "baz error")
         reg.record_crash("foo/baz", "baz error 2")
@@ -580,24 +586,22 @@ class TestWorkerRegistry:
         assert bar is not None and bar.death_count == 1
         assert baz is not None and baz.death_count == 2
 
-    def test_record_crash_is_threadsafe(self) -> None:
-        """Concurrent record_crash calls must not corrupt the death count."""
-        reg, _ = self._make_registry()
+    def test_record_crash_accumulates_count(self) -> None:
+        """Sequential record_crash calls accumulate death_count correctly.
+
+        record_crash is single-writer (watchdog-thread only) by contract —
+        it reads and increments from the class-owned _crash_records store,
+        then publishes via a pure lens write.  This test verifies the counter
+        accumulates without loss over many sequential calls.
+        """
+        reg, _ = self._make_registry(repos=["foo/bar"])
         n = 200
-
-        def crasher() -> None:
-            for _ in range(n):
-                reg.record_crash("foo/bar", "err")
-
-        threads = [threading.Thread(target=crasher) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
+        for _ in range(n):
+            reg.record_crash("foo/bar", "err")
 
         info = reg.get_crash_info("foo/bar")
         assert info is not None
-        assert info.death_count == 4 * n
+        assert info.death_count == n
 
     def test_worker_crash_dataclass_fields(self) -> None:
         import datetime as dt
@@ -607,6 +611,23 @@ class TestWorkerRegistry:
         assert crash.death_count == 3
         assert crash.last_error == "oops"
         assert crash.last_crash_time == ts
+
+    def test_crash_record_survives_start(self, tmp_path: Path) -> None:
+        """crash_record is preserved across start() so history accumulates."""
+        threads = [MagicMock(), MagicMock()]
+        factory = MagicMock(side_effect=threads)
+        reg = WorkerRegistry(factory)
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        reg.record_crash("foo/bar", "boom")
+        # Simulate crash so the FSM accepts the second start
+        threads[0].is_alive.return_value = False
+        threads[0].was_stopped = False
+        reg.start(cfg)
+        info = reg.get_crash_info("foo/bar")
+        assert info is not None
+        assert info.death_count == 1
+        assert info.last_error == "boom"
 
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -419,48 +419,6 @@ class TestWorkerRegistry:
         activities = reg.get_all_activities()
         assert activities[0].last_progress_at == t2
 
-    def test_is_stale_false_when_no_activity(self) -> None:
-        reg, _ = self._make_registry()
-        assert reg.is_stale("foo/bar", threshold=60.0) is False
-
-    def test_is_stale_false_when_recent(self) -> None:
-        import datetime as dt
-
-        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        t_now = dt.datetime(2026, 1, 1, 12, 0, 30, tzinfo=dt.timezone.utc)  # 30s later
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
-        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
-
-    def test_is_stale_true_when_old(self) -> None:
-        import datetime as dt
-
-        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)  # 10m later
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
-        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
-
-    def test_is_stale_exactly_at_threshold_is_not_stale(self) -> None:
-        import datetime as dt
-
-        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        t_now = dt.datetime(2026, 1, 1, 12, 1, 0, tzinfo=dt.timezone.utc)  # exactly 60s
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: t0)
-        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is False
-
-    def test_is_stale_per_repo(self) -> None:
-        import datetime as dt
-
-        t0 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        t_now = dt.datetime(2026, 1, 1, 12, 10, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
-        reg.report_activity("foo/bar", "old", busy=True, _now=lambda: t0)
-        reg.report_activity("foo/baz", "fresh", busy=True, _now=lambda: t_now)
-        assert reg.is_stale("foo/bar", threshold=60.0, _now=lambda: t_now) is True
-        assert reg.is_stale("foo/baz", threshold=60.0, _now=lambda: t_now) is False
-
     def test_concurrent_report_and_read_are_safe(self) -> None:
         """report_activity and get_all_activities are safe under concurrent load.
 
@@ -536,17 +494,17 @@ class TestWorkerRegistry:
 
         assert max_concurrent == 1
 
-    def test_get_crash_info_returns_none_before_any_crash(self) -> None:
-        reg, _ = self._make_registry()
-        assert reg.get_crash_info("foo/bar") is None
+    def test_get_state_returns_fido_state(self) -> None:
+        reg, _ = self._make_registry(repos=["foo/bar"])
+        state = reg.get_state()
+        assert "foo/bar" in state.repos
 
     def test_record_crash_stores_error_and_count(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "boom")
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert info.death_count == 1
-        assert info.last_error == "boom"
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.death_count == 1
+        assert crash.last_error == "boom"
 
     def test_record_crash_sets_last_crash_time(self) -> None:
         import datetime as dt
@@ -555,36 +513,24 @@ class TestWorkerRegistry:
         reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "oops")
         after = dt.datetime.now(tz=dt.timezone.utc)
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert before <= info.last_crash_time <= after
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.death_count > 0
+        assert before <= crash.last_crash_time <= after
 
     def test_record_crash_increments_death_count(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "err1")
         reg.record_crash("foo/bar", "err2")
         reg.record_crash("foo/bar", "err3")
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert info.death_count == 3
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.death_count == 3
 
     def test_record_crash_updates_last_error(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "first")
         reg.record_crash("foo/bar", "second")
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert info.last_error == "second"
-
-    def test_crash_info_is_per_repo(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
-        reg.record_crash("foo/bar", "bar error")
-        reg.record_crash("foo/baz", "baz error")
-        reg.record_crash("foo/baz", "baz error 2")
-        bar = reg.get_crash_info("foo/bar")
-        baz = reg.get_crash_info("foo/baz")
-        assert bar is not None and bar.death_count == 1
-        assert baz is not None and baz.death_count == 2
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.last_error == "second"
 
     def test_record_crash_accumulates_count(self) -> None:
         """Sequential record_crash calls accumulate death_count correctly.
@@ -599,9 +545,8 @@ class TestWorkerRegistry:
         for _ in range(n):
             reg.record_crash("foo/bar", "err")
 
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert info.death_count == n
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.death_count == n
 
     def test_worker_crash_dataclass_fields(self) -> None:
         import datetime as dt
@@ -624,10 +569,9 @@ class TestWorkerRegistry:
         threads[0].is_alive.return_value = False
         threads[0].was_stopped = False
         reg.start(cfg)
-        info = reg.get_crash_info("foo/bar")
-        assert info is not None
-        assert info.death_count == 1
-        assert info.last_error == "boom"
+        crash = reg.get_state().repos["foo/bar"].crash_record
+        assert crash.death_count == 1
+        assert crash.last_error == "boom"
 
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
@@ -794,18 +738,6 @@ class TestMakeRegistry:
             _thread_factory=mock_factory,
         )
         assert mock_factory.call_args.kwargs["config"] is config
-
-
-class TestThreadStartedAt:
-    def test_records_on_start(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
-        cfg = _repo("foo/bar", tmp_path)
-        reg.start(cfg)
-        assert reg.thread_started_at("foo/bar") is not None
-
-    def test_returns_none_for_unknown(self) -> None:
-        reg = WorkerRegistry(MagicMock())
-        assert reg.thread_started_at("nope/none") is None
 
 
 class TestWebhookActivity:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,12 +8,14 @@ import threading
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from datetime import datetime, timezone
 from http.server import HTTPServer
 from pathlib import Path
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from frozendict import frozendict
 
 from fido import provider
 from fido.claude import ClaudeClient
@@ -26,11 +28,53 @@ from fido.events import (
 )
 from fido.infra import Infra
 from fido.provider import ProviderID
+from fido.registry import FidoState, RepoState, WorkerActivity, WorkerCrash
 from fido.server import FidoHTTPServer, PreflightError, WebhookHandler, _repo_status
 from fido.store import FidoStore
 from fido.tasks import Tasks
 from fido.types import TaskStatus, TaskType
 from tests.fakes import _FakeDispatcher
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _zero_crash() -> WorkerCrash:
+    return WorkerCrash(death_count=0, last_error="", last_crash_time=_EPOCH)
+
+
+def _repo_state(
+    repo_name: str,
+    what: str = "Working on: #1",
+    busy: bool = True,
+    crash_count: int = 0,
+    last_error: str = "",
+    stale: bool = False,
+    started_at: datetime | None = None,
+) -> RepoState:
+    progress_at = (
+        datetime(2020, 1, 1, tzinfo=timezone.utc)
+        if stale
+        else datetime.now(tz=timezone.utc)
+    )
+    return RepoState(
+        key=repo_name,
+        started_at=started_at or _EPOCH,
+        activity=WorkerActivity(
+            repo_name=repo_name,
+            what=what,
+            busy=busy,
+            last_progress_at=progress_at,
+        ),
+        crash_record=WorkerCrash(
+            death_count=crash_count,
+            last_error=last_error,
+            last_crash_time=_EPOCH,
+        ),
+    )
+
+
+def _fido_state(*repo_states: RepoState) -> FidoState:
+    return FidoState(repos=frozendict({rs.key: rs for rs in repo_states}))
 
 
 class RepoConfig(_RepoConfig):
@@ -238,22 +282,10 @@ class TestGetEndpoint:
         assert b"fido is running" in resp.read()
 
     def test_status_endpoint_returns_activities(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -273,7 +305,7 @@ class TestGetEndpoint:
         assert entry["crash_count"] == 0
         assert entry["last_crash_error"] is None
         assert entry["is_stuck"] is False
-        assert entry["worker_uptime_seconds"] is None
+        assert isinstance(entry["worker_uptime_seconds"], float)
         assert entry["webhook_activities"] == []
         assert entry["session_owner"] is None
         assert entry["session_dropped_count"] == 0
@@ -281,22 +313,10 @@ class TestGetEndpoint:
         assert entry["session_received_count"] == 0
 
     def test_status_endpoint_includes_session_owner(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
         WebhookHandler.registry.get_session_alive.return_value = True
@@ -313,22 +333,10 @@ class TestGetEndpoint:
         assert data["activities"][0]["session_received_count"] == 8
 
     def test_status_endpoint_includes_session_alive(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="idle",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
@@ -340,26 +348,16 @@ class TestGetEndpoint:
         assert data["activities"][0]["session_owner"] is None
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity, WorkerCrash
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state(
+                "owner/repo",
                 what="Napping",
                 busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = WorkerCrash(
-            death_count=3,
-            last_error="RuntimeError: boom",
-            last_crash_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                crash_count=3,
+                last_error="RuntimeError: boom",
+            )
         )
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -372,7 +370,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_empty_when_no_activities(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
         assert json.loads(resp.read()) == {
@@ -383,27 +381,26 @@ class TestGetEndpoint:
 
     def test_status_endpoint_content_type_json(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.headers.get("Content-Type") == "application/json"
 
-    def test_status_endpoint_is_stuck_true_when_stale(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
+    def test_status_endpoint_skips_zero_sentinel_repos(self, server: tuple) -> None:
+        """Repos whose activity is still the zero sentinel (what='') are excluded."""
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = True
-        WebhookHandler.registry.thread_started_at.return_value = None
+        # A repo in the snapshot with what="" — prepopulated but never active.
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="")
+        )
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        assert data["activities"] == []
+
+    def test_status_endpoint_is_stuck_true_when_stale(self, server: tuple) -> None:
+        url, _ = server
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", stale=True)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -414,22 +411,10 @@ class TestGetEndpoint:
         assert data["activities"][0]["is_stuck"] is True
 
     def test_status_endpoint_includes_rescoping_flag(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -445,23 +430,12 @@ class TestGetEndpoint:
         """A real ``RateLimitMonitor`` with a refreshed snapshot serializes
         into ``/status.json`` under the top-level ``rate_limit`` key
         (closes #812 follow-up)."""
-        from datetime import datetime, timezone
-
         from fido.rate_limit import RateLimitMonitor
-        from fido.registry import WorkerActivity
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="idle",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -492,22 +466,10 @@ class TestGetEndpoint:
         self, server: tuple
     ) -> None:
         """No monitor instance attached → ``rate_limit`` is ``None``."""
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="idle",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -523,23 +485,12 @@ class TestGetEndpoint:
         self, server: tuple
     ) -> None:
         """Monitor present but ``latest()`` returns None → rate_limit None."""
-        from datetime import datetime, timezone
-
         from fido.rate_limit import RateLimitMonitor
-        from fido.registry import WorkerActivity
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="idle",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -560,23 +511,12 @@ class TestGetEndpoint:
         and verify the /status.json payload includes the cache snapshot
         (closes #812 status half).
         """
-        from datetime import datetime, timezone
-
         from fido.issue_cache import IssueTreeCache
-        from fido.registry import WorkerActivity
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -616,22 +556,10 @@ class TestGetEndpoint:
         from ``get_issue_cache``; ``_serialize_issue_cache`` must reject
         it as non-cache and emit ``None`` rather than raise.
         """
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -644,22 +572,10 @@ class TestGetEndpoint:
         assert data["activities"][0]["issue_cache"] is None
 
     def test_status_endpoint_includes_provider_status(self, server: tuple) -> None:
-        from datetime import UTC, datetime
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=UTC),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -673,7 +589,7 @@ class TestGetEndpoint:
                     window_name="five_hour",
                     pressure=0.96,
                     percent_used=96,
-                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=timezone.utc),
                     unavailable_reason=None,
                     level="paused",
                     warning=False,
@@ -688,22 +604,10 @@ class TestGetEndpoint:
         assert data["activities"][0]["provider_status"]["percent_used"] == 96
 
     def test_status_endpoint_rescoping_false_by_default(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Napping",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="Napping", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -717,22 +621,10 @@ class TestGetEndpoint:
         self, server: tuple
     ) -> None:
         """With no state.json or tasks.json on disk, fido_state fields default."""
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -760,10 +652,6 @@ class TestGetEndpoint:
         self, server: tuple, tmp_path: Path
     ) -> None:
         """state.json and tasks.json on disk are surfaced in the activity entry."""
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         # Write state.json
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
@@ -804,17 +692,9 @@ class TestGetEndpoint:
         tasks_path.write_text(json.dumps(tasks))
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #42",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="Working on: #42")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -842,23 +722,11 @@ class TestGetEndpoint:
         self, server: tuple
     ) -> None:
         """When a repo has no config entry, fido_state fields are all defaults."""
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
         # Report an activity for a repo not in config
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="unknown/repo",
-                what="idle",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("unknown/repo", what="idle", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1136,7 +1004,7 @@ class TestRepoStatus:
 class TestStatusXml:
     def test_status_returns_namespaced_xml_with_xslt_pi(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert resp.headers.get("Content-Type") == "application/xml; charset=utf-8"
@@ -1146,22 +1014,10 @@ class TestStatusXml:
         assert 'xmlns="https://fidocancode.dog/fido"' in body
 
     def test_status_xml_contains_repo_data_with_namespaces(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #1",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1176,7 +1032,7 @@ class TestStatusXml:
 
     def test_status_xml_empty_fido(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert 'xmlns="https://fidocancode.dog/fido"' in body
@@ -1184,10 +1040,7 @@ class TestStatusXml:
         assert "/>" in body
 
     def test_status_xml_includes_claude_talker(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
         from fido.provider import SessionTalker
-        from fido.registry import WorkerActivity
 
         url, _ = server
         talker = SessionTalker(
@@ -1198,17 +1051,9 @@ class TestStatusXml:
             claude_pid=9999,
             started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
         )
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="working",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="working")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1221,22 +1066,10 @@ class TestStatusXml:
         assert "<claude_pid>9999</claude_pid>" in body
 
     def test_status_xml_includes_provider_status(self, server: tuple) -> None:
-        from datetime import UTC, datetime
-
-        from fido.registry import WorkerActivity
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="working",
-                busy=False,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=UTC),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="working", busy=False)
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1250,7 +1083,7 @@ class TestStatusXml:
                     window_name="five_hour",
                     pressure=0.96,
                     percent_used=96,
-                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=UTC),
+                    resets_at=datetime(2026, 4, 16, 7, 0, tzinfo=timezone.utc),
                     unavailable_reason=None,
                     level="paused",
                     warning=False,
@@ -1265,22 +1098,12 @@ class TestStatusXml:
         assert "<percent_used>96</percent_used>" in body
 
     def test_status_xml_includes_webhooks(self, server: tuple) -> None:
-        from datetime import datetime, timezone
-
-        from fido.registry import WebhookActivity, WorkerActivity
+        from fido.registry import WebhookActivity
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="working",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="working")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = [
             WebhookActivity(
                 handle_id=1,
@@ -1300,10 +1123,8 @@ class TestStatusXml:
 
     def test_status_xml_includes_fido_uptime(self, server: tuple) -> None:
         """<fido_uptime_seconds> appears in the root element when fido_started_at is set."""
-        from datetime import datetime, timezone
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         WebhookHandler.fido_started_at = datetime(
             2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
         )
@@ -1314,7 +1135,7 @@ class TestStatusXml:
     def test_status_xml_no_fido_uptime_when_not_started(self, server: tuple) -> None:
         """<fido_uptime_seconds> is absent when fido_started_at is None (default)."""
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         assert WebhookHandler.fido_started_at is None
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
@@ -1322,8 +1143,6 @@ class TestStatusXml:
 
     def test_status_xml_includes_rate_limit(self, server: tuple) -> None:
         """<rate_limit> with nested windows appears in the root element when available."""
-        from datetime import UTC, datetime
-
         from fido.rate_limit import (
             RateLimitMonitor,
             RateLimitSnapshot,
@@ -1331,21 +1150,21 @@ class TestStatusXml:
         )
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         snap = RateLimitSnapshot(
             rest=RateLimitWindow(
                 name="rest",
                 used=100,
                 limit=5000,
-                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=UTC),
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
             ),
             graphql=RateLimitWindow(
                 name="graphql",
                 used=5,
                 limit=5000,
-                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=UTC),
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
             ),
-            fetched_at=datetime(2026, 4, 19, 12, 0, tzinfo=UTC),
+            fetched_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
         )
         monitor = MagicMock(spec=RateLimitMonitor)
         monitor.latest.return_value = snap
@@ -1360,10 +1179,8 @@ class TestStatusXml:
 
     def test_status_json_includes_fido_uptime(self, server: tuple) -> None:
         """fido_uptime_seconds appears in /status.json when fido_started_at is set."""
-        from datetime import datetime, timezone
-
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         WebhookHandler.fido_started_at = datetime(
             2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
         )
@@ -1375,7 +1192,7 @@ class TestStatusXml:
     def test_status_json_fido_uptime_null_when_not_started(self, server: tuple) -> None:
         """fido_uptime_seconds is null in /status.json when fido_started_at is None."""
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = []
+        WebhookHandler.registry.get_state.return_value = _fido_state()
         assert WebhookHandler.fido_started_at is None
         resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
@@ -1390,10 +1207,6 @@ class TestStatusXml:
         non-completed list is reported — so the counter can show "2/3" rather
         than always "1/N".
         """
-        from datetime import datetime, timezone
-
-        from fido.registry import WorkerActivity
-
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         tasks = [
@@ -1429,17 +1242,9 @@ class TestStatusXml:
         (fido_dir / "tasks.json").write_text(json.dumps(tasks))
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="Working on: #10",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="Working on: #10")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1455,23 +1260,12 @@ class TestStatusXml:
         self, server: tuple
     ) -> None:
         """issue_cache dict is emitted as nested XML children, not as str(dict)."""
-        from datetime import datetime, timezone
-
         from fido.issue_cache import IssueTreeCache
-        from fido.registry import WorkerActivity
 
         url, _ = server
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="working",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="working")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -1994,10 +1788,7 @@ class TestProcessAction:
 
     def test_status_endpoint_includes_claude_talker(self, server: tuple) -> None:
         """Active SessionTalker appears in /status as a structured object."""
-        from datetime import datetime, timezone
-
         from fido.provider import SessionTalker
-        from fido.registry import WorkerActivity
 
         url, _ = server
         talker = SessionTalker(
@@ -2008,17 +1799,9 @@ class TestProcessAction:
             claude_pid=12345,
             started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
         )
-        WebhookHandler.registry.get_all_activities.return_value = [
-            WorkerActivity(
-                repo_name="owner/repo",
-                what="running",
-                busy=True,
-                last_progress_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        ]
-        WebhookHandler.registry.get_crash_info.return_value = None
-        WebhookHandler.registry.is_stale.return_value = False
-        WebhookHandler.registry.thread_started_at.return_value = None
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="running")
+        )
         WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -831,6 +831,9 @@ class TestWorker:
         from fido.registry import WorkerRegistry
 
         registry = WorkerRegistry(MagicMock())
+        # Prepopulate FidoState so report_activity can lens-write into it.
+        for i in range(3):
+            registry.start(_default_repo_cfg(tmp_path, repo_name=f"owner/repo{i}"))
         inside_count = 0
         max_concurrent = 0
         counter_lock = threading.Lock()


### PR DESCRIPTION
Migrate `_activity_lock` and `_crash_lock` out of `WorkerRegistry` into the lock-free `FidoState` / `RepoState` snapshot. The class owns activity and crash values independently and publishes them into a prepopulated zero-value tree via pure lens writes — no read-modify-write through FidoState, no `None` fields, no missing-key branches. Also collapses `update` and `lens_update` on `AtomicReference` into a single `update(selector, value)` method, and has `_collect_activities` pull activity + crash + started_at from a single snapshot to avoid cross-generation reads.

Fixes #1344.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (5)</summary>

- [x] Update _collect_activities to read activity and crash from single snapshot <!-- type:spec -->
- [x] [Use lens_update method instead of raw update for the CAS operations. Inline update into lens_update, delete old update, rename lens_update to update.](https://github.com/FidoCanCode/home/pull/1405#discussion_r3190727993) <!-- type:thread -->
- [x] Migrate record_crash and get_crash_info to CAS-update, delete _crash_lock <!-- type:spec -->
- [x] Migrate report_activity and is_stale to CAS-update, delete _activity_lock <!-- type:spec -->
- [x] Make WorkerActivity and WorkerCrash frozen, add fields to RepoState <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->