### PR TITLE
Bug: lockfree status PR 3/6 — migrate _webhook_lock (per-repo webhook activities) to RegistrySnapshot (closes #1345)

### DIFF
--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -35,7 +35,7 @@ def _utcnow() -> datetime:
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WorkerActivity:
     """Snapshot of what one worker is currently doing.
 
@@ -49,7 +49,7 @@ class WorkerActivity:
     last_progress_at: datetime
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WorkerCrash:
     """Running record of unexpected worker deaths for one repo.
 
@@ -79,7 +79,7 @@ def _zero_activity(repo_name: str) -> WorkerActivity:
     )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WebhookActivity:
     """One in-flight webhook handler running alongside the worker.
 
@@ -104,7 +104,7 @@ class WebhookActivity:
     thread_id: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RepoState:
     """Per-repo sub-snapshot within :class:`FidoState`.
 
@@ -142,7 +142,7 @@ class RepoState:
     webhook_activities: tuple[WebhookActivity, ...] = field(default_factory=tuple)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FidoState:
     """Atomically-swapped coordination snapshot owned by :class:`WorkerRegistry`.
 
@@ -172,7 +172,7 @@ class FidoState:
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WebhookActivityHandle:
     """Opaque handle for updating one in-flight webhook activity safely."""
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -138,7 +138,7 @@ class RepoState:
     started_at: datetime
     activity: WorkerActivity
     crash_record: WorkerCrash
-    webhook_activities: tuple[WebhookActivity, ...] = field(default_factory=tuple)
+    webhook_activities: tuple[WebhookActivity, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,7 +4,8 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,7 @@ from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
+from fido.lens import Lens
 from fido.provider import PromptSession, Provider
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -78,6 +80,31 @@ def _zero_activity(repo_name: str) -> WorkerActivity:
 
 
 @dataclass(frozen=True)
+class WebhookActivity:
+    """One in-flight webhook handler running alongside the worker.
+
+    Created when ``_process_action`` starts handling a webhook action; removed
+    when that handler returns (success or failure).  Surfaced in ``fido
+    status`` as a sub-bullet under the repo so we can see what's being
+    handled beyond the worker's own task.
+
+    *thread_id* is :func:`threading.get_ident` captured at context entry so
+    status display can match this webhook to the active
+    :class:`~fido.provider.SessionTalker` (whose ``thread_id`` field is from
+    the same call) — letting the CLI attach claude stats to the specific
+    webhook line that's driving claude.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+    """
+
+    handle_id: int
+    description: str
+    started_at: datetime
+    thread_id: int
+
+
+@dataclass(frozen=True)
 class RepoState:
     """Per-repo sub-snapshot within :class:`FidoState`.
 
@@ -95,6 +122,10 @@ class RepoState:
     repo.  Initialised to ``_ZERO_CRASH`` (``death_count=0``) by
     :meth:`start`; the watchdog replaces it on each crash.
 
+    *webhook_activities* is the tuple of in-flight webhook handlers for this
+    repo.  Managed via CAS-update by
+    :meth:`~WorkerRegistry._modify_webhook_activities`; starts empty.
+
     No field is ``None`` — the full tree is prepopulated by :meth:`start`
     with zero values so lens-path writes never encounter missing keys.
 
@@ -108,6 +139,7 @@ class RepoState:
     started_at: datetime
     activity: WorkerActivity
     crash_record: WorkerCrash
+    webhook_activities: tuple[WebhookActivity, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -138,28 +170,6 @@ class FidoState:
 
 
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())
-
-
-@dataclass
-class WebhookActivity:
-    """One in-flight webhook handler running alongside the worker.
-
-    Created when ``_process_action`` starts handling a webhook action; removed
-    when that handler returns (success or failure).  Surfaced in ``fido
-    status`` as a sub-bullet under the repo so we can see what's being
-    handled beyond the worker's own task.
-
-    *thread_id* is :func:`threading.get_ident` captured at context entry so
-    status display can match this webhook to the active
-    :class:`~fido.provider.SessionTalker` (whose ``thread_id`` field is from
-    the same call) — letting the CLI attach claude stats to the specific
-    webhook line that's driving claude.
-    """
-
-    handle_id: int
-    description: str
-    started_at: datetime
-    thread_id: int
 
 
 @dataclass(frozen=True)
@@ -209,8 +219,6 @@ class WorkerRegistry:
         # (also on the watchdog thread after startup).  No lock needed —
         # single-writer per repo.
         self._crash_records: dict[str, WorkerCrash] = {}
-        self._webhook_activities: dict[str, list[WebhookActivity]] = {}
-        self._webhook_lock = threading.Lock()
         self._rescoping: dict[str, bool] = {}
         self._rescoping_lock = threading.Lock()
         # Per-repo untriaged-webhook inbox (#1067).  Counts model-needing
@@ -423,6 +431,51 @@ class WorkerRegistry:
         _name = repo_name
         self._state.update(lambda root: root.repos[_name].crash_record, new_crash)
 
+    def _modify_webhook_activities(
+        self,
+        repo_name: str,
+        transform: Callable[
+            [tuple[WebhookActivity, ...]], tuple[WebhookActivity, ...] | None
+        ],
+    ) -> None:
+        """Apply *transform* to the webhook-activity tuple for *repo_name* via CAS loop.
+
+        *transform* receives the current tuple and returns the new tuple to
+        install, or ``None`` to skip the update (early-exit / no-op).  The
+        loop retries on contention; *transform* must be pure and may be called
+        more than once.
+
+        If *repo_name* is not yet registered in the snapshot (e.g. during
+        tests that call :meth:`webhook_activity` before :meth:`start`), a
+        zero-value :class:`RepoState` is bootstrapped inline so the tuple has
+        somewhere to live.  In production :meth:`start` always runs first and
+        the bootstrap path is never taken.
+        """
+        _name = repo_name
+        old = self._state.get()
+        while True:
+            if _name in old.repos:
+                old_acts = old.repos[_name].webhook_activities
+                new_acts = transform(old_acts)
+                if new_acts is None:
+                    return
+                new_state = Lens(old).repos[_name].webhook_activities.set(new_acts)
+            else:
+                new_acts = transform(())
+                if new_acts is None:
+                    return
+                stub = RepoState(
+                    key=_name,
+                    started_at=_EPOCH,
+                    activity=_zero_activity(_name),
+                    crash_record=_ZERO_CRASH,
+                    webhook_activities=new_acts,
+                )
+                new_state = Lens(old).repos[_name].set(stub)
+            success, old = self._state.compare_and_set(old, new_state)
+            if success:
+                return
+
     @contextmanager
     def webhook_activity(
         self,
@@ -440,6 +493,9 @@ class WorkerRegistry:
 
         Appears in ``fido status`` as a sub-bullet under the repo.  Entries
         self-unregister on block exit (both success and exception paths).
+
+        Entry and exit each perform a CAS-update retry loop on
+        :class:`FidoState` — enter appends, exit removes.
         """
         activity = WebhookActivity(
             handle_id=id(object()),  # cheap unique id per call
@@ -448,41 +504,49 @@ class WorkerRegistry:
             thread_id=threading.get_ident(),
         )
         handle = WebhookActivityHandle(repo_name, activity.handle_id, self)
-        with self._webhook_lock:
-            self._webhook_activities.setdefault(repo_name, []).append(activity)
+        self._modify_webhook_activities(repo_name, lambda acts: acts + (activity,))
         try:
             yield handle
         finally:
-            with self._webhook_lock:
-                items = self._webhook_activities.get(repo_name)
-                if items is not None:
-                    self._webhook_activities[repo_name] = [
-                        a for a in items if a.handle_id != activity.handle_id
-                    ]
+            _handle_id = activity.handle_id
+            self._modify_webhook_activities(
+                repo_name,
+                lambda acts: tuple(a for a in acts if a.handle_id != _handle_id),
+            )
 
     def set_webhook_description(
         self, repo_name: str, handle_id: int, description: str
     ) -> None:
-        """Replace one webhook activity entry with an updated description."""
-        with self._webhook_lock:
-            items = self._webhook_activities.get(repo_name)
-            if items is None:
-                return
-            for i, activity in enumerate(items):
-                if activity.handle_id != handle_id:
-                    continue
-                items[i] = WebhookActivity(
-                    handle_id=activity.handle_id,
-                    description=description,
-                    started_at=activity.started_at,
-                    thread_id=activity.thread_id,
-                )
-                return
+        """Replace one webhook activity entry with an updated description.
+
+        Lock-free: uses a CAS-update retry loop on :class:`FidoState`.
+        No-op if *handle_id* is not present for *repo_name*.
+        """
+
+        def _update(
+            acts: tuple[WebhookActivity, ...],
+        ) -> tuple[WebhookActivity, ...] | None:
+            if not any(a.handle_id == handle_id for a in acts):
+                return None  # no-op — handle already removed or never registered
+            return tuple(
+                dc_replace(a, description=description)
+                if a.handle_id == handle_id
+                else a
+                for a in acts
+            )
+
+        self._modify_webhook_activities(repo_name, _update)
 
     def get_webhook_activities(self, repo_name: str) -> list[WebhookActivity]:
-        """Return a snapshot of in-flight webhook activities for *repo_name*."""
-        with self._webhook_lock:
-            return list(self._webhook_activities.get(repo_name, []))
+        """Return a snapshot of in-flight webhook activities for *repo_name*.
+
+        Lock-free: reads from the current :class:`FidoState` snapshot.
+        Returns an empty list if *repo_name* is not registered.
+        """
+        repos = self._state.get().repos
+        if repo_name not in repos:
+            return []
+        return list(repos[repo_name].webhook_activities)
 
     @contextmanager
     def status_update(self) -> Generator[None, None, None]:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -138,7 +138,7 @@ class RepoState:
     started_at: datetime
     activity: WorkerActivity
     crash_record: WorkerCrash
-    webhook_activities: tuple[WebhookActivity, ...] = ()
+    webhook_activities: tuple[WebhookActivity, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -345,6 +345,7 @@ class WorkerRegistry:
             started_at=_now,
             activity=_zero_activity(_name),
             crash_record=crash_record,
+            webhook_activities=(),
         )
         self._state.update(lambda root: root.repos[_name], new_repo)
         thread.start()

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -15,7 +15,6 @@ from fido.atomic import AtomicReference
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
-from fido.lens import Lens
 from fido.provider import PromptSession, Provider
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -123,8 +122,8 @@ class RepoState:
     :meth:`start`; the watchdog replaces it on each crash.
 
     *webhook_activities* is the tuple of in-flight webhook handlers for this
-    repo.  Managed via CAS-update by
-    :meth:`~WorkerRegistry._modify_webhook_activities`; starts empty.
+    repo.  Published from the authoritative ``_webhook_activities`` dict on
+    :class:`WorkerRegistry` via :meth:`~WorkerRegistry._publish_webhook_activities`; starts empty.
 
     No field is ``None`` — the full tree is prepopulated by :meth:`start`
     with zero values so lens-path writes never encounter missing keys.
@@ -240,6 +239,12 @@ class WorkerRegistry:
         # start(), which is called sequentially during startup and from the
         # single watchdog daemon thread during crash recovery — no lock needed.
         self._registry_fsm_states: dict[str, registry_fsm.State] = {}
+        # Per-repo in-flight webhook activities.  _webhook_activities is the
+        # authoritative store; mutations update it under _webhook_lock and then
+        # publish the frozen tuple to FidoState via _publish_webhook_activities
+        # so the snapshot is always up to date.
+        self._webhook_activities: dict[str, list[WebhookActivity]] = {}
+        self._webhook_lock = threading.Lock()
 
     def _registry_fsm_transition(
         self, repo_name: str, event: registry_fsm.Event
@@ -431,50 +436,21 @@ class WorkerRegistry:
         _name = repo_name
         self._state.update(lambda root: root.repos[_name].crash_record, new_crash)
 
-    def _modify_webhook_activities(
-        self,
-        repo_name: str,
-        transform: Callable[
-            [tuple[WebhookActivity, ...]], tuple[WebhookActivity, ...] | None
-        ],
-    ) -> None:
-        """Apply *transform* to the webhook-activity tuple for *repo_name* via CAS loop.
+    def _publish_webhook_activities(self, repo_name: str) -> None:
+        """Publish the webhook-activity tuple for *repo_name* to :class:`FidoState`.
 
-        *transform* receives the current tuple and returns the new tuple to
-        install, or ``None`` to skip the update (early-exit / no-op).  The
-        loop retries on contention; *transform* must be pure and may be called
-        more than once.
+        Reads the current list from ``_webhook_activities``, builds the frozen
+        tuple, and installs it at ``repos[name].webhook_activities`` via a
+        single lens write.  No-op if *repo_name* is not yet in the snapshot
+        (only possible in tests that bypass :meth:`start`).
 
-        If *repo_name* is not yet registered in the snapshot (e.g. during
-        tests that call :meth:`webhook_activity` before :meth:`start`), a
-        zero-value :class:`RepoState` is bootstrapped inline so the tuple has
-        somewhere to live.  In production :meth:`start` always runs first and
-        the bootstrap path is never taken.
+        Must be called under ``_webhook_lock``.
         """
+        acts = tuple(self._webhook_activities.get(repo_name, []))
+        if repo_name not in self._state.get().repos:
+            return
         _name = repo_name
-        old = self._state.get()
-        while True:
-            if _name in old.repos:
-                old_acts = old.repos[_name].webhook_activities
-                new_acts = transform(old_acts)
-                if new_acts is None:
-                    return
-                new_state = Lens(old).repos[_name].webhook_activities.set(new_acts)
-            else:
-                new_acts = transform(())
-                if new_acts is None:
-                    return
-                stub = RepoState(
-                    key=_name,
-                    started_at=_EPOCH,
-                    activity=_zero_activity(_name),
-                    crash_record=_ZERO_CRASH,
-                    webhook_activities=new_acts,
-                )
-                new_state = Lens(old).repos[_name].set(stub)
-            success, old = self._state.compare_and_set(old, new_state)
-            if success:
-                return
+        self._state.update(lambda root: root.repos[_name].webhook_activities, acts)
 
     @contextmanager
     def webhook_activity(
@@ -494,8 +470,9 @@ class WorkerRegistry:
         Appears in ``fido status`` as a sub-bullet under the repo.  Entries
         self-unregister on block exit (both success and exception paths).
 
-        Entry and exit each perform a CAS-update retry loop on
-        :class:`FidoState` — enter appends, exit removes.
+        The authoritative activity list is kept in ``_webhook_activities``
+        (protected by ``_webhook_lock``); each mutation publishes a fresh
+        frozen tuple to :class:`FidoState` via :meth:`_publish_webhook_activities`.
         """
         activity = WebhookActivity(
             handle_id=id(object()),  # cheap unique id per call
@@ -504,49 +481,48 @@ class WorkerRegistry:
             thread_id=threading.get_ident(),
         )
         handle = WebhookActivityHandle(repo_name, activity.handle_id, self)
-        self._modify_webhook_activities(repo_name, lambda acts: acts + (activity,))
+        with self._webhook_lock:
+            self._webhook_activities.setdefault(repo_name, []).append(activity)
+            self._publish_webhook_activities(repo_name)
         try:
             yield handle
         finally:
-            _handle_id = activity.handle_id
-            self._modify_webhook_activities(
-                repo_name,
-                lambda acts: tuple(a for a in acts if a.handle_id != _handle_id),
-            )
+            with self._webhook_lock:
+                acts = self._webhook_activities.get(repo_name, [])
+                self._webhook_activities[repo_name] = [
+                    a for a in acts if a.handle_id != activity.handle_id
+                ]
+                self._publish_webhook_activities(repo_name)
 
     def set_webhook_description(
         self, repo_name: str, handle_id: int, description: str
     ) -> None:
         """Replace one webhook activity entry with an updated description.
 
-        Lock-free: uses a CAS-update retry loop on :class:`FidoState`.
-        No-op if *handle_id* is not present for *repo_name*.
+        Updates the authoritative ``_webhook_activities`` dict and publishes the
+        new frozen tuple to :class:`FidoState`.  No-op if *handle_id* is not
+        present for *repo_name*.
         """
-
-        def _update(
-            acts: tuple[WebhookActivity, ...],
-        ) -> tuple[WebhookActivity, ...] | None:
+        with self._webhook_lock:
+            acts = self._webhook_activities.get(repo_name, [])
             if not any(a.handle_id == handle_id for a in acts):
-                return None  # no-op — handle already removed or never registered
-            return tuple(
+                return
+            self._webhook_activities[repo_name] = [
                 dc_replace(a, description=description)
                 if a.handle_id == handle_id
                 else a
                 for a in acts
-            )
-
-        self._modify_webhook_activities(repo_name, _update)
+            ]
+            self._publish_webhook_activities(repo_name)
 
     def get_webhook_activities(self, repo_name: str) -> list[WebhookActivity]:
         """Return a snapshot of in-flight webhook activities for *repo_name*.
 
-        Lock-free: reads from the current :class:`FidoState` snapshot.
-        Returns an empty list if *repo_name* is not registered.
+        Reads from the authoritative ``_webhook_activities`` dict.  Returns an
+        empty list if *repo_name* is not registered.
         """
-        repos = self._state.get().repos
-        if repo_name not in repos:
-            return []
-        return list(repos[repo_name].webhook_activities)
+        with self._webhook_lock:
+            return list(self._webhook_activities.get(repo_name, []))
 
     @contextmanager
     def status_update(self) -> Generator[None, None, None]:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -441,14 +441,12 @@ class WorkerRegistry:
 
         Reads the current list from ``_webhook_activities``, builds the frozen
         tuple, and installs it at ``repos[name].webhook_activities`` via a
-        single lens write.  No-op if *repo_name* is not yet in the snapshot
-        (only possible in tests that bypass :meth:`start`).
+        single lens write.  The repo must have been :meth:`start`-ed first —
+        crashes (``KeyError``) if it is not yet in the snapshot.
 
         Must be called under ``_webhook_lock``.
         """
         acts = tuple(self._webhook_activities.get(repo_name, []))
-        if repo_name not in self._state.get().repos:
-            return
         _name = repo_name
         self._state.update(lambda root: root.repos[_name].webhook_activities, acts)
 

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1294,7 +1294,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
                     "elapsed_seconds": (now - w.started_at).total_seconds(),
                     "thread_id": w.thread_id,
                 }
-                for w in self.registry.get_webhook_activities(repo_state.key)
+                for w in repo_state.webhook_activities
             ]
             fido_state = (
                 _collect_fido_state(repo_cfg.work_dir, now)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -807,6 +807,26 @@ class TestWebhookActivity:
         reg.set_webhook_description("ghost/repo", 1, "triaging")
         assert reg.get_webhook_activities("ghost/repo") == []
 
+    def test_publishes_to_fido_state_when_repo_started(self, tmp_path: Path) -> None:
+        """webhook_activity publishes activities into FidoState when start() has run."""
+        reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
+        with reg.webhook_activity("foo/bar", "handling"):
+            acts = reg.get_state().repos["foo/bar"].webhook_activities
+            assert len(acts) == 1
+            assert acts[0].description == "handling"
+        assert reg.get_state().repos["foo/bar"].webhook_activities == ()
+
+    def test_publishes_description_update_to_fido_state(self, tmp_path: Path) -> None:
+        """set_webhook_description publishes the update into FidoState."""
+        reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
+        with reg.webhook_activity("foo/bar", "original") as handle:
+            handle.set_description("updated")
+            acts = reg.get_state().repos["foo/bar"].webhook_activities
+            assert len(acts) == 1
+            assert acts[0].description == "updated"
+
 
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -741,8 +741,9 @@ class TestMakeRegistry:
 
 
 class TestWebhookActivity:
-    def test_registers_and_unregisters(self) -> None:
+    def test_registers_and_unregisters(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_webhook_activities("foo/bar") == []
         with reg.webhook_activity("foo/bar", "triaging"):
             activities = reg.get_webhook_activities("foo/bar")
@@ -750,17 +751,19 @@ class TestWebhookActivity:
             assert activities[0].description == "triaging"
         assert reg.get_webhook_activities("foo/bar") == []
 
-    def test_unregisters_on_exception(self) -> None:
+    def test_unregisters_on_exception(self, tmp_path: Path) -> None:
         import pytest as _pytest
 
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         with _pytest.raises(RuntimeError):
             with reg.webhook_activity("foo/bar", "oops"):
                 raise RuntimeError("boom")
         assert reg.get_webhook_activities("foo/bar") == []
 
-    def test_multiple_concurrent_activities(self) -> None:
+    def test_multiple_concurrent_activities(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "first"):
             with reg.webhook_activity("foo/bar", "second"):
                 descs = sorted(
@@ -769,8 +772,10 @@ class TestWebhookActivity:
                 assert descs == ["first", "second"]
         assert reg.get_webhook_activities("foo/bar") == []
 
-    def test_activities_isolated_per_repo(self) -> None:
+    def test_activities_isolated_per_repo(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("a/b", tmp_path))
+        reg.start(_repo("c/d", tmp_path))
         with reg.webhook_activity("a/b", "work-ab"):
             with reg.webhook_activity("c/d", "work-cd"):
                 a = reg.get_webhook_activities("a/b")
@@ -782,22 +787,25 @@ class TestWebhookActivity:
         reg = WorkerRegistry(MagicMock())
         assert reg.get_webhook_activities("ghost/repo") == []
 
-    def test_handle_can_update_description(self) -> None:
+    def test_handle_can_update_description(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
             activity.set_description("triaging")
             assert reg.get_webhook_activities("foo/bar")[0].description == "triaging"
 
-    def test_handle_update_after_exit_is_noop(self) -> None:
+    def test_handle_update_after_exit_is_noop(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             pass
         activity.set_description("triaging")
         assert reg.get_webhook_activities("foo/bar") == []
 
-    def test_unknown_handle_update_is_noop(self) -> None:
+    def test_unknown_handle_update_is_noop(self, tmp_path: Path) -> None:
         reg = WorkerRegistry(MagicMock())
+        reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             reg.set_webhook_description("foo/bar", -1, "triaging")
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1903,6 +1903,7 @@ class TestProcessAction:
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
         handler.registry = WorkerRegistry(MagicMock())
+        handler.registry.start(cfg.repos["owner/repo"])
         handler.gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
         phases: list[str] = []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,7 +28,13 @@ from fido.events import (
 )
 from fido.infra import Infra
 from fido.provider import ProviderID
-from fido.registry import FidoState, RepoState, WorkerActivity, WorkerCrash
+from fido.registry import (
+    FidoState,
+    RepoState,
+    WebhookActivity,
+    WorkerActivity,
+    WorkerCrash,
+)
 from fido.server import FidoHTTPServer, PreflightError, WebhookHandler, _repo_status
 from fido.store import FidoStore
 from fido.tasks import Tasks
@@ -50,6 +56,7 @@ def _repo_state(
     last_error: str = "",
     stale: bool = False,
     started_at: datetime | None = None,
+    webhook_activities: tuple[WebhookActivity, ...] = (),
 ) -> RepoState:
     progress_at = (
         datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -70,6 +77,7 @@ def _repo_state(
             last_error=last_error,
             last_crash_time=_EPOCH,
         ),
+        webhook_activities=webhook_activities,
     )
 
 
@@ -286,7 +294,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -317,7 +324,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -337,7 +343,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -358,7 +363,6 @@ class TestGetEndpoint:
                 last_error="RuntimeError: boom",
             )
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -401,7 +405,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", stale=True)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -415,7 +418,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -436,7 +438,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -470,7 +471,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -491,7 +491,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -517,7 +516,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -560,7 +558,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -576,7 +573,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -608,7 +604,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="Napping", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -625,7 +620,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -695,7 +689,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="Working on: #42")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -727,7 +720,6 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("unknown/repo", what="idle", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1018,7 +1010,6 @@ class TestStatusXml:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1054,7 +1045,6 @@ class TestStatusXml:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="working")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1070,7 +1060,6 @@ class TestStatusXml:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="working", busy=False)
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1098,20 +1087,21 @@ class TestStatusXml:
         assert "<percent_used>96</percent_used>" in body
 
     def test_status_xml_includes_webhooks(self, server: tuple) -> None:
-        from fido.registry import WebhookActivity
-
         url, _ = server
         WebhookHandler.registry.get_state.return_value = _fido_state(
-            _repo_state("owner/repo", what="working")
+            _repo_state(
+                "owner/repo",
+                what="working",
+                webhook_activities=(
+                    WebhookActivity(
+                        handle_id=1,
+                        description="replying to review",
+                        started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                        thread_id=789,
+                    ),
+                ),
+            )
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = [
-            WebhookActivity(
-                handle_id=1,
-                description="replying to review",
-                started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
-                thread_id=789,
-            ),
-        ]
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1245,7 +1235,6 @@ class TestStatusXml:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="Working on: #10")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1266,7 +1255,6 @@ class TestStatusXml:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="working")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
@@ -1802,7 +1790,6 @@ class TestProcessAction:
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="running")
         )
-        WebhookHandler.registry.get_webhook_activities.return_value = []
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = True
         WebhookHandler.registry.get_session_pid.return_value = None


### PR DESCRIPTION
Fixes #1345.

Add `webhook_activities` field to `RepoState` and make `WebhookActivity` frozen so webhook entries live in the immutable snapshot tree. Keep authoritative webhook-activity state on `WorkerRegistry` as a plain locked dict and publish into `FidoState` via a zero-parameter method — no CAS read-modify-write loops, no silent early-return guards. Add `slots=True` to all frozen dataclasses in registry.py and update the `/status.json` endpoint to read directly from the snapshot.

Fixes #1345.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] [Remove the `= ()` default from `RepoState.webhook_activities`, making it a required field. Update `start()` in WorkerRegistry to pass `webhook_activities=()` explicitly at the RepoState construction site.](https://github.com/FidoCanCode/home/pull/1409#discussion_r3191688085) <!-- type:thread -->
- [x] [In RepoState, replace `webhook_activities: tuple[WebhookActivity, ...] = field(default_factory=tuple)` with `webhook_activities: tuple[WebhookActivity, ...] = ()`. The `field()` wrapper is unnecessary for an immutable default value.](https://github.com/FidoCanCode/home/pull/1409#discussion_r3191651860) <!-- type:thread -->
- [x] [In _publish_webhook_activities, remove the early-return guard that skips the update when the repo is not yet in the FidoState snapshot. Let it crash instead — FidoState should always have the repo prepopulated by start() before any webhook_activity call. Update all TestWebhookActivity tests that currently call webhook_activity without a preceding start() to call start() first.](https://github.com/FidoCanCode/home/pull/1409#discussion_r3191585122) <!-- type:thread -->
- [x] Simplify webhook activity writes: drop _modify_webhook_activities, use owner-held state + lens publish <!-- type:spec -->
- [x] [Update the 'Simplify webhook activity writes' task: the pattern should be — record the change on the local object (e.g. a plain dict on WorkerRegistry), then call a zero-parameter method that returns a correct frozen dataclass value, and pass that to self._state.update for wholesale replacement. Never read old FidoState values to calculate new ones.](https://github.com/FidoCanCode/home/pull/1409#discussion_r3191463938) <!-- type:thread -->
- [x] [Add slots=True to all frozen dataclasses in registry.py: WorkerActivity, WorkerCrash, WebhookActivity, RepoState, FidoState, WebhookActivityHandle.](https://github.com/FidoCanCode/home/pull/1409#discussion_r3191403989) <!-- type:thread -->
- [x] Migrate webhook activities to FidoState CAS-snapshot <!-- type:spec -->
- [x] Read webhook activities from snapshot in status endpoint <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->