### PR TITLE
Bug: triage runs implementation work — make tool policy explicit per-call (closes #1413)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -20,6 +20,8 @@ import requests as _requests
 from fido import provider
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
+    GLOBAL_DISALLOWED_TOOLS,
+    READ_ONLY_ALLOWED_TOOLS,
     OwnedSession,
     PromptSession,
     Provider,
@@ -50,19 +52,6 @@ _CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _CLAUDE_USAGE_BETA = "oauth-2025-04-20"
 _CLAUDE_USAGE_USER_AGENT = "claude-code/2.1.110"
 _CLAUDE_USAGE_CACHE_SECONDS = 300.0
-
-# Tool policy constants now live in :mod:`fido.provider` so the protocol
-# signatures can reference them as defaults without importing claude (closes
-# #1413).  Re-exported here for back-compat with existing call sites.
-from fido.provider import (  # noqa: E402  (re-export at top of module)
-    GLOBAL_DISALLOWED_TOOLS,
-    READ_ONLY_ALLOWED_TOOLS,
-)
-
-__all_tools__ = (
-    "GLOBAL_DISALLOWED_TOOLS",
-    "READ_ONLY_ALLOWED_TOOLS",
-)
 
 
 class _Trunc:

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1795,6 +1795,9 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Run claude --print reading system prompt and user prompt from files."""
+        # `timeout` is on the protocol because codex/copilot use a wall-clock
+        # cap; the persistent-session path here applies idle_timeout via
+        # _streaming_runner instead, so the wall-clock cap is unused.
         del timeout
         cmd = [
             "claude",
@@ -1829,6 +1832,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Continue an existing claude session by ID, feeding prompt_file on stdin."""
+        # See note on print_prompt_from_file: claude uses idle_timeout, not timeout.
         del timeout
         cmd = [
             "claude",

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -51,22 +51,17 @@ _CLAUDE_USAGE_BETA = "oauth-2025-04-20"
 _CLAUDE_USAGE_USER_AGENT = "claude-code/2.1.110"
 _CLAUDE_USAGE_CACHE_SECONDS = 300.0
 
-# Handler tool allowlist for handler turns (#1042).  Handler prompts
-# (triage, reply, status, rescope) must never perform implementation work —
-# they may *inspect* the codebase and perform triage actions (file issues,
-# create tasks) but not edit source files.  Passed as ``--allowedTools`` to
-# the claude subprocess when switching into handler mode.
-# Format: space-separated tool specs per ``claude --help``.
-HANDLER_ALLOWED_TOOLS = (
-    "Read"
-    " Grep"
-    " Glob"
-    " Bash(git log *,git show *,git diff *,git status *,"
-    "git rev-parse *,git describe *,git tag *,git ls-files *,"
-    "git blame *,git shortlog *,git cat-file *,"
-    "git rev-list *,"
-    "gh issue create *,gh issue list *,gh issue view *,"
-    "gh pr view *,gh pr list *)"
+# Tool policy constants now live in :mod:`fido.provider` so the protocol
+# signatures can reference them as defaults without importing claude (closes
+# #1413).  Re-exported here for back-compat with existing call sites.
+from fido.provider import (  # noqa: E402  (re-export at top of module)
+    GLOBAL_DISALLOWED_TOOLS,
+    READ_ONLY_ALLOWED_TOOLS,
+)
+
+__all_tools__ = (
+    "GLOBAL_DISALLOWED_TOOLS",
+    "READ_ONLY_ALLOWED_TOOLS",
 )
 
 
@@ -510,7 +505,7 @@ class ClaudeSession(OwnedSession):
         # Allowed-tools restriction passed as ``--allowedTools`` to the
         # subprocess.  ``None`` = no restriction (worker mode, default);
         # any string = triage allowlist (handler mode, typically
-        # :data:`HANDLER_ALLOWED_TOOLS`).  Changed via :meth:`switch_tools`,
+        # :data:`READ_ONLY_ALLOWED_TOOLS`).  Changed via :meth:`switch_tools`,
         # which respawns the subprocess while keeping ``--resume`` so
         # conversation context survives the mode transition (#1042).
         self._tools: str | None = tools
@@ -536,12 +531,6 @@ class ClaudeSession(OwnedSession):
         # :meth:`hold_for_handler` can nest inner :meth:`prompt` calls
         # without double-registering the talker (fix for #658).
         self._init_handler_reentry()
-        # Activate the triage allowlist for handler turns: override the
-        # OwnedSession default (None = no restriction) with the Claude Code
-        # handler allowlist so hold_for_handler automatically switches the
-        # subprocess into triage mode on entry and back to full tools on
-        # exit (#1042).
-        self._handler_tools = HANDLER_ALLOWED_TOOLS
         # Wakeup pipe: writing a byte to _wakeup_w kicks select() out of its
         # blocking wait in iter_events() so the cancel signal is noticed
         # immediately instead of waiting up to _SELECT_POLL_INTERVAL.
@@ -660,14 +649,11 @@ class ClaudeSession(OwnedSession):
         ]
         if self._tools is not None:
             cmd += ["--allowedTools", self._tools]
-        cmd += [
-            "--disallowedTools",
-            "Bash(git commit *) Bash(git push *)"
-            " Bash(git rebase *) Bash(git reset *)"
-            " Bash(git checkout *)"
-            " Bash(./fido task *)"
-            " TaskCreate TaskUpdate TaskList TodoWrite TodoRead",
-        ]
+        # GLOBAL_DISALLOWED_TOOLS applies to every spawn regardless of
+        # which phase's allowlist is active — these are tools no phase can
+        # legitimately use (harness owns commit/push, bypass-prone Agent /
+        # Skill / Task* family always denied).
+        cmd += ["--disallowedTools", GLOBAL_DISALLOWED_TOOLS]
         if self._session_id:
             cmd += ["--resume", self._session_id]
         proc = self._popen_fn(
@@ -1110,16 +1096,24 @@ class ClaudeSession(OwnedSession):
     def prompt(
         self,
         content: str,
+        *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
     ) -> str:
         """Send *content* as a user message on the persistent session and
         return the result.
 
         Acquires the session lock and runs one turn: optional
-        :meth:`switch_model`, :meth:`send` (which drains any lingering
-        boundary events from a prior aborted turn), and
+        :meth:`switch_model`, :meth:`switch_tools`, :meth:`send` (which
+        drains any lingering boundary events from a prior aborted turn), and
         :meth:`consume_until_result`.
+
+        ``allowed_tools`` defaults to :data:`READ_ONLY_ALLOWED_TOOLS` (closes
+        #1413) — the safe shape for synthesis / rescope / setup / status /
+        voice rewrite / reply drafting.  Task implementation passes ``None``
+        explicitly to permit edits and arbitrary Bash.
+        :data:`GLOBAL_DISALLOWED_TOOLS` is applied unconditionally on top.
 
         Preemption (cancelling a running worker turn so a webhook handler can
         acquire the lock promptly) is handled upstream: the HTTP handler fires
@@ -1138,6 +1132,7 @@ class ClaudeSession(OwnedSession):
             )
             if model is not None:
                 self.switch_model(model)
+            self.switch_tools(allowed_tools)
             if system_prompt:
                 body = f"{system_prompt}\n\n---\n\n{content}"
             else:
@@ -1193,7 +1188,7 @@ class ClaudeSession(OwnedSession):
         ``--allowedTools`` value.
 
         When *tools* is a non-None string (typically
-        :data:`HANDLER_ALLOWED_TOOLS`), the subprocess is spawned with
+        :data:`READ_ONLY_ALLOWED_TOOLS`), the subprocess is spawned with
         ``--allowedTools <value>`` so only triage tools are available —
         this is the handler mode that enforces the invariant from #1042:
         webhook handlers may inspect the codebase and perform triage actions
@@ -1769,11 +1764,14 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Ask claude to generate a GitHub status (two lines: emoji + text)."""
         return self.run_turn(
             prompt,
             model=self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
             system_prompt=system_prompt,
         )
 
@@ -1782,12 +1780,15 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Ask claude to choose a single emoji for a GitHub status."""
         return self._run_turn_json_value(
             prompt,
             "emoji",
             self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
             system_prompt=system_prompt,
         )
 
@@ -1801,8 +1802,11 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 30,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Run claude --print reading system prompt and user prompt from files."""
+        del timeout
         cmd = [
             "claude",
             "--model",
@@ -1815,6 +1819,9 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             str(system_file),
             "--print",
         ]
+        if allowed_tools is not None:
+            cmd += ["--allowedTools", allowed_tools]
+        cmd += ["--disallowedTools", GLOBAL_DISALLOWED_TOOLS]
         output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()
@@ -1829,8 +1836,11 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 300,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Continue an existing claude session by ID, feeding prompt_file on stdin."""
+        del timeout
         cmd = [
             "claude",
             "--model",
@@ -1843,6 +1853,9 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             session_id,
             "--print",
         ]
+        if allowed_tools is not None:
+            cmd += ["--allowedTools", allowed_tools]
+        cmd += ["--disallowedTools", GLOBAL_DISALLOWED_TOOLS]
         output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
         ).strip()

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -737,9 +737,16 @@ class CodexSession(OwnedSession):
     def prompt(
         self,
         content: str,
+        *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = None,  # see comment below
         system_prompt: str | None = None,
     ) -> str:
+        # ``allowed_tools`` is part of the ``PromptSession`` protocol (closes
+        # #1413), but Codex's runtime has no equivalent of ``--allowedTools``
+        # so the kwarg is informational here.  Default differs from the
+        # protocol's READ_ONLY default because there's nothing to enforce.
+        del allowed_tools
         with self:
             if model is not None:
                 self.switch_model(model)
@@ -842,9 +849,6 @@ class CodexSession(OwnedSession):
 
     def switch_model(self, model: ProviderModel | str) -> None:
         self._model = coerce_provider_model(model)
-
-    def switch_tools(self, tools: str | None) -> None:
-        del tools
 
     def recover(self) -> None:
         with self._turn_lock:
@@ -1185,8 +1189,10 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 30,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = None,  # informational; Codex has no equivalent
     ) -> str:
-        del idle_timeout
+        del idle_timeout, allowed_tools
         prompt = _combine_prompt(prompt_file.read_text(), system_file.read_text(), None)
         return run_codex_exec(
             prompt,
@@ -1204,8 +1210,10 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 300,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = None,  # informational; Codex has no equivalent
     ) -> str:
-        del idle_timeout
+        del idle_timeout, allowed_tools
         return run_codex_exec_resume(
             session_id,
             prompt_file.read_text(),

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1025,9 +1025,17 @@ class CopilotCLISession(OwnedSession):
     def prompt(
         self,
         content: str,
+        *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = None,  # see comment below
         system_prompt: str | None = None,
     ) -> str:
+        # ``allowed_tools`` is part of the ``PromptSession`` protocol (closes
+        # #1413), but Copilot CLI's ACP runtime has no equivalent of
+        # ``--allowedTools`` so the kwarg is informational here.  Default
+        # differs from the protocol's READ_ONLY default because there's
+        # nothing to enforce.
+        del allowed_tools
         with self:
             return self._prompt_locked(
                 content, model=model, system_prompt=system_prompt
@@ -1047,11 +1055,6 @@ class CopilotCLISession(OwnedSession):
         normalized = coerce_provider_model(model)
         self._session_id = self._runtime.ensure_session(self._session_id, normalized)
         self._model = normalized
-
-    def switch_tools(self, tools: str | None) -> None:
-        """No-op for Copilot CLI — the ACP protocol does not support a
-        per-session tool restriction flag equivalent to ``--tools``."""
-        del tools
 
     def recover(self) -> None:
         self._session_id = self._runtime.recover_session(self._session_id, self._model)
@@ -1351,8 +1354,10 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 30,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = None,  # informational; Copilot has no equivalent
     ) -> str:
-        del idle_timeout
+        del idle_timeout, allowed_tools
         prompt = _combine_prompt(
             prompt_file.read_text(),
             base_system_prompt=system_file.read_text(),
@@ -1367,8 +1372,10 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         timeout: int = 300,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = None,  # informational; Copilot has no equivalent
     ) -> str:
-        del idle_timeout
+        del idle_timeout, allowed_tools
         return self._run_cli_prompt(
             prompt_file.read_text(),
             model=model,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from fido.claude import READ_ONLY_ALLOWED_TOOLS
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
@@ -1774,7 +1775,11 @@ def needs_more_context(
         "Reply with exactly YES or NO."
     )
     log.info("needs-more-context check: requesting haiku")
-    answer = agent.run_turn(prompt, model=agent.brief_model).upper()
+    answer = agent.run_turn(
+        prompt,
+        model=agent.brief_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+    ).upper()
     log.info(
         "needs-more-context check: returned %d chars (answer=%r)",
         len(answer),
@@ -2133,6 +2138,7 @@ def _notify_thread_change(
         agent,
         prompts.persona_wrap(instruction),
         model=agent.voice_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         system_prompt=prompts.reply_system_prompt(),
         log_prefix="_notify_thread_change",
     )

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -10,11 +10,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from fido.claude import READ_ONLY_ALLOWED_TOOLS
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
 from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
     ProviderAgent,
     safe_voice_turn,
     set_thread_kind,

--- a/src/fido/gh_status.py
+++ b/src/fido/gh_status.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from fido.claude import ClaudeClient
+from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
 from fido.config import RepoConfig, default_sub_dir
 from fido.github import GitHub
 from fido.provider import ProviderAgent, safe_voice_turn
@@ -92,6 +92,7 @@ def generate_persona_status(
         provider,
         f"Rewrite this status in Fido's voice: {message}",
         model=provider.voice_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         system_prompt=system,
         log_prefix="generate_persona_status",
     )
@@ -110,6 +111,7 @@ def generate_persona_emoji(
         f"Pick an emoji for this status: {status_text}",
         system,
         model=provider.voice_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
     )
     if not result:
         raise ValueError("generate_persona_emoji: generate_status_emoji returned empty")

--- a/src/fido/gh_status.py
+++ b/src/fido/gh_status.py
@@ -6,10 +6,10 @@ import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
+from fido.claude import ClaudeClient
 from fido.config import RepoConfig, default_sub_dir
 from fido.github import GitHub
-from fido.provider import ProviderAgent, safe_voice_turn
+from fido.provider import READ_ONLY_ALLOWED_TOOLS, ProviderAgent, safe_voice_turn
 from fido.provider_factory import DefaultProviderFactory
 from fido.status import running_repo_configs
 

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -251,6 +251,46 @@ class ProviderPressureStatus:
         return self.level == "paused"
 
 
+# Per-call tool policy constants (closes #1413).
+#
+# Every LLM call site declares its phase's tool policy via the
+# ``allowed_tools`` kwarg.  Default is :data:`READ_ONLY_ALLOWED_TOOLS` —
+# the safe shape that suits synthesis / rescope / setup / status / voice
+# rewrite / reply drafting (the LLM emits structured text or JSON; the
+# harness applies all state changes).  Task implementation passes
+# ``allowed_tools=None`` explicitly to permit edits and arbitrary Bash.
+#
+# :data:`GLOBAL_DISALLOWED_TOOLS` is applied unconditionally to every spawn,
+# every phase.  Tools listed here are never legitimate under any phase: the
+# harness owns commit/push/branch ops, and bypass-prone tools (``Agent``,
+# ``Skill``, the ``TaskCreate``/``Update``/``List``/``Todo*`` family) are
+# always denied.
+
+READ_ONLY_ALLOWED_TOOLS = (
+    "Read"
+    " Grep"
+    " Glob"
+    " Bash(git log *,git show *,git diff *,git status *,"
+    "git rev-parse *,git describe *,git tag *,git ls-files *,"
+    "git blame *,git shortlog *,git cat-file *,"
+    "git rev-list *,"
+    "gh issue view *,gh issue list *,"
+    "gh pr view *,gh pr list *,gh pr diff *)"
+)
+
+GLOBAL_DISALLOWED_TOOLS = (
+    "Bash(git commit *)"
+    " Bash(git push *)"
+    " Bash(git rebase *)"
+    " Bash(git reset *)"
+    " Bash(git checkout *)"
+    " Bash(./fido task *)"
+    " Agent"
+    " Skill"
+    " TaskCreate TaskUpdate TaskList TodoWrite TodoRead"
+)
+
+
 class PromptSession(Protocol):
     """Persistent prompt/session collaborator owned by a repo worker thread."""
 
@@ -295,10 +335,19 @@ class PromptSession(Protocol):
     def prompt(
         self,
         content: str,
+        *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
     ) -> str:
-        """Run a single prompt turn and return the final assistant text."""
+        """Run a single prompt turn and return the final assistant text.
+
+        ``allowed_tools`` defaults to :data:`READ_ONLY_ALLOWED_TOOLS` (closes
+        #1413) — the safe shape for synthesis / rescope / setup / status /
+        voice rewrite / reply drafting.  Task implementation must pass
+        ``allowed_tools=None`` explicitly to permit edits and arbitrary Bash.
+        :data:`GLOBAL_DISALLOWED_TOOLS` applies on top regardless.
+        """
         ...
 
     def send(self, content: str) -> None:
@@ -317,19 +366,6 @@ class PromptSession(Protocol):
     def switch_model(self, model: ProviderModel) -> None:
         """Switch the live session to *model* in-place without kill, respawn,
         or session-state loss."""
-        ...
-
-    def switch_tools(self, tools: str | None) -> None:
-        """Restrict or restore available tools for the continued session.
-
-        *tools* is passed as ``--allowedTools`` to the subprocess on respawn
-        while preserving ``--resume`` so conversation context carries across
-        the mode boundary.  ``None`` = no restriction (worker mode); a
-        non-empty string = the triage allowlist (handler mode, typically
-        :data:`~fido.claude.HANDLER_ALLOWED_TOOLS`, enforcing #1042).
-        No-op if unchanged.  Called automatically by
-        :meth:`OwnedSession.hold_for_handler`.
-        """
         ...
 
     def recover(self) -> None:
@@ -622,11 +658,6 @@ class OwnedSession:
     # otherwise crash on ``release_only_by_owner`` because the FSM has
     # already moved past the holder's state).  Guarded by ``_fsm_cond``.
     _evicted_tids: set[int]
-    # Allowed-tools value passed to :meth:`switch_tools` on handler entry.
-    # ``None`` means no restriction (default for CopilotCLISession whose
-    # switch_tools is a no-op; ClaudeSession sets this to
-    # :data:`~fido.claude.HANDLER_ALLOWED_TOOLS` in its constructor).
-    _handler_tools: str | None
 
     def _init_handler_reentry(self) -> None:
         """Subclasses call this from their ``__init__`` to set up the
@@ -647,9 +678,6 @@ class OwnedSession:
         # consults this set under ``_fsm_cond`` and skips the normal
         # ``_fsm_release`` so the double-release does not raise.
         self._evicted_tids: set[int] = set()
-        # Tool restriction applied on handler entry via switch_tools().
-        # ClaudeSession overrides to HANDLER_ALLOWED_TOOLS in its constructor.
-        self._handler_tools: str | None = None
 
     def _bump_entry_depth(self) -> int:
         """Increment and return the new per-thread entry depth (1 at
@@ -943,20 +971,6 @@ class OwnedSession:
         with their provider-specific cancel mechanism."""
         raise NotImplementedError  # pragma: no cover — abstract hook
 
-    def switch_tools(self, tools: str | None) -> None:
-        """Restrict or restore the subprocess tool allowlist.
-
-        Subclasses that wrap a persistent Claude Code subprocess (e.g.
-        :class:`~fido.claude.ClaudeSession`) override this to respawn with
-        ``--allowedTools <value>`` so handler turns get a triage tool set
-        and worker turns get the full set back.  Subclasses that do not
-        support tool switching (e.g. CopilotCLISession) override with a no-op.
-
-        Called automatically by :meth:`hold_for_handler` on entry
-        (``tools = self._handler_tools``) and on exit (``tools = None``).
-        """
-        raise NotImplementedError  # pragma: no cover — abstract hook
-
     def preempt_worker(self) -> bool:
         """Fire the cancel signal synchronously if a worker currently holds
         the session.
@@ -1007,16 +1021,15 @@ class OwnedSession:
         worker currently holds the session, see #637).  No opt-in flag
         is needed here.
 
-        Switches the session to triage handler mode (via
-        :meth:`switch_tools` with :attr:`_handler_tools`) on entry, then
-        restores the unrestricted worker tool set on exit (#1042).
+        Tool restriction is now per-call (closes #1413): every
+        :meth:`PromptSession.prompt` (or wrapper) declares its own
+        ``allowed_tools`` policy.  This context manager no longer switches
+        tools on enter/exit — the previous FSM-dispatch dance was a no-op
+        for the actual triage work because synthesis runs *after* this
+        context exits, with tools already restored.
         """
         with self:  # type: ignore[attr-defined]
-            self.switch_tools(self._handler_tools)
-            try:
-                yield self
-            finally:
-                self.switch_tools(None)
+            yield self
 
 
 class ProviderAgent(Protocol):
@@ -1109,11 +1122,16 @@ class ProviderAgent(Protocol):
         content: str,
         *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
         session_mode: TurnSessionMode = TurnSessionMode.REUSE,
     ) -> str:
-        """Run one interactive turn through the persistent session and return text."""
+        """Run one interactive turn through the persistent session and return text.
+
+        ``allowed_tools`` defaults to :data:`READ_ONLY_ALLOWED_TOOLS` (closes
+        #1413).  Task implementation must pass ``None`` explicitly.
+        """
         ...
 
     def print_prompt_from_file(
@@ -1124,6 +1142,8 @@ class ProviderAgent(Protocol):
         timeout: int = 30,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Run a one-shot prompt sourced from files and return raw provider output."""
         ...
@@ -1136,6 +1156,8 @@ class ProviderAgent(Protocol):
         timeout: int = 300,
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Resume a prior one-shot provider session and return raw output."""
         ...
@@ -1145,6 +1167,8 @@ class ProviderAgent(Protocol):
         prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 30,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Generate a short natural-language reply for a GitHub comment flow."""
         ...
@@ -1154,6 +1178,8 @@ class ProviderAgent(Protocol):
         prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 15,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Generate a git branch-name slug from *prompt*."""
         ...
@@ -1163,6 +1189,8 @@ class ProviderAgent(Protocol):
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Generate a two-line GitHub status message."""
         ...
@@ -1172,6 +1200,8 @@ class ProviderAgent(Protocol):
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         """Generate a single emoji suitable for a GitHub status."""
         ...
@@ -1206,6 +1236,7 @@ def safe_voice_turn(
     content: str,
     *,
     model: ProviderModel | None = None,
+    allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     system_prompt: str | None = None,
     log_prefix: str = "safe_voice_turn",
 ) -> str:
@@ -1215,10 +1246,14 @@ def safe_voice_turn(
     site automatically retries when a session preemption returns an empty
     result.  If the result is still empty after retries, raises
     ``ValueError`` — the session reconnect layer handles recovery.
+
+    ``allowed_tools`` defaults to :data:`READ_ONLY_ALLOWED_TOOLS` (voice
+    turns are text rewriting; the harness applies all state changes).
     """
     result = agent.run_turn(
         content,
         model=model,
+        allowed_tools=allowed_tools,
         system_prompt=system_prompt,
         retry_on_preempt=True,
     )

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -6,7 +6,12 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from fido.provider import PromptSession, ProviderModel, TurnSessionMode
+from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
+    PromptSession,
+    ProviderModel,
+    TurnSessionMode,
+)
 
 log = logging.getLogger(__name__)
 
@@ -191,6 +196,7 @@ class SessionBackedAgent:
         content: str,
         *,
         model: ProviderModel | None = None,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
         retry_on_preempt: bool = False,
         session_mode: TurnSessionMode = TurnSessionMode.REUSE,
@@ -205,6 +211,7 @@ class SessionBackedAgent:
                 session,
                 content,
                 model=model,
+                allowed_tools=allowed_tools,
                 system_prompt=system_prompt,
             )
             if (
@@ -229,6 +236,8 @@ class SessionBackedAgent:
         prompt: str,
         key: str,
         model: ProviderModel,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
     ) -> str:
         json_instruction = (
@@ -240,7 +249,12 @@ class SessionBackedAgent:
             if system_prompt
             else json_instruction
         )
-        raw = self.run_turn(prompt, model=model, system_prompt=full_system)
+        raw = self.run_turn(
+            prompt,
+            model=model,
+            allowed_tools=allowed_tools,
+            system_prompt=full_system,
+        )
         if not raw:
             return ""
         for candidate in self._json_parse_candidates(raw):
@@ -286,13 +300,17 @@ class SessionBackedAgent:
         content: str,
         *,
         model: ProviderModel | None,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None,
     ) -> str:
         recovered = False
         while True:
             try:
                 result = session.prompt(
-                    content, model=model, system_prompt=system_prompt
+                    content,
+                    model=model,
+                    allowed_tools=allowed_tools,
+                    system_prompt=system_prompt,
                 )
             except Exception as exc:
                 if self._prompt_failure_is_passthrough(exc):
@@ -328,6 +346,7 @@ class SessionBackedAgent:
         content: str,
         *,
         model: ProviderModel,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
         system_prompt: str | None = None,
     ) -> tuple[str, str]:
         # Route through _prompt_with_recovery so a stale subprocess (BrokenPipe
@@ -338,7 +357,11 @@ class SessionBackedAgent:
             session_mode=TurnSessionMode.REUSE,
         )
         text = self._prompt_with_recovery(
-            session, content, model=model, system_prompt=system_prompt
+            session,
+            content,
+            model=model,
+            allowed_tools=allowed_tools,
+            system_prompt=system_prompt,
         )
         session_id = getattr(session, "session_id", None)
         return text, session_id if isinstance(session_id, str) else ""
@@ -360,10 +383,13 @@ class SessionBackedAgent:
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         return self.run_turn(
             prompt,
             model=self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
             system_prompt=system_prompt,
         )
 
@@ -372,11 +398,14 @@ class SessionBackedAgent:
         prompt: str,
         system_prompt: str,
         model: ProviderModel | None = None,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         return self._run_turn_json_value(
             prompt,
             "emoji",
             self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
             system_prompt=system_prompt,
         )
 
@@ -385,11 +414,14 @@ class SessionBackedAgent:
         prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 30,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         del timeout
         text, _ = self._run_shared_turn(
             prompt,
             model=self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
         )
         return text.strip()
 
@@ -398,11 +430,14 @@ class SessionBackedAgent:
         prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 15,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         del timeout
         text, _ = self._run_shared_turn(
             prompt,
             model=self.brief_model if model is None else model,
+            allowed_tools=allowed_tools,
         )
         stripped = text.strip()
         return stripped.splitlines()[0] if stripped else ""
@@ -413,11 +448,14 @@ class SessionBackedAgent:
         system_prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 15,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> tuple[str, str]:
         del timeout
         text, session_id = self._run_shared_turn(
             prompt,
             model=self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
             system_prompt=system_prompt,
         )
         return text.strip(), session_id
@@ -428,10 +466,13 @@ class SessionBackedAgent:
         prompt: str,
         model: ProviderModel | None = None,
         timeout: int = 15,
+        *,
+        allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS,
     ) -> str:
         del timeout
         session = self._require_matching_session(session_id)
         return session.prompt(
             prompt,
             model=self.voice_model if model is None else model,
+            allowed_tools=allowed_tools,
         ).strip()

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -12,6 +12,7 @@ import json
 import logging
 from typing import Any
 
+from fido.claude import READ_ONLY_ALLOWED_TOOLS
 from fido.prompts import Prompts
 from fido.provider import ProviderAgent
 from fido.synthesis import (
@@ -203,7 +204,11 @@ def call_synthesis(
         user_prompt = (
             base_user_prompt if attempt == 0 else base_user_prompt + _RETRY_SUFFIX
         )
-        raw = agent.run_turn(user_prompt, system_prompt=system_prompt)
+        raw = agent.run_turn(
+            user_prompt,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt=system_prompt,
+        )
         log.debug(
             "synthesis attempt %d/%d raw output: %r", attempt + 1, MAX_RETRIES, raw
         )
@@ -260,7 +265,10 @@ def call_failure_explanation(
     last_error: Exception | None = None
     for attempt in range(MAX_RETRIES):
         suffix = _FAILURE_EXPLANATION_RETRY_SUFFIX if attempt > 0 else ""
-        raw = agent.run_turn(user_prompt + suffix)
+        raw = agent.run_turn(
+            user_prompt + suffix,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
         log.debug(
             "failure-explanation attempt %d/%d raw output: %r",
             attempt + 1,

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -12,9 +12,8 @@ import json
 import logging
 from typing import Any
 
-from fido.claude import READ_ONLY_ALLOWED_TOOLS
 from fido.prompts import Prompts
-from fido.provider import ProviderAgent
+from fido.provider import READ_ONLY_ALLOWED_TOOLS, ProviderAgent
 from fido.synthesis import (
     VALID_REACTIONS,
     CommentResponse,

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
 
-from fido.claude import ClaudeClient
+from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
 from fido.github import GitHub
 from fido.prompts import Prompts
 from fido.provider import ProviderAgent
@@ -944,7 +944,11 @@ def reorder_tasks(
         prior_attempts=prior_attempts,
         intents=intents,
     )
-    raw = agent.run_turn(prompt, model=agent.voice_model)
+    raw = agent.run_turn(
+        prompt,
+        model=agent.voice_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+    )
     if not raw:
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return
@@ -975,7 +979,11 @@ def reorder_tasks(
         nudge = prompts.rescope_duplicate_nudge(
             duplicates, attempts_remaining=attempts_remaining
         )
-        nudge_raw = agent.run_turn(nudge, model=agent.voice_model)
+        nudge_raw = agent.run_turn(
+            nudge,
+            model=agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
         if not nudge_raw:
             log.warning(
                 "reorder_tasks: empty response after duplicate nudge — "

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -12,10 +12,10 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
 
-from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
+from fido.claude import ClaudeClient
 from fido.github import GitHub
 from fido.prompts import Prompts
-from fido.provider import ProviderAgent
+from fido.provider import READ_ONLY_ALLOWED_TOOLS, ProviderAgent
 from fido.rocq import pr_body_task_store as task_store_oracle
 from fido.rocq import task_queue_rescope as rescope_oracle
 from fido.rocq import thread_auto_resolve as thread_resolve_oracle

--- a/src/fido/turn_outcome.py
+++ b/src/fido/turn_outcome.py
@@ -8,6 +8,10 @@ pending for another turn, or skip the commit and record a reason.
 The LLM declares intent; Python acts on it.  Git operations are never the
 LLM's responsibility.
 
+Optional ``insights`` and ``out_of_scope_asks`` arrays let the LLM declare
+auxiliary issues for the harness to file on its behalf.  Both default to
+empty arrays and may appear alongside any ``turn_outcome`` value.
+
 Type definitions (``CommitTaskComplete``, ``CommitTaskInProgress``,
 ``SkipTaskWithReason``, ``TurnOutcome``) live in the Rocq-extracted module
 :mod:`fido.rocq.turn_outcome`.  Importers should get types directly from
@@ -16,6 +20,7 @@ that module.  This module owns only the parser boundary adapter.
 
 import json
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from fido.rocq.turn_outcome import (
     CommitTaskComplete,
@@ -27,8 +32,43 @@ from fido.rocq.turn_outcome import (
 )
 
 __all__ = [
+    "Insight",
+    "OutOfScopeAsk",
+    "TurnOutcomeBundle",
     "parse_turn_outcome",
 ]
+
+
+@dataclass(frozen=True)
+class Insight:
+    """A bug-or-design observation the LLM declared in its turn output;
+    filed by the harness as a GitHub issue with the ``Insight`` label.
+
+    Mirrors :class:`fido.synthesis.Insight` but is the task-phase variant
+    consumed via the turn_outcome sentinel."""
+
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class OutOfScopeAsk:
+    """A request that arrived during task work but is out of scope for
+    the current task; filed by the harness as a tracked GitHub issue so
+    the work isn't lost but doesn't bloat the current PR."""
+
+    title: str
+    body: str
+
+
+@dataclass(frozen=True)
+class TurnOutcomeBundle:
+    """Full result of parsing a turn_outcome sentinel: the dispatch outcome
+    plus any auxiliary issues the LLM declared for harness-side filing."""
+
+    outcome: TurnOutcome
+    insights: tuple[Insight, ...]
+    out_of_scope_asks: tuple[OutOfScopeAsk, ...]
 
 
 def _assert_parse_oracle(kind: str, payload: str, result: TurnOutcome) -> None:
@@ -93,11 +133,43 @@ def _parse_outcome_field(
     return result
 
 
-def parse_turn_outcome(text: str) -> TurnOutcome:
+def _parse_aux_issues(
+    obj: dict[str, object], field: str, factory: Callable[[str, str], object]
+) -> tuple[object, ...]:
+    """Parse an optional auxiliary-issue array (``insights`` or
+    ``out_of_scope_asks``) from *obj*.
+
+    Returns an empty tuple when the field is absent or ``None``.  Raises
+    ``ValueError`` when present but malformed (non-list, items missing
+    required fields, etc.).
+    """
+    raw = obj.get(field)
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f'turn_outcome "{field}" must be a JSON array, got: {raw!r}')
+    out: list[object] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"{field}[{i}] is not a JSON object: {item!r}")
+        title = item.get("title")
+        body = item.get("body")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError(f'{field}[{i}] requires a non-empty "title" string')
+        if not isinstance(body, str) or not body.strip():
+            raise ValueError(f'{field}[{i}] requires a non-empty "body" string')
+        out.append(factory(title.strip(), body))
+    return tuple(out)
+
+
+def parse_turn_outcome(text: str) -> TurnOutcomeBundle:
     """Parse the turn_outcome sentinel from the last non-empty line of *text*.
 
     Only the final non-empty line is examined — stale sentinels earlier in
     the response are ignored.
+
+    Returns a :class:`TurnOutcomeBundle` with the dispatch ``outcome`` plus
+    any optional ``insights`` and ``out_of_scope_asks`` declared by the LLM.
 
     Raises:
         ValueError: If the line is absent, not valid JSON, not a recognised
@@ -120,19 +192,19 @@ def parse_turn_outcome(text: str) -> TurnOutcome:
     kind = obj.get("turn_outcome")
     match kind:
         case "commit-task-complete":
-            return _parse_outcome_field(
+            outcome: TurnOutcome = _parse_outcome_field(
                 obj, kind, "summary", lambda s: CommitTaskComplete(summary=s)
             )
         case "commit-task-in-progress":
-            return _parse_outcome_field(
+            outcome = _parse_outcome_field(
                 obj, kind, "summary", lambda s: CommitTaskInProgress(summary=s)
             )
         case "skip-task-with-reason":
-            return _parse_outcome_field(
+            outcome = _parse_outcome_field(
                 obj, kind, "reason", lambda s: SkipTaskWithReason(reason=s)
             )
         case "stuck-on-task":
-            return _parse_outcome_field(
+            outcome = _parse_outcome_field(
                 obj, kind, "reason", lambda s: StuckOnTask(reason=s)
             )
         case None:
@@ -143,3 +215,18 @@ def parse_turn_outcome(text: str) -> TurnOutcome:
             # unknown kind regardless of payload content.
             _assert_reject_oracle(kind, "x")
             raise ValueError(f"Unrecognised turn_outcome value: {kind!r}")
+    insights = _parse_aux_issues(
+        obj, "insights", lambda title, body: Insight(title=title, body=body)
+    )
+    asks = _parse_aux_issues(
+        obj,
+        "out_of_scope_asks",
+        lambda title, body: OutOfScopeAsk(title=title, body=body),
+    )
+    # mypy/pyright: tuple element types are object[]; cast the homogeneous
+    # tuples for the bundle type signature.
+    return TurnOutcomeBundle(
+        outcome=outcome,
+        insights=tuple(i for i in insights if isinstance(i, Insight)),
+        out_of_scope_asks=tuple(a for a in asks if isinstance(a, OutOfScopeAsk)),
+    )

--- a/src/fido/turn_outcome.py
+++ b/src/fido/turn_outcome.py
@@ -21,6 +21,7 @@ that module.  This module owns only the parser boundary adapter.
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeVar
 
 from fido.rocq.turn_outcome import (
     CommitTaskComplete,
@@ -30,6 +31,9 @@ from fido.rocq.turn_outcome import (
     TurnOutcome,
     parse_sentinel,
 )
+from fido.synthesis import Insight
+
+_T = TypeVar("_T")
 
 __all__ = [
     "Insight",
@@ -37,18 +41,6 @@ __all__ = [
     "TurnOutcomeBundle",
     "parse_turn_outcome",
 ]
-
-
-@dataclass(frozen=True)
-class Insight:
-    """A bug-or-design observation the LLM declared in its turn output;
-    filed by the harness as a GitHub issue with the ``Insight`` label.
-
-    Mirrors :class:`fido.synthesis.Insight` but is the task-phase variant
-    consumed via the turn_outcome sentinel."""
-
-    title: str
-    body: str
 
 
 @dataclass(frozen=True)
@@ -133,33 +125,60 @@ def _parse_outcome_field(
     return result
 
 
+def _require_aux_str(item: dict[str, object], field: str, label: str) -> str:
+    """Pull a required non-empty string field out of an aux-issue item dict."""
+    value = item.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f'{label} requires a non-empty "{field}" string')
+    return value
+
+
 def _parse_aux_issues(
-    obj: dict[str, object], field: str, factory: Callable[[str, str], object]
-) -> tuple[object, ...]:
+    obj: dict[str, object],
+    field: str,
+    item_parser: Callable[[dict[str, object], str], _T],
+) -> tuple[_T, ...]:
     """Parse an optional auxiliary-issue array (``insights`` or
     ``out_of_scope_asks``) from *obj*.
 
-    Returns an empty tuple when the field is absent or ``None``.  Raises
-    ``ValueError`` when present but malformed (non-list, items missing
-    required fields, etc.).
+    *item_parser* receives the raw item dict and a label like ``"insights[2]"``
+    suitable for error messages, and returns the typed dataclass.  Returns an
+    empty tuple when *field* is absent or ``None``; raises ``ValueError`` when
+    present but malformed (non-list, missing required keys, etc.).
     """
     raw = obj.get(field)
     if raw is None:
         return ()
     if not isinstance(raw, list):
         raise ValueError(f'turn_outcome "{field}" must be a JSON array, got: {raw!r}')
-    out: list[object] = []
+    out: list[_T] = []
     for i, item in enumerate(raw):
+        label = f"{field}[{i}]"
         if not isinstance(item, dict):
-            raise ValueError(f"{field}[{i}] is not a JSON object: {item!r}")
-        title = item.get("title")
-        body = item.get("body")
-        if not isinstance(title, str) or not title.strip():
-            raise ValueError(f'{field}[{i}] requires a non-empty "title" string')
-        if not isinstance(body, str) or not body.strip():
-            raise ValueError(f'{field}[{i}] requires a non-empty "body" string')
-        out.append(factory(title.strip(), body))
+            raise ValueError(f"{label} is not a JSON object: {item!r}")
+        out.append(item_parser(item, label))
     return tuple(out)
+
+
+def _parse_insight(item: dict[str, object], label: str) -> Insight:
+    """Parse one entry from the sentinel's ``insights`` array.
+
+    Schema matches :class:`fido.synthesis.Insight` so the comment-driven
+    and task-driven insight pipelines share one type and one filing shape.
+    """
+    return Insight(
+        title=_require_aux_str(item, "title", label).strip(),
+        hook=_require_aux_str(item, "hook", label),
+        why=_require_aux_str(item, "why", label),
+    )
+
+
+def _parse_out_of_scope_ask(item: dict[str, object], label: str) -> "OutOfScopeAsk":
+    """Parse one entry from the sentinel's ``out_of_scope_asks`` array."""
+    return OutOfScopeAsk(
+        title=_require_aux_str(item, "title", label).strip(),
+        body=_require_aux_str(item, "body", label),
+    )
 
 
 def parse_turn_outcome(text: str) -> TurnOutcomeBundle:
@@ -215,18 +234,10 @@ def parse_turn_outcome(text: str) -> TurnOutcomeBundle:
             # unknown kind regardless of payload content.
             _assert_reject_oracle(kind, "x")
             raise ValueError(f"Unrecognised turn_outcome value: {kind!r}")
-    insights = _parse_aux_issues(
-        obj, "insights", lambda title, body: Insight(title=title, body=body)
-    )
-    asks = _parse_aux_issues(
-        obj,
-        "out_of_scope_asks",
-        lambda title, body: OutOfScopeAsk(title=title, body=body),
-    )
-    # mypy/pyright: tuple element types are object[]; cast the homogeneous
-    # tuples for the bundle type signature.
     return TurnOutcomeBundle(
         outcome=outcome,
-        insights=tuple(i for i in insights if isinstance(i, Insight)),
-        out_of_scope_asks=tuple(a for a in asks if isinstance(a, OutOfScopeAsk)),
+        insights=_parse_aux_issues(obj, "insights", _parse_insight),
+        out_of_scope_asks=_parse_aux_issues(
+            obj, "out_of_scope_asks", _parse_out_of_scope_ask
+        ),
     )

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2822,12 +2822,17 @@ class Worker:
         #1413).  Called after a successful harness commit so the LLM's
         side-channel observations don't depend on the LLM's permission set
         — the harness owns issue creation, the LLM only declares intent.
+
+        On a mid-bundle ``create_issue`` failure we propagate; the partial
+        filing is intentional — duplicate-on-retry is preferable to lost
+        insights, and GitHub has no native dedup for issue creation.
         """
+        source = f"{repo_ctx.repo}#{pr_number}"
         for insight in bundle.insights:
             self.gh.create_issue(
                 repo_ctx.repo,
                 f"Insight: {insight.title}",
-                f"{insight.body}\n\nSource: {repo_ctx.repo}#{pr_number}",
+                f"{insight.hook}\n\n{insight.why}\n\nSource: {source}",
                 labels=["Insight"],
             )
             log.info("filed insight from turn sentinel: %s", insight.title[:60])
@@ -2835,7 +2840,7 @@ class Worker:
             self.gh.create_issue(
                 repo_ctx.repo,
                 ask.title,
-                f"{ask.body}\n\nOut-of-scope from: {repo_ctx.repo}#{pr_number}",
+                f"{ask.body}\n\nOut-of-scope from: {source}",
             )
             log.info("filed out-of-scope ask from turn sentinel: %s", ask.title[:60])
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 import requests as _requests
 
 from fido import hooks, tasks
-from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeCode
+from fido.claude import ClaudeCode
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.harness_commit import HarnessCommitter
@@ -31,6 +31,7 @@ from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.nudges import Nudges
 from fido.prompts import Prompts, render_active_context
 from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
     ContextOverflowError,
     PromptSession,
     Provider,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 import requests as _requests
 
 from fido import hooks, tasks
-from fido.claude import ClaudeCode
+from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeCode
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.harness_commit import HarnessCommitter
@@ -64,7 +64,7 @@ from fido.state import (
 )
 from fido.store import FidoStore, PRCommentQueueRecord, ReplyPromiseRecord
 from fido.tasks import Tasks
-from fido.turn_outcome import parse_turn_outcome
+from fido.turn_outcome import TurnOutcomeBundle, parse_turn_outcome
 from fido.types import (
     ActiveIssue,
     ActivePR,
@@ -457,6 +457,7 @@ def provider_start(
         output = agent.run_turn(
             _session_turn_prompt(fido_dir),
             model=model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
             retry_on_preempt=True,
             session_mode=session_mode,
         )
@@ -464,7 +465,12 @@ def provider_start(
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
     output = agent.print_prompt_from_file(
-        system_file, prompt_file, model, timeout, cwd=cwd
+        system_file,
+        prompt_file,
+        model,
+        timeout,
+        cwd=cwd,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
     )
     return agent.extract_session_id(output), output
 
@@ -513,6 +519,8 @@ def provider_run(
         output = agent.run_turn(
             _session_turn_prompt(fido_dir),
             model=model,
+            # Task implementation: implicit ``*`` minus GLOBAL_DISALLOWED_TOOLS.
+            allowed_tools=None,
             retry_on_preempt=retry_on_preempt,
             session_mode=session_mode,
         )
@@ -520,7 +528,13 @@ def provider_run(
     system_file = fido_dir / "system"
     prompt_file = fido_dir / "prompt"
     output = agent.print_prompt_from_file(
-        system_file, prompt_file, model, timeout, cwd=cwd
+        system_file,
+        prompt_file,
+        model,
+        timeout,
+        cwd=cwd,
+        # Task implementation: implicit ``*`` minus GLOBAL_DISALLOWED_TOOLS.
+        allowed_tools=None,
     )
     new_session_id = agent.extract_session_id(output)
     return new_session_id, output
@@ -1093,7 +1107,11 @@ def _write_pr_description(
         assert agent is not None
         prompt = Prompts("").rewrite_description_prompt(existing_body, task_list)
         raw = safe_voice_turn(
-            agent, prompt, model=agent.voice_model, log_prefix="_write_pr_description"
+            agent,
+            prompt,
+            model=agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            log_prefix="_write_pr_description",
         )
         new_desc = _extract_body(raw)
         if not new_desc:
@@ -1448,6 +1466,7 @@ class Worker:
             raw = self._provider_agent.run_turn(
                 prompts.status_prompt(activities),
                 model=self._provider_agent.voice_model,
+                allowed_tools=READ_ONLY_ALLOWED_TOOLS,
                 system_prompt=prompts.status_system_prompt(),
             )
             text, emoji = _parse_status_nudge(raw)
@@ -1817,7 +1836,9 @@ class Worker:
         prompts = self._get_prompts()
         prompt = prompts.pickup_retry_comment_prompt(issue_title, closed_prs)
         msg = self._provider_agent.generate_reply(
-            prompt, self._provider_agent.voice_model
+            prompt,
+            self._provider_agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         )
         if not msg:
             pr_list = ", ".join(f"#{n}" for n in closed_prs)
@@ -1961,6 +1982,7 @@ class Worker:
             " No explanation, no punctuation, just the branch name."
             f"\n\nRequest: {request}",
             self._provider_agent.brief_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         )
         slug = _sanitize_slug(raw_slug, request)
         log.info("new branch: %s", slug)
@@ -2788,6 +2810,34 @@ class Worker:
                     pr_number,
                 )
 
+    def _file_aux_issues_from_bundle(
+        self,
+        bundle: TurnOutcomeBundle,
+        repo_ctx: RepoContext,
+        pr_number: int,
+    ) -> None:
+        """File any ``insights`` and ``out_of_scope_asks`` declared in the
+        turn_outcome sentinel as GitHub issues on behalf of Fido (closes
+        #1413).  Called after a successful harness commit so the LLM's
+        side-channel observations don't depend on the LLM's permission set
+        — the harness owns issue creation, the LLM only declares intent.
+        """
+        for insight in bundle.insights:
+            self.gh.create_issue(
+                repo_ctx.repo,
+                f"Insight: {insight.title}",
+                f"{insight.body}\n\nSource: {repo_ctx.repo}#{pr_number}",
+                labels=["Insight"],
+            )
+            log.info("filed insight from turn sentinel: %s", insight.title[:60])
+        for ask in bundle.out_of_scope_asks:
+            self.gh.create_issue(
+                repo_ctx.repo,
+                ask.title,
+                f"{ask.body}\n\nOut-of-scope from: {repo_ctx.repo}#{pr_number}",
+            )
+            log.info("filed out-of-scope ask from turn sentinel: %s", ask.title[:60])
+
     def _finish_task(
         self,
         task: dict[str, Any],
@@ -3278,7 +3328,8 @@ class Worker:
         # Sentinel loop: each iteration processes one provider turn's output.
         while True:
             try:
-                outcome = parse_turn_outcome(output)
+                bundle = parse_turn_outcome(output)
+                outcome = bundle.outcome
             except ValueError as exc:
                 # LLM did not emit a valid turn_outcome sentinel — nudge it.
                 nudge = self._nudges.missing_sentinel(
@@ -3372,6 +3423,13 @@ class Worker:
                         # Task complete: push and advance the queue.
                         pushed = self._push_with_retry("origin", slug)
                         if pushed:
+                            # File any LLM-declared insights / out-of-scope
+                            # asks before advancing — the harness owns issue
+                            # creation; the LLM's tool set never includes
+                            # ``gh issue create`` (closes #1413).
+                            self._file_aux_issues_from_bundle(
+                                bundle, repo_ctx, pr_number
+                            )
                             self._finish_task(
                                 task, fido_dir, repo_ctx, pr_number, leak_before_ids
                             )
@@ -3400,6 +3458,11 @@ class Worker:
                         return True
                     case cra_oracle.ActionContinueSession():
                         assert isinstance(commit_result, CommitSuccess)
+                        # File any LLM-declared aux issues alongside the
+                        # partial commit (closes #1413).  The harness owns
+                        # issue creation across all turn types, not only
+                        # task-complete turns.
+                        self._file_aux_issues_from_bundle(bundle, repo_ctx, pr_number)
                         # CommitTaskInProgress: partial commit — continue.
                         log.info(
                             "task in-progress commit %s — continuing session",
@@ -3539,7 +3602,9 @@ class Worker:
         prompts = self._get_prompts()
         prompt = prompts.pickup_comment_prompt(issue_title)
         msg = self._provider_agent.generate_reply(
-            prompt, self._provider_agent.voice_model
+            prompt,
+            self._provider_agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         )
         if not msg:
             msg = f"Picking up issue: {issue_title}"

--- a/sub/task.md
+++ b/sub/task.md
@@ -72,6 +72,19 @@ Every turn **must** end with a `turn_outcome` JSON object as the final non-empty
   {"turn_outcome": "stuck-on-task", "reason": "<what you need from the human>"}
   ```
 
+### Optional fields on any sentinel
+
+The harness files GitHub issues on your behalf when the sentinel includes either of these arrays.  You **never** call `gh issue create` yourself — the harness owns issue creation.
+
+- **`insights`** — surprising invariants, design lessons, or root-cause observations worth preserving.  Each entry becomes an issue with the `Insight` label.
+- **`out_of_scope_asks`** — requests that arrived during this task but are out of scope for the current PR.  Each entry becomes a normal tracked issue so the work isn't lost while keeping this PR focused.
+
+Combined example:
+
+```json
+{"turn_outcome": "commit-task-complete", "summary": "Migrate webhook activities to FidoState", "insights": [{"title": "Snapshot ownership belongs to the writer class", "body": "When CAS read-modify-write breaks down, the right fix is moving ownership of the value out of the snapshot."}], "out_of_scope_asks": [{"title": "Webhook redelivery dedup window", "body": "Saw a duplicate `pull_request_review` arrive 10s apart from GitHub. Worth a dedup window in webhook ingest."}]}
+```
+
 The sentinel must be the literal last non-empty line of your response — nothing after it.  Do not wrap it in a code fence or markdown block.
 
 ## Done when
@@ -100,4 +113,5 @@ Never post a `BLOCKED:` comment yourself — emit `stuck-on-task` and the harnes
 - **Never** call any `/reviews` endpoint (read or write). Use only `pulls/{pr}/comments` with `in_reply_to=<comment_id>` for thread replies.
 - **Never** use TaskCreate, TaskUpdate, TaskList, TodoWrite, TodoRead, or `./fido task`.
 - **Never** edit the PR body directly. The Fido server owns PR body sync.
-- **Never** fix unrelated bugs in this PR. If you encounter a bug that is not directly related to the current task title, file a GitHub issue for it (`gh issue create`) — do NOT fix it here. One PR, one purpose. Scope creep breaks reviewability.
+- **Never** fix unrelated bugs in this PR. If you encounter a bug that is not directly related to the current task title, declare it via the sentinel's `out_of_scope_asks` array (the harness files the issue) — do NOT fix it here, and do NOT call `gh issue create` directly. One PR, one purpose. Scope creep breaks reviewability.
+- **Never** call `gh issue create` yourself. The harness creates issues on your behalf via the sentinel's `insights` and `out_of_scope_asks` arrays — your tool set does not permit direct issue creation under any phase.

--- a/sub/task.md
+++ b/sub/task.md
@@ -76,13 +76,13 @@ Every turn **must** end with a `turn_outcome` JSON object as the final non-empty
 
 The harness files GitHub issues on your behalf when the sentinel includes either of these arrays.  You **never** call `gh issue create` yourself — the harness owns issue creation.
 
-- **`insights`** — surprising invariants, design lessons, or root-cause observations worth preserving.  Each entry becomes an issue with the `Insight` label.
-- **`out_of_scope_asks`** — requests that arrived during this task but are out of scope for the current PR.  Each entry becomes a normal tracked issue so the work isn't lost while keeping this PR focused.
+- **`insights`** — surprising invariants, design lessons, or root-cause observations worth preserving.  Each entry has `title`, `hook` (one-sentence lede), and `why` (2–3 sentences on what broader lesson it carries).  Each entry becomes an issue with the `Insight` label.
+- **`out_of_scope_asks`** — requests that arrived during this task but are out of scope for the current PR.  Each entry has `title` and `body`.  Each entry becomes a normal tracked issue so the work isn't lost while keeping this PR focused.
 
 Combined example:
 
 ```json
-{"turn_outcome": "commit-task-complete", "summary": "Migrate webhook activities to FidoState", "insights": [{"title": "Snapshot ownership belongs to the writer class", "body": "When CAS read-modify-write breaks down, the right fix is moving ownership of the value out of the snapshot."}], "out_of_scope_asks": [{"title": "Webhook redelivery dedup window", "body": "Saw a duplicate `pull_request_review` arrive 10s apart from GitHub. Worth a dedup window in webhook ingest."}]}
+{"turn_outcome": "commit-task-complete", "summary": "Migrate webhook activities to FidoState", "insights": [{"title": "Snapshot ownership belongs to the writer class", "hook": "CAS read-modify-write broke down on the snapshot.", "why": "The right fix was moving ownership of the value out of the snapshot. Generalises to any place a reader and writer share a struct that needs serial mutation."}], "out_of_scope_asks": [{"title": "Webhook redelivery dedup window", "body": "Saw a duplicate `pull_request_review` arrive 10s apart from GitHub. Worth a dedup window in webhook ingest."}]}
 ```
 
 The sentinel must be the literal last non-empty line of your response — nothing after it.  Do not wrap it in a code fence or markdown block.

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -13,7 +13,6 @@ from fido import provider
 from fido.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
-    READ_ONLY_ALLOWED_TOOLS,
     ClaudeAPI,
     ClaudeClient,
     ClaudeCode,
@@ -34,6 +33,7 @@ from fido.claude import (
     raise_for_provider_error_output,
 )
 from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
     ProviderID,
     ProviderLimitSnapshot,
     ProviderLimitWindow,

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -13,7 +13,7 @@ from fido import provider
 from fido.claude import (
     _LOG_LINE_TRUNCATE,
     _RETURNCODE_IDLE_TIMEOUT,
-    HANDLER_ALLOWED_TOOLS,
+    READ_ONLY_ALLOWED_TOOLS,
     ClaudeAPI,
     ClaudeClient,
     ClaudeCode,
@@ -1716,8 +1716,8 @@ class TestClaudeSessionSwitchTools:
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
         with patch.object(session, "_respawn") as mock_respawn:
-            session.switch_tools(HANDLER_ALLOWED_TOOLS)
-        assert session._tools == HANDLER_ALLOWED_TOOLS
+            session.switch_tools(READ_ONLY_ALLOWED_TOOLS)
+        assert session._tools == READ_ONLY_ALLOWED_TOOLS
         mock_respawn.assert_called_once()
         kwargs = mock_respawn.call_args.kwargs
         assert kwargs["clear_session_id"] is False
@@ -1728,7 +1728,7 @@ class TestClaudeSessionSwitchTools:
         """Switching from restricted back to None respawns with resume."""
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        session._tools = HANDLER_ALLOWED_TOOLS  # pretend handler mode
+        session._tools = READ_ONLY_ALLOWED_TOOLS  # pretend handler mode
         with patch.object(session, "_respawn") as mock_respawn:
             session.switch_tools(None)
         assert session._tools is None
@@ -1743,7 +1743,7 @@ class TestClaudeSessionSwitchTools:
         boom = OSError("kill failed")
         with patch.object(session, "_respawn", side_effect=boom):
             with pytest.raises(OSError, match="kill failed"):
-                session.switch_tools(HANDLER_ALLOWED_TOOLS)
+                session.switch_tools(READ_ONLY_ALLOWED_TOOLS)
 
 
 class TestClaudeSessionSpawnTools:
@@ -1774,11 +1774,11 @@ class TestClaudeSessionSpawnTools:
             system_file,
             popen=fake_popen,
             selector=fake_selector,
-            tools=HANDLER_ALLOWED_TOOLS,
+            tools=READ_ONLY_ALLOWED_TOOLS,
         )
         cmd = fake_popen.call_args.args[0]
         assert "--allowedTools" in cmd
-        assert cmd[cmd.index("--allowedTools") + 1] == HANDLER_ALLOWED_TOOLS
+        assert cmd[cmd.index("--allowedTools") + 1] == READ_ONLY_ALLOWED_TOOLS
 
     def test_allowed_tools_flag_appears_before_resume(self, tmp_path: Path) -> None:
         """``--allowedTools`` is placed before ``--resume`` in the command."""
@@ -1791,7 +1791,7 @@ class TestClaudeSessionSpawnTools:
             system_file,
             popen=fake_popen,
             selector=fake_selector,
-            tools=HANDLER_ALLOWED_TOOLS,
+            tools=READ_ONLY_ALLOWED_TOOLS,
             session_id="sess-123",
         )
         cmd = fake_popen.call_args.args[0]
@@ -2068,60 +2068,6 @@ class TestClaudeSessionLock:
         finally:
             provider.set_thread_kind(None)
             session.stop()
-
-    def test_hold_for_handler_switches_to_triage_tools_and_restores(
-        self, tmp_path: Path
-    ) -> None:
-        """hold_for_handler calls switch_tools(HANDLER_ALLOWED_TOOLS) on entry
-        and switch_tools(None) on exit so handler turns are automatically
-        restricted to the triage allowlist (#1042)."""
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        calls: list[str | None] = []
-        original_switch = session.switch_tools
-
-        def recording_switch(tools: str | None) -> None:
-            calls.append(tools)
-            original_switch(tools)
-
-        session.switch_tools = recording_switch  # type: ignore[method-assign]
-        provider.set_thread_kind("webhook")
-        try:
-            with patch("fido.provider.try_preempt_worker", return_value=(False, None)):
-                with session.hold_for_handler():
-                    pass
-        finally:
-            provider.set_thread_kind(None)
-            session.stop()
-
-        assert len(calls) == 2
-        assert calls[0] == HANDLER_ALLOWED_TOOLS  # restricted on entry
-        assert calls[1] is None  # restored on exit
-
-    def test_hold_for_handler_restores_tools_on_exception(self, tmp_path: Path) -> None:
-        """hold_for_handler restores tools even when the body raises."""
-        proc = _make_session_proc([])
-        session = _make_session(tmp_path, proc)
-        calls: list[str | None] = []
-        original_switch = session.switch_tools
-
-        def recording_switch(tools: str | None) -> None:
-            calls.append(tools)
-            original_switch(tools)
-
-        session.switch_tools = recording_switch  # type: ignore[method-assign]
-        provider.set_thread_kind("webhook")
-        try:
-            with patch("fido.provider.try_preempt_worker", return_value=(False, None)):
-                with pytest.raises(RuntimeError, match="boom"):
-                    with session.hold_for_handler():
-                        raise RuntimeError("boom")
-        finally:
-            provider.set_thread_kind(None)
-            session.stop()
-
-        assert calls[0] == HANDLER_ALLOWED_TOOLS
-        assert calls[-1] is None  # always restored
 
     def test_enter_uses_thread_kind_not_shared_attribute(self, tmp_path: Path) -> None:
         """Regression for #981: __enter__ must read the talker kind from
@@ -2641,7 +2587,10 @@ class TestClaudeClientRunTurn:
         client = ClaudeClient(session_fn=lambda: session)
         assert client.run_turn("hi", model="claude-opus-4-6") == "hello"
         session.prompt.assert_called_once_with(
-            "hi", model="claude-opus-4-6", system_prompt=None
+            "hi",
+            model="claude-opus-4-6",
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt=None,
         )
 
     def test_passes_system_prompt(self) -> None:
@@ -3212,7 +3161,10 @@ class TestClaudeClientGenerateStatus:
             == "🐶\ncoding up a storm"
         )
         session.prompt.assert_called_once_with(
-            "working on #42", model="claude-opus-4-6", system_prompt="be fido"
+            "working on #42",
+            model="claude-opus-4-6",
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt="be fido",
         )
 
     def test_custom_model(self) -> None:
@@ -3232,6 +3184,7 @@ class TestClaudeClientGenerateStatusEmojiDelegation:
         session.prompt.assert_called_once_with(
             "pick emoji",
             model="claude-opus-4-6",
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
             system_prompt=(
                 "be fido\n\nRespond with ONLY a JSON object in the form "
                 '{"emoji": "your answer"}. No other text before or after the JSON.'

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -976,14 +976,6 @@ class TestCodexSessionLeafBranches:
         session = self._session(tmp_path, repo_name=None)
         assert session.owner is None  # type: ignore[union-attr]
 
-    def test_switch_tools_is_a_noop(self, tmp_path: Path) -> None:
-        """codex.py:847 — Codex doesn't support per-session tool flags;
-        ``switch_tools`` accepts the call and discards the value."""
-        session = self._session(tmp_path)
-        # Should not raise; nothing observable to assert.
-        session.switch_tools("triage")  # type: ignore[union-attr]
-        session.switch_tools(None)  # type: ignore[union-attr]
-
     def test_reset_with_explicit_model(self, tmp_path: Path) -> None:
         """codex.py:863 — reset(model=...) coerces the new model."""
         from fido.provider import ProviderModel

--- a/tests/test_turn_outcome.py
+++ b/tests/test_turn_outcome.py
@@ -207,12 +207,14 @@ class TestParseTurnOutcomeAuxIssues:
     def test_insights_parsed(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": [{"title": "T1", "body": "B1"}, {"title": "T2", "body": "B2"}]}'
+            '"insights": ['
+            '{"title": "T1", "hook": "H1", "why": "W1"}, '
+            '{"title": "T2", "hook": "H2", "why": "W2"}]}'
         )
         bundle = parse_turn_outcome(line)
         assert bundle.insights == (
-            Insight(title="T1", body="B1"),
-            Insight(title="T2", body="B2"),
+            Insight(title="T1", hook="H1", why="W1"),
+            Insight(title="T2", hook="H2", why="W2"),
         )
         assert bundle.out_of_scope_asks == ()
 
@@ -228,7 +230,7 @@ class TestParseTurnOutcomeAuxIssues:
     def test_insights_must_be_array(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": {"title": "T", "body": "B"}}'
+            '"insights": {"title": "T", "hook": "H", "why": "W"}}'
         )
         with pytest.raises(ValueError, match="must be a JSON array"):
             parse_turn_outcome(line)
@@ -244,31 +246,47 @@ class TestParseTurnOutcomeAuxIssues:
     def test_insight_missing_title(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": [{"body": "B"}]}'
+            '"insights": [{"hook": "H", "why": "W"}]}'
         )
         with pytest.raises(ValueError, match=r'requires a non-empty "title"'):
             parse_turn_outcome(line)
 
-    def test_insight_missing_body(self) -> None:
+    def test_insight_missing_hook(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": [{"title": "T"}]}'
+            '"insights": [{"title": "T", "why": "W"}]}'
         )
-        with pytest.raises(ValueError, match=r'requires a non-empty "body"'):
+        with pytest.raises(ValueError, match=r'requires a non-empty "hook"'):
+            parse_turn_outcome(line)
+
+    def test_insight_missing_why(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"title": "T", "hook": "H"}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "why"'):
             parse_turn_outcome(line)
 
     def test_insight_title_whitespace_only(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": [{"title": "   ", "body": "B"}]}'
+            '"insights": [{"title": "   ", "hook": "H", "why": "W"}]}'
         )
         with pytest.raises(ValueError, match=r'requires a non-empty "title"'):
             parse_turn_outcome(line)
 
-    def test_insight_body_whitespace_only(self) -> None:
+    def test_insight_hook_whitespace_only(self) -> None:
         line = (
             '{"turn_outcome": "commit-task-complete", "summary": "x", '
-            '"insights": [{"title": "T", "body": "  "}]}'
+            '"insights": [{"title": "T", "hook": "  ", "why": "W"}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "hook"'):
+            parse_turn_outcome(line)
+
+    def test_out_of_scope_ask_missing_body(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"out_of_scope_asks": [{"title": "Ask"}]}'
         )
         with pytest.raises(ValueError, match=r'requires a non-empty "body"'):
             parse_turn_outcome(line)

--- a/tests/test_turn_outcome.py
+++ b/tests/test_turn_outcome.py
@@ -11,7 +11,7 @@ from fido.rocq.turn_outcome import (
     SkipTaskWithReason,
     StuckOnTask,
 )
-from fido.turn_outcome import parse_turn_outcome
+from fido.turn_outcome import Insight, OutOfScopeAsk, parse_turn_outcome
 
 
 class TestParseTurnOutcomeEmpty:
@@ -47,7 +47,7 @@ class TestParseTurnOutcomeUnrecognized:
 class TestParseTurnOutcomeCommitTaskComplete:
     def test_valid(self) -> None:
         line = '{"turn_outcome": "commit-task-complete", "summary": "Add foo"}'
-        assert parse_turn_outcome(line) == CommitTaskComplete(summary="Add foo")
+        assert parse_turn_outcome(line).outcome == CommitTaskComplete(summary="Add foo")
 
     def test_missing_summary(self) -> None:
         with pytest.raises(ValueError, match="non-empty.*summary"):
@@ -72,7 +72,9 @@ class TestParseTurnOutcomeCommitTaskComplete:
 class TestParseTurnOutcomeCommitTaskInProgress:
     def test_valid(self) -> None:
         line = '{"turn_outcome": "commit-task-in-progress", "summary": "WIP: Add bar"}'
-        assert parse_turn_outcome(line) == CommitTaskInProgress(summary="WIP: Add bar")
+        assert parse_turn_outcome(line).outcome == CommitTaskInProgress(
+            summary="WIP: Add bar"
+        )
 
     def test_missing_summary(self) -> None:
         with pytest.raises(ValueError, match="non-empty.*summary"):
@@ -97,7 +99,7 @@ class TestParseTurnOutcomeCommitTaskInProgress:
 class TestParseTurnOutcomeSkipTaskWithReason:
     def test_valid(self) -> None:
         line = '{"turn_outcome": "skip-task-with-reason", "reason": "already done in abc1234"}'
-        assert parse_turn_outcome(line) == SkipTaskWithReason(
+        assert parse_turn_outcome(line).outcome == SkipTaskWithReason(
             reason="already done in abc1234"
         )
 
@@ -124,7 +126,9 @@ class TestParseTurnOutcomeSkipTaskWithReason:
 class TestParseTurnOutcomeStuckOnTask:
     def test_valid(self) -> None:
         line = '{"turn_outcome": "stuck-on-task", "reason": "need API credentials"}'
-        assert parse_turn_outcome(line) == StuckOnTask(reason="need API credentials")
+        assert parse_turn_outcome(line).outcome == StuckOnTask(
+            reason="need API credentials"
+        )
 
     def test_missing_reason(self) -> None:
         with pytest.raises(ValueError, match="non-empty.*reason"):
@@ -153,7 +157,9 @@ class TestParseTurnOutcomeMultiLine:
             "All tests pass.\n"
             '{"turn_outcome": "commit-task-complete", "summary": "Implement thing"}'
         )
-        assert parse_turn_outcome(text) == CommitTaskComplete(summary="Implement thing")
+        assert parse_turn_outcome(text).outcome == CommitTaskComplete(
+            summary="Implement thing"
+        )
 
     def test_stale_sentinel_in_middle_non_json_at_end(self) -> None:
         """A valid-looking sentinel buried in the middle is invisible — only the
@@ -168,16 +174,104 @@ class TestParseTurnOutcomeMultiLine:
     def test_trailing_blank_lines_ignored(self) -> None:
         """Trailing blank lines are filtered out; the sentinel still parses."""
         text = '{"turn_outcome": "skip-task-with-reason", "reason": "no-op"}\n\n\n  \n'
-        assert parse_turn_outcome(text) == SkipTaskWithReason(reason="no-op")
+        assert parse_turn_outcome(text).outcome == SkipTaskWithReason(reason="no-op")
 
     def test_in_progress_on_last_line(self) -> None:
         text = (
             "Staged the first batch of changes.\n"
             '{"turn_outcome": "commit-task-in-progress", "summary": "wip: part 1 of 3"}'
         )
-        assert parse_turn_outcome(text) == CommitTaskInProgress(
+        assert parse_turn_outcome(text).outcome == CommitTaskInProgress(
             summary="wip: part 1 of 3"
         )
+
+
+class TestParseTurnOutcomeAuxIssues:
+    """Optional ``insights`` and ``out_of_scope_asks`` arrays on any sentinel."""
+
+    def test_no_aux_arrays_default_empty(self) -> None:
+        bundle = parse_turn_outcome(
+            '{"turn_outcome": "commit-task-complete", "summary": "x"}'
+        )
+        assert bundle.insights == ()
+        assert bundle.out_of_scope_asks == ()
+
+    def test_explicit_null_aux_arrays_default_empty(self) -> None:
+        bundle = parse_turn_outcome(
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": null, "out_of_scope_asks": null}'
+        )
+        assert bundle.insights == ()
+        assert bundle.out_of_scope_asks == ()
+
+    def test_insights_parsed(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"title": "T1", "body": "B1"}, {"title": "T2", "body": "B2"}]}'
+        )
+        bundle = parse_turn_outcome(line)
+        assert bundle.insights == (
+            Insight(title="T1", body="B1"),
+            Insight(title="T2", body="B2"),
+        )
+        assert bundle.out_of_scope_asks == ()
+
+    def test_out_of_scope_asks_parsed(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"out_of_scope_asks": [{"title": "Ask", "body": "Body"}]}'
+        )
+        bundle = parse_turn_outcome(line)
+        assert bundle.out_of_scope_asks == (OutOfScopeAsk(title="Ask", body="Body"),)
+        assert bundle.insights == ()
+
+    def test_insights_must_be_array(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": {"title": "T", "body": "B"}}'
+        )
+        with pytest.raises(ValueError, match="must be a JSON array"):
+            parse_turn_outcome(line)
+
+    def test_insight_item_must_be_object(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": ["not an object"]}'
+        )
+        with pytest.raises(ValueError, match=r"insights\[0\] is not a JSON object"):
+            parse_turn_outcome(line)
+
+    def test_insight_missing_title(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"body": "B"}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "title"'):
+            parse_turn_outcome(line)
+
+    def test_insight_missing_body(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"title": "T"}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "body"'):
+            parse_turn_outcome(line)
+
+    def test_insight_title_whitespace_only(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"title": "   ", "body": "B"}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "title"'):
+            parse_turn_outcome(line)
+
+    def test_insight_body_whitespace_only(self) -> None:
+        line = (
+            '{"turn_outcome": "commit-task-complete", "summary": "x", '
+            '"insights": [{"title": "T", "body": "  "}]}'
+        )
+        with pytest.raises(ValueError, match=r'requires a non-empty "body"'):
+            parse_turn_outcome(line)
 
 
 class TestOracleDivergenceDetection:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4073,8 +4073,16 @@ class TestFileAuxIssuesFromBundle:
         bundle = TurnOutcomeBundle(
             outcome=CommitTaskComplete(summary="x"),
             insights=(
-                Insight(title="Snapshot ownership", body="When CAS breaks down…"),
-                Insight(title="Webhook ordering", body="Two events 10s apart"),
+                Insight(
+                    title="Snapshot ownership",
+                    hook="CAS broke down on the snapshot.",
+                    why="The fix was to move ownership of the value out.",
+                ),
+                Insight(
+                    title="Webhook ordering",
+                    hook="Two pull_request_review events 10s apart.",
+                    why="Worth a dedup window in webhook ingest.",
+                ),
             ),
             out_of_scope_asks=(),
         )
@@ -4083,13 +4091,17 @@ class TestFileAuxIssuesFromBundle:
             (
                 "alice/myrepo",
                 "Insight: Snapshot ownership",
-                "When CAS breaks down…\n\nSource: alice/myrepo#99",
+                "CAS broke down on the snapshot.\n\n"
+                "The fix was to move ownership of the value out.\n\n"
+                "Source: alice/myrepo#99",
                 ["Insight"],
             ),
             (
                 "alice/myrepo",
                 "Insight: Webhook ordering",
-                "Two events 10s apart\n\nSource: alice/myrepo#99",
+                "Two pull_request_review events 10s apart.\n\n"
+                "Worth a dedup window in webhook ingest.\n\n"
+                "Source: alice/myrepo#99",
                 ["Insight"],
             ),
         ]
@@ -4137,7 +4149,7 @@ class TestFileAuxIssuesFromBundle:
         worker = Worker(tmp_path, _Failing(), registry=MagicMock(spec=ActivityReporter))
         bundle = TurnOutcomeBundle(
             outcome=CommitTaskComplete(summary="x"),
-            insights=(Insight(title="T", body="B"),),
+            insights=(Insight(title="T", hook="H", why="W"),),
             out_of_scope_asks=(),
         )
         with pytest.raises(RuntimeError, match="api down"):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,11 +14,12 @@ import pytest
 
 import fido.worker as worker_module
 from fido import provider
-from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
+from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.prompts import Prompts
 from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
     ContextOverflowError,
     ProviderID,
     ProviderLimitSnapshot,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,7 +14,7 @@ import pytest
 
 import fido.worker as worker_module
 from fido import provider
-from fido.claude import ClaudeClient
+from fido.claude import READ_ONLY_ALLOWED_TOOLS, ClaudeClient
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.issue_cache import IssueNode, IssueTreeCache
 from fido.prompts import Prompts
@@ -3677,6 +3677,7 @@ class TestProviderStart:
             "claude-opus-4-6",
             300,
             cwd=".",
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
         )
 
     def test_passes_custom_model(self, tmp_path: Path) -> None:
@@ -3787,6 +3788,7 @@ class TestProviderStart:
         client.run_turn.assert_called_once_with(
             "setup instructions\n\n---\n\nthe task prompt",
             model=client.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
             retry_on_preempt=True,
             session_mode=TurnSessionMode.REUSE,
         )
@@ -3870,6 +3872,7 @@ class TestProviderRun:
             "claude-sonnet-4-6",
             300,
             cwd=".",
+            allowed_tools=None,
         )
 
     def test_start_returns_empty_session_id_on_failure(self, tmp_path: Path) -> None:
@@ -3957,6 +3960,7 @@ class TestProviderRun:
         client.run_turn.assert_called_once_with(
             "task instructions\n\n---\n\nrun this task",
             model=client.work_model,
+            allowed_tools=None,
             retry_on_preempt=True,
             session_mode=TurnSessionMode.REUSE,
         )
@@ -3975,6 +3979,7 @@ class TestProviderRun:
         client.run_turn.assert_called_once_with(
             "skill\n\n---\n\nprompt",
             model=client.work_model,
+            allowed_tools=None,
             retry_on_preempt=False,
             session_mode=TurnSessionMode.REUSE,
         )
@@ -4003,6 +4008,139 @@ class TestProviderRun:
         provider_run(fido_dir, agent=client, model=client.work_model)
         session.__enter__.assert_not_called()
         session.__exit__.assert_not_called()
+
+
+class _RecordingGh:
+    """Hand-rolled fake GitHub client that records ``create_issue`` calls.
+
+    Matches the production ``GitHub.create_issue`` signature exactly so the
+    fake is a drop-in for the worker call site (#1413).  Returns a stable
+    URL per call so callers that propagate the URL don't blow up.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, list[str] | None]] = []
+
+    def create_issue(
+        self,
+        repo: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> str:
+        self.calls.append((repo, title, body, labels))
+        return f"https://github.com/{repo}/issues/{len(self.calls)}"
+
+
+class TestFileAuxIssuesFromBundle:
+    """Worker._file_aux_issues_from_bundle dispatches sentinel ``insights``
+    and ``out_of_scope_asks`` arrays to ``gh.create_issue`` so the LLM never
+    needs the ``gh issue create`` permission itself (closes #1413)."""
+
+    def _repo_ctx(self) -> RepoContext:
+        return RepoContext(
+            repo="alice/myrepo",
+            owner="alice",
+            repo_name="myrepo",
+            gh_user="bot",
+            default_branch="main",
+        )
+
+    def _make_worker(self, tmp_path: Path, gh: _RecordingGh) -> Worker:
+        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+
+    def test_empty_bundle_files_nothing(self, tmp_path: Path) -> None:
+        from fido.rocq.turn_outcome import CommitTaskComplete
+        from fido.turn_outcome import TurnOutcomeBundle
+
+        gh = _RecordingGh()
+        worker = self._make_worker(tmp_path, gh)
+        bundle = TurnOutcomeBundle(
+            outcome=CommitTaskComplete(summary="x"),
+            insights=(),
+            out_of_scope_asks=(),
+        )
+        worker._file_aux_issues_from_bundle(bundle, self._repo_ctx(), pr_number=42)
+        assert gh.calls == []
+
+    def test_files_each_insight_with_label_and_source(self, tmp_path: Path) -> None:
+        from fido.rocq.turn_outcome import CommitTaskComplete
+        from fido.turn_outcome import Insight, TurnOutcomeBundle
+
+        gh = _RecordingGh()
+        worker = self._make_worker(tmp_path, gh)
+        bundle = TurnOutcomeBundle(
+            outcome=CommitTaskComplete(summary="x"),
+            insights=(
+                Insight(title="Snapshot ownership", body="When CAS breaks down…"),
+                Insight(title="Webhook ordering", body="Two events 10s apart"),
+            ),
+            out_of_scope_asks=(),
+        )
+        worker._file_aux_issues_from_bundle(bundle, self._repo_ctx(), pr_number=99)
+        assert gh.calls == [
+            (
+                "alice/myrepo",
+                "Insight: Snapshot ownership",
+                "When CAS breaks down…\n\nSource: alice/myrepo#99",
+                ["Insight"],
+            ),
+            (
+                "alice/myrepo",
+                "Insight: Webhook ordering",
+                "Two events 10s apart\n\nSource: alice/myrepo#99",
+                ["Insight"],
+            ),
+        ]
+
+    def test_files_each_out_of_scope_ask_without_label(self, tmp_path: Path) -> None:
+        from fido.rocq.turn_outcome import CommitTaskComplete
+        from fido.turn_outcome import OutOfScopeAsk, TurnOutcomeBundle
+
+        gh = _RecordingGh()
+        worker = self._make_worker(tmp_path, gh)
+        bundle = TurnOutcomeBundle(
+            outcome=CommitTaskComplete(summary="x"),
+            insights=(),
+            out_of_scope_asks=(
+                OutOfScopeAsk(title="Dedup window", body="Worth investigating"),
+            ),
+        )
+        worker._file_aux_issues_from_bundle(bundle, self._repo_ctx(), pr_number=7)
+        assert gh.calls == [
+            (
+                "alice/myrepo",
+                "Dedup window",
+                "Worth investigating\n\nOut-of-scope from: alice/myrepo#7",
+                None,
+            ),
+        ]
+
+    def test_create_issue_failure_propagates(self, tmp_path: Path) -> None:
+        """Failures are not swallowed — defensive try/except hid bugs.  When
+        issue filing fails the watchdog surfaces it on next tick."""
+        from fido.rocq.turn_outcome import CommitTaskComplete
+        from fido.turn_outcome import Insight, TurnOutcomeBundle
+
+        class _Failing:
+            def create_issue(
+                self,
+                repo: str,
+                title: str,
+                body: str,
+                labels: list[str] | None = None,
+            ) -> str:
+                del repo, title, body, labels
+                raise RuntimeError("api down")
+
+        worker = Worker(tmp_path, _Failing(), registry=MagicMock(spec=ActivityReporter))
+        bundle = TurnOutcomeBundle(
+            outcome=CommitTaskComplete(summary="x"),
+            insights=(Insight(title="T", body="B"),),
+            out_of_scope_asks=(),
+        )
+        with pytest.raises(RuntimeError, match="api down"):
+            worker._file_aux_issues_from_bundle(bundle, self._repo_ctx(), pr_number=1)
 
 
 class TestSanitizeSlug:


### PR DESCRIPTION
## Why

Watching home worker on PR #1409 caught the LLM trying to bypass the
`Bash(git commit *)` permission block by escalating through sub-agents and
the `update-config` skill. The smoking gun was the `:eyes:` reaction never
coming off the comment — that meant the *triage* phase, which is supposed
to be a 30-second read-only triage, was actually running implementation
work and racing the worker for the full toolset.

Diagnosis (from #1413): synthesis (and any non-task LLM call) ran with
`tools=None` because the FSM ENTER/EXIT `switch_tools` dance fired briefly
during dispatch and the actual `generate_status` / `reply_to_review` call
happened later with tools already restored.

## What

Tool policy is now explicit per call — every LLM invocation declares its
own `allowed_tools`, just like it declares its model.

- New constants in `provider.py`:
  - `READ_ONLY_ALLOWED_TOOLS` — Read/Grep/Glob + ro git + `gh ... view/list/diff`.
  - `GLOBAL_DISALLOWED_TOOLS` — applied unconditionally on every Claude
    spawn: `Bash(git commit|push|rebase|reset|checkout *)`,
    `Bash(./fido task *)`, `Agent`, `Skill`, `TaskCreate|Update|List|TodoWrite|TodoRead`.
- `ProviderAgent.run_turn` / `print_prompt_from_file` / `resume_session` /
  `generate_reply` / `generate_branch_name` / `generate_status` /
  `generate_status_emoji` and `PromptSession.prompt` all take
  `allowed_tools: str | None = READ_ONLY_ALLOWED_TOOLS`.
- `ClaudeSession.prompt` calls `self.switch_tools(allowed_tools)` itself —
  same shape as `switch_model`, no FSM-level dispatch.
- `provider_run` (task implementation) passes `allowed_tools=None`.  All
  other call sites (setup, rescope, replies, status, branch names) get the
  read-only default.

The LLM no longer needs `gh issue create` either — `turn_outcome` now
accepts optional `insights[]` and `out_of_scope_asks[]` arrays, parsed
into a `TurnOutcomeBundle`. After a successful harness commit, the worker
files them via `gh.create_issue` (Insight label on insights, plain tracked
issue on asks). `sub/task.md` documents the new fields and forbids direct
`gh issue create` calls.

Cleanup of now-dead coordination state:
- `hold_for_handler` no longer dispatches `switch_tools`; just yields under
  the lock.
- `_handler_tools` field removed from `OwnedSession` (was never read).
- `switch_tools` removed from `PromptSession` protocol and `OwnedSession`
  abstract base — only `ClaudeSession.switch_tools` remains. Codex and
  Copilot lose their no-op overrides.
- `HANDLER_ALLOWED_TOOLS` alias dropped (was equal to
  `READ_ONLY_ALLOWED_TOOLS` after the read-only narrowing).
- `_file_aux_issues_from_bundle` doesn't catch-log-continue on
  `create_issue` failures — surface real errors, don't synthesize success.

## Test plan
- [x] `./fido ci` green (4027 tests, 100% coverage)
- [ ] After merge: watch a webhook-triggered triage cycle on a fresh PR
      and confirm the `:eyes:` reaction comes off as soon as triage finishes.
- [ ] Confirm a task-impl turn that emits `insights` / `out_of_scope_asks`
      gets issues filed with the right labels.

Closes #1413.