### PR TITLE
Bug: lockfree status PR 4/6 — migrate rate_limit cache to RegistrySnapshot (closes #1346)

### DIFF
--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -1,4 +1,4 @@
-"""AtomicReference[T] — single-lock pointer-swap primitive for lock-free reads.
+"""Atomic reference cell — lock-free read, lock-serialized write.
 
 Writers hold ``_lock`` for the duration of the pointer swap so concurrent
 writes are serialized and no update is lost.  Readers call :meth:`get`
@@ -10,9 +10,14 @@ etc.) so that readers who hold a reference to the snapshot can inspect all
 fields without encountering races inside the value itself.
 
 :class:`AtomicReader` and :class:`AtomicUpdater` are the two narrow
-Protocol faces of :class:`AtomicReference`.  Collaborators should accept
-one of those, not the concrete class — a callee that holds both is usually
-doing something that belongs inside the owner (code smell).
+public Protocol faces.  Use :func:`create_atomic` to create a cell — it
+returns ``(reader, updater)`` so callers accept only the face they need.
+A collaborator that holds *both* faces is doing something that belongs
+inside the owner of the cell (code smell).
+
+:class:`_AtomicReference` is the private backing implementation.  Import
+it only in unit tests that need to exercise ``set`` / ``compare_and_set``
+internals; production code should use :func:`create_atomic` exclusively.
 """
 
 import threading
@@ -61,18 +66,22 @@ class AtomicUpdater(Protocol[_T_upd]):
         ...
 
 
-class AtomicReference(Generic[_T]):
-    """A reference cell whose pointer swap is serialized by a single lock.
+class _AtomicReference(Generic[_T]):
+    """Private backing implementation of an atomic reference cell.
 
     Readers are observationally lock-free — :meth:`get` is a bare attribute
     read with no lock acquire.  Writers hold the internal ``_lock`` only for
     the atomic swap, keeping write-side latency minimal.
 
+    Do not import this class in production code.  Use :func:`create_atomic`
+    instead, which returns ``(AtomicReader[T], AtomicUpdater[T])`` so each
+    collaborator gets exactly the face it needs.
+
     The typical usage pattern is *lens update*::
 
-        ref = AtomicReference(initial_snapshot)
-
-        ref.update(lambda root: root.counter, new_counter_value)
+        reader, updater = create_atomic(initial_snapshot)
+        updater.update(lambda root: root.counter, new_counter_value)
+        current = reader.get()
 
     *selector* passed to :meth:`update` must be a **pure function** — the
     retry loop may call it more than once under write contention.
@@ -145,4 +154,18 @@ class AtomicReference(Generic[_T]):
                 return new
 
 
-__all__ = ["AtomicReader", "AtomicReference", "AtomicUpdater"]
+def create_atomic(initial: _T) -> "tuple[AtomicReader[_T], AtomicUpdater[_T]]":
+    """Create an atomic reference cell seeded with *initial*.
+
+    Returns a ``(reader, updater)`` pair backed by a single
+    :class:`_AtomicReference`.  Pass the reader to collaborators that only
+    observe state; pass the updater to collaborators that publish updates.
+
+    A collaborator that holds *both* is crossing an ownership boundary —
+    prefer putting that logic in the class that called :func:`create_atomic`.
+    """
+    ref: _AtomicReference[_T] = _AtomicReference(initial)
+    return ref, ref
+
+
+__all__ = ["AtomicReader", "AtomicUpdater", "create_atomic"]

--- a/src/fido/atomic.py
+++ b/src/fido/atomic.py
@@ -8,15 +8,57 @@ CPython-supported architectures, including the free-threaded (no-GIL) build.
 ``T`` should be an immutable value (frozen dataclass, namedtuple, ``None``,
 etc.) so that readers who hold a reference to the snapshot can inspect all
 fields without encountering races inside the value itself.
+
+:class:`AtomicReader` and :class:`AtomicUpdater` are the two narrow
+Protocol faces of :class:`AtomicReference`.  Collaborators should accept
+one of those, not the concrete class — a callee that holds both is usually
+doing something that belongs inside the owner (code smell).
 """
 
 import threading
 from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 from fido.lens import Lens
 
 _T = TypeVar("_T")
+_T_co = TypeVar("_T_co", covariant=True)
+_T_upd = TypeVar("_T_upd")
+
+
+class AtomicReader(Protocol[_T_co]):
+    """Read-only face of an atomic reference cell.
+
+    Pass this to collaborators that only need to observe the latest snapshot.
+    A collaborator that also calls :meth:`~AtomicUpdater.update` is likely
+    crossing an ownership boundary — prefer passing an :class:`AtomicUpdater`
+    to the writer and letting the registry expose snapshots via a separate read
+    path.
+    """
+
+    def get(self) -> _T_co:
+        """Return the current value.  Lock-free; safe to call from any thread."""
+        ...
+
+
+class AtomicUpdater(Protocol[_T_upd]):
+    """Write-only face of an atomic reference cell.
+
+    Pass this to collaborators that only need to publish updates.  Receiving
+    an :class:`AtomicUpdater` makes the intent clear: *this object writes,
+    it does not read back what it wrote*.  If a collaborator needs to read
+    the current snapshot, it should receive an :class:`AtomicReader` as a
+    separate dependency — and if it truly needs both, that is usually a sign
+    the logic belongs in the owner that holds the full :class:`AtomicReference`.
+    """
+
+    def update(
+        self,
+        selector: "Callable[[Lens[_T_upd]], Lens[_T_upd]]",
+        value: object,
+    ) -> "_T_upd":
+        """Install *value* at the path described by *selector* atomically."""
+        ...
 
 
 class AtomicReference(Generic[_T]):
@@ -101,3 +143,6 @@ class AtomicReference(Generic[_T]):
             success, old = self.compare_and_set(old, new)
             if success:
                 return new
+
+
+__all__ = ["AtomicReader", "AtomicReference", "AtomicUpdater"]

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -49,11 +49,18 @@ class ContextOverflowError(RuntimeError):
 
 
 class ProviderID(StrEnum):
-    """Supported LLM providers for fido."""
+    """Supported LLM providers for fido.
+
+    ``GITHUB`` represents the GitHub platform API itself (REST + GraphQL
+    rate-limit windows) — not an LLM provider, but tracked in the same
+    :attr:`~fido.registry.FidoState.provider_limits` map so all quota
+    pressure lives in one place.
+    """
 
     CLAUDE_CODE = "claude-code"
     COPILOT_CLI = "copilot-cli"
     CODEX = "codex"
+    GITHUB = "github"
 
 
 @dataclass(frozen=True)

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -51,16 +51,16 @@ class ContextOverflowError(RuntimeError):
 class ProviderID(StrEnum):
     """Supported LLM providers for fido.
 
-    ``GITHUB`` represents the GitHub platform API itself (REST + GraphQL
-    rate-limit windows) — not an LLM provider, but tracked in the same
-    :attr:`~fido.registry.FidoState.provider_limits` map so all quota
-    pressure lives in one place.
+    Each value identifies an interactive LLM agent.  GitHub platform
+    rate-limit state is tracked separately in
+    :attr:`~fido.registry.FidoState.github_limits` as a
+    :class:`~fido.rate_limit.GitHubLimit` — GitHub is not an LLM provider
+    and does not belong here.
     """
 
     CLAUDE_CODE = "claude-code"
     COPILOT_CLI = "copilot-cli"
     CODEX = "codex"
-    GITHUB = "github"
 
 
 @dataclass(frozen=True)

--- a/src/fido/rate_limit.py
+++ b/src/fido/rate_limit.py
@@ -1,14 +1,14 @@
 """GitHub rate-limit monitor for ``fido status`` (closes #812 follow-up).
 
 Polls ``GET /rate_limit`` once per minute (per GitHub docs, this endpoint
-itself does not count against any quota), keeps the latest snapshot in a
-lock-protected slot, and exposes it to the server's ``/rate_limit.json``
-endpoint so ``fido status`` can show REST-core and GraphQL pressure.
+itself does not count against any quota), and publishes the latest snapshot
+into :class:`~fido.registry.FidoState` via a CAS update on the registry's
+:class:`~fido.atomic.AtomicReference`.  Reads are lock-free: callers call
+:meth:`~RateLimitMonitor.latest` which simply reads
+:attr:`~fido.registry.FidoState.rate_limit` from the current snapshot.
 
-Thread-safe under Python 3.14t (free-threaded, no GIL): every read and
-write of ``_snapshot`` happens under :attr:`_lock`.  The poller thread
-treats fetch failures as soft errors — the previous snapshot stays put
-until the next successful refresh.
+The poller thread treats fetch failures as soft errors — the previous
+snapshot stays put until the next successful refresh.
 """
 
 import logging
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from fido.atomic import AtomicReference
 from fido.github import GitHub
 
 log = logging.getLogger(__name__)
@@ -59,33 +60,38 @@ class RateLimitSnapshot:
 
 
 class RateLimitMonitor:
-    """Lock-protected holder for the latest ``GET /rate_limit`` snapshot.
+    """Lock-free holder for the latest ``GET /rate_limit`` snapshot.
 
-    Construct with a :class:`~fido.github.GitHub` client (constructor
-    DI per CLAUDE.md), then either call :meth:`refresh` directly or hand
-    the monitor to :meth:`start_thread` for the 60s poller.
+    Construct with a :class:`~fido.github.GitHub` client and the
+    :class:`~fido.atomic.AtomicReference` backing
+    :class:`~fido.registry.WorkerRegistry`'s
+    :class:`~fido.registry.FidoState` (constructor DI per CLAUDE.md).
+    Either call :meth:`refresh` directly or hand the monitor to
+    :meth:`start_thread` for the 60s poller.
 
     A failed refresh logs the exception and leaves the prior snapshot in
     place — ``fido status`` keeps showing the last known good numbers
     rather than blanking.
+
+    Single writer: only the poller thread calls :meth:`refresh`.  Reads
+    are lock-free via :meth:`latest`.
     """
 
-    def __init__(self, gh: GitHub) -> None:
+    def __init__(self, gh: GitHub, state: AtomicReference[Any]) -> None:
         self._gh = gh
-        self._lock = threading.Lock()
-        self._snapshot: RateLimitSnapshot | None = None
+        self._state = state
 
     def latest(self) -> RateLimitSnapshot | None:
-        """Snapshot copy of the latest reading, or ``None`` before the
-        first successful refresh."""
-        with self._lock:
-            return self._snapshot
+        """Lock-free read of the latest rate-limit snapshot, or ``None``
+        before the first successful refresh."""
+        return self._state.get().rate_limit
 
     def refresh(self) -> RateLimitSnapshot | None:
-        """Hit ``GET /rate_limit`` and update the cached snapshot.
+        """Hit ``GET /rate_limit`` and publish the snapshot into
+        :class:`~fido.registry.FidoState` via CAS update.
 
         Returns the new snapshot on success, ``None`` on failure (the
-        prior snapshot remains in :attr:`_snapshot`).
+        prior snapshot remains in the shared state).
         """
         try:
             resources = self._gh.get_rate_limit()
@@ -97,8 +103,7 @@ class RateLimitMonitor:
             graphql=_parse_window("graphql", resources.get("graphql") or {}),
             fetched_at=datetime.now(tz=timezone.utc),
         )
-        with self._lock:
-            self._snapshot = snapshot
+        self._state.update(lambda root: root.rate_limit, snapshot)
         log.info(
             "rate-limit: rest %d/%d, graphql %d/%d",
             snapshot.rest.used,

--- a/src/fido/rate_limit.py
+++ b/src/fido/rate_limit.py
@@ -2,10 +2,10 @@
 
 Polls ``GET /rate_limit`` once per minute (per GitHub docs, this endpoint
 itself does not count against any quota), and publishes the latest snapshot
-into :class:`~fido.registry.FidoState` via a CAS update on the registry's
-:class:`~fido.atomic.AtomicReference`.  Reads are lock-free: callers call
-:meth:`~RateLimitMonitor.latest` which simply reads
-:attr:`~fido.registry.FidoState.rate_limit` from the current snapshot.
+into :attr:`~fido.registry.FidoState.provider_limits` under the
+``"github"`` key via a CAS update on the registry's
+:class:`~fido.atomic.AtomicReference`.  Reads are lock-free: callers read
+``provider_limits["github"]`` from the current :class:`~fido.registry.FidoState`.
 
 The poller thread treats fetch failures as soft errors — the previous
 snapshot stays put until the next successful refresh.
@@ -14,49 +14,16 @@ snapshot stays put until the next successful refresh.
 import logging
 import threading
 import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from fido.atomic import AtomicReference
 from fido.github import GitHub
+from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
 
 log = logging.getLogger(__name__)
 
 _REFRESH_INTERVAL: float = 60.0
-
-
-@dataclass(frozen=True)
-class RateLimitWindow:
-    """One resource window from ``GET /rate_limit``.
-
-    *resets_at* is the tz-aware datetime when *used* drops back to zero
-    (parsed from GitHub's epoch-seconds ``reset`` field).
-    """
-
-    name: str
-    used: int
-    limit: int
-    resets_at: datetime
-
-    @property
-    def remaining(self) -> int:
-        return max(self.limit - self.used, 0)
-
-    @property
-    def percent_remaining(self) -> float:
-        if self.limit <= 0:
-            return 0.0
-        return 100.0 * self.remaining / self.limit
-
-
-@dataclass(frozen=True)
-class RateLimitSnapshot:
-    """One full ``/rate_limit`` response, parsed for the windows we display."""
-
-    rest: RateLimitWindow
-    graphql: RateLimitWindow
-    fetched_at: datetime
 
 
 class RateLimitMonitor:
@@ -80,15 +47,23 @@ class RateLimitMonitor:
     def __init__(self, gh: GitHub, state: AtomicReference[Any]) -> None:
         self._gh = gh
         self._state = state
+        # Seed the provider_limits map with a zero-value entry so the Lens
+        # path exists before the first refresh completes.
+        limits = self._state.get().provider_limits
+        if ProviderID.GITHUB not in limits:
+            zero = ProviderLimitSnapshot(provider=ProviderID.GITHUB)
+            self._state.update(
+                lambda root: root.provider_limits[ProviderID.GITHUB], zero
+            )
 
-    def latest(self) -> RateLimitSnapshot | None:
+    def latest(self) -> ProviderLimitSnapshot | None:
         """Lock-free read of the latest rate-limit snapshot, or ``None``
         before the first successful refresh."""
-        return self._state.get().rate_limit
+        return self._state.get().provider_limits.get(ProviderID.GITHUB)
 
-    def refresh(self) -> RateLimitSnapshot | None:
+    def refresh(self) -> ProviderLimitSnapshot | None:
         """Hit ``GET /rate_limit`` and publish the snapshot into
-        :class:`~fido.registry.FidoState` via CAS update.
+        :attr:`~fido.registry.FidoState.provider_limits` via CAS update.
 
         Returns the new snapshot on success, ``None`` on failure (the
         prior snapshot remains in the shared state).
@@ -98,18 +73,24 @@ class RateLimitMonitor:
         except Exception:
             log.exception("rate-limit monitor: refresh failed — keeping prior snapshot")
             return None
-        snapshot = RateLimitSnapshot(
-            rest=_parse_window("core", resources.get("core") or {}),
-            graphql=_parse_window("graphql", resources.get("graphql") or {}),
-            fetched_at=datetime.now(tz=timezone.utc),
+        snapshot = ProviderLimitSnapshot(
+            provider=ProviderID.GITHUB,
+            windows=(
+                _parse_window("rest", resources.get("core") or {}),
+                _parse_window("graphql", resources.get("graphql") or {}),
+            ),
         )
-        self._state.update(lambda root: root.rate_limit, snapshot)
+        self._state.update(
+            lambda root: root.provider_limits[ProviderID.GITHUB], snapshot
+        )
+        rest = snapshot.windows[0] if snapshot.windows else None
+        gql = snapshot.windows[1] if len(snapshot.windows) > 1 else None
         log.info(
-            "rate-limit: rest %d/%d, graphql %d/%d",
-            snapshot.rest.used,
-            snapshot.rest.limit,
-            snapshot.graphql.used,
-            snapshot.graphql.limit,
+            "rate-limit: rest %s/%s, graphql %s/%s",
+            rest.used if rest else "?",
+            rest.limit if rest else "?",
+            gql.used if gql else "?",
+            gql.limit if gql else "?",
         )
         return snapshot
 
@@ -132,8 +113,8 @@ class RateLimitMonitor:
         return t
 
 
-def _parse_window(name: str, raw: dict[str, Any]) -> RateLimitWindow:
-    """Convert one ``resources.<name>`` entry into a :class:`RateLimitWindow`.
+def _parse_window(name: str, raw: dict[str, Any]) -> ProviderLimitWindow:
+    """Convert one ``resources.<name>`` entry into a :class:`ProviderLimitWindow`.
 
     Defaults to ``0/0`` and the unix epoch when fields are missing — the
     poller never raises just because GitHub omitted a field; the caller
@@ -144,7 +125,7 @@ def _parse_window(name: str, raw: dict[str, Any]) -> RateLimitWindow:
         resets_at = datetime.fromtimestamp(int(reset_epoch), tz=timezone.utc)
     except TypeError, ValueError, OverflowError, OSError:
         resets_at = datetime.fromtimestamp(0, tz=timezone.utc)
-    return RateLimitWindow(
+    return ProviderLimitWindow(
         name=name,
         used=int(raw.get("used", 0)),
         limit=int(raw.get("limit", 0)),
@@ -154,6 +135,4 @@ def _parse_window(name: str, raw: dict[str, Any]) -> RateLimitWindow:
 
 __all__ = [
     "RateLimitMonitor",
-    "RateLimitSnapshot",
-    "RateLimitWindow",
 ]

--- a/src/fido/rate_limit.py
+++ b/src/fido/rate_limit.py
@@ -1,11 +1,12 @@
 """GitHub rate-limit monitor for ``fido status`` (closes #812 follow-up).
 
 Polls ``GET /rate_limit`` once per minute (per GitHub docs, this endpoint
-itself does not count against any quota), and publishes the latest snapshot
-into :attr:`~fido.registry.FidoState.provider_limits` under the
-``"github"`` key via a CAS update on the registry's
-:class:`~fido.atomic.AtomicReference`.  Reads are lock-free: callers read
-``provider_limits["github"]`` from the current :class:`~fido.registry.FidoState`.
+itself does not count against any quota), and publishes the latest
+:class:`GitHubLimit` snapshot into
+:attr:`~fido.registry.FidoState.github_limits` via a CAS update on the
+registry's :class:`~fido.atomic.AtomicUpdater`.  Reads are lock-free:
+callers read ``state.github_limits`` from the current
+:class:`~fido.registry.FidoState`.
 
 The poller thread treats fetch failures as soft errors — the previous
 snapshot stays put until the next successful refresh.
@@ -14,85 +15,92 @@ snapshot stays put until the next successful refresh.
 import logging
 import threading
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from fido.atomic import AtomicReference
+from fido.atomic import AtomicUpdater
 from fido.github import GitHub
-from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
+from fido.provider import ProviderLimitWindow
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
 _REFRESH_INTERVAL: float = 60.0
 
+_ZERO_WINDOW_REST = ProviderLimitWindow(name="rest")
+_ZERO_WINDOW_GRAPHQL = ProviderLimitWindow(name="graphql")
 
-class RateLimitMonitor:
-    """Lock-free holder for the latest ``GET /rate_limit`` snapshot.
 
-    Construct with a :class:`~fido.github.GitHub` client and the
-    :class:`~fido.atomic.AtomicReference` backing
-    :class:`~fido.registry.WorkerRegistry`'s
-    :class:`~fido.registry.FidoState` (constructor DI per CLAUDE.md).
-    Either call :meth:`refresh` directly or hand the monitor to
-    :meth:`start_thread` for the 60s poller.
+@dataclass(frozen=True)
+class GitHubLimit:
+    """Normalized GitHub platform rate-limit state (REST + GraphQL windows).
 
-    A failed refresh logs the exception and leaves the prior snapshot in
-    place — ``fido status`` keeps showing the last known good numbers
-    rather than blanking.
+    The zero value (``GitHubLimit()``) is the initial sentinel — both
+    windows have ``used=None``, meaning the monitor has not yet completed
+    a successful poll.  After the first successful :meth:`RateLimitMonitor.refresh`
+    the ``used`` fields will be integers (possibly ``0``).
 
-    Single writer: only the poller thread calls :meth:`refresh`.  Reads
-    are lock-free via :meth:`latest`.
+    Stored at :attr:`~fido.registry.FidoState.github_limits`; updated
+    atomically via :class:`~fido.atomic.AtomicUpdater`.
     """
 
-    def __init__(self, gh: GitHub, state: AtomicReference[Any]) -> None:
+    rest: ProviderLimitWindow = field(default_factory=lambda: _ZERO_WINDOW_REST)
+    graphql: ProviderLimitWindow = field(default_factory=lambda: _ZERO_WINDOW_GRAPHQL)
+
+
+class RateLimitMonitor:
+    """Polls ``GET /rate_limit`` and publishes into the registry snapshot.
+
+    Construct with a :class:`~fido.github.GitHub` client and an
+    :class:`~fido.atomic.AtomicUpdater` for the registry's
+    :class:`~fido.registry.FidoState` (constructor DI per CLAUDE.md).
+
+    This object is write-only relative to the snapshot — it holds an
+    :class:`~fido.atomic.AtomicUpdater`, not an
+    :class:`~fido.atomic.AtomicReader`.  Status display reads
+    ``registry.get_state().github_limits`` directly without going through
+    the monitor.
+
+    Either call :meth:`refresh` directly or hand the monitor to
+    :meth:`start_thread` for the 60 s poller.  A failed refresh logs the
+    exception and leaves the prior snapshot in place — ``fido status`` keeps
+    showing the last known good numbers rather than blanking.
+
+    Single writer: only the poller thread calls :meth:`refresh`.
+    """
+
+    def __init__(self, gh: GitHub, state: "AtomicUpdater[FidoState]") -> None:
         self._gh = gh
         self._state = state
-        # Seed the provider_limits map with a zero-value entry so the Lens
-        # path exists before the first refresh completes.
-        limits = self._state.get().provider_limits
-        if ProviderID.GITHUB not in limits:
-            zero = ProviderLimitSnapshot(provider=ProviderID.GITHUB)
-            self._state.update(
-                lambda root: root.provider_limits[ProviderID.GITHUB], zero
-            )
 
-    def latest(self) -> ProviderLimitSnapshot | None:
-        """Lock-free read of the latest rate-limit snapshot, or ``None``
-        before the first successful refresh."""
-        return self._state.get().provider_limits.get(ProviderID.GITHUB)
-
-    def refresh(self) -> ProviderLimitSnapshot | None:
+    def refresh(self) -> "GitHubLimit | None":
         """Hit ``GET /rate_limit`` and publish the snapshot into
-        :attr:`~fido.registry.FidoState.provider_limits` via CAS update.
+        :attr:`~fido.registry.FidoState.github_limits` via CAS update.
 
-        Returns the new snapshot on success, ``None`` on failure (the
-        prior snapshot remains in the shared state).
+        Returns the new :class:`GitHubLimit` on success, ``None`` on failure
+        (the prior snapshot remains in the shared state).
         """
         try:
             resources = self._gh.get_rate_limit()
         except Exception:
             log.exception("rate-limit monitor: refresh failed — keeping prior snapshot")
             return None
-        snapshot = ProviderLimitSnapshot(
-            provider=ProviderID.GITHUB,
-            windows=(
-                _parse_window("rest", resources.get("core") or {}),
-                _parse_window("graphql", resources.get("graphql") or {}),
-            ),
+        limits = GitHubLimit(
+            rest=_parse_window("rest", resources.get("core") or {}),
+            graphql=_parse_window("graphql", resources.get("graphql") or {}),
         )
-        self._state.update(
-            lambda root: root.provider_limits[ProviderID.GITHUB], snapshot
-        )
-        rest = snapshot.windows[0] if snapshot.windows else None
-        gql = snapshot.windows[1] if len(snapshot.windows) > 1 else None
+        self._state.update(lambda root: root.github_limits, limits)
         log.info(
             "rate-limit: rest %s/%s, graphql %s/%s",
-            rest.used if rest else "?",
-            rest.limit if rest else "?",
-            gql.used if gql else "?",
-            gql.limit if gql else "?",
+            limits.rest.used,
+            limits.rest.limit,
+            limits.graphql.used,
+            limits.graphql.limit,
         )
-        return snapshot
+        return limits
 
     def start_thread(self, *, _interval: float = _REFRESH_INTERVAL) -> threading.Thread:
         """Start a daemon thread that calls :meth:`refresh` every
@@ -133,6 +141,4 @@ def _parse_window(name: str, raw: dict[str, Any]) -> ProviderLimitWindow:
     )
 
 
-__all__ = [
-    "RateLimitMonitor",
-]
+__all__ = ["GitHubLimit", "RateLimitMonitor"]

--- a/src/fido/rate_limit.py
+++ b/src/fido/rate_limit.py
@@ -15,7 +15,7 @@ snapshot stays put until the next successful refresh.
 import logging
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -47,8 +47,8 @@ class GitHubLimit:
     atomically via :class:`~fido.atomic.AtomicUpdater`.
     """
 
-    rest: ProviderLimitWindow = field(default_factory=lambda: _ZERO_WINDOW_REST)
-    graphql: ProviderLimitWindow = field(default_factory=lambda: _ZERO_WINDOW_GRAPHQL)
+    rest: ProviderLimitWindow = _ZERO_WINDOW_REST
+    graphql: ProviderLimitWindow = _ZERO_WINDOW_GRAPHQL
 
 
 class RateLimitMonitor:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,25 +4,25 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReference
+from fido.atomic import AtomicReader, AtomicReference, AtomicUpdater
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
 from fido.provider import PromptSession, Provider
+from fido.rate_limit import GitHubLimit
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
 from fido.worker import WorkerThread
 
 if TYPE_CHECKING:
     from fido.events import Dispatcher
-    from fido.provider import ProviderLimitSnapshot
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +167,7 @@ class FidoState:
     """
 
     repos: frozendict[str, RepoState]
-    provider_limits: "frozendict[str, ProviderLimitSnapshot]" = frozendict()
+    github_limits: GitHubLimit = field(default_factory=GitHubLimit)
 
 
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())
@@ -419,15 +419,24 @@ class WorkerRegistry:
         """Return the current FidoState snapshot.  Lock-free."""
         return self._state.get()
 
-    def get_state_ref(self) -> AtomicReference[FidoState]:
-        """Return the raw :class:`~fido.atomic.AtomicReference` backing
-        :attr:`_state`.
+    def get_state_reader(self) -> "AtomicReader[FidoState]":
+        """Return a read-only view of the :class:`FidoState` snapshot.
 
-        Used by collaborators that are the single writer for a top-level
-        field and need to publish directly into the snapshot via CAS update
-        (e.g. :class:`~fido.rate_limit.RateLimitMonitor`).  Callers must
-        only update fields they own — writing to another collaborator's field
-        creates a silent ownership conflict.
+        Pass to collaborators that only need to observe the latest state.
+        Holding both a reader and an updater in one collaborator is a code
+        smell — it usually means logic that belongs in the owner.
+        """
+        return self._state
+
+    def get_state_updater(self) -> "AtomicUpdater[FidoState]":
+        """Return a write-only view for single-field writers.
+
+        Pass to collaborators that publish into a single top-level field
+        they own (e.g. :class:`~fido.rate_limit.RateLimitMonitor` owns
+        ``github_limits``).  Callers must only update fields they own —
+        writing to another collaborator's field creates a silent ownership
+        conflict.  Holding both reader and updater in one collaborator is
+        a code smell.
         """
         return self._state
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReader, AtomicReference, AtomicUpdater
+from fido.atomic import AtomicReader, AtomicUpdater, create_atomic
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
@@ -210,10 +210,13 @@ class WorkerRegistry:
         self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._status_lock = threading.Lock()
-        # _state holds the atomically-swapped FidoState snapshot.  Writers
-        # call AtomicReference.update(selector, value) to install a value at a
-        # path via CAS; readers call .get() without any lock (lock-free).
-        self._state: AtomicReference[FidoState] = AtomicReference(_EMPTY_FIDO_STATE)
+        # _state_reader / _state_updater are the two narrow faces of the
+        # atomic FidoState cell.  Writers call _state_updater.update(selector,
+        # value) to CAS-install a value at a Lens path; readers call
+        # _state_reader.get() without any lock (lock-free).
+        self._state_reader: AtomicReader[FidoState]
+        self._state_updater: AtomicUpdater[FidoState]
+        self._state_reader, self._state_updater = create_atomic(_EMPTY_FIDO_STATE)
         # Owner-side crash records: the watchdog increments death_count here,
         # then publishes the result into FidoState via a pure lens write.
         # Only the watchdog thread writes; start() reads during crash recovery
@@ -349,7 +352,7 @@ class WorkerRegistry:
             crash_record=crash_record,
             webhook_activities=(),
         )
-        self._state.update(lambda root: root.repos[_name], new_repo)
+        self._state_updater.update(lambda root: root.repos[_name], new_repo)
         thread.start()
         log.info("started WorkerThread for %s", repo_cfg.name)
 
@@ -404,7 +407,7 @@ class WorkerRegistry:
             repo_name=repo_name, what=what, busy=busy, last_progress_at=_now()
         )
         _name = repo_name
-        self._state.update(lambda root: root.repos[_name].activity, activity)
+        self._state_updater.update(lambda root: root.repos[_name].activity, activity)
 
     def get_all_activities(self) -> list[WorkerActivity]:
         """Return a snapshot of all registered workers' current activities.
@@ -412,12 +415,12 @@ class WorkerRegistry:
         Lock-free: reads from the current :class:`FidoState` snapshot.
         Excludes repos whose activity is still the zero sentinel (``what=""``).
         """
-        repos = self._state.get().repos
+        repos = self._state_reader.get().repos
         return [rs.activity for rs in repos.values() if rs.activity.what != ""]
 
     def get_state(self) -> FidoState:
         """Return the current FidoState snapshot.  Lock-free."""
-        return self._state.get()
+        return self._state_reader.get()
 
     def get_state_reader(self) -> "AtomicReader[FidoState]":
         """Return a read-only view of the :class:`FidoState` snapshot.
@@ -426,7 +429,7 @@ class WorkerRegistry:
         Holding both a reader and an updater in one collaborator is a code
         smell — it usually means logic that belongs in the owner.
         """
-        return self._state
+        return self._state_reader
 
     def get_state_updater(self) -> "AtomicUpdater[FidoState]":
         """Return a write-only view for single-field writers.
@@ -438,7 +441,7 @@ class WorkerRegistry:
         conflict.  Holding both reader and updater in one collaborator is
         a code smell.
         """
-        return self._state
+        return self._state_updater
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.
@@ -458,7 +461,9 @@ class WorkerRegistry:
         )
         self._crash_records[repo_name] = new_crash
         _name = repo_name
-        self._state.update(lambda root: root.repos[_name].crash_record, new_crash)
+        self._state_updater.update(
+            lambda root: root.repos[_name].crash_record, new_crash
+        )
 
     def _publish_webhook_activities(self, repo_name: str) -> None:
         """Publish the webhook-activity tuple for *repo_name* to :class:`FidoState`.
@@ -472,7 +477,9 @@ class WorkerRegistry:
         """
         acts = tuple(self._webhook_activities.get(repo_name, []))
         _name = repo_name
-        self._state.update(lambda root: root.repos[_name].webhook_activities, acts)
+        self._state_updater.update(
+            lambda root: root.repos[_name].webhook_activities, acts
+        )
 
     @contextmanager
     def webhook_activity(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -22,6 +22,7 @@ from fido.worker import WorkerThread
 
 if TYPE_CHECKING:
     from fido.events import Dispatcher
+    from fido.rate_limit import RateLimitSnapshot
 
 log = logging.getLogger(__name__)
 
@@ -166,6 +167,7 @@ class FidoState:
     """
 
     repos: frozendict[str, RepoState]
+    rate_limit: "RateLimitSnapshot | None" = None
 
 
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())
@@ -416,6 +418,18 @@ class WorkerRegistry:
     def get_state(self) -> FidoState:
         """Return the current FidoState snapshot.  Lock-free."""
         return self._state.get()
+
+    def get_state_ref(self) -> AtomicReference[FidoState]:
+        """Return the raw :class:`~fido.atomic.AtomicReference` backing
+        :attr:`_state`.
+
+        Used by collaborators that are the single writer for a top-level
+        field and need to publish directly into the snapshot via CAS update
+        (e.g. :class:`~fido.rate_limit.RateLimitMonitor`).  Callers must
+        only update fields they own — writing to another collaborator's field
+        creates a silent ownership conflict.
+        """
+        return self._state
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -175,10 +175,10 @@ class FidoState:
     """
 
     repos: frozendict[str, RepoState]
-    github_limits: GitHubLimit = field(default_factory=GitHubLimit)
+    github_limits: GitHubLimit
 
 
-_EMPTY_FIDO_STATE = FidoState(repos=frozendict())
+_EMPTY_FIDO_STATE = FidoState(repos=frozendict(), github_limits=GitHubLimit())
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -22,7 +22,7 @@ from fido.worker import WorkerThread
 
 if TYPE_CHECKING:
     from fido.events import Dispatcher
-    from fido.rate_limit import RateLimitSnapshot
+    from fido.provider import ProviderLimitSnapshot
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +167,7 @@ class FidoState:
     """
 
     repos: frozendict[str, RepoState]
-    rate_limit: "RateLimitSnapshot | None" = None
+    provider_limits: "frozendict[str, ProviderLimitSnapshot]" = frozendict()
 
 
 _EMPTY_FIDO_STATE = FidoState(repos=frozendict())

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -11,7 +11,8 @@ from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReader, AtomicUpdater, create_atomic
+from fido.atomic import AtomicReader, AtomicUpdater
+from fido.atomic import create_atomic as _create_atomic
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
@@ -144,12 +145,19 @@ class RepoState:
 
 @dataclass(frozen=True, slots=True)
 class FidoState:
-    """Atomically-swapped coordination snapshot owned by :class:`WorkerRegistry`.
+    """Atomically-swapped coordination snapshot.
 
     ``repos`` maps each repo slug to its :class:`RepoState` snapshot.  It is
     a :class:`frozendict` so stale readers that hold a reference to an old
     snapshot can never accidentally mutate the mapping — the immutability
     guarantee holds even on the free-threaded (no-GIL) build.
+
+    The atomic cell is owned by the composition root (``run()`` in
+    ``server.py``), not by :class:`WorkerRegistry`.  The root creates both
+    faces via :func:`~fido.atomic.create_atomic`, passes the
+    :class:`~fido.atomic.AtomicUpdater` to ``WorkerRegistry`` and
+    :class:`~fido.rate_limit.RateLimitMonitor`, and passes the
+    :class:`~fido.atomic.AtomicReader` to the status serialisation path.
 
     **Convergence target**: ``FidoState`` is intended to grow to cover all
     coordination fields currently scattered across the per-lock dicts in
@@ -194,15 +202,26 @@ class WorkerRegistry:
     Threads are created via the injected *thread_factory* so tests can
     supply mock threads without patching module-level names.
 
+    Write-only relative to :class:`FidoState` — the registry holds only the
+    :class:`~fido.atomic.AtomicUpdater` face of the atomic cell.  The
+    :class:`~fido.atomic.AtomicReader` face lives in the composition root and
+    is passed directly to the status serialisation path so only the one
+    collaborator that actually reads holds the read face.
+
     Usage::
 
-        registry = WorkerRegistry(my_factory)
+        state_reader, state_updater = create_fido_atomic()
+        registry = WorkerRegistry(my_factory, state_updater)
         registry.start(repo_cfg)   # create + start thread
         registry.wake("owner/repo")  # nudge thread to check for work
         registry.stop_all()          # clean shutdown
     """
 
-    def __init__(self, thread_factory: Callable[..., WorkerThread]) -> None:
+    def __init__(
+        self,
+        thread_factory: Callable[..., WorkerThread],
+        state_updater: "AtomicUpdater[FidoState]",
+    ) -> None:
         self._threads: dict[str, WorkerThread] = {}
         # _threads_lock guards _threads: written by start() on the watchdog
         # thread, read from HTTP handler threads (wake, abort_task, get_session,
@@ -210,13 +229,11 @@ class WorkerRegistry:
         self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._status_lock = threading.Lock()
-        # _state_reader / _state_updater are the two narrow faces of the
-        # atomic FidoState cell.  Writers call _state_updater.update(selector,
-        # value) to CAS-install a value at a Lens path; readers call
-        # _state_reader.get() without any lock (lock-free).
-        self._state_reader: AtomicReader[FidoState]
-        self._state_updater: AtomicUpdater[FidoState]
-        self._state_reader, self._state_updater = create_atomic(_EMPTY_FIDO_STATE)
+        # _state_updater is the write-only face of the atomic FidoState cell.
+        # Writers call _state_updater.update(selector, value) to CAS-install a
+        # value at a Lens path.  The read face (AtomicReader) lives in the
+        # composition root; this class never reads the snapshot.
+        self._state_updater: AtomicUpdater[FidoState] = state_updater
         # Owner-side crash records: the watchdog increments death_count here,
         # then publishes the result into FidoState via a pure lens write.
         # Only the watchdog thread writes; start() reads during crash recovery
@@ -408,40 +425,6 @@ class WorkerRegistry:
         )
         _name = repo_name
         self._state_updater.update(lambda root: root.repos[_name].activity, activity)
-
-    def get_all_activities(self) -> list[WorkerActivity]:
-        """Return a snapshot of all registered workers' current activities.
-
-        Lock-free: reads from the current :class:`FidoState` snapshot.
-        Excludes repos whose activity is still the zero sentinel (``what=""``).
-        """
-        repos = self._state_reader.get().repos
-        return [rs.activity for rs in repos.values() if rs.activity.what != ""]
-
-    def get_state(self) -> FidoState:
-        """Return the current FidoState snapshot.  Lock-free."""
-        return self._state_reader.get()
-
-    def get_state_reader(self) -> "AtomicReader[FidoState]":
-        """Return a read-only view of the :class:`FidoState` snapshot.
-
-        Pass to collaborators that only need to observe the latest state.
-        Holding both a reader and an updater in one collaborator is a code
-        smell — it usually means logic that belongs in the owner.
-        """
-        return self._state_reader
-
-    def get_state_updater(self) -> "AtomicUpdater[FidoState]":
-        """Return a write-only view for single-field writers.
-
-        Pass to collaborators that publish into a single top-level field
-        they own (e.g. :class:`~fido.rate_limit.RateLimitMonitor` owns
-        ``github_limits``).  Callers must only update fields they own —
-        writing to another collaborator's field creates a silent ownership
-        conflict.  Holding both reader and updater in one collaborator is
-        a code smell.
-        """
-        return self._state_updater
 
     def record_crash(self, repo_name: str, error: str) -> None:
         """Record an unexpected worker death for *repo_name*.
@@ -907,6 +890,34 @@ class WorkerRegistry:
             return list(self._issue_caches.values())
 
 
+def get_all_activities(reader: "AtomicReader[FidoState]") -> list[WorkerActivity]:
+    """Return a snapshot of all registered workers' current activities.
+
+    Lock-free: reads from the current :class:`FidoState` snapshot via *reader*.
+    Excludes repos whose activity is still the zero sentinel (``what=""``).
+
+    Accepts the :class:`~fido.atomic.AtomicReader` face directly so that the
+    caller (the composition root) remains the sole holder of the read face —
+    :class:`WorkerRegistry` is write-only and is never passed here.
+    """
+    repos = reader.get().repos
+    return [rs.activity for rs in repos.values() if rs.activity.what != ""]
+
+
+def create_fido_atomic() -> tuple[
+    "AtomicReader[FidoState]", "AtomicUpdater[FidoState]"
+]:
+    """Create the atomic cell for :class:`FidoState` and return both faces.
+
+    Thin wrapper around :func:`~fido.atomic.create_atomic` with the correct
+    initial value.  Call this once at the composition root (``run()``), pass
+    the updater to :class:`WorkerRegistry` and
+    :class:`~fido.rate_limit.RateLimitMonitor`, and keep the reader in the
+    composition root for the status serialisation path.
+    """
+    return _create_atomic(_EMPTY_FIDO_STATE)
+
+
 def _make_thread(
     repo_cfg: RepoConfig,
     registry: WorkerRegistry,
@@ -945,12 +956,15 @@ def make_registry(
     config: Config | None = None,
     *,
     dispatchers: "dict[str, Dispatcher]",
+    state_updater: "AtomicUpdater[FidoState]",
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
     """Create a :class:`WorkerRegistry` and start threads for all repos.
 
     Uses :func:`_make_thread` as the factory; all threads share the provided
-    :class:`~fido.github.GitHub` client.  Pass a custom registry directly
+    :class:`~fido.github.GitHub` client.  The caller (composition root) is
+    responsible for creating the atomic cell via :func:`create_fido_atomic`
+    and passing the updater face here.  Pass a custom registry directly
     (with a mock factory) in tests instead of calling this.
     """
 
@@ -970,7 +984,7 @@ def make_registry(
             dispatchers=dispatchers,
         )
 
-    registry = WorkerRegistry(factory)
+    registry = WorkerRegistry(factory, state_updater)
     for repo_cfg in repos.values():
         registry.start(repo_cfg)
     return registry

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReader, AtomicUpdater
+from fido.atomic import AtomicUpdater
 from fido.atomic import create_atomic as _create_atomic
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
@@ -23,6 +23,7 @@ from fido.rocq import worker_registry_crash as registry_fsm
 from fido.worker import WorkerThread
 
 if TYPE_CHECKING:
+    from fido.atomic import AtomicReader
     from fido.events import Dispatcher
 
 log = logging.getLogger(__name__)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -890,20 +890,6 @@ class WorkerRegistry:
             return list(self._issue_caches.values())
 
 
-def get_all_activities(reader: "AtomicReader[FidoState]") -> list[WorkerActivity]:
-    """Return a snapshot of all registered workers' current activities.
-
-    Lock-free: reads from the current :class:`FidoState` snapshot via *reader*.
-    Excludes repos whose activity is still the zero sentinel (``what=""``).
-
-    Accepts the :class:`~fido.atomic.AtomicReader` face directly so that the
-    caller (the composition root) remains the sole holder of the read face —
-    :class:`WorkerRegistry` is write-only and is never passed here.
-    """
-    repos = reader.get().repos
-    return [rs.activity for rs in repos.values() if rs.activity.what != ""]
-
-
 def create_fido_atomic() -> tuple[
     "AtomicReader[FidoState]", "AtomicUpdater[FidoState]"
 ]:

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -22,6 +22,7 @@ from xml.etree.ElementTree import Element, SubElement, register_namespace, tostr
 import requests
 
 from fido import provider
+from fido.atomic import AtomicReader, AtomicUpdater
 from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.events import (
@@ -48,7 +49,13 @@ from fido.infra import (
 from fido.provider import ProviderLimitWindow
 from fido.provider_factory import DefaultProviderFactory
 from fido.rate_limit import GitHubLimit, RateLimitMonitor
-from fido.registry import WebhookActivityHandle, WorkerRegistry, make_registry
+from fido.registry import (
+    FidoState,
+    WebhookActivityHandle,
+    WorkerRegistry,
+    create_fido_atomic,
+    make_registry,
+)
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
 from fido.state import State
@@ -610,6 +617,9 @@ def _noop_after_post() -> None:
 class WebhookHandler(BaseHTTPRequestHandler):
     config: Config
     registry: WorkerRegistry
+    # Read face of the FidoState atomic cell — set by run() alongside
+    # registry.  Status serialisation reads from here; registry only writes.
+    state_reader: AtomicReader[FidoState]
     provider_factory: DefaultProviderFactory | None = None
     # Set by run() to record when the server came up, used for fido uptime.
     fido_started_at: datetime | None = None
@@ -1259,9 +1269,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         fido_uptime = (now - started).total_seconds() if started is not None else None
         return {
             "activities": self._collect_activities(),
-            "rate_limit": _serialize_rate_limit(
-                self.registry.get_state().github_limits
-            ),
+            "rate_limit": _serialize_rate_limit(self.state_reader.get().github_limits),
             "fido_uptime_seconds": fido_uptime,
         }
 
@@ -1273,7 +1281,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             list(self.config.repos.values()),
             _provider_factory=self.provider_factory,
         )
-        snapshot = self.registry.get_state()
+        snapshot = self.state_reader.get()
         for repo_state in snapshot.repos.values():
             a = repo_state.activity
             if a.what == "":
@@ -1481,6 +1489,9 @@ def run(
     _preflight_gh_auth: Callable[..., None] = preflight_gh_auth,
     _GitHub: type[GitHub] = GitHub,
     _bootstrap_issue_caches: Callable[..., None] = bootstrap_issue_caches,
+    _create_fido_atomic: Callable[
+        [], tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]
+    ] = create_fido_atomic,
 ) -> None:
     config = _from_args()
 
@@ -1543,8 +1554,17 @@ def run(
     WebhookHandler.provider_factory = DefaultProviderFactory(
         session_system_file=config.sub_dir / "persona.md"
     )
-    registry = _make_registry(config.repos, gh, config, dispatchers=dispatchers)
+    # Create the atomic FidoState cell here (composition root) and hand the
+    # two faces to their respective owners: the updater goes to the registry
+    # (write-only) and to the rate-limit monitor; the reader stays here and
+    # is placed on WebhookHandler so the status serialisation path can read
+    # without going through the registry at all.
+    state_reader, state_updater = _create_fido_atomic()
+    registry = _make_registry(
+        config.repos, gh, config, dispatchers=dispatchers, state_updater=state_updater
+    )
     WebhookHandler.registry = registry
+    WebhookHandler.state_reader = state_reader
     # Bootstrap issue caches eagerly so the picker has populated data immediately —
     # even for repos whose worker resumes on an existing issue and never calls
     # find_next_issue during this run (closes #837).
@@ -1559,7 +1579,7 @@ def run(
     # ``consume_until_result`` on a streaming-forever subprocess holds
     # the lock indefinitely (closes #1377).
     _SessionLockWatchdog(registry, config.repos).start_thread()
-    _RateLimitMonitor(gh, registry.get_state_updater()).start_thread()
+    _RateLimitMonitor(gh, state_updater).start_thread()
     WebhookHandler.fido_started_at = datetime.now(tz=timezone.utc)
 
     server = _HTTPServer(("", config.port), WebhookHandler)

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -45,8 +45,9 @@ from fido.infra import (
     ProcessRunner,
     real_infra,
 )
+from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
 from fido.provider_factory import DefaultProviderFactory
-from fido.rate_limit import RateLimitMonitor, RateLimitSnapshot, RateLimitWindow
+from fido.rate_limit import RateLimitMonitor
 from fido.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
@@ -193,14 +194,10 @@ def _activities_to_xml(payload: dict[str, Any]) -> bytes:
     if rate_limit is not None:
         rl_el = SubElement(root, f"{{{_NS_FIDO}}}rate_limit")
         for rl_key, rl_val in rate_limit.items():
-            if isinstance(rl_val, dict):
-                child_el = SubElement(rl_el, f"{{{_NS_FIDO}}}{rl_key}")
-                for k, v in rl_val.items():
-                    sub_el = SubElement(child_el, f"{{{_NS_FIDO}}}{k}")
-                    sub_el.text = _xml_text(v)
-            else:
-                child_el = SubElement(rl_el, f"{{{_NS_FIDO}}}{rl_key}")
-                child_el.text = _xml_text(rl_val)
+            child_el = SubElement(rl_el, f"{{{_NS_FIDO}}}{rl_key}")
+            for k, v in rl_val.items():
+                sub_el = SubElement(child_el, f"{{{_NS_FIDO}}}{k}")
+                sub_el.text = _xml_text(v)
 
     for act in payload.get("activities", []):
         repo = SubElement(root, f"{{{_NS_FIDO}}}repo")
@@ -276,30 +273,32 @@ def _serialize_provider_status(
     }
 
 
-def _serialize_rate_limit(snap: RateLimitSnapshot | None) -> dict[str, Any] | None:
-    """Serialize a :class:`~fido.rate_limit.RateLimitSnapshot` for the
-    ``/status.json`` payload.
+def _serialize_rate_limit(snap: ProviderLimitSnapshot | None) -> dict[str, Any] | None:
+    """Serialize the GitHub :class:`~fido.provider.ProviderLimitSnapshot` for
+    the ``/status.json`` payload.
 
     Returns ``None`` when *snap* is ``None`` — i.e. before the rate-limit
     monitor has completed its first successful poll.  The snapshot is read
-    directly from :attr:`~fido.registry.FidoState.rate_limit` on the
+    directly from :attr:`~fido.registry.FidoState.provider_limits` on the
     registry's atomically-swapped state, so no separate lock is needed.
     """
     if snap is None:
         return None
+    windows_by_name = {w.name: w for w in snap.windows}
     return {
-        "rest": _serialize_rate_window(snap.rest),
-        "graphql": _serialize_rate_window(snap.graphql),
-        "fetched_at": snap.fetched_at.isoformat(),
+        "rest": _serialize_rate_window(windows_by_name.get("rest")),
+        "graphql": _serialize_rate_window(windows_by_name.get("graphql")),
     }
 
 
-def _serialize_rate_window(window: RateLimitWindow) -> dict[str, Any]:
+def _serialize_rate_window(window: ProviderLimitWindow | None) -> dict[str, Any]:
+    if window is None:
+        return {"name": "unknown", "used": 0, "limit": 0, "resets_at": None}
     return {
         "name": window.name,
         "used": window.used,
         "limit": window.limit,
-        "resets_at": window.resets_at.isoformat(),
+        "resets_at": window.resets_at.isoformat() if window.resets_at else None,
     }
 
 
@@ -1262,7 +1261,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
         fido_uptime = (now - started).total_seconds() if started is not None else None
         return {
             "activities": self._collect_activities(),
-            "rate_limit": _serialize_rate_limit(self.registry.get_state().rate_limit),
+            "rate_limit": _serialize_rate_limit(
+                self.registry.get_state().provider_limits.get(ProviderID.GITHUB)
+            ),
             "fido_uptime_seconds": fido_uptime,
         }
 

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1564,7 +1564,7 @@ def run(
     # ``consume_until_result`` on a streaming-forever subprocess holds
     # the lock indefinitely (closes #1377).
     _SessionLockWatchdog(registry, config.repos).start_thread()
-    rate_limit_monitor = _RateLimitMonitor(gh)
+    rate_limit_monitor = _RateLimitMonitor(gh, registry.get_state_ref())
     rate_limit_monitor.start_thread()
     WebhookHandler.rate_limit_monitor = rate_limit_monitor
     WebhookHandler.fido_started_at = datetime.now(tz=timezone.utc)

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -46,7 +46,7 @@ from fido.infra import (
     real_infra,
 )
 from fido.provider_factory import DefaultProviderFactory
-from fido.rate_limit import RateLimitMonitor, RateLimitWindow
+from fido.rate_limit import RateLimitMonitor, RateLimitSnapshot, RateLimitWindow
 from fido.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
@@ -276,18 +276,15 @@ def _serialize_provider_status(
     }
 
 
-def _serialize_rate_limit(monitor: object) -> dict[str, Any] | None:
-    """Serialize the latest :class:`~fido.rate_limit.RateLimitSnapshot`
-    for the ``/status.json`` payload (closes #812 follow-up).
+def _serialize_rate_limit(snap: RateLimitSnapshot | None) -> dict[str, Any] | None:
+    """Serialize a :class:`~fido.rate_limit.RateLimitSnapshot` for the
+    ``/status.json`` payload.
 
-    Returns ``None`` when *monitor* is missing (tests with a MagicMock
-    registry omit it) or hasn't yet completed its first refresh.
+    Returns ``None`` when *snap* is ``None`` — i.e. before the rate-limit
+    monitor has completed its first successful poll.  The snapshot is read
+    directly from :attr:`~fido.registry.FidoState.rate_limit` on the
+    registry's atomically-swapped state, so no separate lock is needed.
     """
-    from fido.rate_limit import RateLimitMonitor
-
-    if not isinstance(monitor, RateLimitMonitor):
-        return None
-    snap = monitor.latest()
     if snap is None:
         return None
     return {
@@ -617,7 +614,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
     config: Config
     registry: WorkerRegistry
     provider_factory: DefaultProviderFactory | None = None
-    rate_limit_monitor: Any = None
     # Set by run() to record when the server came up, used for fido uptime.
     fido_started_at: datetime | None = None
     # Injectable collaborators — set as class attributes so HTTP-driven tests
@@ -1266,7 +1262,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         fido_uptime = (now - started).total_seconds() if started is not None else None
         return {
             "activities": self._collect_activities(),
-            "rate_limit": _serialize_rate_limit(self.rate_limit_monitor),
+            "rate_limit": _serialize_rate_limit(self.registry.get_state().rate_limit),
             "fido_uptime_seconds": fido_uptime,
         }
 
@@ -1564,9 +1560,7 @@ def run(
     # ``consume_until_result`` on a streaming-forever subprocess holds
     # the lock indefinitely (closes #1377).
     _SessionLockWatchdog(registry, config.repos).start_thread()
-    rate_limit_monitor = _RateLimitMonitor(gh, registry.get_state_ref())
-    rate_limit_monitor.start_thread()
-    WebhookHandler.rate_limit_monitor = rate_limit_monitor
+    _RateLimitMonitor(gh, registry.get_state_ref()).start_thread()
     WebhookHandler.fido_started_at = datetime.now(tz=timezone.utc)
 
     server = _HTTPServer(("", config.port), WebhookHandler)

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -45,9 +45,9 @@ from fido.infra import (
     ProcessRunner,
     real_infra,
 )
-from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
+from fido.provider import ProviderLimitWindow
 from fido.provider_factory import DefaultProviderFactory
-from fido.rate_limit import RateLimitMonitor
+from fido.rate_limit import GitHubLimit, RateLimitMonitor
 from fido.registry import WebhookActivityHandle, WorkerRegistry, make_registry
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
@@ -273,27 +273,25 @@ def _serialize_provider_status(
     }
 
 
-def _serialize_rate_limit(snap: ProviderLimitSnapshot | None) -> dict[str, Any] | None:
-    """Serialize the GitHub :class:`~fido.provider.ProviderLimitSnapshot` for
-    the ``/status.json`` payload.
+def _serialize_rate_limit(limits: GitHubLimit) -> dict[str, Any] | None:
+    """Serialize :class:`~fido.rate_limit.GitHubLimit` for the ``/status.json``
+    payload.
 
-    Returns ``None`` when *snap* is ``None`` — i.e. before the rate-limit
-    monitor has completed its first successful poll.  The snapshot is read
-    directly from :attr:`~fido.registry.FidoState.provider_limits` on the
-    registry's atomically-swapped state, so no separate lock is needed.
+    Returns ``None`` when *limits* is the zero-value sentinel — both windows
+    have ``used=None``, meaning the monitor has not yet completed its first
+    successful poll.  The value is read lock-free from
+    :attr:`~fido.registry.FidoState.github_limits` on the registry's
+    atomically-swapped state.
     """
-    if snap is None:
+    if limits.rest.used is None and limits.graphql.used is None:
         return None
-    windows_by_name = {w.name: w for w in snap.windows}
     return {
-        "rest": _serialize_rate_window(windows_by_name.get("rest")),
-        "graphql": _serialize_rate_window(windows_by_name.get("graphql")),
+        "rest": _serialize_rate_window(limits.rest),
+        "graphql": _serialize_rate_window(limits.graphql),
     }
 
 
-def _serialize_rate_window(window: ProviderLimitWindow | None) -> dict[str, Any]:
-    if window is None:
-        return {"name": "unknown", "used": 0, "limit": 0, "resets_at": None}
+def _serialize_rate_window(window: ProviderLimitWindow) -> dict[str, Any]:
     return {
         "name": window.name,
         "used": window.used,
@@ -1262,7 +1260,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         return {
             "activities": self._collect_activities(),
             "rate_limit": _serialize_rate_limit(
-                self.registry.get_state().provider_limits.get(ProviderID.GITHUB)
+                self.registry.get_state().github_limits
             ),
             "fido_uptime_seconds": fido_uptime,
         }
@@ -1561,7 +1559,7 @@ def run(
     # ``consume_until_result`` on a streaming-forever subprocess holds
     # the lock indefinitely (closes #1377).
     _SessionLockWatchdog(registry, config.repos).start_thread()
-    _RateLimitMonitor(gh, registry.get_state_ref()).start_thread()
+    _RateLimitMonitor(gh, registry.get_state_updater()).start_thread()
     WebhookHandler.fido_started_at = datetime.now(tz=timezone.utc)
 
     server = _HTTPServer(("", config.port), WebhookHandler)

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -83,7 +83,6 @@ class RateLimitInfo:
 
     rest: RateLimitWindowInfo
     graphql: RateLimitWindowInfo
-    fetched_at: datetime
 
 
 @dataclass
@@ -500,15 +499,11 @@ def _parse_rate_limit(raw: object) -> RateLimitInfo | None:
         return None
     rest_raw = raw.get("rest")
     graphql_raw = raw.get("graphql")
-    fetched_at = _parse_iso_datetime(raw.get("fetched_at"))
     if not isinstance(rest_raw, dict) or not isinstance(graphql_raw, dict):
-        return None
-    if fetched_at is None:
         return None
     return RateLimitInfo(
         rest=_parse_rate_window(rest_raw),
         graphql=_parse_rate_window(graphql_raw),
-        fetched_at=fetched_at,
     )
 
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 import requests as _requests
 
 from fido import hooks, tasks
+from fido.atomic import AtomicReader
 from fido.claude import ClaudeCode
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
@@ -216,8 +217,6 @@ class ActivityReporter(Protocol):
     """
 
     def report_activity(self, repo_name: str, what: str, busy: bool) -> None: ...
-
-    def get_all_activities(self) -> list[Any]: ...
 
     def status_update(self) -> AbstractContextManager[None]: ...
 
@@ -1218,6 +1217,7 @@ class Worker:
         provider_factory: DefaultProviderFactory | None = None,
         first_iteration: bool = False,
         nudges: Nudges | None = None,
+        state_reader: "AtomicReader[Any] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -1236,6 +1236,7 @@ class Worker:
         # iteration; webhook events keep the cache in sync.
         self._issue_cache = issue_cache
         self._registry = registry
+        self._state_reader: AtomicReader[Any] | None = state_reader
         self._membership = membership if membership is not None else RepoMembership()
         self._session_issue: int | None = session_issue
         self._next_turn_session_mode = TurnSessionMode.REUSE
@@ -1452,10 +1453,15 @@ class Worker:
         with ctx:
             if self._registry is not None:
                 self._registry.report_activity(self._repo_name, what, busy)
-                activities = [
-                    (a.repo_name, a.what, a.busy)
-                    for a in self._registry.get_all_activities()
-                ]
+                if self._state_reader is not None:
+                    repos = self._state_reader.get().repos
+                    activities = [
+                        (rs.activity.repo_name, rs.activity.what, rs.activity.busy)
+                        for rs in repos.values()
+                        if rs.activity.what != ""
+                    ]
+                else:
+                    activities = [(self._repo_name, what, busy)]
             else:
                 activities = [(self.work_dir.name, what, busy)]
 
@@ -4209,6 +4215,7 @@ class WorkerThread(threading.Thread):
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
+        state_reader: "AtomicReader[Any] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -4218,6 +4225,7 @@ class WorkerThread(threading.Thread):
         self._repo_name = repo_name
         self._gh = gh
         self._registry = registry
+        self._state_reader: AtomicReader[Any] | None = state_reader
         self._membership = membership if membership is not None else RepoMembership()
         self._wake = threading.Event()
         self._abort_task = AbortHandle()
@@ -4535,8 +4543,9 @@ class WorkerThread(threading.Thread):
                     config=self._config,
                     repo_cfg=self._repo_cfg,
                     provider_factory=self._provider_factory,
-                    dispatcher=self._dispatcher,
                     first_iteration=self._is_first_iteration,
+                    state_reader=self._state_reader,
+                    dispatcher=self._dispatcher,
                     issue_cache=self._issue_cache,
                 )
                 worker._provider = provider  # pyright: ignore[reportPrivateUsage]

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 import requests as _requests
 
 from fido import hooks, tasks
-from fido.atomic import AtomicReader
 from fido.claude import ClaudeCode
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
@@ -1217,7 +1216,6 @@ class Worker:
         provider_factory: DefaultProviderFactory | None = None,
         first_iteration: bool = False,
         nudges: Nudges | None = None,
-        state_reader: "AtomicReader[Any] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -1236,7 +1234,6 @@ class Worker:
         # iteration; webhook events keep the cache in sync.
         self._issue_cache = issue_cache
         self._registry = registry
-        self._state_reader: AtomicReader[Any] | None = state_reader
         self._membership = membership if membership is not None else RepoMembership()
         self._session_issue: int | None = session_issue
         self._next_turn_session_mode = TurnSessionMode.REUSE
@@ -1453,15 +1450,7 @@ class Worker:
         with ctx:
             if self._registry is not None:
                 self._registry.report_activity(self._repo_name, what, busy)
-                if self._state_reader is not None:
-                    repos = self._state_reader.get().repos
-                    activities = [
-                        (rs.activity.repo_name, rs.activity.what, rs.activity.busy)
-                        for rs in repos.values()
-                        if rs.activity.what != ""
-                    ]
-                else:
-                    activities = [(self._repo_name, what, busy)]
+                activities = [(self._repo_name, what, busy)]
             else:
                 activities = [(self.work_dir.name, what, busy)]
 
@@ -4215,7 +4204,6 @@ class WorkerThread(threading.Thread):
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
-        state_reader: "AtomicReader[Any] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -4225,7 +4213,6 @@ class WorkerThread(threading.Thread):
         self._repo_name = repo_name
         self._gh = gh
         self._registry = registry
-        self._state_reader: AtomicReader[Any] | None = state_reader
         self._membership = membership if membership is not None else RepoMembership()
         self._wake = threading.Event()
         self._abort_task = AbortHandle()
@@ -4544,7 +4531,6 @@ class WorkerThread(threading.Thread):
                     repo_cfg=self._repo_cfg,
                     provider_factory=self._provider_factory,
                     first_iteration=self._is_first_iteration,
-                    state_reader=self._state_reader,
                     dispatcher=self._dispatcher,
                     issue_cache=self._issue_cache,
                 )

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -5,13 +5,26 @@ from dataclasses import dataclass
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReference
+from fido.atomic import AtomicReader, AtomicReference, AtomicUpdater
 from fido.lens import Lens
 
 
 @dataclass(frozen=True)
 class _State:
     n: int
+
+
+class TestAtomicProtocols:
+    def test_atomic_reference_is_atomic_reader(self) -> None:
+        ref: AtomicReader[int] = AtomicReference(7)
+        assert ref.get() == 7
+
+    def test_atomic_reference_is_atomic_updater(self) -> None:
+        state = _Container(items=frozendict({"x": _Item(0)}))
+        ref: AtomicUpdater[_Container] = AtomicReference(state)
+        ref.update(lambda root: root.items["x"], _Item(9))
+        assert isinstance(ref, AtomicReference)
+        assert ref.get().items["x"] == _Item(9)  # type: ignore[attr-defined]
 
 
 class TestAtomicReferenceGet:

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,11 +1,16 @@
-"""Tests for fido.atomic — AtomicReference[T] primitive."""
+"""Tests for fido.atomic — create_atomic factory and _AtomicReference internals."""
 
 import threading
 from dataclasses import dataclass
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReader, AtomicReference, AtomicUpdater
+from fido.atomic import (
+    AtomicReader,
+    AtomicUpdater,
+    _AtomicReference,  # noqa: PLC2701
+    create_atomic,
+)
 from fido.lens import Lens
 
 
@@ -14,40 +19,61 @@ class _State:
     n: int
 
 
-class TestAtomicProtocols:
-    def test_atomic_reference_is_atomic_reader(self) -> None:
-        ref: AtomicReader[int] = AtomicReference(7)
+class TestCreateAtomic:
+    """Tests for the public create_atomic factory."""
+
+    def test_returns_reader_updater_tuple(self) -> None:
+        reader, updater = create_atomic(42)
+        assert reader.get() == 42
+
+    def test_reader_satisfies_atomic_reader_protocol(self) -> None:
+        reader, _ = create_atomic(7)
+        ref: AtomicReader[int] = reader
         assert ref.get() == 7
 
-    def test_atomic_reference_is_atomic_updater(self) -> None:
+    def test_updater_satisfies_atomic_updater_protocol(self) -> None:
         state = _Container(items=frozendict({"x": _Item(0)}))
-        ref: AtomicUpdater[_Container] = AtomicReference(state)
+        _, updater = create_atomic(state)
+        ref: AtomicUpdater[_Container] = updater
         ref.update(lambda root: root.items["x"], _Item(9))
-        assert isinstance(ref, AtomicReference)
-        assert ref.get().items["x"] == _Item(9)  # type: ignore[attr-defined]
+
+    def test_reader_and_updater_share_state(self) -> None:
+        reader, updater = create_atomic(_Container(items=frozendict({"k": _Item(0)})))
+        updater.update(lambda root: root.items["k"], _Item(99))
+        assert reader.get().items["k"] == _Item(99)
+
+    def test_reader_has_no_update_attribute(self) -> None:
+        reader, _ = create_atomic(0)
+        # AtomicReader protocol exposes only .get() — no .update()
+        assert not hasattr(AtomicReader, "update")
+
+    def test_updater_has_no_get_attribute(self) -> None:
+        _, updater = create_atomic(0)
+        # AtomicUpdater protocol exposes only .update() — no .get()
+        assert not hasattr(AtomicUpdater, "get")
 
 
 class TestAtomicReferenceGet:
     def test_get_returns_initial_value(self) -> None:
-        ref: AtomicReference[int] = AtomicReference(42)
+        ref: _AtomicReference[int] = _AtomicReference(42)
         assert ref.get() == 42
 
     def test_get_returns_same_object(self) -> None:
         obj = object()
-        ref: AtomicReference[object] = AtomicReference(obj)
+        ref: _AtomicReference[object] = _AtomicReference(obj)
         assert ref.get() is obj
 
 
 class TestAtomicReferenceSet:
     def test_set_replaces_value(self) -> None:
-        ref: AtomicReference[int] = AtomicReference(1)
+        ref: _AtomicReference[int] = _AtomicReference(1)
         ref.set(99)
         assert ref.get() == 99
 
     def test_set_replaces_with_new_object(self) -> None:
         a = _State(0)
         b = _State(1)
-        ref: AtomicReference[_State] = AtomicReference(a)
+        ref: _AtomicReference[_State] = _AtomicReference(a)
         ref.set(b)
         assert ref.get() is b
 
@@ -56,7 +82,7 @@ class TestAtomicReferenceCompareAndSet:
     def test_succeeds_when_expected_matches(self) -> None:
         a = _State(0)
         b = _State(1)
-        ref: AtomicReference[_State] = AtomicReference(a)
+        ref: _AtomicReference[_State] = _AtomicReference(a)
         success, value = ref.compare_and_set(a, b)
         assert success is True
         assert value is b
@@ -66,7 +92,7 @@ class TestAtomicReferenceCompareAndSet:
         a = _State(0)
         other = _State(0)  # equal value, different identity
         b = _State(1)
-        ref: AtomicReference[_State] = AtomicReference(a)
+        ref: _AtomicReference[_State] = _AtomicReference(a)
         success, current = ref.compare_and_set(other, b)
         assert success is False
         assert current is a  # returned current reference, not the rejected new value
@@ -81,7 +107,7 @@ class TestAtomicReferenceCompareAndSet:
         assert x == y
         assert x is not y  # distinct objects despite equal values
         new: tuple[int, ...] = tuple(range(4, 7))
-        ref: AtomicReference[tuple[int, ...]] = AtomicReference(x)
+        ref: _AtomicReference[tuple[int, ...]] = _AtomicReference(x)
         success, current = ref.compare_and_set(y, new)
         assert success is False
         assert current is x  # returned the actual current reference
@@ -91,7 +117,7 @@ class TestAtomicReferenceCompareAndSet:
         a = _State(10)
         wrong = _State(99)
         new = _State(20)
-        ref: AtomicReference[_State] = AtomicReference(a)
+        ref: _AtomicReference[_State] = _AtomicReference(a)
         success, current = ref.compare_and_set(wrong, new)
         assert success is False
         assert current is a
@@ -111,14 +137,14 @@ class _Container:
 class TestAtomicReferenceUpdate:
     def test_installs_value_at_path(self) -> None:
         state = _Container(items=frozendict({"a": _Item(1)}))
-        ref: AtomicReference[_Container] = AtomicReference(state)
+        ref: _AtomicReference[_Container] = _AtomicReference(state)
         new_item = _Item(99)
         result = ref.update(lambda root: root.items["a"], new_item)
         assert result.items["a"] is new_item
         assert ref.get().items["a"] is new_item
 
     def test_inserts_new_key(self) -> None:
-        ref: AtomicReference[_Container] = AtomicReference(
+        ref: _AtomicReference[_Container] = _AtomicReference(
             _Container(items=frozendict())
         )
         new_item = _Item(7)
@@ -126,7 +152,7 @@ class TestAtomicReferenceUpdate:
         assert ref.get().items["new"] is new_item
 
     def test_returns_installed_root(self) -> None:
-        ref: AtomicReference[_Container] = AtomicReference(
+        ref: _AtomicReference[_Container] = _AtomicReference(
             _Container(items=frozendict({"x": _Item(0)}))
         )
         result = ref.update(lambda root: root.items["x"], _Item(5))
@@ -140,7 +166,7 @@ class TestAtomicReferenceUpdate:
             received.append(root)
             return root.items["a"]
 
-        ref: AtomicReference[_Container] = AtomicReference(
+        ref: _AtomicReference[_Container] = _AtomicReference(
             _Container(items=frozendict({"a": _Item(1)}))
         )
         ref.update(selector, _Item(2))
@@ -149,7 +175,7 @@ class TestAtomicReferenceUpdate:
     def test_preserves_sibling_keys(self) -> None:
         a = _Item(1)
         b = _Item(2)
-        ref: AtomicReference[_Container] = AtomicReference(
+        ref: _AtomicReference[_Container] = _AtomicReference(
             _Container(items=frozendict({"a": a, "b": b}))
         )
         ref.update(lambda root: root.items["a"], _Item(99))
@@ -157,7 +183,7 @@ class TestAtomicReferenceUpdate:
 
     def test_retries_after_concurrent_modification(self) -> None:
         """update() retries when a concurrent writer sneaks in between get() and CAS."""
-        ref: AtomicReference[_Container] = AtomicReference(
+        ref: _AtomicReference[_Container] = _AtomicReference(
             _Container(items=frozendict({"a": _Item(0)}))
         )
         injected = [False]
@@ -181,7 +207,7 @@ class TestAtomicReferenceUpdate:
         """Many concurrent update() calls on disjoint keys; no writes lost."""
         n_threads = 20
         items = frozendict({f"k{i}": _Item(0) for i in range(n_threads)})
-        ref: AtomicReference[_Container] = AtomicReference(_Container(items=items))
+        ref: _AtomicReference[_Container] = _AtomicReference(_Container(items=items))
 
         def run(key: str) -> None:
             for v in range(1, 51):

--- a/tests/test_build_wrapper.py
+++ b/tests/test_build_wrapper.py
@@ -372,7 +372,7 @@ class TestFidoLauncher:
                 ],
                 "rate_limit": {
                     "rest": {
-                        "name": "core",
+                        "name": "rest",
                         "used": 7,
                         "limit": 5000,
                         "resets_at": "2026-04-24T13:00:00+00:00",
@@ -383,7 +383,6 @@ class TestFidoLauncher:
                         "limit": 5000,
                         "resets_at": "2026-04-24T14:00:00+00:00",
                     },
-                    "fetched_at": "2026-04-24T12:00:00+00:00",
                 },
                 "fido_uptime_seconds": 7322,
             },

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -18,7 +18,7 @@ import pytest
 
 from fido import provider
 from fido.provider_factory import DefaultProviderFactory
-from fido.registry import WorkerRegistry
+from fido.registry import WorkerRegistry, create_fido_atomic
 from fido.tasks import (
     _merge_thread_lineage,
     _review_thread_contains_comment,
@@ -63,7 +63,8 @@ class TestWorkerRegistryPreemptionHelpers:
     def _registry(self) -> WorkerRegistry:
         # WorkerRegistry takes a thread factory callable; tests don't
         # need real WorkerThreads, so a no-op factory is fine.
-        return WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), updater)
 
     def test_note_provider_interrupt_requested(self) -> None:
         registry = self._registry()

--- a/tests/test_lens.py
+++ b/tests/test_lens.py
@@ -141,10 +141,10 @@ class TestLensFidoStatePattern:
         assert result.repos["b/b"] is b
 
     def test_with_atomic_update(self) -> None:
-        """End-to-end: AtomicReference.update navigates and installs atomically."""
-        from fido.atomic import AtomicReference
+        """End-to-end: create_atomic updater navigates and installs atomically."""
+        from fido.atomic import create_atomic
 
-        ref: AtomicReference[FidoState] = AtomicReference(FidoState(repos=frozendict()))
+        reader, updater = create_atomic(FidoState(repos=frozendict()))
         new_repo = RepoState(key="owner/repo", started_at="now")
-        ref.update(lambda root: root.repos["owner/repo"], new_repo)
-        assert ref.get().repos["owner/repo"] is new_repo
+        updater.update(lambda root: root.repos["owner/repo"], new_repo)
+        assert reader.get().repos["owner/repo"] is new_repo

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicReference
+from fido.atomic import AtomicReader, AtomicUpdater, create_atomic
 from fido.provider import ProviderLimitWindow
 from fido.rate_limit import (
     _REFRESH_INTERVAL,  # noqa: PLC2701
@@ -18,10 +18,10 @@ from fido.rate_limit import (
 from fido.registry import FidoState
 
 
-def _make_state() -> AtomicReference[FidoState]:
-    """Return a fresh :class:`~fido.atomic.AtomicReference` seeded with an
-    empty :class:`~fido.registry.FidoState` for use in monitor tests."""
-    return AtomicReference(FidoState(repos=frozendict()))
+def _make_state() -> tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]:
+    """Return a fresh ``(reader, updater)`` pair seeded with an empty
+    :class:`~fido.registry.FidoState` for use in monitor tests."""
+    return create_atomic(FidoState(repos=frozendict()))
 
 
 # ── _parse_window ─────────────────────────────────────────────────────────────
@@ -112,49 +112,49 @@ def _resources(rest_used: int = 5, gql_used: int = 7) -> dict:
 class TestRateLimitMonitorRefresh:
     def test_state_has_zero_limits_before_first_refresh(self) -> None:
         gh = MagicMock()
-        state = _make_state()
-        RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        RateLimitMonitor(gh, state_updater)
         # Monitor construction does not seed the state; zero-value until refresh
-        assert state.get().github_limits.rest.used is None
+        assert state_reader.get().github_limits.rest.used is None
         gh.get_rate_limit.assert_not_called()
 
     def test_refresh_stores_snapshot_in_state(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         limits = m.refresh()
         assert limits is not None
         assert limits.rest.used == 5
         assert limits.graphql.used == 7
-        assert state.get().github_limits is limits
+        assert state_reader.get().github_limits is limits
 
     def test_refresh_failure_keeps_prior_state(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         first = m.refresh()
         gh.get_rate_limit.side_effect = RuntimeError("network down")
         second = m.refresh()
         assert second is None
-        assert state.get().github_limits is first
+        assert state_reader.get().github_limits is first
 
     def test_refresh_updates_when_new_data_arrives(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         m.refresh()
         gh.get_rate_limit.return_value = _resources(rest_used=42)
         m.refresh()
-        assert state.get().github_limits.rest.used == 42
+        assert state_reader.get().github_limits.rest.used == 42
 
     def test_handles_missing_resources_keys(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = {}
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        _, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         limits = m.refresh()
         assert limits is not None
         assert limits.rest.limit == 0
@@ -165,23 +165,25 @@ class TestRateLimitMonitorStartThread:
     def test_returns_daemon_thread(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        t = RateLimitMonitor(gh, _make_state()).start_thread(_interval=60.0)
+        _, state_updater = _make_state()
+        t = RateLimitMonitor(gh, state_updater).start_thread(_interval=60.0)
         assert t.daemon
 
     def test_thread_name(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        t = RateLimitMonitor(gh, _make_state()).start_thread(_interval=60.0)
+        _, state_updater = _make_state()
+        t = RateLimitMonitor(gh, state_updater).start_thread(_interval=60.0)
         assert t.name == "rate-limit-monitor"
 
     def test_does_initial_refresh_before_loop(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         m.start_thread(_interval=60.0)
         # At least the inline initial refresh happened
-        limits = state.get().github_limits
+        limits = state_reader.get().github_limits
         assert limits.rest.used is not None
         assert limits.graphql.used is not None
         gh.get_rate_limit.assert_called()
@@ -189,7 +191,8 @@ class TestRateLimitMonitorStartThread:
     def test_calls_refresh_periodically(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh, _make_state())
+        _, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         m.start_thread(_interval=0.01)
         time.sleep(0.1)
         assert gh.get_rate_limit.call_count >= 2
@@ -202,8 +205,8 @@ class TestRateLimitMonitorThreadSafety:
     def test_concurrent_refresh_and_latest(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        state = _make_state()
-        m = RateLimitMonitor(gh, state)
+        state_reader, state_updater = _make_state()
+        m = RateLimitMonitor(gh, state_updater)
         m.refresh()  # seed
 
         stop = threading.Event()
@@ -214,7 +217,7 @@ class TestRateLimitMonitorThreadSafety:
 
         def reader() -> None:
             while not stop.is_set():
-                limits = state.get().github_limits
+                limits = state_reader.get().github_limits
                 # always either the zero seed or a real populated snapshot
                 assert isinstance(limits, GitHubLimit)
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,5 +1,6 @@
 """Tests for fido.rate_limit — RateLimitMonitor + parsers (closes #812)."""
 
+import threading
 import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -7,11 +8,10 @@ from unittest.mock import MagicMock
 from frozendict import frozendict
 
 from fido.atomic import AtomicReference
+from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
 from fido.rate_limit import (
     _REFRESH_INTERVAL,  # noqa: PLC2701
     RateLimitMonitor,
-    RateLimitSnapshot,
-    RateLimitWindow,
     _parse_window,  # noqa: PLC2701
 )
 from fido.registry import FidoState
@@ -29,9 +29,9 @@ def _make_state() -> AtomicReference[FidoState]:
 class TestParseWindow:
     def test_parses_full_payload(self) -> None:
         w = _parse_window(
-            "core", {"used": 5, "limit": 5000, "reset": 1700000000, "remaining": 4995}
+            "rest", {"used": 5, "limit": 5000, "reset": 1700000000, "remaining": 4995}
         )
-        assert w.name == "core"
+        assert w.name == "rest"
         assert w.used == 5
         assert w.limit == 5000
         assert w.resets_at == datetime.fromtimestamp(1700000000, tz=timezone.utc)
@@ -43,33 +43,27 @@ class TestParseWindow:
         assert w.resets_at == datetime.fromtimestamp(0, tz=timezone.utc)
 
     def test_handles_garbage_reset_value(self) -> None:
-        w = _parse_window("core", {"reset": "not-a-number"})
+        w = _parse_window("rest", {"reset": "not-a-number"})
         assert w.resets_at == datetime.fromtimestamp(0, tz=timezone.utc)
 
 
-# ── RateLimitWindow properties ────────────────────────────────────────────────
+# ── ProviderLimitWindow properties ───────────────────────────────────────────
 
 
-class TestRateLimitWindowProperties:
-    def _w(self, used: int, limit: int) -> RateLimitWindow:
-        return RateLimitWindow(
-            name="core",
+class TestProviderLimitWindowProperties:
+    def _w(self, used: int, limit: int) -> ProviderLimitWindow:
+        return ProviderLimitWindow(
+            name="rest",
             used=used,
             limit=limit,
             resets_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
         )
 
-    def test_remaining_basic(self) -> None:
-        assert self._w(used=10, limit=100).remaining == 90
+    def test_pressure_basic(self) -> None:
+        assert self._w(used=10, limit=100).pressure == 0.1
 
-    def test_remaining_clamps_to_zero_when_over(self) -> None:
-        assert self._w(used=200, limit=100).remaining == 0
-
-    def test_percent_remaining(self) -> None:
-        assert self._w(used=25, limit=100).percent_remaining == 75.0
-
-    def test_percent_remaining_zero_limit(self) -> None:
-        assert self._w(used=0, limit=0).percent_remaining == 0.0
+    def test_pressure_none_when_limit_zero(self) -> None:
+        assert self._w(used=0, limit=0).pressure is None
 
 
 # ── RateLimitMonitor ──────────────────────────────────────────────────────────
@@ -93,10 +87,14 @@ def _resources(rest_used: int = 5, gql_used: int = 7) -> dict:
 
 
 class TestRateLimitMonitorRefresh:
-    def test_returns_none_before_first_refresh(self) -> None:
+    def test_returns_zero_snapshot_before_first_refresh(self) -> None:
         gh = MagicMock()
         m = RateLimitMonitor(gh, _make_state())
-        assert m.latest() is None
+        snap = m.latest()
+        # Seeded with zero-value snapshot (no windows populated from API yet)
+        assert snap is not None
+        assert snap.provider == ProviderID.GITHUB
+        assert snap.windows == ()
         gh.get_rate_limit.assert_not_called()
 
     def test_refresh_stores_snapshot(self) -> None:
@@ -105,8 +103,11 @@ class TestRateLimitMonitorRefresh:
         m = RateLimitMonitor(gh, _make_state())
         snap = m.refresh()
         assert snap is not None
-        assert snap.rest.used == 5
-        assert snap.graphql.used == 7
+        assert snap.provider == ProviderID.GITHUB
+        rest_w = snap.windows[0]
+        gql_w = snap.windows[1]
+        assert rest_w.used == 5
+        assert gql_w.used == 7
         assert m.latest() is snap
 
     def test_refresh_failure_keeps_prior_snapshot(self) -> None:
@@ -128,7 +129,7 @@ class TestRateLimitMonitorRefresh:
         m.refresh()
         latest = m.latest()
         assert latest is not None
-        assert latest.rest.used == 42
+        assert latest.windows[0].used == 42
 
     def test_handles_missing_resources_keys(self) -> None:
         gh = MagicMock()
@@ -136,8 +137,8 @@ class TestRateLimitMonitorRefresh:
         m = RateLimitMonitor(gh, _make_state())
         snap = m.refresh()
         assert snap is not None
-        assert snap.rest.limit == 0
-        assert snap.graphql.limit == 0
+        assert snap.windows[0].limit == 0
+        assert snap.windows[1].limit == 0
 
 
 class TestRateLimitMonitorStartThread:
@@ -159,7 +160,9 @@ class TestRateLimitMonitorStartThread:
         m = RateLimitMonitor(gh, _make_state())
         m.start_thread(_interval=60.0)
         # At least the inline initial refresh happened
-        assert m.latest() is not None
+        snap = m.latest()
+        assert snap is not None
+        assert len(snap.windows) == 2
         gh.get_rate_limit.assert_called()
 
     def test_calls_refresh_periodically(self) -> None:
@@ -176,8 +179,6 @@ class TestRateLimitMonitorThreadSafety:
     when called concurrently from many threads (Python 3.14t free-threaded)."""
 
     def test_concurrent_refresh_and_latest(self) -> None:
-        import threading
-
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
         m = RateLimitMonitor(gh, _make_state())
@@ -192,8 +193,9 @@ class TestRateLimitMonitorThreadSafety:
         def reader() -> None:
             while not stop.is_set():
                 snap = m.latest()
-                # always either None (briefly) or a real RateLimitSnapshot
-                assert snap is None or isinstance(snap, RateLimitSnapshot)
+                # always either the zero seed or a real populated snapshot
+                assert snap is not None
+                assert isinstance(snap, ProviderLimitSnapshot)
 
         threads = [threading.Thread(target=writer) for _ in range(2)] + [
             threading.Thread(target=reader) for _ in range(4)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -21,7 +21,7 @@ from fido.registry import FidoState
 def _make_state() -> tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]:
     """Return a fresh ``(reader, updater)`` pair seeded with an empty
     :class:`~fido.registry.FidoState` for use in monitor tests."""
-    return create_atomic(FidoState(repos=frozendict()))
+    return create_atomic(FidoState(repos=frozendict(), github_limits=GitHubLimit()))
 
 
 # ── _parse_window ─────────────────────────────────────────────────────────────

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -8,9 +8,10 @@ from unittest.mock import MagicMock
 from frozendict import frozendict
 
 from fido.atomic import AtomicReference
-from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
+from fido.provider import ProviderLimitWindow
 from fido.rate_limit import (
     _REFRESH_INTERVAL,  # noqa: PLC2701
+    GitHubLimit,
     RateLimitMonitor,
     _parse_window,  # noqa: PLC2701
 )
@@ -66,6 +67,28 @@ class TestProviderLimitWindowProperties:
         assert self._w(used=0, limit=0).pressure is None
 
 
+# ── GitHubLimit ───────────────────────────────────────────────────────────────
+
+
+class TestGitHubLimit:
+    def test_zero_value_has_none_used(self) -> None:
+        gl = GitHubLimit()
+        assert gl.rest.used is None
+        assert gl.graphql.used is None
+
+    def test_zero_value_window_names(self) -> None:
+        gl = GitHubLimit()
+        assert gl.rest.name == "rest"
+        assert gl.graphql.name == "graphql"
+
+    def test_custom_windows(self) -> None:
+        rest = ProviderLimitWindow(name="rest", used=5, limit=5000)
+        gql = ProviderLimitWindow(name="graphql", used=7, limit=5000)
+        gl = GitHubLimit(rest=rest, graphql=gql)
+        assert gl.rest.used == 5
+        assert gl.graphql.used == 7
+
+
 # ── RateLimitMonitor ──────────────────────────────────────────────────────────
 
 
@@ -87,58 +110,55 @@ def _resources(rest_used: int = 5, gql_used: int = 7) -> dict:
 
 
 class TestRateLimitMonitorRefresh:
-    def test_returns_zero_snapshot_before_first_refresh(self) -> None:
+    def test_state_has_zero_limits_before_first_refresh(self) -> None:
         gh = MagicMock()
-        m = RateLimitMonitor(gh, _make_state())
-        snap = m.latest()
-        # Seeded with zero-value snapshot (no windows populated from API yet)
-        assert snap is not None
-        assert snap.provider == ProviderID.GITHUB
-        assert snap.windows == ()
+        state = _make_state()
+        RateLimitMonitor(gh, state)
+        # Monitor construction does not seed the state; zero-value until refresh
+        assert state.get().github_limits.rest.used is None
         gh.get_rate_limit.assert_not_called()
 
-    def test_refresh_stores_snapshot(self) -> None:
+    def test_refresh_stores_snapshot_in_state(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh, _make_state())
-        snap = m.refresh()
-        assert snap is not None
-        assert snap.provider == ProviderID.GITHUB
-        rest_w = snap.windows[0]
-        gql_w = snap.windows[1]
-        assert rest_w.used == 5
-        assert gql_w.used == 7
-        assert m.latest() is snap
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
+        limits = m.refresh()
+        assert limits is not None
+        assert limits.rest.used == 5
+        assert limits.graphql.used == 7
+        assert state.get().github_limits is limits
 
-    def test_refresh_failure_keeps_prior_snapshot(self) -> None:
+    def test_refresh_failure_keeps_prior_state(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        m = RateLimitMonitor(gh, _make_state())
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
         first = m.refresh()
         gh.get_rate_limit.side_effect = RuntimeError("network down")
         second = m.refresh()
         assert second is None
-        assert m.latest() is first
+        assert state.get().github_limits is first
 
     def test_refresh_updates_when_new_data_arrives(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        m = RateLimitMonitor(gh, _make_state())
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
         m.refresh()
         gh.get_rate_limit.return_value = _resources(rest_used=42)
         m.refresh()
-        latest = m.latest()
-        assert latest is not None
-        assert latest.windows[0].used == 42
+        assert state.get().github_limits.rest.used == 42
 
     def test_handles_missing_resources_keys(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = {}
-        m = RateLimitMonitor(gh, _make_state())
-        snap = m.refresh()
-        assert snap is not None
-        assert snap.windows[0].limit == 0
-        assert snap.windows[1].limit == 0
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
+        limits = m.refresh()
+        assert limits is not None
+        assert limits.rest.limit == 0
+        assert limits.graphql.limit == 0
 
 
 class TestRateLimitMonitorStartThread:
@@ -157,12 +177,13 @@ class TestRateLimitMonitorStartThread:
     def test_does_initial_refresh_before_loop(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh, _make_state())
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
         m.start_thread(_interval=60.0)
         # At least the inline initial refresh happened
-        snap = m.latest()
-        assert snap is not None
-        assert len(snap.windows) == 2
+        limits = state.get().github_limits
+        assert limits.rest.used is not None
+        assert limits.graphql.used is not None
         gh.get_rate_limit.assert_called()
 
     def test_calls_refresh_periodically(self) -> None:
@@ -175,13 +196,14 @@ class TestRateLimitMonitorStartThread:
 
 
 class TestRateLimitMonitorThreadSafety:
-    """Smoke-test: refresh() and latest() don't deadlock or corrupt state
+    """Smoke-test: refresh() and state reads don't deadlock or corrupt state
     when called concurrently from many threads (Python 3.14t free-threaded)."""
 
     def test_concurrent_refresh_and_latest(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh, _make_state())
+        state = _make_state()
+        m = RateLimitMonitor(gh, state)
         m.refresh()  # seed
 
         stop = threading.Event()
@@ -192,10 +214,9 @@ class TestRateLimitMonitorThreadSafety:
 
         def reader() -> None:
             while not stop.is_set():
-                snap = m.latest()
+                limits = state.get().github_limits
                 # always either the zero seed or a real populated snapshot
-                assert snap is not None
-                assert isinstance(snap, ProviderLimitSnapshot)
+                assert isinstance(limits, GitHubLimit)
 
         threads = [threading.Thread(target=writer) for _ in range(2)] + [
             threading.Thread(target=reader) for _ in range(4)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -4,6 +4,9 @@ import time
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
+from frozendict import frozendict
+
+from fido.atomic import AtomicReference
 from fido.rate_limit import (
     _REFRESH_INTERVAL,  # noqa: PLC2701
     RateLimitMonitor,
@@ -11,6 +14,14 @@ from fido.rate_limit import (
     RateLimitWindow,
     _parse_window,  # noqa: PLC2701
 )
+from fido.registry import FidoState
+
+
+def _make_state() -> AtomicReference[FidoState]:
+    """Return a fresh :class:`~fido.atomic.AtomicReference` seeded with an
+    empty :class:`~fido.registry.FidoState` for use in monitor tests."""
+    return AtomicReference(FidoState(repos=frozendict()))
+
 
 # ── _parse_window ─────────────────────────────────────────────────────────────
 
@@ -84,14 +95,14 @@ def _resources(rest_used: int = 5, gql_used: int = 7) -> dict:
 class TestRateLimitMonitorRefresh:
     def test_returns_none_before_first_refresh(self) -> None:
         gh = MagicMock()
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         assert m.latest() is None
         gh.get_rate_limit.assert_not_called()
 
     def test_refresh_stores_snapshot(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         snap = m.refresh()
         assert snap is not None
         assert snap.rest.used == 5
@@ -101,7 +112,7 @@ class TestRateLimitMonitorRefresh:
     def test_refresh_failure_keeps_prior_snapshot(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         first = m.refresh()
         gh.get_rate_limit.side_effect = RuntimeError("network down")
         second = m.refresh()
@@ -111,7 +122,7 @@ class TestRateLimitMonitorRefresh:
     def test_refresh_updates_when_new_data_arrives(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources(rest_used=10)
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         m.refresh()
         gh.get_rate_limit.return_value = _resources(rest_used=42)
         m.refresh()
@@ -122,7 +133,7 @@ class TestRateLimitMonitorRefresh:
     def test_handles_missing_resources_keys(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = {}
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         snap = m.refresh()
         assert snap is not None
         assert snap.rest.limit == 0
@@ -133,19 +144,19 @@ class TestRateLimitMonitorStartThread:
     def test_returns_daemon_thread(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        t = RateLimitMonitor(gh).start_thread(_interval=60.0)
+        t = RateLimitMonitor(gh, _make_state()).start_thread(_interval=60.0)
         assert t.daemon
 
     def test_thread_name(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        t = RateLimitMonitor(gh).start_thread(_interval=60.0)
+        t = RateLimitMonitor(gh, _make_state()).start_thread(_interval=60.0)
         assert t.name == "rate-limit-monitor"
 
     def test_does_initial_refresh_before_loop(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         m.start_thread(_interval=60.0)
         # At least the inline initial refresh happened
         assert m.latest() is not None
@@ -154,7 +165,7 @@ class TestRateLimitMonitorStartThread:
     def test_calls_refresh_periodically(self) -> None:
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         m.start_thread(_interval=0.01)
         time.sleep(0.1)
         assert gh.get_rate_limit.call_count >= 2
@@ -169,7 +180,7 @@ class TestRateLimitMonitorThreadSafety:
 
         gh = MagicMock()
         gh.get_rate_limit.return_value = _resources()
-        m = RateLimitMonitor(gh)
+        m = RateLimitMonitor(gh, _make_state())
         m.refresh()  # seed
 
         stop = threading.Event()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -499,13 +499,21 @@ class TestWorkerRegistry:
         state = reg.get_state()
         assert "foo/bar" in state.repos
 
-    def test_get_state_ref_returns_backing_atomic_reference(self) -> None:
+    def test_get_state_reader_returns_lock_free_view(self) -> None:
         from fido.atomic import AtomicReference
 
         reg, _ = self._make_registry(repos=["foo/bar"])
-        ref = reg.get_state_ref()
-        assert isinstance(ref, AtomicReference)
-        assert ref.get() is reg.get_state()
+        reader = reg.get_state_reader()
+        assert isinstance(reader, AtomicReference)
+        assert reader.get() is reg.get_state()
+
+    def test_get_state_updater_returns_write_view(self) -> None:
+        from fido.atomic import AtomicReference
+
+        reg, _ = self._make_registry(repos=["foo/bar"])
+        updater = reg.get_state_updater()
+        assert isinstance(updater, AtomicReference)
+        assert updater is reg.get_state_reader()
 
     def test_record_crash_stores_error_and_count(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -499,6 +499,14 @@ class TestWorkerRegistry:
         state = reg.get_state()
         assert "foo/bar" in state.repos
 
+    def test_get_state_ref_returns_backing_atomic_reference(self) -> None:
+        from fido.atomic import AtomicReference
+
+        reg, _ = self._make_registry(repos=["foo/bar"])
+        ref = reg.get_state_ref()
+        assert isinstance(ref, AtomicReference)
+        assert ref.get() is reg.get_state()
+
     def test_record_crash_stores_error_and_count(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "boom")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -500,20 +500,16 @@ class TestWorkerRegistry:
         assert "foo/bar" in state.repos
 
     def test_get_state_reader_returns_lock_free_view(self) -> None:
-        from fido.atomic import AtomicReference
-
         reg, _ = self._make_registry(repos=["foo/bar"])
         reader = reg.get_state_reader()
-        assert isinstance(reader, AtomicReference)
+        # reader satisfies AtomicReader — has .get(), returns FidoState
         assert reader.get() is reg.get_state()
 
     def test_get_state_updater_returns_write_view(self) -> None:
-        from fido.atomic import AtomicReference
-
         reg, _ = self._make_registry(repos=["foo/bar"])
         updater = reg.get_state_updater()
-        assert isinstance(updater, AtomicReference)
-        assert updater is reg.get_state_reader()
+        # updater satisfies AtomicUpdater — has .update()
+        assert callable(getattr(updater, "update", None))
 
     def test_record_crash_stores_error_and_count(self) -> None:
         reg, _ = self._make_registry(repos=["foo/bar"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,6 +14,8 @@ from fido.registry import (
     WorkerCrash,
     WorkerRegistry,
     _make_thread,
+    create_fido_atomic,
+    get_all_activities,
     make_registry,
 )
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -37,16 +39,17 @@ def _repo(name: str, work_dir: Path) -> RepoConfig:
 class TestWorkerRegistry:
     def _make_registry(
         self, *, repos: list[str] | None = None
-    ) -> tuple[WorkerRegistry, MagicMock]:
+    ) -> tuple[WorkerRegistry, MagicMock, object]:
         factory = MagicMock()
-        reg = WorkerRegistry(factory)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         if repos:
             for name in repos:
                 reg.start(_repo(name, Path("/tmp/fake")))
-        return reg, factory
+        return reg, factory, reader
 
     def test_start_calls_factory_with_repo_cfg(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         factory.assert_called_once_with(cfg, provider=None, session_issue=None)
@@ -56,7 +59,8 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         # First start — no prior thread
         reg.start(cfg)
@@ -85,7 +89,8 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         threads[0].is_alive.return_value = False
@@ -100,7 +105,8 @@ class TestWorkerRegistry:
         """No provider rescue when the old thread exited via orderly stop()."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate orderly shutdown: was_stopped is True (session was already stopped)
@@ -114,25 +120,25 @@ class TestWorkerRegistry:
         threads[0].detach_provider.assert_not_called()
 
     def test_start_starts_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         factory.return_value.start.assert_called_once()
 
     def test_wake_calls_thread_wake(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.wake("foo/bar")
         factory.return_value.wake.assert_called_once()
 
     def test_wake_unknown_repo_is_noop(self) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         reg.wake("unknown/repo")  # must not raise
         factory.return_value.wake.assert_not_called()
 
     def test_stop_all_calls_stop_on_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.stop_all()
@@ -140,7 +146,8 @@ class TestWorkerRegistry:
 
     def test_stop_all_calls_stop_on_every_thread(self, tmp_path: Path) -> None:
         factory = MagicMock(side_effect=[MagicMock(), MagicMock()])
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -158,7 +165,8 @@ class TestWorkerRegistry:
     def test_stop_all_calls_stop_count(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -166,146 +174,146 @@ class TestWorkerRegistry:
             t.stop.assert_called_once()
 
     def test_stop_all_empty_is_noop(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         reg.stop_all()  # must not raise
 
     def test_stop_and_join_calls_stop_and_join_on_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         reg.start(_repo("foo/bar", tmp_path))
         reg.stop_and_join("foo/bar", timeout=5.0)
         factory.return_value.stop.assert_called_once()
         factory.return_value.join.assert_called_once_with(timeout=5.0)
 
     def test_stop_and_join_unknown_repo_is_noop(self) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         reg.stop_and_join("unknown/repo")  # must not raise
         factory.return_value.stop.assert_not_called()
         factory.return_value.join.assert_not_called()
 
     def test_abort_task_calls_thread_abort_task(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.abort_task("foo/bar", task_id="t-1")
         factory.return_value.abort_task.assert_called_once_with(task_id="t-1")
 
     def test_abort_task_unknown_repo_is_noop(self) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         reg.abort_task("unknown/repo", task_id="t-1")  # must not raise
         factory.return_value.abort_task.assert_not_called()
 
     def test_recover_provider_calls_thread_recover_provider(
         self, tmp_path: Path
     ) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.recover_provider.return_value = True
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.recover_provider("foo/bar") is True
         factory.return_value.recover_provider.assert_called_once_with()
 
     def test_recover_provider_unknown_repo_returns_false(self) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         assert reg.recover_provider("unknown/repo") is False
         factory.return_value.recover_provider.assert_not_called()
 
     def test_stop_and_join_default_timeout(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         reg.start(_repo("foo/bar", tmp_path))
         reg.stop_and_join("foo/bar")
         factory.return_value.join.assert_called_once_with(timeout=30.0)
 
     def test_is_alive_true_when_thread_alive(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         factory.return_value.is_alive.return_value = True
         reg.start(cfg)
         assert reg.is_alive("foo/bar") is True
 
     def test_is_alive_false_when_thread_dead(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         cfg = _repo("foo/bar", tmp_path)
         factory.return_value.is_alive.return_value = False
         reg.start(cfg)
         assert reg.is_alive("foo/bar") is False
 
     def test_is_alive_false_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.is_alive("unknown/repo") is False
 
     def test_get_thread_crash_error_returns_none_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_thread_crash_error("unknown/repo") is None
 
     def test_get_session_owner_returns_none_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_owner("unknown/repo") is None
 
     def test_get_session_owner_delegates_to_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_owner = "worker-home"
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_owner("foo/bar") == "worker-home"
 
     def test_get_session_alive_returns_false_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_alive("unknown/repo") is False
 
     def test_get_session_alive_delegates_to_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_alive = True
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_alive("foo/bar") is True
 
     def test_get_session_pid_returns_none_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_pid("unknown/repo") is None
 
     def test_get_session_pid_delegates_to_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_pid = 77777
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_pid("foo/bar") == 77777
 
     def test_get_session_dropped_count_returns_zero_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_dropped_count("unknown/repo") == 0
 
     def test_get_session_dropped_count_delegates_to_thread(
         self, tmp_path: Path
     ) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_dropped_count = 4
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_dropped_count("foo/bar") == 4
 
     def test_get_session_sent_count_returns_zero_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_sent_count("unknown/repo") == 0
 
     def test_get_session_sent_count_delegates_to_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_sent_count = 17
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_sent_count("foo/bar") == 17
 
     def test_get_session_received_count_returns_zero_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session_received_count("unknown/repo") == 0
 
     def test_get_session_received_count_delegates_to_thread(
         self, tmp_path: Path
     ) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.session_received_count = 15
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_session_received_count("foo/bar") == 15
 
     def test_get_session_returns_none_for_unknown_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.get_session("unknown/repo") is None
 
     def test_get_session_delegates_to_thread(self, tmp_path: Path) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         fake_session = MagicMock()
         factory.return_value.current_provider.return_value.agent.session = fake_session
         reg.start(_repo("foo/bar", tmp_path))
@@ -316,24 +324,24 @@ class TestWorkerRegistry:
     def test_get_issue_cache_creates_lazily(self) -> None:
         from fido.issue_cache import IssueTreeCache
 
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         cache = reg.get_issue_cache("foo/bar")
         assert isinstance(cache, IssueTreeCache)
 
     def test_get_issue_cache_returns_same_instance(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         a = reg.get_issue_cache("foo/bar")
         b = reg.get_issue_cache("foo/bar")
         assert a is b
 
     def test_get_issue_cache_per_repo(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         a = reg.get_issue_cache("foo/bar")
         b = reg.get_issue_cache("foo/baz")
         assert a is not b
 
     def test_all_issue_caches_returns_snapshot(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         assert reg.all_issue_caches() == []
         reg.get_issue_cache("a/1")
         reg.get_issue_cache("b/2")
@@ -346,7 +354,7 @@ class TestWorkerRegistry:
     def test_get_thread_crash_error_returns_thread_crash_error(
         self, tmp_path: Path
     ) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.crash_error = "RuntimeError: boom"
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_thread_crash_error("foo/bar") == "RuntimeError: boom"
@@ -354,47 +362,47 @@ class TestWorkerRegistry:
     def test_get_thread_crash_error_returns_none_when_thread_has_no_error(
         self, tmp_path: Path
     ) -> None:
-        reg, factory = self._make_registry()
+        reg, factory, reader = self._make_registry()
         factory.return_value.crash_error = None
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_thread_crash_error("foo/bar") is None
 
     def test_report_activity_stores_entry(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
-        activities = reg.get_all_activities()
+        activities = get_all_activities(reader)
         assert len(activities) == 1
         assert activities[0].repo_name == "foo/bar"
         assert activities[0].what == "Working on: #1"
         assert activities[0].busy is True
 
     def test_report_activity_overwrites_previous(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/bar", "Napping", busy=False)
-        activities = reg.get_all_activities()
+        activities = get_all_activities(reader)
         assert len(activities) == 1
         assert activities[0].what == "Napping"
         assert activities[0].busy is False
 
     def test_get_all_activities_returns_all_repos(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar", "foo/baz"])
+        reg, _, reader = self._make_registry(repos=["foo/bar", "foo/baz"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/baz", "Napping", busy=False)
-        activities = sorted(reg.get_all_activities(), key=lambda a: a.repo_name)
+        activities = sorted(get_all_activities(reader), key=lambda a: a.repo_name)
         assert [(a.repo_name, a.what, a.busy) for a in activities] == [
             ("foo/bar", "Working on: #1", True),
             ("foo/baz", "Napping", False),
         ]
 
     def test_get_all_activities_empty_initially(self) -> None:
-        reg, _ = self._make_registry()
-        assert reg.get_all_activities() == []
+        reg, _, reader = self._make_registry()
+        assert get_all_activities(reader) == []
 
     def test_get_all_activities_returns_snapshot(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
-        snapshot = reg.get_all_activities()
+        snapshot = get_all_activities(reader)
         reg.report_activity("foo/bar", "Napping", busy=False)
         # snapshot must not reflect the later update
         assert snapshot[0].what == "Working on: #1"
@@ -403,9 +411,9 @@ class TestWorkerRegistry:
         import datetime as dt
 
         fixed = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: fixed)
-        activities = reg.get_all_activities()
+        activities = get_all_activities(reader)
         assert activities[0].last_progress_at == fixed
 
     def test_report_activity_updates_last_progress_at(self) -> None:
@@ -413,10 +421,10 @@ class TestWorkerRegistry:
 
         t1 = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         t2 = dt.datetime(2026, 1, 1, 12, 5, 0, tzinfo=dt.timezone.utc)
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "first", busy=True, _now=lambda: t1)
         reg.report_activity("foo/bar", "second", busy=True, _now=lambda: t2)
-        activities = reg.get_all_activities()
+        activities = get_all_activities(reader)
         assert activities[0].last_progress_at == t2
 
     def test_concurrent_report_and_read_are_safe(self) -> None:
@@ -429,7 +437,7 @@ class TestWorkerRegistry:
         """
         n_repos = 8
         repos = [f"owner/repo{i}" for i in range(n_repos)]
-        reg, _ = self._make_registry(repos=repos)
+        reg, _, state_reader = self._make_registry(repos=repos)
         n_writes = 200
         errors: list[Exception] = []
 
@@ -440,17 +448,17 @@ class TestWorkerRegistry:
             except Exception as exc:
                 errors.append(exc)
 
-        def reader() -> None:
+        def reader_fn() -> None:
             try:
                 for _ in range(n_writes * n_repos):
-                    activities = reg.get_all_activities()
+                    activities = get_all_activities(state_reader)
                     # snapshot must be a plain list — no shared references
                     assert isinstance(activities, list)
             except Exception as exc:
                 errors.append(exc)
 
         threads = [threading.Thread(target=writer, args=(r,)) for r in repos]
-        threads.append(threading.Thread(target=reader))
+        threads.append(threading.Thread(target=reader_fn))
 
         for t in threads:
             t.start()
@@ -459,19 +467,19 @@ class TestWorkerRegistry:
 
         assert not errors, f"concurrent errors: {errors}"
 
-        final = {a.repo_name: a for a in reg.get_all_activities()}
+        final = {a.repo_name: a for a in get_all_activities(state_reader)}
         assert set(final) == set(repos)
         for repo in repos:
             assert final[repo].what == f"step {n_writes - 1}"
 
     def test_status_update_is_context_manager(self) -> None:
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         with reg.status_update():
             pass  # must not raise
 
     def test_status_update_serializes_concurrent_callers(self) -> None:
         """Only one caller may be inside status_update() at a time."""
-        reg, _ = self._make_registry()
+        reg, _, reader = self._make_registry()
         inside_count = 0
         max_concurrent = 0
         counter_lock = threading.Lock()
@@ -494,27 +502,23 @@ class TestWorkerRegistry:
 
         assert max_concurrent == 1
 
-    def test_get_state_returns_fido_state(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        state = reg.get_state()
-        assert "foo/bar" in state.repos
+    def test_create_fido_atomic_reader_sees_state(self) -> None:
+        """create_fido_atomic reader reflects writes made via the updater."""
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
+        # reader sees the repo populated by start()
+        assert "foo/bar" in reader.get().repos
 
-    def test_get_state_reader_returns_lock_free_view(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        reader = reg.get_state_reader()
-        # reader satisfies AtomicReader — has .get(), returns FidoState
-        assert reader.get() is reg.get_state()
-
-    def test_get_state_updater_returns_write_view(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
-        updater = reg.get_state_updater()
-        # updater satisfies AtomicUpdater — has .update()
-        assert callable(getattr(updater, "update", None))
+    def test_registry_is_write_only_for_fido_state(self) -> None:
+        """WorkerRegistry has no read face — get_state/get_state_reader/get_state_updater are gone."""
+        reg, _, reader = self._make_registry()
+        assert not hasattr(reg, "get_state")
+        assert not hasattr(reg, "get_state_reader")
+        assert not hasattr(reg, "get_state_updater")
 
     def test_record_crash_stores_error_and_count(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "boom")
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.death_count == 1
         assert crash.last_error == "boom"
 
@@ -522,26 +526,26 @@ class TestWorkerRegistry:
         import datetime as dt
 
         before = dt.datetime.now(tz=dt.timezone.utc)
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "oops")
         after = dt.datetime.now(tz=dt.timezone.utc)
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.death_count > 0
         assert before <= crash.last_crash_time <= after
 
     def test_record_crash_increments_death_count(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "err1")
         reg.record_crash("foo/bar", "err2")
         reg.record_crash("foo/bar", "err3")
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.death_count == 3
 
     def test_record_crash_updates_last_error(self) -> None:
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.record_crash("foo/bar", "first")
         reg.record_crash("foo/bar", "second")
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.last_error == "second"
 
     def test_record_crash_accumulates_count(self) -> None:
@@ -552,12 +556,12 @@ class TestWorkerRegistry:
         then publishes via a pure lens write.  This test verifies the counter
         accumulates without loss over many sequential calls.
         """
-        reg, _ = self._make_registry(repos=["foo/bar"])
+        reg, _, reader = self._make_registry(repos=["foo/bar"])
         n = 200
         for _ in range(n):
             reg.record_crash("foo/bar", "err")
 
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.death_count == n
 
     def test_worker_crash_dataclass_fields(self) -> None:
@@ -573,7 +577,8 @@ class TestWorkerRegistry:
         """crash_record is preserved across start() so history accumulates."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.record_crash("foo/bar", "boom")
@@ -581,14 +586,15 @@ class TestWorkerRegistry:
         threads[0].is_alive.return_value = False
         threads[0].was_stopped = False
         reg.start(cfg)
-        crash = reg.get_state().repos["foo/bar"].crash_record
+        crash = reader.get().repos["foo/bar"].crash_record
         assert crash.death_count == 1
         assert crash.last_error == "boom"
 
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate a crash so the FSM accepts the second start
@@ -690,10 +696,12 @@ class TestMakeRegistry:
     def test_returns_worker_registry(self, tmp_path: Path) -> None:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
+        _, updater = create_fido_atomic()
         result = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
+            state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert isinstance(result, WorkerRegistry)
@@ -703,17 +711,20 @@ class TestMakeRegistry:
         cfg2 = _repo("foo/baz", tmp_path)
         mock_thread = MagicMock()
         mock_factory = MagicMock(return_value=mock_thread)
+        _, updater = create_fido_atomic()
         make_registry(
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
             dispatchers={},
+            state_updater=updater,
             _thread_factory=mock_factory,
         )
         assert mock_factory.call_count == 2
         assert mock_thread.start.call_count == 2
 
     def test_empty_repos_returns_empty_registry(self) -> None:
-        result = make_registry({}, MagicMock(), dispatchers={})
+        _, updater = create_fido_atomic()
+        result = make_registry({}, MagicMock(), dispatchers={}, state_updater=updater)
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
 
@@ -721,10 +732,12 @@ class TestMakeRegistry:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = True
+        _, updater = create_fido_atomic()
         reg = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
+            state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
         assert reg.is_alive("foo/bar") is True
@@ -742,11 +755,13 @@ class TestMakeRegistry:
             sub_dir=tmp_path,
         )
         mock_factory = MagicMock(return_value=MagicMock())
+        _, updater = create_fido_atomic()
         make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             config,
             dispatchers={},
+            state_updater=updater,
             _thread_factory=mock_factory,
         )
         assert mock_factory.call_args.kwargs["config"] is config
@@ -754,7 +769,8 @@ class TestMakeRegistry:
 
 class TestWebhookActivity:
     def test_registers_and_unregisters(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_webhook_activities("foo/bar") == []
         with reg.webhook_activity("foo/bar", "triaging"):
@@ -766,7 +782,8 @@ class TestWebhookActivity:
     def test_unregisters_on_exception(self, tmp_path: Path) -> None:
         import pytest as _pytest
 
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with _pytest.raises(RuntimeError):
             with reg.webhook_activity("foo/bar", "oops"):
@@ -774,7 +791,8 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_multiple_concurrent_activities(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "first"):
             with reg.webhook_activity("foo/bar", "second"):
@@ -785,7 +803,8 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_activities_isolated_per_repo(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("a/b", tmp_path))
         reg.start(_repo("c/d", tmp_path))
         with reg.webhook_activity("a/b", "work-ab"):
@@ -796,11 +815,13 @@ class TestWebhookActivity:
                 assert [x.description for x in c] == ["work-cd"]
 
     def test_unknown_repo_returns_empty_list(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_handle_can_update_description(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
@@ -808,7 +829,8 @@ class TestWebhookActivity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "triaging"
 
     def test_handle_update_after_exit_is_noop(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             pass
@@ -816,63 +838,72 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_unknown_handle_update_is_noop(self, tmp_path: Path) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             reg.set_webhook_description("foo/bar", -1, "triaging")
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
 
     def test_unknown_repo_handle_update_is_noop(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_webhook_description("ghost/repo", 1, "triaging")
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_publishes_to_fido_state_when_repo_started(self, tmp_path: Path) -> None:
         """webhook_activity publishes activities into FidoState when start() has run."""
-        reg = WorkerRegistry(MagicMock())
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
-            acts = reg.get_state().repos["foo/bar"].webhook_activities
+            acts = reader.get().repos["foo/bar"].webhook_activities
             assert len(acts) == 1
             assert acts[0].description == "handling"
-        assert reg.get_state().repos["foo/bar"].webhook_activities == ()
+        assert reader.get().repos["foo/bar"].webhook_activities == ()
 
     def test_publishes_description_update_to_fido_state(self, tmp_path: Path) -> None:
         """set_webhook_description publishes the update into FidoState."""
-        reg = WorkerRegistry(MagicMock())
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "original") as handle:
             handle.set_description("updated")
-            acts = reg.get_state().repos["foo/bar"].webhook_activities
+            acts = reader.get().repos["foo/bar"].webhook_activities
             assert len(acts) == 1
             assert acts[0].description == "updated"
 
 
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         assert reg.is_rescoping("unknown/repo") is False
 
     def test_set_rescoping_true(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
 
     def test_set_rescoping_false_clears_flag(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         reg.set_rescoping("foo/bar", False)
         assert reg.is_rescoping("foo/bar") is False
 
     def test_rescoping_is_per_repo(self) -> None:
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
         assert reg.is_rescoping("foo/baz") is False
 
     def test_rescoping_is_threadsafe(self) -> None:
         """Concurrent set_rescoping and is_rescoping calls must not corrupt state."""
-        reg = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         errors: list[Exception] = []
 
         def toggler(repo: str) -> None:
@@ -904,7 +935,8 @@ class TestUntriagedInbox:
     """Tests for the per-repo untriaged-webhook inbox (fix #1067)."""
 
     def _reg(self) -> WorkerRegistry:
-        return WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), updater)
 
     # ── has_untriaged ─────────────────────────────────────────────────────
 
@@ -1134,7 +1166,8 @@ class TestPreemptionFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        return WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), updater)
 
     # ── worker_blocked_when_nonempty ─────────────────────────────────────
 
@@ -1359,7 +1392,8 @@ class TestRegistryFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        return WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), updater)
 
     def _cfg(self, tmp_path: Path, name: str = "foo/bar") -> RepoConfig:
         return _repo(name, tmp_path)
@@ -1446,7 +1480,8 @@ class TestRegistryFsmOracle:
         """start() after crash fires ThreadDies then Rescue: Active → Crashed → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         assert isinstance(
@@ -1468,7 +1503,8 @@ class TestRegistryFsmOracle:
         """start() after orderly stop fires ThreadStops then Launch: Active → Stopped → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Simulate orderly stop
@@ -1491,7 +1527,8 @@ class TestRegistryFsmOracle:
         """
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Leave thread alive (is_alive() returns a truthy MagicMock by default)
@@ -1503,7 +1540,8 @@ class TestRegistryFsmOracle:
         """FSM state is independent for each repo — no cross-repo contamination."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reg = WorkerRegistry(factory)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("org/a", tmp_path))
         reg.start(_repo("org/b", tmp_path))
         assert isinstance(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,6 @@ from fido.registry import (
     WorkerRegistry,
     _make_thread,
     create_fido_atomic,
-    get_all_activities,
     make_registry,
 )
 from fido.rocq import worker_registry_crash as registry_fsm
@@ -370,42 +369,18 @@ class TestWorkerRegistry:
     def test_report_activity_stores_entry(self) -> None:
         reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
-        activities = get_all_activities(reader)
-        assert len(activities) == 1
-        assert activities[0].repo_name == "foo/bar"
-        assert activities[0].what == "Working on: #1"
-        assert activities[0].busy is True
+        activity = reader.get().repos["foo/bar"].activity
+        assert activity.repo_name == "foo/bar"
+        assert activity.what == "Working on: #1"
+        assert activity.busy is True
 
     def test_report_activity_overwrites_previous(self) -> None:
         reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "Working on: #1", busy=True)
         reg.report_activity("foo/bar", "Napping", busy=False)
-        activities = get_all_activities(reader)
-        assert len(activities) == 1
-        assert activities[0].what == "Napping"
-        assert activities[0].busy is False
-
-    def test_get_all_activities_returns_all_repos(self) -> None:
-        reg, _, reader = self._make_registry(repos=["foo/bar", "foo/baz"])
-        reg.report_activity("foo/bar", "Working on: #1", busy=True)
-        reg.report_activity("foo/baz", "Napping", busy=False)
-        activities = sorted(get_all_activities(reader), key=lambda a: a.repo_name)
-        assert [(a.repo_name, a.what, a.busy) for a in activities] == [
-            ("foo/bar", "Working on: #1", True),
-            ("foo/baz", "Napping", False),
-        ]
-
-    def test_get_all_activities_empty_initially(self) -> None:
-        reg, _, reader = self._make_registry()
-        assert get_all_activities(reader) == []
-
-    def test_get_all_activities_returns_snapshot(self) -> None:
-        reg, _, reader = self._make_registry(repos=["foo/bar"])
-        reg.report_activity("foo/bar", "Working on: #1", busy=True)
-        snapshot = get_all_activities(reader)
-        reg.report_activity("foo/bar", "Napping", busy=False)
-        # snapshot must not reflect the later update
-        assert snapshot[0].what == "Working on: #1"
+        activity = reader.get().repos["foo/bar"].activity
+        assert activity.what == "Napping"
+        assert activity.busy is False
 
     def test_report_activity_records_last_progress_at(self) -> None:
         import datetime as dt
@@ -413,8 +388,8 @@ class TestWorkerRegistry:
         fixed = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
         reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "busy", busy=True, _now=lambda: fixed)
-        activities = get_all_activities(reader)
-        assert activities[0].last_progress_at == fixed
+        activity = reader.get().repos["foo/bar"].activity
+        assert activity.last_progress_at == fixed
 
     def test_report_activity_updates_last_progress_at(self) -> None:
         import datetime as dt
@@ -424,16 +399,16 @@ class TestWorkerRegistry:
         reg, _, reader = self._make_registry(repos=["foo/bar"])
         reg.report_activity("foo/bar", "first", busy=True, _now=lambda: t1)
         reg.report_activity("foo/bar", "second", busy=True, _now=lambda: t2)
-        activities = get_all_activities(reader)
-        assert activities[0].last_progress_at == t2
+        activity = reader.get().repos["foo/bar"].activity
+        assert activity.last_progress_at == t2
 
     def test_concurrent_report_and_read_are_safe(self) -> None:
-        """report_activity and get_all_activities are safe under concurrent load.
+        """report_activity is safe under concurrent load.
 
         Multiple writer threads each own one repo and hammer report_activity;
-        a reader thread continuously calls get_all_activities.  After all
-        writers finish, every repo must appear exactly once in the snapshot
-        with its final value, proving no data was lost or corrupted.
+        a reader thread continuously snapshots FidoState.  After all writers
+        finish, every repo must appear with its final value, proving no data
+        was lost or corrupted.
         """
         n_repos = 8
         repos = [f"owner/repo{i}" for i in range(n_repos)]
@@ -451,9 +426,8 @@ class TestWorkerRegistry:
         def reader_fn() -> None:
             try:
                 for _ in range(n_writes * n_repos):
-                    activities = get_all_activities(state_reader)
-                    # snapshot must be a plain list — no shared references
-                    assert isinstance(activities, list)
+                    snapshot = state_reader.get().repos
+                    assert isinstance(snapshot, dict)
             except Exception as exc:
                 errors.append(exc)
 
@@ -467,10 +441,10 @@ class TestWorkerRegistry:
 
         assert not errors, f"concurrent errors: {errors}"
 
-        final = {a.repo_name: a for a in get_all_activities(state_reader)}
-        assert set(final) == set(repos)
+        final_repos = state_reader.get().repos
+        assert set(final_repos) == set(repos)
         for repo in repos:
-            assert final[repo].what == f"step {n_writes - 1}"
+            assert final_repos[repo].activity.what == f"step {n_writes - 1}"
 
     def test_status_update_is_context_manager(self) -> None:
         reg, _, reader = self._make_registry()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,8 @@ from fido.events import (
     WebhookIngressOracle,
 )
 from fido.infra import Infra
-from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
+from fido.provider import ProviderID, ProviderLimitWindow
+from fido.rate_limit import GitHubLimit
 from fido.registry import (
     FidoState,
     RepoState,
@@ -81,16 +82,16 @@ def _repo_state(
     )
 
 
+_ZERO_GITHUB_LIMITS = GitHubLimit()
+
+
 def _fido_state(
     *repo_states: RepoState,
-    rate_limit: ProviderLimitSnapshot | None = None,
+    github_limits: GitHubLimit = _ZERO_GITHUB_LIMITS,
 ) -> FidoState:
-    provider_limits: frozendict[str, ProviderLimitSnapshot] = frozendict()
-    if rate_limit is not None:
-        provider_limits = frozendict({ProviderID.GITHUB: rate_limit})
     return FidoState(
         repos=frozendict({rs.key: rs for rs in repo_states}),
-        provider_limits=provider_limits,
+        github_limits=github_limits,
     )
 
 
@@ -438,32 +439,29 @@ class TestGetEndpoint:
     def test_status_endpoint_includes_rate_limit_when_snapshot_present(
         self, server: tuple
     ) -> None:
-        """A rate-limit snapshot in ``FidoState`` serializes into ``/status.json``
+        """A :class:`GitHubLimit` in ``FidoState`` serializes into ``/status.json``
         under the top-level ``rate_limit`` key (lock-free read via registry
         snapshot, closes #812 follow-up)."""
         from datetime import timezone
 
         url, _ = server
-        snap = ProviderLimitSnapshot(
-            provider=ProviderID.GITHUB,
-            windows=(
-                ProviderLimitWindow(
-                    name="rest",
-                    used=5,
-                    limit=5000,
-                    resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
-                ),
-                ProviderLimitWindow(
-                    name="graphql",
-                    used=12,
-                    limit=5000,
-                    resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
-                ),
+        limits = GitHubLimit(
+            rest=ProviderLimitWindow(
+                name="rest",
+                used=5,
+                limit=5000,
+                resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
+            ),
+            graphql=ProviderLimitWindow(
+                name="graphql",
+                used=12,
+                limit=5000,
+                resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
             ),
         )
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False),
-            rate_limit=snap,
+            github_limits=limits,
         )
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -481,7 +479,7 @@ class TestGetEndpoint:
     def test_status_endpoint_omits_rate_limit_when_snapshot_absent(
         self, server: tuple
     ) -> None:
-        """``FidoState.provider_limits`` has no GitHub entry → ``rate_limit``
+        """Zero-value ``GitHubLimit`` (not yet polled) → ``rate_limit``
         key is ``None`` in the ``/status.json`` response."""
         url, _ = server
         WebhookHandler.registry.get_state.return_value = _fido_state(
@@ -496,28 +494,26 @@ class TestGetEndpoint:
         data = json.loads(resp.read())
         assert data["rate_limit"] is None
 
-    def test_status_endpoint_rate_limit_missing_window_fallback(
+    def test_status_endpoint_rate_limit_graphql_zero_when_only_rest_polled(
         self, server: tuple
     ) -> None:
-        """When a GitHub snapshot has only one window, the missing window
-        serializes with zero defaults."""
+        """When ``GitHubLimit`` has rest populated but graphql is zero-value
+        (used=None), the serialized graphql window carries None fields."""
         from datetime import timezone
 
         url, _ = server
-        snap = ProviderLimitSnapshot(
-            provider=ProviderID.GITHUB,
-            windows=(
-                ProviderLimitWindow(
-                    name="rest",
-                    used=5,
-                    limit=5000,
-                    resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
-                ),
+        limits = GitHubLimit(
+            rest=ProviderLimitWindow(
+                name="rest",
+                used=5,
+                limit=5000,
+                resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
             ),
+            # graphql uses zero-value default: used=None, limit=None
         )
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False),
-            rate_limit=snap,
+            github_limits=limits,
         )
         WebhookHandler.registry.get_session_owner.return_value = None
         WebhookHandler.registry.get_session_alive.return_value = False
@@ -529,9 +525,9 @@ class TestGetEndpoint:
         rl = data["rate_limit"]
         assert rl is not None
         assert rl["rest"]["used"] == 5
-        # graphql window is missing → fallback
-        assert rl["graphql"]["name"] == "unknown"
-        assert rl["graphql"]["used"] == 0
+        # graphql window is zero-value: used and limit are None
+        assert rl["graphql"]["name"] == "graphql"
+        assert rl["graphql"]["used"] is None
 
     def test_status_endpoint_serializes_loaded_issue_cache(self, server: tuple) -> None:
         """Wire a real loaded :class:`IssueTreeCache` through the registry
@@ -1161,26 +1157,25 @@ class TestStatusXml:
 
     def test_status_xml_includes_rate_limit(self, server: tuple) -> None:
         """<rate_limit> with nested windows appears in the root element when
-        ``FidoState.provider_limits`` has a GitHub entry."""
+        ``FidoState.github_limits`` has been populated."""
         url, _ = server
-        snap = ProviderLimitSnapshot(
-            provider=ProviderID.GITHUB,
-            windows=(
-                ProviderLimitWindow(
-                    name="rest",
-                    used=100,
-                    limit=5000,
-                    resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
-                ),
-                ProviderLimitWindow(
-                    name="graphql",
-                    used=5,
-                    limit=5000,
-                    resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
-                ),
+        limits = GitHubLimit(
+            rest=ProviderLimitWindow(
+                name="rest",
+                used=100,
+                limit=5000,
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
+            ),
+            graphql=ProviderLimitWindow(
+                name="graphql",
+                used=5,
+                limit=5000,
+                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
             ),
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(rate_limit=snap)
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            github_limits=limits
+        )
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert "<rate_limit>" in body
@@ -3541,8 +3536,10 @@ class TestRun:
             _RateLimitMonitor=mock_rl_cls,
         )
 
-        expected_state_ref = mock_make_registry.return_value.get_state_ref.return_value
-        mock_rl_cls.assert_called_once_with(mock_gh_instance, expected_state_ref)
+        expected_state_updater = (
+            mock_make_registry.return_value.get_state_updater.return_value
+        )
+        mock_rl_cls.assert_called_once_with(mock_gh_instance, expected_state_updater)
         mock_rl_cls.return_value.start_thread.assert_called_once()
 
     def test_run_starts_reconcile_watchdog_with_registry_repos_and_gh(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,8 +27,7 @@ from fido.events import (
     WebhookIngressOracle,
 )
 from fido.infra import Infra
-from fido.provider import ProviderID
-from fido.rate_limit import RateLimitSnapshot, RateLimitWindow
+from fido.provider import ProviderID, ProviderLimitSnapshot, ProviderLimitWindow
 from fido.registry import (
     FidoState,
     RepoState,
@@ -84,11 +83,14 @@ def _repo_state(
 
 def _fido_state(
     *repo_states: RepoState,
-    rate_limit: RateLimitSnapshot | None = None,
+    rate_limit: ProviderLimitSnapshot | None = None,
 ) -> FidoState:
+    provider_limits: frozendict[str, ProviderLimitSnapshot] = frozendict()
+    if rate_limit is not None:
+        provider_limits = frozendict({ProviderID.GITHUB: rate_limit})
     return FidoState(
         repos=frozendict({rs.key: rs for rs in repo_states}),
-        rate_limit=rate_limit,
+        provider_limits=provider_limits,
     )
 
 
@@ -442,20 +444,22 @@ class TestGetEndpoint:
         from datetime import timezone
 
         url, _ = server
-        snap = RateLimitSnapshot(
-            rest=RateLimitWindow(
-                name="core",
-                used=5,
-                limit=5000,
-                resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
+        snap = ProviderLimitSnapshot(
+            provider=ProviderID.GITHUB,
+            windows=(
+                ProviderLimitWindow(
+                    name="rest",
+                    used=5,
+                    limit=5000,
+                    resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
+                ),
+                ProviderLimitWindow(
+                    name="graphql",
+                    used=12,
+                    limit=5000,
+                    resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
+                ),
             ),
-            graphql=RateLimitWindow(
-                name="graphql",
-                used=12,
-                limit=5000,
-                resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
-            ),
-            fetched_at=datetime(2024, 11, 14, 11, 0, tzinfo=timezone.utc),
         )
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False),
@@ -473,13 +477,12 @@ class TestGetEndpoint:
         assert rl["rest"]["used"] == 5
         assert rl["rest"]["limit"] == 5000
         assert rl["graphql"]["used"] == 12
-        assert "fetched_at" in rl
 
     def test_status_endpoint_omits_rate_limit_when_snapshot_absent(
         self, server: tuple
     ) -> None:
-        """``FidoState.rate_limit`` is ``None`` → ``rate_limit`` key is ``None``
-        in the ``/status.json`` response."""
+        """``FidoState.provider_limits`` has no GitHub entry → ``rate_limit``
+        key is ``None`` in the ``/status.json`` response."""
         url, _ = server
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
@@ -492,6 +495,43 @@ class TestGetEndpoint:
         resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data["rate_limit"] is None
+
+    def test_status_endpoint_rate_limit_missing_window_fallback(
+        self, server: tuple
+    ) -> None:
+        """When a GitHub snapshot has only one window, the missing window
+        serializes with zero defaults."""
+        from datetime import timezone
+
+        url, _ = server
+        snap = ProviderLimitSnapshot(
+            provider=ProviderID.GITHUB,
+            windows=(
+                ProviderLimitWindow(
+                    name="rest",
+                    used=5,
+                    limit=5000,
+                    resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
+                ),
+            ),
+        )
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False),
+            rate_limit=snap,
+        )
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        rl = data["rate_limit"]
+        assert rl is not None
+        assert rl["rest"]["used"] == 5
+        # graphql window is missing → fallback
+        assert rl["graphql"]["name"] == "unknown"
+        assert rl["graphql"]["used"] == 0
 
     def test_status_endpoint_serializes_loaded_issue_cache(self, server: tuple) -> None:
         """Wire a real loaded :class:`IssueTreeCache` through the registry
@@ -1121,22 +1161,24 @@ class TestStatusXml:
 
     def test_status_xml_includes_rate_limit(self, server: tuple) -> None:
         """<rate_limit> with nested windows appears in the root element when
-        ``FidoState.rate_limit`` is populated."""
+        ``FidoState.provider_limits`` has a GitHub entry."""
         url, _ = server
-        snap = RateLimitSnapshot(
-            rest=RateLimitWindow(
-                name="rest",
-                used=100,
-                limit=5000,
-                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
+        snap = ProviderLimitSnapshot(
+            provider=ProviderID.GITHUB,
+            windows=(
+                ProviderLimitWindow(
+                    name="rest",
+                    used=100,
+                    limit=5000,
+                    resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
+                ),
+                ProviderLimitWindow(
+                    name="graphql",
+                    used=5,
+                    limit=5000,
+                    resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
+                ),
             ),
-            graphql=RateLimitWindow(
-                name="graphql",
-                used=5,
-                limit=5000,
-                resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
-            ),
-            fetched_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
         )
         WebhookHandler.registry.get_state.return_value = _fido_state(rate_limit=snap)
         resp = urllib.request.urlopen(f"{url}/status")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,6 @@ import pytest
 from frozendict import frozendict
 
 from fido import provider
-from fido.atomic import AtomicReference
 from fido.claude import ClaudeClient
 from fido.config import Config
 from fido.config import RepoConfig as _RepoConfig
@@ -29,6 +28,7 @@ from fido.events import (
 )
 from fido.infra import Infra
 from fido.provider import ProviderID
+from fido.rate_limit import RateLimitSnapshot, RateLimitWindow
 from fido.registry import (
     FidoState,
     RepoState,
@@ -82,8 +82,14 @@ def _repo_state(
     )
 
 
-def _fido_state(*repo_states: RepoState) -> FidoState:
-    return FidoState(repos=frozendict({rs.key: rs for rs in repo_states}))
+def _fido_state(
+    *repo_states: RepoState,
+    rate_limit: RateLimitSnapshot | None = None,
+) -> FidoState:
+    return FidoState(
+        repos=frozendict({rs.key: rs for rs in repo_states}),
+        rate_limit=rate_limit,
+    )
 
 
 class RepoConfig(_RepoConfig):
@@ -427,14 +433,53 @@ class TestGetEndpoint:
         data = json.loads(resp.read())
         assert data["activities"][0]["rescoping"] is True
 
-    def test_status_endpoint_includes_rate_limit_when_monitor_present(
+    def test_status_endpoint_includes_rate_limit_when_snapshot_present(
         self, server: tuple
     ) -> None:
-        """A real ``RateLimitMonitor`` with a refreshed snapshot serializes
-        into ``/status.json`` under the top-level ``rate_limit`` key
-        (closes #812 follow-up)."""
-        from fido.rate_limit import RateLimitMonitor
+        """A rate-limit snapshot in ``FidoState`` serializes into ``/status.json``
+        under the top-level ``rate_limit`` key (lock-free read via registry
+        snapshot, closes #812 follow-up)."""
+        from datetime import timezone
 
+        url, _ = server
+        snap = RateLimitSnapshot(
+            rest=RateLimitWindow(
+                name="core",
+                used=5,
+                limit=5000,
+                resets_at=datetime(2024, 11, 14, 12, 0, tzinfo=timezone.utc),
+            ),
+            graphql=RateLimitWindow(
+                name="graphql",
+                used=12,
+                limit=5000,
+                resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
+            ),
+            fetched_at=datetime(2024, 11, 14, 11, 0, tzinfo=timezone.utc),
+        )
+        WebhookHandler.registry.get_state.return_value = _fido_state(
+            _repo_state("owner/repo", what="idle", busy=False),
+            rate_limit=snap,
+        )
+        WebhookHandler.registry.get_session_owner.return_value = None
+        WebhookHandler.registry.get_session_alive.return_value = False
+        WebhookHandler.registry.get_session_pid.return_value = None
+        WebhookHandler.registry.is_rescoping.return_value = False
+
+        resp = urllib.request.urlopen(f"{url}/status.json")
+        data = json.loads(resp.read())
+        rl = data["rate_limit"]
+        assert rl is not None
+        assert rl["rest"]["used"] == 5
+        assert rl["rest"]["limit"] == 5000
+        assert rl["graphql"]["used"] == 12
+        assert "fetched_at" in rl
+
+    def test_status_endpoint_omits_rate_limit_when_snapshot_absent(
+        self, server: tuple
+    ) -> None:
+        """``FidoState.rate_limit`` is ``None`` → ``rate_limit`` key is ``None``
+        in the ``/status.json`` response."""
         url, _ = server
         WebhookHandler.registry.get_state.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
@@ -443,70 +488,10 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_alive.return_value = False
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
-
-        gh = MagicMock()
-        gh.get_rate_limit.return_value = {
-            "core": {"used": 5, "limit": 5000, "reset": 1700000000},
-            "graphql": {"used": 12, "limit": 5000, "reset": 1700003600},
-        }
-        monitor = RateLimitMonitor(gh, AtomicReference(FidoState(repos=frozendict())))
-        monitor.refresh()
-        WebhookHandler.rate_limit_monitor = monitor
-        try:
-            resp = urllib.request.urlopen(f"{url}/status.json")
-            data = json.loads(resp.read())
-            rl = data["rate_limit"]
-            assert rl is not None
-            assert rl["rest"]["used"] == 5
-            assert rl["rest"]["limit"] == 5000
-            assert rl["graphql"]["used"] == 12
-            assert "fetched_at" in rl
-        finally:
-            WebhookHandler.rate_limit_monitor = None
-
-    def test_status_endpoint_omits_rate_limit_when_monitor_absent(
-        self, server: tuple
-    ) -> None:
-        """No monitor instance attached → ``rate_limit`` is ``None``."""
-        url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
-            _repo_state("owner/repo", what="idle", busy=False)
-        )
-        WebhookHandler.registry.get_session_owner.return_value = None
-        WebhookHandler.registry.get_session_alive.return_value = False
-        WebhookHandler.registry.get_session_pid.return_value = None
-        WebhookHandler.registry.is_rescoping.return_value = False
-        WebhookHandler.rate_limit_monitor = None
 
         resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
         assert data["rate_limit"] is None
-
-    def test_status_endpoint_omits_rate_limit_before_first_refresh(
-        self, server: tuple
-    ) -> None:
-        """Monitor present but ``latest()`` returns None → rate_limit None."""
-        from fido.rate_limit import RateLimitMonitor
-
-        url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
-            _repo_state("owner/repo", what="idle", busy=False)
-        )
-        WebhookHandler.registry.get_session_owner.return_value = None
-        WebhookHandler.registry.get_session_alive.return_value = False
-        WebhookHandler.registry.get_session_pid.return_value = None
-        WebhookHandler.registry.is_rescoping.return_value = False
-
-        monitor = RateLimitMonitor(
-            MagicMock(), AtomicReference(FidoState(repos=frozendict()))
-        )
-        WebhookHandler.rate_limit_monitor = monitor
-        try:
-            resp = urllib.request.urlopen(f"{url}/status.json")
-            data = json.loads(resp.read())
-            assert data["rate_limit"] is None
-        finally:
-            WebhookHandler.rate_limit_monitor = None
 
     def test_status_endpoint_serializes_loaded_issue_cache(self, server: tuple) -> None:
         """Wire a real loaded :class:`IssueTreeCache` through the registry
@@ -1135,15 +1120,9 @@ class TestStatusXml:
         assert "<fido_uptime_seconds>" not in body
 
     def test_status_xml_includes_rate_limit(self, server: tuple) -> None:
-        """<rate_limit> with nested windows appears in the root element when available."""
-        from fido.rate_limit import (
-            RateLimitMonitor,
-            RateLimitSnapshot,
-            RateLimitWindow,
-        )
-
+        """<rate_limit> with nested windows appears in the root element when
+        ``FidoState.rate_limit`` is populated."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
         snap = RateLimitSnapshot(
             rest=RateLimitWindow(
                 name="rest",
@@ -1159,9 +1138,7 @@ class TestStatusXml:
             ),
             fetched_at=datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc),
         )
-        monitor = MagicMock(spec=RateLimitMonitor)
-        monitor.latest.return_value = snap
-        WebhookHandler.rate_limit_monitor = monitor
+        WebhookHandler.registry.get_state.return_value = _fido_state(rate_limit=snap)
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert "<rate_limit>" in body
@@ -3496,7 +3473,7 @@ class TestRun:
         mock_watchdog_cls.return_value.start_thread.assert_called_once()
 
     def test_run_starts_rate_limit_monitor_with_gh(self, tmp_path: Path) -> None:
-        from fido.server import WebhookHandler, run
+        from fido.server import run
 
         fake_cfg = self._fake_cfg(tmp_path)
         mock_server = MagicMock()
@@ -3525,7 +3502,6 @@ class TestRun:
         expected_state_ref = mock_make_registry.return_value.get_state_ref.return_value
         mock_rl_cls.assert_called_once_with(mock_gh_instance, expected_state_ref)
         mock_rl_cls.return_value.start_thread.assert_called_once()
-        assert WebhookHandler.rate_limit_monitor is mock_rl_cls.return_value
 
     def test_run_starts_reconcile_watchdog_with_registry_repos_and_gh(
         self, tmp_path: Path

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -220,6 +220,7 @@ def server(tmp_path: Path) -> object:
     repo_cfg = cfg.repos["owner/repo"]
     WebhookHandler.config = cfg
     WebhookHandler.registry = MagicMock()
+    WebhookHandler.state_reader = MagicMock()
     WebhookHandler.dispatchers = {"owner/repo": Dispatcher(cfg, repo_cfg, MagicMock())}
     WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
@@ -301,7 +302,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_returns_activities(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -331,7 +332,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_includes_session_owner(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = "worker-home"
@@ -350,7 +351,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_includes_session_alive(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -364,7 +365,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_includes_crash_info(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state(
                 "owner/repo",
                 what="Napping",
@@ -384,7 +385,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_empty_when_no_activities(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.status == 200
         assert json.loads(resp.read()) == {
@@ -395,7 +396,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_content_type_json(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status.json")
         assert resp.headers.get("Content-Type") == "application/json"
 
@@ -403,7 +404,7 @@ class TestGetEndpoint:
         """Repos whose activity is still the zero sentinel (what='') are excluded."""
         url, _ = server
         # A repo in the snapshot with what="" — prepopulated but never active.
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="")
         )
         resp = urllib.request.urlopen(f"{url}/status.json")
@@ -412,7 +413,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_is_stuck_true_when_stale(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", stale=True)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -425,7 +426,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_includes_rescoping_flag(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -459,7 +460,7 @@ class TestGetEndpoint:
                 resets_at=datetime(2024, 11, 14, 13, 0, tzinfo=timezone.utc),
             ),
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False),
             github_limits=limits,
         )
@@ -482,7 +483,7 @@ class TestGetEndpoint:
         """Zero-value ``GitHubLimit`` (not yet polled) → ``rate_limit``
         key is ``None`` in the ``/status.json`` response."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -511,7 +512,7 @@ class TestGetEndpoint:
             ),
             # graphql uses zero-value default: used=None, limit=None
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="idle", busy=False),
             github_limits=limits,
         )
@@ -537,7 +538,7 @@ class TestGetEndpoint:
         from fido.issue_cache import IssueTreeCache
 
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -579,7 +580,7 @@ class TestGetEndpoint:
         it as non-cache and emit ``None`` rather than raise.
         """
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -594,7 +595,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_includes_provider_status(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -625,7 +626,7 @@ class TestGetEndpoint:
 
     def test_status_endpoint_rescoping_false_by_default(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="Napping", busy=False)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -641,7 +642,7 @@ class TestGetEndpoint:
     ) -> None:
         """With no state.json or tasks.json on disk, fido_state fields default."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -710,7 +711,7 @@ class TestGetEndpoint:
         tasks_path.write_text(json.dumps(tasks))
 
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="Working on: #42")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -741,7 +742,7 @@ class TestGetEndpoint:
         """When a repo has no config entry, fido_state fields are all defaults."""
         url, _ = server
         # Report an activity for a repo not in config
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("unknown/repo", what="idle", busy=False)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1020,7 +1021,7 @@ class TestRepoStatus:
 class TestStatusXml:
     def test_status_returns_namespaced_xml_with_xslt_pi(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert resp.headers.get("Content-Type") == "application/xml; charset=utf-8"
@@ -1031,7 +1032,7 @@ class TestStatusXml:
 
     def test_status_xml_contains_repo_data_with_namespaces(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1047,7 +1048,7 @@ class TestStatusXml:
 
     def test_status_xml_empty_fido(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert 'xmlns="https://fidocancode.dog/fido"' in body
@@ -1066,7 +1067,7 @@ class TestStatusXml:
             claude_pid=9999,
             started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="working")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1081,7 +1082,7 @@ class TestStatusXml:
 
     def test_status_xml_includes_provider_status(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="working", busy=False)
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1112,7 +1113,7 @@ class TestStatusXml:
 
     def test_status_xml_includes_webhooks(self, server: tuple) -> None:
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state(
                 "owner/repo",
                 what="working",
@@ -1138,7 +1139,7 @@ class TestStatusXml:
     def test_status_xml_includes_fido_uptime(self, server: tuple) -> None:
         """<fido_uptime_seconds> appears in the root element when fido_started_at is set."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         WebhookHandler.fido_started_at = datetime(
             2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
         )
@@ -1149,7 +1150,7 @@ class TestStatusXml:
     def test_status_xml_no_fido_uptime_when_not_started(self, server: tuple) -> None:
         """<fido_uptime_seconds> is absent when fido_started_at is None (default)."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         assert WebhookHandler.fido_started_at is None
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
@@ -1173,9 +1174,7 @@ class TestStatusXml:
                 resets_at=datetime(2026, 4, 19, 13, 0, tzinfo=timezone.utc),
             ),
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(
-            github_limits=limits
-        )
+        WebhookHandler.state_reader.get.return_value = _fido_state(github_limits=limits)
         resp = urllib.request.urlopen(f"{url}/status")
         body = resp.read().decode()
         assert "<rate_limit>" in body
@@ -1187,7 +1186,7 @@ class TestStatusXml:
     def test_status_json_includes_fido_uptime(self, server: tuple) -> None:
         """fido_uptime_seconds appears in /status.json when fido_started_at is set."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         WebhookHandler.fido_started_at = datetime(
             2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc
         )
@@ -1199,7 +1198,7 @@ class TestStatusXml:
     def test_status_json_fido_uptime_null_when_not_started(self, server: tuple) -> None:
         """fido_uptime_seconds is null in /status.json when fido_started_at is None."""
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state()
+        WebhookHandler.state_reader.get.return_value = _fido_state()
         assert WebhookHandler.fido_started_at is None
         resp = urllib.request.urlopen(f"{url}/status.json")
         data = json.loads(resp.read())
@@ -1249,7 +1248,7 @@ class TestStatusXml:
         (fido_dir / "tasks.json").write_text(json.dumps(tasks))
 
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="Working on: #10")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1269,7 +1268,7 @@ class TestStatusXml:
         from fido.issue_cache import IssueTreeCache
 
         url, _ = server
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="working")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1804,7 +1803,7 @@ class TestProcessAction:
             claude_pid=12345,
             started_at=datetime(2026, 4, 14, 16, 0, tzinfo=timezone.utc),
         )
-        WebhookHandler.registry.get_state.return_value = _fido_state(
+        WebhookHandler.state_reader.get.return_value = _fido_state(
             _repo_state("owner/repo", what="running")
         )
         WebhookHandler.registry.get_session_owner.return_value = None
@@ -1914,12 +1913,13 @@ class TestProcessAction:
 
     def test_issue_comment_webhook_activity_tracks_phase(self, tmp_path: Path) -> None:
         from fido.events import Action
-        from fido.registry import WorkerRegistry
+        from fido.registry import WorkerRegistry, create_fido_atomic
 
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
-        handler.registry = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        handler.registry = WorkerRegistry(MagicMock(), updater)
         handler.registry.start(cfg.repos["owner/repo"])
         handler.gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
@@ -3536,10 +3536,15 @@ class TestRun:
             _RateLimitMonitor=mock_rl_cls,
         )
 
-        expected_state_updater = (
-            mock_make_registry.return_value.get_state_updater.return_value
-        )
-        mock_rl_cls.assert_called_once_with(mock_gh_instance, expected_state_updater)
+        # The state_updater is the second element returned by _create_fido_atomic().
+        # RateLimitMonitor must be wired with the same updater that was passed to
+        # make_registry — verify positional args rather than the updater value.
+        assert mock_rl_cls.call_count == 1
+        rl_args = mock_rl_cls.call_args[0]
+        assert rl_args[0] is mock_gh_instance
+        # The updater passed to RateLimitMonitor must be the same object that was
+        # passed as state_updater to make_registry.
+        assert rl_args[1] is mock_make_registry.call_args.kwargs["state_updater"]
         mock_rl_cls.return_value.start_thread.assert_called_once()
 
     def test_run_starts_reconcile_watchdog_with_registry_repos_and_gh(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,7 @@ import pytest
 from frozendict import frozendict
 
 from fido import provider
+from fido.atomic import AtomicReference
 from fido.claude import ClaudeClient
 from fido.config import Config
 from fido.config import RepoConfig as _RepoConfig
@@ -448,7 +449,7 @@ class TestGetEndpoint:
             "core": {"used": 5, "limit": 5000, "reset": 1700000000},
             "graphql": {"used": 12, "limit": 5000, "reset": 1700003600},
         }
-        monitor = RateLimitMonitor(gh)
+        monitor = RateLimitMonitor(gh, AtomicReference(FidoState(repos=frozendict())))
         monitor.refresh()
         WebhookHandler.rate_limit_monitor = monitor
         try:
@@ -496,7 +497,9 @@ class TestGetEndpoint:
         WebhookHandler.registry.get_session_pid.return_value = None
         WebhookHandler.registry.is_rescoping.return_value = False
 
-        monitor = RateLimitMonitor(MagicMock())
+        monitor = RateLimitMonitor(
+            MagicMock(), AtomicReference(FidoState(repos=frozendict()))
+        )
         WebhookHandler.rate_limit_monitor = monitor
         try:
             resp = urllib.request.urlopen(f"{url}/status.json")
@@ -3519,7 +3522,8 @@ class TestRun:
             _RateLimitMonitor=mock_rl_cls,
         )
 
-        mock_rl_cls.assert_called_once_with(mock_gh_instance)
+        expected_state_ref = mock_make_registry.return_value.get_state_ref.return_value
+        mock_rl_cls.assert_called_once_with(mock_gh_instance, expected_state_ref)
         mock_rl_cls.return_value.start_thread.assert_called_once()
         assert WebhookHandler.rate_limit_monitor is mock_rl_cls.return_value
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3045,21 +3045,17 @@ class TestParseRateLimit:
         assert _parse_rate_limit("nope") is None
 
     def test_returns_none_when_rest_missing(self) -> None:
-        raw = {"graphql": {}, "fetched_at": "2026-04-19T12:00:00+00:00"}
+        raw = {"graphql": {}}
         assert _parse_rate_limit(raw) is None
 
     def test_returns_none_when_graphql_missing(self) -> None:
-        raw = {"rest": {}, "fetched_at": "2026-04-19T12:00:00+00:00"}
-        assert _parse_rate_limit(raw) is None
-
-    def test_returns_none_when_fetched_at_missing(self) -> None:
-        raw = {"rest": {}, "graphql": {}}
+        raw = {"rest": {}}
         assert _parse_rate_limit(raw) is None
 
     def test_parses_full_payload(self) -> None:
         raw = {
             "rest": {
-                "name": "core",
+                "name": "rest",
                 "used": 5,
                 "limit": 5000,
                 "resets_at": "2026-04-19T13:00:00+00:00",
@@ -3070,19 +3066,16 @@ class TestParseRateLimit:
                 "limit": 5000,
                 "resets_at": "2026-04-19T14:00:00+00:00",
             },
-            "fetched_at": "2026-04-19T12:00:00+00:00",
         }
         info = _parse_rate_limit(raw)
         assert info is not None
         assert info.rest.used == 5
         assert info.graphql.used == 12
-        assert info.fetched_at.year == 2026
 
     def test_window_falls_back_to_epoch_when_resets_at_invalid(self) -> None:
         raw = {
-            "rest": {"name": "core", "used": 0, "limit": 5000, "resets_at": "garbage"},
+            "rest": {"name": "rest", "used": 0, "limit": 5000, "resets_at": "garbage"},
             "graphql": {"name": "graphql", "used": 0, "limit": 5000},
-            "fetched_at": "2026-04-19T12:00:00+00:00",
         }
         info = _parse_rate_limit(raw)
         assert info is not None
@@ -3152,7 +3145,6 @@ class TestFormatRateLimitLine:
         info = RateLimitInfo(
             rest=_window("core", used=5, limit=5000),
             graphql=_window("graphql", used=10, limit=5000),
-            fetched_at=datetime.now(tz=timezone.utc),
         )
         out = _format_rate_limit_line(info)
         assert out is not None
@@ -3186,7 +3178,6 @@ class TestFormatStatusRateLimitIntegration:
         info = RateLimitInfo(
             rest=_window("core", used=5, limit=5000),
             graphql=_window("graphql", used=12, limit=5000),
-            fetched_at=datetime.now(tz=timezone.utc),
         )
         status = FidoStatus(
             fido_pid=None,
@@ -3227,7 +3218,7 @@ class TestFetchActivitiesRateLimit:
     def test_parses_rate_limit_payload(self) -> None:
         rate = {
             "rest": {
-                "name": "core",
+                "name": "rest",
                 "used": 7,
                 "limit": 5000,
                 "resets_at": "2026-04-19T13:00:00+00:00",
@@ -3238,7 +3229,6 @@ class TestFetchActivitiesRateLimit:
                 "limit": 5000,
                 "resets_at": "2026-04-19T14:00:00+00:00",
             },
-            "fetched_at": "2026-04-19T12:00:00+00:00",
         }
         data = self._wrap([], rate)
         _, info = _fetch_activities(9000, _urlopen=self._make_urlopen(data))

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -769,13 +769,15 @@ class TestWorker:
     def test_set_status_reports_activity_to_registry(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         registry = MagicMock()
-        registry.get_all_activities.return_value = []
+        state_reader = MagicMock()
+        state_reader.get.return_value.repos = {}
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
             tmp_path,
             gh,
             repo_name="owner/myrepo",
             registry=registry,
+            state_reader=state_reader,
             session=self._session(status="working"),
         ).set_status("working", busy=True, _sub_dir_fn=lambda: tmp_path)
         registry.report_activity.assert_called_once_with(
@@ -787,15 +789,20 @@ class TestWorker:
     ) -> None:
         gh = self._make_gh()
         registry = MagicMock()
-        activity_a = MagicMock()
-        activity_a.repo_name = "owner/repo-a"
-        activity_a.what = "fixing bug"
-        activity_a.busy = True
-        activity_b = MagicMock()
-        activity_b.repo_name = "owner/repo-b"
-        activity_b.what = "napping"
-        activity_b.busy = False
-        registry.get_all_activities.return_value = [activity_a, activity_b]
+        # Build a fake state_reader whose repos map contains two repo states.
+        state_reader = MagicMock()
+        rs_a = MagicMock()
+        rs_a.activity.repo_name = "owner/repo-a"
+        rs_a.activity.what = "fixing bug"
+        rs_a.activity.busy = True
+        rs_b = MagicMock()
+        rs_b.activity.repo_name = "owner/repo-b"
+        rs_b.activity.what = "napping"
+        rs_b.activity.busy = False
+        state_reader.get.return_value.repos = {
+            "owner/repo-a": rs_a,
+            "owner/repo-b": rs_b,
+        }
         (tmp_path / "persona.md").write_text("I am Fido.")
         session = self._session(status="fixing bug")
         Worker(
@@ -803,6 +810,7 @@ class TestWorker:
             gh,
             repo_name="owner/repo-a",
             registry=registry,
+            state_reader=state_reader,
             session=session,
         ).set_status("fixing bug", _sub_dir_fn=lambda: tmp_path)
         prompt_arg = session.prompt.call_args[0][0]
@@ -814,13 +822,15 @@ class TestWorker:
     ) -> None:
         gh = self._make_gh()
         registry = MagicMock()
-        registry.get_all_activities.return_value = []
+        state_reader = MagicMock()
+        state_reader.get.return_value.repos = {}
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
             tmp_path,
             gh,
             repo_name="owner/repo",
             registry=registry,
+            state_reader=state_reader,
             session=self._session(status="working"),
         ).set_status("working", _sub_dir_fn=lambda: tmp_path)
         registry.status_update.assert_called_once()
@@ -829,9 +839,10 @@ class TestWorker:
         self, tmp_path: Path
     ) -> None:
         """Concurrent set_status calls on different workers sharing a registry serialize."""
-        from fido.registry import WorkerRegistry
+        from fido.registry import WorkerRegistry, create_fido_atomic
 
-        registry = WorkerRegistry(MagicMock())
+        _, updater = create_fido_atomic()
+        registry = WorkerRegistry(MagicMock(), updater)
         # Prepopulate FidoState so report_activity can lens-write into it.
         for i in range(3):
             registry.start(_default_repo_cfg(tmp_path, repo_name=f"owner/repo{i}"))
@@ -11784,9 +11795,6 @@ class _FakeActivityReporter:
     ) -> None:  # pragma: no cover — unused in these tests
         _ = (repo_name, what, busy)
 
-    def get_all_activities(self) -> list[object]:  # pragma: no cover — unused
-        return []
-
     def status_update(
         self,
     ) -> AbstractContextManager[None]:  # pragma: no cover — unused
@@ -15104,11 +15112,12 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
-            dispatcher: object = None,
             first_iteration: bool = False,
+            state_reader: object = None,
+            dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -15212,11 +15221,12 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
-            dispatcher: object = None,
             first_iteration: bool = False,
+            state_reader: object = None,
+            dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -15267,11 +15277,12 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
-            dispatcher: object = None,
             first_iteration: bool = False,
+            state_reader: object = None,
+            dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -15728,11 +15739,12 @@ class TestWorkerThread:
             config: object = None,
             repo_cfg: object = None,
             provider_factory: object = None,
-            dispatcher: object = None,
             first_iteration: bool = False,
+            state_reader: object = None,
+            dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -769,68 +769,29 @@ class TestWorker:
     def test_set_status_reports_activity_to_registry(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         registry = MagicMock()
-        state_reader = MagicMock()
-        state_reader.get.return_value.repos = {}
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
             tmp_path,
             gh,
             repo_name="owner/myrepo",
             registry=registry,
-            state_reader=state_reader,
             session=self._session(status="working"),
         ).set_status("working", busy=True, _sub_dir_fn=lambda: tmp_path)
         registry.report_activity.assert_called_once_with(
             "owner/myrepo", "working", True
         )
 
-    def test_set_status_uses_full_registry_snapshot_for_prompt(
-        self, tmp_path: Path
-    ) -> None:
-        gh = self._make_gh()
-        registry = MagicMock()
-        # Build a fake state_reader whose repos map contains two repo states.
-        state_reader = MagicMock()
-        rs_a = MagicMock()
-        rs_a.activity.repo_name = "owner/repo-a"
-        rs_a.activity.what = "fixing bug"
-        rs_a.activity.busy = True
-        rs_b = MagicMock()
-        rs_b.activity.repo_name = "owner/repo-b"
-        rs_b.activity.what = "napping"
-        rs_b.activity.busy = False
-        state_reader.get.return_value.repos = {
-            "owner/repo-a": rs_a,
-            "owner/repo-b": rs_b,
-        }
-        (tmp_path / "persona.md").write_text("I am Fido.")
-        session = self._session(status="fixing bug")
-        Worker(
-            tmp_path,
-            gh,
-            repo_name="owner/repo-a",
-            registry=registry,
-            state_reader=state_reader,
-            session=session,
-        ).set_status("fixing bug", _sub_dir_fn=lambda: tmp_path)
-        prompt_arg = session.prompt.call_args[0][0]
-        assert "owner/repo-a" in prompt_arg
-        assert "owner/repo-b" in prompt_arg
-
     def test_set_status_acquires_status_lock_when_registry_present(
         self, tmp_path: Path
     ) -> None:
         gh = self._make_gh()
         registry = MagicMock()
-        state_reader = MagicMock()
-        state_reader.get.return_value.repos = {}
         (tmp_path / "persona.md").write_text("I am Fido.")
         Worker(
             tmp_path,
             gh,
             repo_name="owner/repo",
             registry=registry,
-            state_reader=state_reader,
             session=self._session(status="working"),
         ).set_status("working", _sub_dir_fn=lambda: tmp_path)
         registry.status_update.assert_called_once()
@@ -15113,11 +15074,10 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
-            state_reader: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -15222,11 +15182,10 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
-            state_reader: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -15278,11 +15237,10 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
-            state_reader: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -15740,11 +15698,10 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
-            state_reader: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, state_reader, dispatcher, first_iteration, issue_cache
+            del provider_factory, dispatcher, first_iteration, issue_cache
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task


### PR DESCRIPTION
Fixes #1346.

Migrates GitHub rate-limit data to a dedicated `github_limits: GitHubLimit` frozen dataclass field on `FidoState` — always present, no default, updated lock-free via Lens CAS by the `RateLimitMonitor` poller thread (write-only; no `latest()` accessor). Makes `AtomicReference` a private implementation detail behind a `create_atomic(value)` factory that returns an `(AtomicReader[T], AtomicUpdater[T])` tuple — callers get exactly the face they need, and holding both is a visible smell. Removes `ProviderID.GITHUB` from the StrEnum so the enum represents only LLM providers. Enforces single-face ownership: `WorkerRegistry` holds only the updater; the composition root passes the reader directly to status serialization. Removes dead `get_all_activities()` helper and the leaked `state_reader` from Worker/WorkerThread — only status.json and /status may hold the read face.

Fixes #1346.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (23)</summary>

- [x] [Move the `AtomicReader` import in registry.py under a `TYPE_CHECKING` guard (string-annotate the return type of `create_fido_atomic()` if needed). It's annotation-only now that `get_all_activities()` is gone.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3211900980) <!-- type:thread -->
- [x] [Remove `get_all_activities()` from registry.py — it is dead code with no production callers. Also remove the corresponding tests in test_registry.py.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3211810665) <!-- type:thread -->
- [x] [Remove `state_reader: AtomicReader[Any] | None` from Worker and WorkerThread. The worker must not hold the AtomicReader face — only status.json and /status are legal consumers of it. Revert any `_set_status` logic that reads from `state_reader` and keep that reading on the status serialization path instead.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3211818069) <!-- type:thread -->
- [x] [Remove the default from `github_limits: GitHubLimit` on `FidoState`. Make it a plain field with no `field(default_factory=...)`. Update `_EMPTY_FIDO_STATE = FidoState(repos=frozendict())` to pass `github_limits=GitHubLimit()` explicitly.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192862625) <!-- type:thread -->
- [x] [In GitHubLimit, replace `field(default_factory=lambda: _ZERO_WINDOW_REST)` and `field(default_factory=lambda: _ZERO_WINDOW_GRAPHQL)` with direct defaults: `rest: ProviderLimitWindow = _ZERO_WINDOW_REST` and `graphql: ProviderLimitWindow = _ZERO_WINDOW_GRAPHQL`.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192669211) <!-- type:thread -->
- [x] [WorkerRegistry must hold ONLY the AtomicUpdater. Remove _state_reader, get_state(), get_all_activities(), get_state_reader(), and get_state_updater() from WorkerRegistry. The composition root in server.py creates the atomic cell via create_atomic() and passes: (1) the updater to WorkerRegistry and RateLimitMonitor, (2) the reader directly to the status serialization path (status.json / _serialize_rate_limit). Read-side methods like get_all_activities() move to whatever object holds the reader, or become standalone functions that accept a reader.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192679171) <!-- type:thread -->
- [x] [Make AtomicReference a private implementation detail (unexported). Add a public factory function — e.g. `create_atomic(value: T) -> tuple[AtomicReader[T], AtomicUpdater[T]]` — as the sole way to create an atomic cell. Update all call sites in registry.py and elsewhere to use the factory. Remove AtomicReference from __all__ and from direct imports in tests/other modules.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192612450) <!-- type:thread -->
- [x] [Remove ProviderID.GITHUB from the ProviderID StrEnum. GitHub platform rate limits must not live in provider_limits — instead create a GitHubLimit frozen dataclass and add a github_limits field directly on FidoState (always present, zero-value default). RateLimitMonitor publishes to root.github_limits via Lens CAS, not to provider_limits["github"].](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192377491) <!-- type:thread -->
- [x] [Type the state parameter as AtomicReference[FidoState] instead of AtomicReference[Any]. Use a TYPE_CHECKING import to avoid circular dependency.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192383370) <!-- type:thread -->
- [x] [Remove the `latest()` method from RateLimitMonitor. The monitor is only a writer — it publishes to FidoState. The sole consumer (status.json serialization) reads directly from `registry.get_state().github_limits`. No read accessor needed on the monitor itself.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192390149) <!-- type:thread -->
- [x] [Split AtomicReference into separate AtomicReader[T] (exposes only .get()) and AtomicUpdater[T] (exposes only .update()) types in this PR. Give writers only the updater, give status.json only the reader. Document that holding both is a code smell.](https://github.com/FidoCanCode/home/pull/1415#issuecomment-4384343509) <!-- type:thread -->
- [x] Update tests for github_limits field on FidoState <!-- type:spec -->
- [x] Migrate serialization and status display to read from github_limits <!-- type:spec -->
- [x] Wire RateLimitMonitor to publish to github_limits field <!-- type:spec -->
- [x] Create GitHubLimit frozen dataclass and add github_limits field to FidoState <!-- type:spec -->
- [x] Update tests for provider_limits-based rate-limit path <!-- type:spec -->
- [x] Migrate _serialize_rate_limit to read from provider_limits map <!-- type:spec -->
- [x] Adapt RateLimitMonitor to publish as ProviderLimitSnapshot <!-- type:spec -->
- [x] Prepopulate provider_limits with zero-value entries at startup <!-- type:spec -->
- [x] [Replace the flat `rate_limit: RateLimitSnapshot | None` field on FidoState with a `frozendict[str, ProviderLimit]` keyed by provider string. Prepopulate with all loaded providers at zero values until data arrives. Keep all metrics in one deeply-nested structure accessed via Lens — don't scatter them as separate root fields.](https://github.com/FidoCanCode/home/pull/1415#discussion_r3192317176) <!-- type:thread -->
- [x] Migrate _serialize_rate_limit to read from FidoState snapshot <!-- type:spec -->
- [x] Update tests for lock-free rate-limit snapshot path <!-- type:spec -->
- [x] Add rate_limit field to FidoState and wire CAS update in RateLimitMonitor <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->