### PR TITLE
Bug: lockfree status PR 5/6 — migrate _threads_lock to RegistrySnapshot AND stop holding lock across thread.join() in stop_and_join (closes #1347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,32 @@ durable store handles *across runs*. Don't conflate them.
 **Reviewer signal:** if an action is taken before the corresponding record is
 written to `tasks.json` (or another durable store), the order is wrong.
 
+### FidoState is a SCADA display projection — not a source of truth
+
+`FidoState` is a frozen, atomically-swapped snapshot whose sole purpose is
+lock-free status serialisation (`/status.json` and `./fido status`).  It is a
+**display projection**, not the authoritative state.
+
+Two rules follow from this:
+
+1. **`AtomicReader[FidoState]` belongs exclusively to the status serialisation
+   path.**  The composition root passes the reader to `WebhookHandler.state_reader`
+   and to nothing else.  `WorkerRegistry`, workers, event handlers, and all other
+   app code must never hold the reader face.  Violations make every future
+   `status.json` enhancement a cross-cutting change.
+
+2. **Mutable objects must not live inside `FidoState` (or any of its nested
+   frozen dataclasses).**  The snapshot must be recursively immutable.  A
+   frozen dataclass field that *references* a mutable object (e.g. a
+   `WorkerThread`) breaks the lock-free promise — snapshot readers can observe
+   partial mutations through the reference even though the field itself is
+   frozen.  Thread references live in a plain dict on `WorkerRegistry`; only
+   frozen, value-type data belongs in `FidoState`.
+
+**Reviewer signal:** if any class other than the status serialisation path
+holds an `AtomicReader[FidoState]`, or if any `FidoState` / `RepoState` field
+references a mutable object, that's a violation of this boundary.
+
 ### Rocq-modeled coordination boundary
 
 Long-term coordination work under #710 must make the scheduler/reducer

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -107,24 +107,6 @@ class WebhookActivity:
 
 
 @dataclass(frozen=True, slots=True)
-class ThreadHandle:
-    """Frozen reference to a :class:`~fido.worker.WorkerThread`.
-
-    Stored inside :class:`RepoState` so snapshot readers can reach the
-    thread's session metadata and liveness state without holding any lock.
-    The thread itself is mutable — ``ThreadHandle`` only freezes the
-    *reference*, not the object it points to.
-
-    ``thread_handle`` is ``None`` only in a zero-value :class:`RepoState`
-    that was constructed before :meth:`~WorkerRegistry.start` ran for that
-    repo.  After :meth:`~WorkerRegistry.start` completes the field is always
-    non-``None``.
-    """
-
-    thread: WorkerThread
-
-
-@dataclass(frozen=True, slots=True)
 class RepoState:
     """Per-repo sub-snapshot within :class:`FidoState`.
 
@@ -146,16 +128,15 @@ class RepoState:
     repo.  Published from the authoritative ``_webhook_activities`` dict on
     :class:`WorkerRegistry` via :meth:`~WorkerRegistry._publish_webhook_activities`; starts empty.
 
-    *thread_handle* is a :class:`ThreadHandle` wrapping the
-    :class:`~fido.worker.WorkerThread` for this repo.  Populated by
-    :meth:`~WorkerRegistry.start`; ``None`` only before the first start
-    (which never happens in the normal lifecycle).  All thread lookups
-    read from this field via the lock-free snapshot.
-
     As subsequent lock-free PRs migrate fields out of the per-lock dicts in
     :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
     Each migration removes the corresponding lock and dict from
     ``WorkerRegistry.__init__``.
+
+    **Thread references do not belong here.**  :class:`WorkerThread` is mutable,
+    so storing a reference inside the recursively-immutable snapshot would break
+    the lock-free promise of :class:`FidoState`.  Thread lookups go through
+    ``WorkerRegistry._threads`` instead.
     """
 
     key: str
@@ -163,7 +144,6 @@ class RepoState:
     activity: WorkerActivity
     crash_record: WorkerCrash
     webhook_activities: tuple[WebhookActivity, ...]
-    thread_handle: ThreadHandle | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,16 +205,21 @@ class WorkerRegistry:
     Threads are created via the injected *thread_factory* so tests can
     supply mock threads without patching module-level names.
 
-    Holds both faces of the atomic :class:`FidoState` cell: the updater for
-    writing thread and activity state into the snapshot, and the reader for
-    lock-free thread lookups via :meth:`_get_thread`.  Status serialisation
-    reads the snapshot directly via the reader passed to
-    :class:`~fido.server.WebhookHandler` at the composition root.
+    Holds only the **updater** face of the atomic :class:`FidoState` cell.
+    The reader face belongs exclusively to the status serialisation path
+    (``WebhookHandler.state_reader``).  ``WorkerRegistry`` never reads from
+    ``FidoState`` — it is a SCADA display projection for lock-free status
+    reporting, not a source of truth for app logic.
+
+    Thread references live in a plain ``_threads`` dict — written only by the
+    watchdog thread in :meth:`start`, read by command paths.  Mutable objects
+    like :class:`~fido.worker.WorkerThread` must never appear inside the
+    recursively-immutable :class:`FidoState` snapshot.
 
     Usage::
 
         state_reader, state_updater = create_fido_atomic()
-        registry = WorkerRegistry(my_factory, state_reader, state_updater)
+        registry = WorkerRegistry(my_factory, state_updater)
         registry.start(repo_cfg)   # create + start thread
         registry.wake("owner/repo")  # nudge thread to check for work
         registry.stop_all()          # clean shutdown
@@ -243,19 +228,20 @@ class WorkerRegistry:
     def __init__(
         self,
         thread_factory: Callable[..., WorkerThread],
-        state_reader: "AtomicReader[FidoState]",
         state_updater: "AtomicUpdater[FidoState]",
     ) -> None:
         self._factory = thread_factory
         self._status_lock = threading.Lock()
-        # _state_reader is the read face of the atomic FidoState cell.
-        # Lock-free thread lookups (wake, abort_task, get_session, …) call
-        # _get_thread() which reads thread_handle from the snapshot via this reader.
-        self._state_reader: "AtomicReader[FidoState]" = state_reader
         # _state_updater is the write face of the atomic FidoState cell.
         # Writers call _state_updater.update(selector, value) to CAS-install a
         # value at a Lens path.
         self._state_updater: AtomicUpdater[FidoState] = state_updater
+        # Per-repo thread references.  Written only by start() (called from
+        # the single watchdog thread during crash recovery, or sequentially
+        # during startup).  Read by command paths (wake, abort_task, stop_*,
+        # get_session, …).  No lock needed — single-writer, and readers only
+        # need a point-in-time reference.
+        self._threads: dict[str, WorkerThread] = {}
         # Owner-side crash records: the watchdog increments death_count here,
         # then publishes the result into FidoState via a pure lens write.
         # Only the watchdog thread writes; start() reads during crash recovery
@@ -291,16 +277,13 @@ class WorkerRegistry:
         self._webhook_lock = threading.Lock()
 
     def _get_thread(self, repo_name: str) -> WorkerThread | None:
-        """Return the :class:`~fido.worker.WorkerThread` for *repo_name* from
-        the lock-free snapshot, or ``None`` if no thread has been started.
+        """Return the :class:`~fido.worker.WorkerThread` for *repo_name*, or
+        ``None`` if no thread has been started.
 
-        Reads :attr:`RepoState.thread_handle` via the atomic reader — no lock
-        acquisition needed.  All thread lookups go through this method.
+        Reads from the plain ``_threads`` dict — no lock needed (single-writer).
+        All thread lookups go through this method.
         """
-        repo_state = self._state_reader.get().repos.get(repo_name)
-        if repo_state is None or repo_state.thread_handle is None:
-            return None
-        return repo_state.thread_handle.thread
+        return self._threads.get(repo_name)
 
     def _registry_fsm_transition(
         self, repo_name: str, event: registry_fsm.Event
@@ -389,6 +372,9 @@ class WorkerRegistry:
         thread = self._factory(repo_cfg, provider=provider, session_issue=session_issue)
         _name = repo_cfg.name
         _now = _utcnow()
+        # Store the mutable thread reference in the plain dict — never in
+        # FidoState (which must be recursively immutable).
+        self._threads[_name] = thread
         # Prepopulate the full RepoState with zero values.  Crash history
         # comes from the class-owned _crash_records (not from FidoState),
         # so this is a pure write — no read-modify-write CAS.
@@ -399,7 +385,6 @@ class WorkerRegistry:
             activity=_zero_activity(_name),
             crash_record=crash_record,
             webhook_activities=(),
-            thread_handle=ThreadHandle(thread=thread),
         )
         self._state_updater.update(lambda root: root.repos[_name], new_repo)
         thread.start()
@@ -579,13 +564,7 @@ class WorkerRegistry:
 
     def stop_all(self) -> None:
         """Request every managed thread to stop after its current iteration."""
-        snapshot = self._state_reader.get()
-        threads = [
-            rs.thread_handle.thread
-            for rs in snapshot.repos.values()
-            if rs.thread_handle is not None
-        ]
-        for thread in threads:
+        for thread in list(self._threads.values()):
             thread.stop()
 
     def stop_and_join(self, repo_name: str, timeout: float = 30.0) -> None:
@@ -965,7 +944,6 @@ def make_registry(
     config: Config | None = None,
     *,
     dispatchers: "dict[str, Dispatcher]",
-    state_reader: "AtomicReader[FidoState]",
     state_updater: "AtomicUpdater[FidoState]",
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
@@ -974,8 +952,9 @@ def make_registry(
     Uses :func:`_make_thread` as the factory; all threads share the provided
     :class:`~fido.github.GitHub` client.  The caller (composition root) is
     responsible for creating the atomic cell via :func:`create_fido_atomic`
-    and passing both faces here.  Pass a custom registry directly
-    (with a mock factory) in tests instead of calling this.
+    and passing both faces here — the updater comes to us, the reader stays
+    at the composition root for status serialisation.  Pass a custom registry
+    directly (with a mock factory) in tests instead of calling this.
     """
 
     def factory(
@@ -994,7 +973,7 @@ def make_registry(
             dispatchers=dispatchers,
         )
 
-    registry = WorkerRegistry(factory, state_reader, state_updater)
+    registry = WorkerRegistry(factory, state_updater)
     for repo_cfg in repos.values():
         registry.start(repo_cfg)
     return registry

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -149,8 +149,8 @@ class RepoState:
     *thread_handle* is a :class:`ThreadHandle` wrapping the
     :class:`~fido.worker.WorkerThread` for this repo.  Populated by
     :meth:`~WorkerRegistry.start`; ``None`` only before the first start
-    (which never happens in the normal lifecycle).  Lock-free readers use
-    this field instead of acquiring ``_threads_lock``.
+    (which never happens in the normal lifecycle).  All thread lookups
+    read from this field via the lock-free snapshot.
 
     As subsequent lock-free PRs migrate fields out of the per-lock dicts in
     :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
@@ -246,11 +246,6 @@ class WorkerRegistry:
         state_reader: "AtomicReader[FidoState]",
         state_updater: "AtomicUpdater[FidoState]",
     ) -> None:
-        self._threads: dict[str, WorkerThread] = {}
-        # _threads_lock guards _threads: written by start() on the watchdog
-        # thread, read from stop_all/stop_and_join (not yet migrated to the
-        # snapshot).  Python 3.14t has no GIL — dict reads and writes are not atomic.
-        self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._status_lock = threading.Lock()
         # _state_reader is the read face of the atomic FidoState cell.
@@ -300,8 +295,7 @@ class WorkerRegistry:
         the lock-free snapshot, or ``None`` if no thread has been started.
 
         Reads :attr:`RepoState.thread_handle` via the atomic reader — no lock
-        acquisition needed.  Callers that only need to *invoke* thread methods
-        (wake, abort, session lookups) use this instead of ``_threads_lock``.
+        acquisition needed.  All thread lookups go through this method.
         """
         repo_state = self._state_reader.get().repos.get(repo_name)
         if repo_state is None or repo_state.thread_handle is None:
@@ -363,8 +357,7 @@ class WorkerRegistry:
         """
         provider = None
         session_issue = None
-        with self._threads_lock:
-            old_thread = self._threads.get(repo_cfg.name)
+        old_thread = self._get_thread(repo_cfg.name)
         if old_thread is None:
             # No predecessor — initial start: Absent → Active.
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())
@@ -394,8 +387,6 @@ class WorkerRegistry:
             # the no_start_while_active violation as an immediate AssertionError.
             self._registry_fsm_transition(repo_cfg.name, registry_fsm.Launch())
         thread = self._factory(repo_cfg, provider=provider, session_issue=session_issue)
-        with self._threads_lock:
-            self._threads[repo_cfg.name] = thread
         _name = repo_cfg.name
         _now = _utcnow()
         # Prepopulate the full RepoState with zero values.  Crash history
@@ -588,8 +579,12 @@ class WorkerRegistry:
 
     def stop_all(self) -> None:
         """Request every managed thread to stop after its current iteration."""
-        with self._threads_lock:
-            threads = list(self._threads.values())
+        snapshot = self._state_reader.get()
+        threads = [
+            rs.thread_handle.thread
+            for rs in snapshot.repos.values()
+            if rs.thread_handle is not None
+        ]
         for thread in threads:
             thread.stop()
 
@@ -598,8 +593,7 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         if thread:
             thread.stop()
             thread.join(timeout=timeout)

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -225,16 +225,16 @@ class WorkerRegistry:
     Threads are created via the injected *thread_factory* so tests can
     supply mock threads without patching module-level names.
 
-    Write-only relative to :class:`FidoState` — the registry holds only the
-    :class:`~fido.atomic.AtomicUpdater` face of the atomic cell.  The
-    :class:`~fido.atomic.AtomicReader` face lives in the composition root and
-    is passed directly to the status serialisation path so only the one
-    collaborator that actually reads holds the read face.
+    Holds both faces of the atomic :class:`FidoState` cell: the updater for
+    writing thread and activity state into the snapshot, and the reader for
+    lock-free thread lookups via :meth:`_get_thread`.  Status serialisation
+    reads the snapshot directly via the reader passed to
+    :class:`~fido.server.WebhookHandler` at the composition root.
 
     Usage::
 
         state_reader, state_updater = create_fido_atomic()
-        registry = WorkerRegistry(my_factory, state_updater)
+        registry = WorkerRegistry(my_factory, state_reader, state_updater)
         registry.start(repo_cfg)   # create + start thread
         registry.wake("owner/repo")  # nudge thread to check for work
         registry.stop_all()          # clean shutdown
@@ -243,19 +243,23 @@ class WorkerRegistry:
     def __init__(
         self,
         thread_factory: Callable[..., WorkerThread],
+        state_reader: "AtomicReader[FidoState]",
         state_updater: "AtomicUpdater[FidoState]",
     ) -> None:
         self._threads: dict[str, WorkerThread] = {}
         # _threads_lock guards _threads: written by start() on the watchdog
-        # thread, read from HTTP handler threads (wake, abort_task, get_session,
-        # etc.).  Python 3.14t has no GIL — dict reads and writes are not atomic.
+        # thread, read from stop_all/stop_and_join (not yet migrated to the
+        # snapshot).  Python 3.14t has no GIL — dict reads and writes are not atomic.
         self._threads_lock = threading.Lock()
         self._factory = thread_factory
         self._status_lock = threading.Lock()
-        # _state_updater is the write-only face of the atomic FidoState cell.
+        # _state_reader is the read face of the atomic FidoState cell.
+        # Lock-free thread lookups (wake, abort_task, get_session, …) call
+        # _get_thread() which reads thread_handle from the snapshot via this reader.
+        self._state_reader: "AtomicReader[FidoState]" = state_reader
+        # _state_updater is the write face of the atomic FidoState cell.
         # Writers call _state_updater.update(selector, value) to CAS-install a
-        # value at a Lens path.  The read face (AtomicReader) lives in the
-        # composition root; this class never reads the snapshot.
+        # value at a Lens path.
         self._state_updater: AtomicUpdater[FidoState] = state_updater
         # Owner-side crash records: the watchdog increments death_count here,
         # then publishes the result into FidoState via a pure lens write.
@@ -290,6 +294,19 @@ class WorkerRegistry:
         # so the snapshot is always up to date.
         self._webhook_activities: dict[str, list[WebhookActivity]] = {}
         self._webhook_lock = threading.Lock()
+
+    def _get_thread(self, repo_name: str) -> WorkerThread | None:
+        """Return the :class:`~fido.worker.WorkerThread` for *repo_name* from
+        the lock-free snapshot, or ``None`` if no thread has been started.
+
+        Reads :attr:`RepoState.thread_handle` via the atomic reader — no lock
+        acquisition needed.  Callers that only need to *invoke* thread methods
+        (wake, abort, session lookups) use this instead of ``_threads_lock``.
+        """
+        repo_state = self._state_reader.get().repos.get(repo_name)
+        if repo_state is None or repo_state.thread_handle is None:
+            return None
+        return repo_state.thread_handle.thread
 
     def _registry_fsm_transition(
         self, repo_name: str, event: registry_fsm.Event
@@ -402,8 +419,7 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         if thread:
             thread.wake()
 
@@ -416,15 +432,13 @@ class WorkerRegistry:
 
         No-op if no thread is registered for that repo.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         if thread:
             thread.abort_task(task_id=task_id)
 
     def recover_provider(self, repo_name: str) -> bool:
         """Recover the attached provider session for *repo_name*, if present."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         if thread is None:
             return False
         return thread.recover_provider()
@@ -592,14 +606,12 @@ class WorkerRegistry:
 
     def is_alive(self, repo_name: str) -> bool:
         """Return True if the thread for *repo_name* is currently alive."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread is not None and thread.is_alive()
 
     def get_thread_crash_error(self, repo_name: str) -> str | None:
         """Return the crash_error stored on the thread for *repo_name*, or None."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.crash_error if thread is not None else None
 
     def get_session_owner(self, repo_name: str) -> str | None:
@@ -609,8 +621,7 @@ class WorkerRegistry:
         registered thread.  Returns ``None`` when no thread is registered for
         the repo, no session exists, or the lock is currently free.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_owner if thread is not None else None
 
     def get_session_alive(self, repo_name: str) -> bool:
@@ -620,8 +631,7 @@ class WorkerRegistry:
         currently holds still reports ``session_alive=True`` so status display
         can distinguish "session exists, idle" from "no session".
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_alive if thread is not None else False
 
     def get_session_pid(self, repo_name: str) -> int | None:
@@ -631,26 +641,22 @@ class WorkerRegistry:
         pgrep — the system prompt file path changed in #456 so the pgrep
         heuristic in :mod:`fido.status` can no longer locate it.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_pid if thread is not None else None
 
     def get_session_dropped_count(self, repo_name: str) -> int:
         """Return how many stale persistent session ids were dropped for *repo_name*."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_dropped_count if thread is not None else 0
 
     def get_session_sent_count(self, repo_name: str) -> int:
         """Return the number of messages sent to the current session subprocess for *repo_name*."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_sent_count if thread is not None else 0
 
     def get_session_received_count(self, repo_name: str) -> int:
         """Return the number of events received from the current session subprocess for *repo_name*."""
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         return thread.session_received_count if thread is not None else 0
 
     def set_rescoping(self, repo_name: str, active: bool) -> None:
@@ -883,8 +889,7 @@ class WorkerRegistry:
         when no worker thread is registered for the repo or the thread has
         not yet created its session.
         """
-        with self._threads_lock:
-            thread = self._threads.get(repo_name)
+        thread = self._get_thread(repo_name)
         if thread is None:
             return None
         provider = thread.current_provider()
@@ -966,6 +971,7 @@ def make_registry(
     config: Config | None = None,
     *,
     dispatchers: "dict[str, Dispatcher]",
+    state_reader: "AtomicReader[FidoState]",
     state_updater: "AtomicUpdater[FidoState]",
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
 ) -> WorkerRegistry:
@@ -974,7 +980,7 @@ def make_registry(
     Uses :func:`_make_thread` as the factory; all threads share the provided
     :class:`~fido.github.GitHub` client.  The caller (composition root) is
     responsible for creating the atomic cell via :func:`create_fido_atomic`
-    and passing the updater face here.  Pass a custom registry directly
+    and passing both faces here.  Pass a custom registry directly
     (with a mock factory) in tests instead of calling this.
     """
 
@@ -994,7 +1000,7 @@ def make_registry(
             dispatchers=dispatchers,
         )
 
-    registry = WorkerRegistry(factory, state_updater)
+    registry = WorkerRegistry(factory, state_reader, state_updater)
     for repo_cfg in repos.values():
         registry.start(repo_cfg)
     return registry

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -107,6 +107,24 @@ class WebhookActivity:
 
 
 @dataclass(frozen=True, slots=True)
+class ThreadHandle:
+    """Frozen reference to a :class:`~fido.worker.WorkerThread`.
+
+    Stored inside :class:`RepoState` so snapshot readers can reach the
+    thread's session metadata and liveness state without holding any lock.
+    The thread itself is mutable — ``ThreadHandle`` only freezes the
+    *reference*, not the object it points to.
+
+    ``thread_handle`` is ``None`` only in a zero-value :class:`RepoState`
+    that was constructed before :meth:`~WorkerRegistry.start` ran for that
+    repo.  After :meth:`~WorkerRegistry.start` completes the field is always
+    non-``None``.
+    """
+
+    thread: WorkerThread
+
+
+@dataclass(frozen=True, slots=True)
 class RepoState:
     """Per-repo sub-snapshot within :class:`FidoState`.
 
@@ -128,8 +146,11 @@ class RepoState:
     repo.  Published from the authoritative ``_webhook_activities`` dict on
     :class:`WorkerRegistry` via :meth:`~WorkerRegistry._publish_webhook_activities`; starts empty.
 
-    No field is ``None`` — the full tree is prepopulated by :meth:`start`
-    with zero values so lens-path writes never encounter missing keys.
+    *thread_handle* is a :class:`ThreadHandle` wrapping the
+    :class:`~fido.worker.WorkerThread` for this repo.  Populated by
+    :meth:`~WorkerRegistry.start`; ``None`` only before the first start
+    (which never happens in the normal lifecycle).  Lock-free readers use
+    this field instead of acquiring ``_threads_lock``.
 
     As subsequent lock-free PRs migrate fields out of the per-lock dicts in
     :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
@@ -142,6 +163,7 @@ class RepoState:
     activity: WorkerActivity
     crash_record: WorkerCrash
     webhook_activities: tuple[WebhookActivity, ...]
+    thread_handle: ThreadHandle | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -369,6 +391,7 @@ class WorkerRegistry:
             activity=_zero_activity(_name),
             crash_record=crash_record,
             webhook_activities=(),
+            thread_handle=ThreadHandle(thread=thread),
         )
         self._state_updater.update(lambda root: root.repos[_name], new_repo)
         thread.start()

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1565,7 +1565,6 @@ def run(
         gh,
         config,
         dispatchers=dispatchers,
-        state_reader=state_reader,
         state_updater=state_updater,
     )
     WebhookHandler.registry = registry

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1561,7 +1561,12 @@ def run(
     # without going through the registry at all.
     state_reader, state_updater = _create_fido_atomic()
     registry = _make_registry(
-        config.repos, gh, config, dispatchers=dispatchers, state_updater=state_updater
+        config.repos,
+        gh,
+        config,
+        dispatchers=dispatchers,
+        state_reader=state_reader,
+        state_updater=state_updater,
     )
     WebhookHandler.registry = registry
     WebhookHandler.state_reader = state_reader

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -64,7 +64,7 @@ class TestWorkerRegistryPreemptionHelpers:
         # WorkerRegistry takes a thread factory callable; tests don't
         # need real WorkerThreads, so a no-op factory is fine.
         reader, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), reader, updater)
+        return WorkerRegistry(MagicMock(), updater)
 
     def test_note_provider_interrupt_requested(self) -> None:
         registry = self._registry()

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -63,8 +63,8 @@ class TestWorkerRegistryPreemptionHelpers:
     def _registry(self) -> WorkerRegistry:
         # WorkerRegistry takes a thread factory callable; tests don't
         # need real WorkerThreads, so a no-op factory is fine.
-        _, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), reader, updater)
 
     def test_note_provider_interrupt_requested(self) -> None:
         registry = self._registry()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,7 +11,6 @@ import pytest
 from fido.config import RepoConfig as _RepoConfig
 from fido.provider import ProviderID
 from fido.registry import (
-    ThreadHandle,
     WorkerCrash,
     WorkerRegistry,
     _make_thread,
@@ -42,7 +41,7 @@ class TestWorkerRegistry:
     ) -> tuple[WorkerRegistry, MagicMock, object]:
         factory = MagicMock()
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         if repos:
             for name in repos:
                 reg.start(_repo(name, Path("/tmp/fake")))
@@ -60,7 +59,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         # First start — no prior thread
         reg.start(cfg)
@@ -90,7 +89,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         threads[0].is_alive.return_value = False
@@ -106,7 +105,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate orderly shutdown: was_stopped is True (session was already stopped)
@@ -147,7 +146,7 @@ class TestWorkerRegistry:
     def test_stop_all_calls_stop_on_every_thread(self, tmp_path: Path) -> None:
         factory = MagicMock(side_effect=[MagicMock(), MagicMock()])
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -166,7 +165,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -553,7 +552,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.record_crash("foo/bar", "boom")
@@ -569,7 +568,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate a crash so the FSM accepts the second start
@@ -582,60 +581,19 @@ class TestWorkerRegistry:
         threads[1].is_alive.return_value = True
         assert reg.is_alive("foo/bar") is True
 
-    # ── ThreadHandle in RepoState snapshot ───────────────────────────────
-
-    def test_start_publishes_thread_handle_to_snapshot(self, tmp_path: Path) -> None:
-        """start() stores the new WorkerThread in RepoState.thread_handle."""
-        reader, updater = create_fido_atomic()
-        factory = MagicMock()
-        reg = WorkerRegistry(factory, reader, updater)
-        cfg = _repo("foo/bar", tmp_path)
-        reg.start(cfg)
-        handle = reader.get().repos["foo/bar"].thread_handle
-        assert handle is not None
-        assert isinstance(handle, ThreadHandle)
-        assert handle.thread is factory.return_value
-
-    def test_start_thread_handle_is_nonnull_after_start(self, tmp_path: Path) -> None:
-        """thread_handle is non-None in the snapshot immediately after start()."""
-        reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
-        reg.start(_repo("foo/bar", tmp_path))
-        assert reader.get().repos["foo/bar"].thread_handle is not None
-
-    def test_start_replaces_thread_handle_on_restart(self, tmp_path: Path) -> None:
-        """After a crash restart, thread_handle points to the new thread."""
-        threads = [MagicMock(), MagicMock()]
-        factory = MagicMock(side_effect=threads)
-        reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
-        cfg = _repo("foo/bar", tmp_path)
-        reg.start(cfg)
-        first_handle = reader.get().repos["foo/bar"].thread_handle
-        assert first_handle is not None
-        assert first_handle.thread is threads[0]
-        # Simulate crash so FSM accepts the second start
-        threads[0].is_alive.return_value = False
-        threads[0].was_stopped = False
-        reg.start(cfg)
-        second_handle = reader.get().repos["foo/bar"].thread_handle
-        assert second_handle is not None
-        assert second_handle.thread is threads[1]
-        assert second_handle is not first_handle
-
-    # ── _get_thread snapshot lookup ──────────────────────────────────────
+    # ── _get_thread dict lookup ──────────────────────────────────────────
 
     def test_get_thread_returns_none_for_unknown_repo(self) -> None:
-        """_get_thread returns None when no snapshot entry exists."""
-        reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        """_get_thread returns None when no thread has been started."""
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         assert reg._get_thread("unknown/repo") is None  # pyright: ignore[reportPrivateUsage]
 
-    def test_get_thread_returns_thread_from_snapshot(self, tmp_path: Path) -> None:
-        """_get_thread returns the thread stored in the snapshot."""
-        reader, updater = create_fido_atomic()
+    def test_get_thread_returns_thread_from_dict(self, tmp_path: Path) -> None:
+        """_get_thread returns the thread stored in _threads dict."""
+        _, updater = create_fido_atomic()
         factory = MagicMock()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         thread = reg._get_thread("foo/bar")  # pyright: ignore[reportPrivateUsage]
         assert thread is factory.return_value
@@ -734,7 +692,6 @@ class TestMakeRegistry:
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
-            state_reader=reader,
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
@@ -750,7 +707,6 @@ class TestMakeRegistry:
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
             dispatchers={},
-            state_reader=reader,
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -759,9 +715,7 @@ class TestMakeRegistry:
 
     def test_empty_repos_returns_empty_registry(self) -> None:
         reader, updater = create_fido_atomic()
-        result = make_registry(
-            {}, MagicMock(), dispatchers={}, state_reader=reader, state_updater=updater
-        )
+        result = make_registry({}, MagicMock(), dispatchers={}, state_updater=updater)
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
 
@@ -774,7 +728,6 @@ class TestMakeRegistry:
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
-            state_reader=reader,
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
@@ -799,7 +752,6 @@ class TestMakeRegistry:
             MagicMock(),
             config,
             dispatchers={},
-            state_reader=reader,
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -809,7 +761,7 @@ class TestMakeRegistry:
 class TestWebhookActivity:
     def test_registers_and_unregisters(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_webhook_activities("foo/bar") == []
         with reg.webhook_activity("foo/bar", "triaging"):
@@ -822,7 +774,7 @@ class TestWebhookActivity:
         import pytest as _pytest
 
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with _pytest.raises(RuntimeError):
             with reg.webhook_activity("foo/bar", "oops"):
@@ -831,7 +783,7 @@ class TestWebhookActivity:
 
     def test_multiple_concurrent_activities(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "first"):
             with reg.webhook_activity("foo/bar", "second"):
@@ -843,7 +795,7 @@ class TestWebhookActivity:
 
     def test_activities_isolated_per_repo(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("a/b", tmp_path))
         reg.start(_repo("c/d", tmp_path))
         with reg.webhook_activity("a/b", "work-ab"):
@@ -855,12 +807,12 @@ class TestWebhookActivity:
 
     def test_unknown_repo_returns_empty_list(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_handle_can_update_description(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
@@ -869,7 +821,7 @@ class TestWebhookActivity:
 
     def test_handle_update_after_exit_is_noop(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             pass
@@ -878,7 +830,7 @@ class TestWebhookActivity:
 
     def test_unknown_handle_update_is_noop(self, tmp_path: Path) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             reg.set_webhook_description("foo/bar", -1, "triaging")
@@ -886,14 +838,14 @@ class TestWebhookActivity:
 
     def test_unknown_repo_handle_update_is_noop(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_webhook_description("ghost/repo", 1, "triaging")
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_publishes_to_fido_state_when_repo_started(self, tmp_path: Path) -> None:
         """webhook_activity publishes activities into FidoState when start() has run."""
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             acts = reader.get().repos["foo/bar"].webhook_activities
@@ -904,7 +856,7 @@ class TestWebhookActivity:
     def test_publishes_description_update_to_fido_state(self, tmp_path: Path) -> None:
         """set_webhook_description publishes the update into FidoState."""
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "original") as handle:
             handle.set_description("updated")
@@ -916,33 +868,33 @@ class TestWebhookActivity:
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         assert reg.is_rescoping("unknown/repo") is False
 
     def test_set_rescoping_true(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
 
     def test_set_rescoping_false_clears_flag(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         reg.set_rescoping("foo/bar", False)
         assert reg.is_rescoping("foo/bar") is False
 
     def test_rescoping_is_per_repo(self) -> None:
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
         assert reg.is_rescoping("foo/baz") is False
 
     def test_rescoping_is_threadsafe(self) -> None:
         """Concurrent set_rescoping and is_rescoping calls must not corrupt state."""
-        reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), reader, updater)
+        _, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
         errors: list[Exception] = []
 
         def toggler(repo: str) -> None:
@@ -975,7 +927,7 @@ class TestUntriagedInbox:
 
     def _reg(self) -> WorkerRegistry:
         reader, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), reader, updater)
+        return WorkerRegistry(MagicMock(), updater)
 
     # ── has_untriaged ─────────────────────────────────────────────────────
 
@@ -1206,7 +1158,7 @@ class TestPreemptionFsmOracle:
 
     def _reg(self) -> WorkerRegistry:
         reader, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), reader, updater)
+        return WorkerRegistry(MagicMock(), updater)
 
     # ── worker_blocked_when_nonempty ─────────────────────────────────────
 
@@ -1432,7 +1384,7 @@ class TestRegistryFsmOracle:
 
     def _reg(self) -> WorkerRegistry:
         reader, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), reader, updater)
+        return WorkerRegistry(MagicMock(), updater)
 
     def _cfg(self, tmp_path: Path, name: str = "foo/bar") -> RepoConfig:
         return _repo(name, tmp_path)
@@ -1520,7 +1472,7 @@ class TestRegistryFsmOracle:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         assert isinstance(
@@ -1543,7 +1495,7 @@ class TestRegistryFsmOracle:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Simulate orderly stop
@@ -1567,7 +1519,7 @@ class TestRegistryFsmOracle:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Leave thread alive (is_alive() returns a truthy MagicMock by default)
@@ -1580,7 +1532,7 @@ class TestRegistryFsmOracle:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, reader, updater)
+        reg = WorkerRegistry(factory, updater)
         reg.start(_repo("org/a", tmp_path))
         reg.start(_repo("org/b", tmp_path))
         assert isinstance(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -42,7 +42,7 @@ class TestWorkerRegistry:
     ) -> tuple[WorkerRegistry, MagicMock, object]:
         factory = MagicMock()
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reg = WorkerRegistry(factory, reader, updater)
         if repos:
             for name in repos:
                 reg.start(_repo(name, Path("/tmp/fake")))
@@ -59,8 +59,8 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         # First start — no prior thread
         reg.start(cfg)
@@ -89,8 +89,8 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         threads[0].is_alive.return_value = False
@@ -105,8 +105,8 @@ class TestWorkerRegistry:
         """No provider rescue when the old thread exited via orderly stop()."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate orderly shutdown: was_stopped is True (session was already stopped)
@@ -146,8 +146,8 @@ class TestWorkerRegistry:
 
     def test_stop_all_calls_stop_on_every_thread(self, tmp_path: Path) -> None:
         factory = MagicMock(side_effect=[MagicMock(), MagicMock()])
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -165,8 +165,8 @@ class TestWorkerRegistry:
     def test_stop_all_calls_stop_count(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
         reg.stop_all()
@@ -553,7 +553,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         reg.record_crash("foo/bar", "boom")
@@ -568,8 +568,8 @@ class TestWorkerRegistry:
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         # Simulate a crash so the FSM accepts the second start
@@ -588,7 +588,7 @@ class TestWorkerRegistry:
         """start() stores the new WorkerThread in RepoState.thread_handle."""
         reader, updater = create_fido_atomic()
         factory = MagicMock()
-        reg = WorkerRegistry(factory, updater)
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         handle = reader.get().repos["foo/bar"].thread_handle
@@ -599,7 +599,7 @@ class TestWorkerRegistry:
     def test_start_thread_handle_is_nonnull_after_start(self, tmp_path: Path) -> None:
         """thread_handle is non-None in the snapshot immediately after start()."""
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         assert reader.get().repos["foo/bar"].thread_handle is not None
 
@@ -608,7 +608,7 @@ class TestWorkerRegistry:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
         first_handle = reader.get().repos["foo/bar"].thread_handle
@@ -622,6 +622,23 @@ class TestWorkerRegistry:
         assert second_handle is not None
         assert second_handle.thread is threads[1]
         assert second_handle is not first_handle
+
+    # ── _get_thread snapshot lookup ──────────────────────────────────────
+
+    def test_get_thread_returns_none_for_unknown_repo(self) -> None:
+        """_get_thread returns None when no snapshot entry exists."""
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
+        assert reg._get_thread("unknown/repo") is None  # pyright: ignore[reportPrivateUsage]
+
+    def test_get_thread_returns_thread_from_snapshot(self, tmp_path: Path) -> None:
+        """_get_thread returns the thread stored in the snapshot."""
+        reader, updater = create_fido_atomic()
+        factory = MagicMock()
+        reg = WorkerRegistry(factory, reader, updater)
+        reg.start(_repo("foo/bar", tmp_path))
+        thread = reg._get_thread("foo/bar")  # pyright: ignore[reportPrivateUsage]
+        assert thread is factory.return_value
 
 
 class TestMakeThread:
@@ -712,11 +729,12 @@ class TestMakeRegistry:
     def test_returns_worker_registry(self, tmp_path: Path) -> None:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
-        _, updater = create_fido_atomic()
+        reader, updater = create_fido_atomic()
         result = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
+            state_reader=reader,
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
@@ -727,11 +745,12 @@ class TestMakeRegistry:
         cfg2 = _repo("foo/baz", tmp_path)
         mock_thread = MagicMock()
         mock_factory = MagicMock(return_value=mock_thread)
-        _, updater = create_fido_atomic()
+        reader, updater = create_fido_atomic()
         make_registry(
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
             dispatchers={},
+            state_reader=reader,
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -739,8 +758,10 @@ class TestMakeRegistry:
         assert mock_thread.start.call_count == 2
 
     def test_empty_repos_returns_empty_registry(self) -> None:
-        _, updater = create_fido_atomic()
-        result = make_registry({}, MagicMock(), dispatchers={}, state_updater=updater)
+        reader, updater = create_fido_atomic()
+        result = make_registry(
+            {}, MagicMock(), dispatchers={}, state_reader=reader, state_updater=updater
+        )
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
 
@@ -748,11 +769,12 @@ class TestMakeRegistry:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = True
-        _, updater = create_fido_atomic()
+        reader, updater = create_fido_atomic()
         reg = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             dispatchers={},
+            state_reader=reader,
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
@@ -771,12 +793,13 @@ class TestMakeRegistry:
             sub_dir=tmp_path,
         )
         mock_factory = MagicMock(return_value=MagicMock())
-        _, updater = create_fido_atomic()
+        reader, updater = create_fido_atomic()
         make_registry(
             {"foo/bar": cfg},
             MagicMock(),
             config,
             dispatchers={},
+            state_reader=reader,
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -785,8 +808,8 @@ class TestMakeRegistry:
 
 class TestWebhookActivity:
     def test_registers_and_unregisters(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_webhook_activities("foo/bar") == []
         with reg.webhook_activity("foo/bar", "triaging"):
@@ -798,8 +821,8 @@ class TestWebhookActivity:
     def test_unregisters_on_exception(self, tmp_path: Path) -> None:
         import pytest as _pytest
 
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with _pytest.raises(RuntimeError):
             with reg.webhook_activity("foo/bar", "oops"):
@@ -807,8 +830,8 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_multiple_concurrent_activities(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "first"):
             with reg.webhook_activity("foo/bar", "second"):
@@ -819,8 +842,8 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_activities_isolated_per_repo(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("a/b", tmp_path))
         reg.start(_repo("c/d", tmp_path))
         with reg.webhook_activity("a/b", "work-ab"):
@@ -831,13 +854,13 @@ class TestWebhookActivity:
                 assert [x.description for x in c] == ["work-cd"]
 
     def test_unknown_repo_returns_empty_list(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_handle_can_update_description(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
@@ -845,8 +868,8 @@ class TestWebhookActivity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "triaging"
 
     def test_handle_update_after_exit_is_noop(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
             pass
@@ -854,23 +877,23 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_unknown_handle_update_is_noop(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             reg.set_webhook_description("foo/bar", -1, "triaging")
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
 
     def test_unknown_repo_handle_update_is_noop(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.set_webhook_description("ghost/repo", 1, "triaging")
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_publishes_to_fido_state_when_repo_started(self, tmp_path: Path) -> None:
         """webhook_activity publishes activities into FidoState when start() has run."""
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
             acts = reader.get().repos["foo/bar"].webhook_activities
@@ -881,7 +904,7 @@ class TestWebhookActivity:
     def test_publishes_description_update_to_fido_state(self, tmp_path: Path) -> None:
         """set_webhook_description publishes the update into FidoState."""
         reader, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "original") as handle:
             handle.set_description("updated")
@@ -892,34 +915,34 @@ class TestWebhookActivity:
 
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         assert reg.is_rescoping("unknown/repo") is False
 
     def test_set_rescoping_true(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
 
     def test_set_rescoping_false_clears_flag(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.set_rescoping("foo/bar", True)
         reg.set_rescoping("foo/bar", False)
         assert reg.is_rescoping("foo/bar") is False
 
     def test_rescoping_is_per_repo(self) -> None:
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
         assert reg.is_rescoping("foo/baz") is False
 
     def test_rescoping_is_threadsafe(self) -> None:
         """Concurrent set_rescoping and is_rescoping calls must not corrupt state."""
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), reader, updater)
         errors: list[Exception] = []
 
         def toggler(repo: str) -> None:
@@ -951,8 +974,8 @@ class TestUntriagedInbox:
     """Tests for the per-repo untriaged-webhook inbox (fix #1067)."""
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), reader, updater)
 
     # ── has_untriaged ─────────────────────────────────────────────────────
 
@@ -1182,8 +1205,8 @@ class TestPreemptionFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), reader, updater)
 
     # ── worker_blocked_when_nonempty ─────────────────────────────────────
 
@@ -1408,8 +1431,8 @@ class TestRegistryFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
-        return WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        return WorkerRegistry(MagicMock(), reader, updater)
 
     def _cfg(self, tmp_path: Path, name: str = "foo/bar") -> RepoConfig:
         return _repo(name, tmp_path)
@@ -1496,8 +1519,8 @@ class TestRegistryFsmOracle:
         """start() after crash fires ThreadDies then Rescue: Active → Crashed → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         assert isinstance(
@@ -1519,8 +1542,8 @@ class TestRegistryFsmOracle:
         """start() after orderly stop fires ThreadStops then Launch: Active → Stopped → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Simulate orderly stop
@@ -1543,8 +1566,8 @@ class TestRegistryFsmOracle:
         """
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
         # Leave thread alive (is_alive() returns a truthy MagicMock by default)
@@ -1556,8 +1579,8 @@ class TestRegistryFsmOracle:
         """FSM state is independent for each repo — no cross-repo contamination."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
-        reg = WorkerRegistry(factory, updater)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, reader, updater)
         reg.start(_repo("org/a", tmp_path))
         reg.start(_repo("org/b", tmp_path))
         assert isinstance(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,6 +11,7 @@ import pytest
 from fido.config import RepoConfig as _RepoConfig
 from fido.provider import ProviderID
 from fido.registry import (
+    ThreadHandle,
     WorkerCrash,
     WorkerRegistry,
     _make_thread,
@@ -580,6 +581,47 @@ class TestWorkerRegistry:
         # Second start — latest thread is in registry
         threads[1].is_alive.return_value = True
         assert reg.is_alive("foo/bar") is True
+
+    # ── ThreadHandle in RepoState snapshot ───────────────────────────────
+
+    def test_start_publishes_thread_handle_to_snapshot(self, tmp_path: Path) -> None:
+        """start() stores the new WorkerThread in RepoState.thread_handle."""
+        reader, updater = create_fido_atomic()
+        factory = MagicMock()
+        reg = WorkerRegistry(factory, updater)
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        handle = reader.get().repos["foo/bar"].thread_handle
+        assert handle is not None
+        assert isinstance(handle, ThreadHandle)
+        assert handle.thread is factory.return_value
+
+    def test_start_thread_handle_is_nonnull_after_start(self, tmp_path: Path) -> None:
+        """thread_handle is non-None in the snapshot immediately after start()."""
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(MagicMock(), updater)
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reader.get().repos["foo/bar"].thread_handle is not None
+
+    def test_start_replaces_thread_handle_on_restart(self, tmp_path: Path) -> None:
+        """After a crash restart, thread_handle points to the new thread."""
+        threads = [MagicMock(), MagicMock()]
+        factory = MagicMock(side_effect=threads)
+        reader, updater = create_fido_atomic()
+        reg = WorkerRegistry(factory, updater)
+        cfg = _repo("foo/bar", tmp_path)
+        reg.start(cfg)
+        first_handle = reader.get().repos["foo/bar"].thread_handle
+        assert first_handle is not None
+        assert first_handle.thread is threads[0]
+        # Simulate crash so FSM accepts the second start
+        threads[0].is_alive.return_value = False
+        threads[0].was_stopped = False
+        reg.start(cfg)
+        second_handle = reader.get().repos["foo/bar"].thread_handle
+        assert second_handle is not None
+        assert second_handle.thread is threads[1]
+        assert second_handle is not first_handle
 
 
 class TestMakeThread:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -79,7 +79,6 @@ def _repo_state(
             last_crash_time=_EPOCH,
         ),
         webhook_activities=webhook_activities,
-        thread_handle=None,
     )
 
 
@@ -1920,7 +1919,7 @@ class TestProcessAction:
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
         reader, updater = create_fido_atomic()
-        handler.registry = WorkerRegistry(MagicMock(), reader, updater)
+        handler.registry = WorkerRegistry(MagicMock(), updater)
         handler.registry.start(cfg.repos["owner/repo"])
         handler.gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1919,8 +1919,8 @@ class TestProcessAction:
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
-        _, updater = create_fido_atomic()
-        handler.registry = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        handler.registry = WorkerRegistry(MagicMock(), reader, updater)
         handler.registry.start(cfg.repos["owner/repo"])
         handler.gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -79,6 +79,7 @@ def _repo_state(
             last_crash_time=_EPOCH,
         ),
         webhook_activities=webhook_activities,
+        thread_handle=None,
     )
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -803,7 +803,7 @@ class TestWorker:
         from fido.registry import WorkerRegistry, create_fido_atomic
 
         reader, updater = create_fido_atomic()
-        registry = WorkerRegistry(MagicMock(), reader, updater)
+        registry = WorkerRegistry(MagicMock(), updater)
         # Prepopulate FidoState so report_activity can lens-write into it.
         for i in range(3):
             registry.start(_default_repo_cfg(tmp_path, repo_name=f"owner/repo{i}"))

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -802,8 +802,8 @@ class TestWorker:
         """Concurrent set_status calls on different workers sharing a registry serialize."""
         from fido.registry import WorkerRegistry, create_fido_atomic
 
-        _, updater = create_fido_atomic()
-        registry = WorkerRegistry(MagicMock(), updater)
+        reader, updater = create_fido_atomic()
+        registry = WorkerRegistry(MagicMock(), reader, updater)
         # Prepopulate FidoState so report_activity can lens-write into it.
         for i in range(3):
             registry.start(_default_repo_cfg(tmp_path, repo_name=f"owner/repo{i}"))


### PR DESCRIPTION
Fixes #1347.

Migrate every `_threads_lock`-protected method on `WorkerRegistry` to read thread references outside any status-contended lock — fixing the lock-across-join antipattern where `stop_and_join` held `_threads_lock` across a 30-second `thread.join`. Thread references live in a plain `_threads` dict (single-writer, no lock), `_threads_lock` is deleted, and `AtomicReader[FidoState]` is removed from `WorkerRegistry` entirely — only the status serialization path may hold the reader face.

Fixes #1347.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Remove ThreadHandle and thread_handle from RepoState/FidoState. The mutable WorkerThread reference must not live inside the recursively-immutable snapshot. Keep a separate dict (or similar) for command-path thread lookups outside the snapshot. The lock-across-join fix (reading thread ref then calling join outside any status-contended lock) should still be preserved.](https://github.com/FidoCanCode/home/pull/1523#discussion_r3212120024) <!-- type:thread -->
- [x] [Remove AtomicReader[FidoState] from WorkerRegistry entirely (it should only hold the updater). Document in CLAUDE.md that AtomicReader[FidoState] is exclusively for status.json and /status — no other consumer is permitted. Fix any code that violates this.](https://github.com/FidoCanCode/home/pull/1523#discussion_r3212128707) <!-- type:thread -->
- [x] Migrate read-only _threads_lock methods to snapshot lookup <!-- type:spec -->
- [x] Migrate stop_all and stop_and_join to snapshot — fix lock-across-join <!-- type:spec -->
- [x] Delete _threads_lock and _threads dict <!-- type:spec -->
- [x] Add ThreadHandle to RepoState and publish thread ref in start() <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->