### PR TITLE
Provider stats: add injected live snapshot publisher boundary (closes #1598)

### DIFF
--- a/src/fido/appstate.py
+++ b/src/fido/appstate.py
@@ -1,0 +1,224 @@
+"""Coordination snapshot types for FidoState.
+
+All frozen dataclasses that compose :class:`FidoState` — the atomically-swapped
+coordination snapshot shared between :class:`~fido.registry.WorkerRegistry`,
+the composition root, and the status serialisation path.  Extracted from
+``registry.py`` so provider and session modules can import :class:`FidoState`
+directly from this leaf module, with no back-reference to the registry.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from frozendict import frozendict
+
+from fido.atomic import AtomicUpdater
+from fido.atomic import create_atomic as _create_atomic
+from fido.rate_limit import GitHubLimit
+
+if TYPE_CHECKING:
+    from fido.atomic import AtomicReader
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerActivity:
+    """Snapshot of what one worker is currently doing.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+    """
+
+    repo_name: str
+    what: str
+    busy: bool
+    last_progress_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerCrash:
+    """Running record of unexpected worker deaths for one repo.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+
+    Readers check ``death_count == 0`` to detect the "never crashed" zero
+    sentinel (defined as ``_ZERO_CRASH`` in :mod:`fido.registry`).
+    """
+
+    death_count: int
+    last_error: str
+    last_crash_time: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookActivity:
+    """One in-flight webhook handler running alongside the worker.
+
+    Created when ``_process_action`` starts handling a webhook action; removed
+    when that handler returns (success or failure).  Surfaced in ``fido
+    status`` as a sub-bullet under the repo so we can see what's being
+    handled beyond the worker's own task.
+
+    *thread_id* is :func:`threading.get_ident` captured at context entry so
+    status display can match this webhook to the active
+    :class:`~fido.provider.SessionTalker` (whose ``thread_id`` field is from
+    the same call) — letting the CLI attach claude stats to the specific
+    webhook line that's driving claude.
+
+    Frozen so instances can be stored inside frozen :class:`RepoState`
+    without breaking the immutability guarantee of the atomic snapshot.
+    """
+
+    handle_id: int
+    description: str
+    started_at: datetime
+    thread_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSnapshot:
+    """Immutable snapshot of one repo's provider (ClaudeSession) state.
+
+    Captures provider session metadata as primitive values at the moment of
+    each provider lifecycle event (session start, recovery).  Stored on
+    :class:`RepoState` so the SCADA display path reads stale-free values
+    without holding the provider lock.
+
+    Fields mirror the public session properties on
+    :class:`~fido.worker.WorkerThread` that are read by the status display
+    path.  Published by :meth:`~fido.registry.WorkerRegistry._publish_provider_snapshot`
+    at lifecycle boundaries where session state actually changes.
+    """
+
+    session_owner: str | None
+    session_alive: bool
+    session_pid: int | None
+    session_dropped_count: int
+    session_sent_count: int
+    session_received_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ThreadSnapshot:
+    """Immutable snapshot of one :class:`~fido.worker.WorkerThread`'s lifecycle state.
+
+    Captures thread lifecycle metadata as primitive values — no handles to the
+    mutable :class:`~fido.worker.WorkerThread` object itself.  Stored inside
+    the frozen :class:`FidoState` so the SCADA display invariant is preserved:
+    a snapshot reader can never reach through to a live thread and observe
+    partial mutations.
+
+    Provider session state (session_owner, session_alive, session_pid, and
+    the message counters) lives on :class:`ProviderSnapshot` instead so it can
+    be published independently at provider lifecycle boundaries.
+    """
+
+    is_alive: bool
+    was_stopped: bool
+    crash_error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RepoState:
+    """Per-repo sub-snapshot within :class:`FidoState`.
+
+    *key* is the repo slug (e.g. ``"rhencke/confusio"``), matching the key
+    under which this record is stored in :attr:`FidoState.repos`.
+
+    *started_at* is the UTC timestamp when the most recent
+    :class:`~fido.worker.WorkerThread` for this repo was started.
+
+    *activity* is the current :class:`WorkerActivity` for this repo.
+    Initialised to the zero sentinel (``what=""``) by :meth:`~fido.registry.WorkerRegistry.start`; the
+    worker replaces it on its first :meth:`~fido.registry.WorkerRegistry.report_activity` call.
+
+    *crash_record* is the accumulated :class:`WorkerCrash` history for this
+    repo.  Initialised to ``_ZERO_CRASH`` (``death_count=0``) by
+    :meth:`~fido.registry.WorkerRegistry.start`; the watchdog replaces it on each crash.
+
+    *webhook_activities* is the tuple of in-flight webhook handlers for this
+    repo.  Published from the authoritative ``_webhook_activities`` dict on
+    :class:`~fido.registry.WorkerRegistry` via
+    :meth:`~fido.registry.WorkerRegistry._publish_webhook_activities`; starts empty.
+
+    *thread* is the immutable :class:`ThreadSnapshot` for the repo's
+    :class:`~fido.worker.WorkerThread`.  ``None`` until the first
+    :meth:`~fido.registry.WorkerRegistry.start` call; refreshed by
+    :meth:`~fido.registry.WorkerRegistry._publish_thread_snapshot` immediately after the
+    thread is started.  No mutable thread reference is stored here — the
+    snapshot captures primitive values only.
+
+    *provider* is the immutable :class:`ProviderSnapshot` for the repo's
+    provider (ClaudeSession).  ``None`` until the first
+    :meth:`~fido.registry.WorkerRegistry.start` call; refreshed by
+    :meth:`~fido.registry.WorkerRegistry._publish_provider_snapshot` at provider lifecycle
+    events (session start, recovery).
+
+    As subsequent lock-free PRs migrate fields out of the per-lock dicts in
+    :class:`~fido.registry.WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
+    Each migration removes the corresponding lock and dict from
+    ``WorkerRegistry.__init__``.
+    """
+
+    key: str
+    started_at: datetime
+    activity: WorkerActivity
+    crash_record: WorkerCrash
+    webhook_activities: tuple[WebhookActivity, ...]
+    thread: "ThreadSnapshot | None" = None
+    provider: "ProviderSnapshot | None" = None
+
+
+@dataclass(frozen=True, slots=True)
+class FidoState:
+    """Atomically-swapped coordination snapshot.
+
+    ``repos`` maps each repo slug to its :class:`RepoState` snapshot.  It is
+    a :class:`frozendict` so stale readers that hold a reference to an old
+    snapshot can never accidentally mutate the mapping — the immutability
+    guarantee holds even on the free-threaded (no-GIL) build.  Each
+    :class:`RepoState` carries a :class:`ThreadSnapshot` at its ``thread``
+    field — an immutable copy of the thread's observable state at the last
+    :meth:`~fido.registry.WorkerRegistry.start` call.
+
+    The atomic cell is owned by the composition root (``run()`` in
+    ``server.py``), not by :class:`~fido.registry.WorkerRegistry`.  The root
+    creates both faces via :func:`~fido.atomic.create_atomic`, passes the
+    :class:`~fido.atomic.AtomicUpdater` to
+    :class:`~fido.registry.WorkerRegistry` and
+    :class:`~fido.rate_limit.RateLimitMonitor`, and passes the
+    :class:`~fido.atomic.AtomicReader` to the status serialisation path.
+
+    **Convergence target**: ``FidoState`` is intended to grow to cover all
+    coordination fields currently scattered across the per-lock dicts in
+    :class:`~fido.registry.WorkerRegistry` (worker activities, crash records,
+    webhook activities, rescoping flags, …).  As each field migrates here,
+    the corresponding lock disappears.
+
+    **Replaces FidoStatus long-term**: :class:`~fido.status.FidoStatus` in
+    ``status.py`` is a display-oriented dataclass shaped by the old
+    ``/status.json`` schema.  The end-state is to serialise ``FidoState``
+    directly to JSON — even where that changes the wire format — and retire
+    ``FidoStatus``.  The ``./fido status`` CLI output serves as the living
+    requirement: whatever ``FidoState`` carries must be sufficient to render
+    everything that ``./fido status`` currently shows.
+    """
+
+    repos: frozendict[str, RepoState]
+    github_limits: GitHubLimit
+
+
+_EMPTY_FIDO_STATE = FidoState(repos=frozendict(), github_limits=GitHubLimit())
+
+
+def create_fido_atomic() -> "tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]":
+    """Create the atomic cell for :class:`FidoState` and return both faces.
+
+    Thin wrapper around :func:`~fido.atomic.create_atomic` with the correct
+    initial value.  Call this once at the composition root (``run()``), pass
+    the updater to :class:`~fido.registry.WorkerRegistry` and
+    :class:`~fido.rate_limit.RateLimitMonitor`, and keep the reader in the
+    composition root for the status serialisation path.
+    """
+    return _create_atomic(_EMPTY_FIDO_STATE)

--- a/src/fido/appstate.py
+++ b/src/fido/appstate.py
@@ -9,16 +9,10 @@ directly from this leaf module, with no back-reference to the registry.
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from frozendict import frozendict
 
-from fido.atomic import AtomicUpdater
-from fido.atomic import create_atomic as _create_atomic
 from fido.rate_limit import GitHubLimit
-
-if TYPE_CHECKING:
-    from fido.atomic import AtomicReader
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,18 +201,3 @@ class FidoState:
 
     repos: frozendict[str, RepoState]
     github_limits: GitHubLimit
-
-
-_EMPTY_FIDO_STATE = FidoState(repos=frozendict(), github_limits=GitHubLimit())
-
-
-def create_fido_atomic() -> "tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]":
-    """Create the atomic cell for :class:`FidoState` and return both faces.
-
-    Thin wrapper around :func:`~fido.atomic.create_atomic` with the correct
-    initial value.  Call this once at the composition root (``run()``), pass
-    the updater to :class:`~fido.registry.WorkerRegistry` and
-    :class:`~fido.rate_limit.RateLimitMonitor`, and keep the reader in the
-    composition root for the status serialisation path.
-    """
-    return _create_atomic(_EMPTY_FIDO_STATE)

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -31,6 +31,7 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    ProviderStatsPublisher,
     model_name,
 )
 from fido.rocq import claude_session as stream_fsm
@@ -1664,6 +1665,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> None:
         self._runner = runner
         self._streaming_runner = streaming_runner
@@ -1677,6 +1679,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
+            stats_publisher=stats_publisher,
         )
 
     @property

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -13,11 +13,12 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import requests as _requests
 
 from fido import provider
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
@@ -36,9 +37,6 @@ from fido.provider import (
 )
 from fido.rocq import claude_session as stream_fsm
 from fido.session_agent import SessionBackedAgent
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1668,7 +1666,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> None:
         self._runner = runner
         self._streaming_runner = streaming_runner

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -13,11 +13,12 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests as _requests
 
 from fido import provider
+from fido.atomic import AtomicUpdater
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
     GLOBAL_DISALLOWED_TOOLS,
@@ -31,11 +32,13 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
-    ProviderStatsPublisher,
     model_name,
 )
 from fido.rocq import claude_session as stream_fsm
 from fido.session_agent import SessionBackedAgent
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1665,7 +1668,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> None:
         self._runner = runner
         self._streaming_runner = streaming_runner
@@ -1679,7 +1682,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
-            stats_publisher=stats_publisher,
+            state_updater=state_updater,
         )
 
     @property

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -10,9 +10,10 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, NoReturn, Protocol
+from typing import IO, Any, NoReturn, Protocol
 
 from fido import provider
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
@@ -31,9 +32,6 @@ from fido.provider import (
     model_name,
 )
 from fido.session_agent import SessionBackedAgent
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1143,7 +1141,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> None:
         self._runner = runner
         self._session_factory = (

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -26,6 +26,7 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    ProviderStatsPublisher,
     coerce_provider_model,
     model_name,
 )
@@ -1139,6 +1140,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> None:
         self._runner = runner
         self._session_factory = (
@@ -1150,6 +1152,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
+            stats_publisher=stats_publisher,
         )
 
     @property

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -10,9 +10,10 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import IO, Any, NoReturn, Protocol
+from typing import IO, TYPE_CHECKING, Any, NoReturn, Protocol
 
 from fido import provider
+from fido.atomic import AtomicUpdater
 from fido.idle_timeout import IdleDeadline
 from fido.provider import (
     ContextOverflowError,
@@ -26,11 +27,13 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
-    ProviderStatsPublisher,
     coerce_provider_model,
     model_name,
 )
 from fido.session_agent import SessionBackedAgent
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1140,7 +1143,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         work_dir: Path | str | None = None,
         repo_name: str | None = None,
         session: PromptSession | None = None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> None:
         self._runner = runner
         self._session_factory = (
@@ -1152,7 +1155,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
-            stats_publisher=stats_publisher,
+            state_updater=state_updater,
         )
 
     @property

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -15,7 +15,7 @@ from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 import acp
 from acp.exceptions import RequestError
@@ -32,6 +32,7 @@ from acp.schema import (
 )
 
 from fido import provider
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.provider import (
     OwnedSession,
@@ -47,9 +48,6 @@ from fido.provider import (
     coerce_provider_model,
 )
 from fido.session_agent import SessionBackedAgent
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1288,7 +1286,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         repo_name: str | None = None,
         session: PromptSession | None = None,
         api: CopilotCLIAPI | None = None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> None:
         self._runner = runner
         self._sleep_fn = sleep_fn

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -42,6 +42,7 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    ProviderStatsPublisher,
     ReasoningEffort,
     coerce_provider_model,
 )
@@ -1284,6 +1285,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         repo_name: str | None = None,
         session: PromptSession | None = None,
         api: CopilotCLIAPI | None = None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> None:
         self._runner = runner
         self._sleep_fn = sleep_fn
@@ -1299,6 +1301,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
+            stats_publisher=stats_publisher,
         )
 
     @property

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -15,7 +15,7 @@ from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import acp
 from acp.exceptions import RequestError
@@ -32,6 +32,7 @@ from acp.schema import (
 )
 
 from fido import provider
+from fido.atomic import AtomicUpdater
 from fido.provider import (
     OwnedSession,
     PromptSession,
@@ -42,11 +43,13 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
-    ProviderStatsPublisher,
     ReasoningEffort,
     coerce_provider_model,
 )
 from fido.session_agent import SessionBackedAgent
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -1285,7 +1288,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
         repo_name: str | None = None,
         session: PromptSession | None = None,
         api: CopilotCLIAPI | None = None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> None:
         self._runner = runner
         self._sleep_fn = sleep_fn
@@ -1301,7 +1304,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
-            stats_publisher=stats_publisher,
+            state_updater=state_updater,
         )
 
     @property

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -1299,37 +1299,3 @@ class Provider(Protocol):
     def agent(self) -> ProviderAgent:
         """Return the provider's interactive runtime collaborator."""
         ...
-
-
-class ProviderStatsPublisher(Protocol):
-    """Injected collaborator for requesting a provider-stats snapshot publication.
-
-    Sessions and agents hold this collaborator and call :meth:`publish` when
-    they want the registry to refresh the immutable
-    :class:`~fido.registry.ProviderSnapshot` in
-    :class:`~fido.registry.FidoState`.
-
-    Provider modules must **not** import
-    :class:`~fido.registry.WorkerRegistry` directly — this Protocol is the
-    only legal publication path from the provider side.  The real
-    implementation is wired at construction time by
-    :class:`~fido.provider_factory.DefaultProviderFactory`; tests inject a
-    fake that records calls.
-    """
-
-    def publish(self) -> None:
-        """Request a fresh provider-stats snapshot publication."""
-        ...
-
-
-class NullProviderStatsPublisher:
-    """No-op :class:`ProviderStatsPublisher`.
-
-    Used when publication is not wired — for example, standalone agent
-    construction in tests that are not exercising the publication boundary,
-    or in contexts where no registry is available.  Calling :meth:`publish`
-    is a silent no-op.
-    """
-
-    def publish(self) -> None:
-        """Silently ignore the publication request."""

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -1299,3 +1299,37 @@ class Provider(Protocol):
     def agent(self) -> ProviderAgent:
         """Return the provider's interactive runtime collaborator."""
         ...
+
+
+class ProviderStatsPublisher(Protocol):
+    """Injected collaborator for requesting a provider-stats snapshot publication.
+
+    Sessions and agents hold this collaborator and call :meth:`publish` when
+    they want the registry to refresh the immutable
+    :class:`~fido.registry.ProviderSnapshot` in
+    :class:`~fido.registry.FidoState`.
+
+    Provider modules must **not** import
+    :class:`~fido.registry.WorkerRegistry` directly — this Protocol is the
+    only legal publication path from the provider side.  The real
+    implementation is wired at construction time by
+    :class:`~fido.provider_factory.DefaultProviderFactory`; tests inject a
+    fake that records calls.
+    """
+
+    def publish(self) -> None:
+        """Request a fresh provider-stats snapshot publication."""
+        ...
+
+
+class NullProviderStatsPublisher:
+    """No-op :class:`ProviderStatsPublisher`.
+
+    Used when publication is not wired — for example, standalone agent
+    construction in tests that are not exercising the publication boundary,
+    or in contexts where no registry is available.  Calling :meth:`publish`
+    is a silent no-op.
+    """
+
+    def publish(self) -> None:
+        """Silently ignore the publication request."""

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -2,8 +2,8 @@
 
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.claude import ClaudeAPI, ClaudeClient, ClaudeCode
 from fido.codex import Codex, CodexAPI, CodexClient
@@ -16,9 +16,6 @@ from fido.provider import (
     ProviderAPI,
     ProviderID,
 )
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 
 class DefaultProviderFactory:
@@ -53,7 +50,7 @@ class DefaultProviderFactory:
         work_dir: Path,
         repo_name: str,
         session: PromptSession | None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> Provider:
         match repo_cfg.provider:
             case ProviderID.CLAUDE_CODE:

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -8,11 +8,13 @@ from fido.codex import Codex, CodexAPI, CodexClient
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLI, CopilotCLIAPI, CopilotCLIClient
 from fido.provider import (
+    NullProviderStatsPublisher,
     PromptSession,
     Provider,
     ProviderAgent,
     ProviderAPI,
     ProviderID,
+    ProviderStatsPublisher,
 )
 
 
@@ -48,7 +50,13 @@ class DefaultProviderFactory:
         work_dir: Path,
         repo_name: str,
         session: PromptSession | None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> Provider:
+        publisher: ProviderStatsPublisher = (
+            stats_publisher
+            if stats_publisher is not None
+            else NullProviderStatsPublisher()
+        )
         match repo_cfg.provider:
             case ProviderID.CLAUDE_CODE:
                 return ClaudeCode(
@@ -57,6 +65,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
+                        stats_publisher=publisher,
                     )
                 )
             case ProviderID.COPILOT_CLI:
@@ -70,6 +79,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
+                        stats_publisher=publisher,
                     ),
                 )
             case ProviderID.CODEX:
@@ -79,6 +89,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
+                        stats_publisher=publisher,
                     )
                 )
             case _:

--- a/src/fido/provider_factory.py
+++ b/src/fido/provider_factory.py
@@ -2,20 +2,23 @@
 
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from fido.atomic import AtomicUpdater
 from fido.claude import ClaudeAPI, ClaudeClient, ClaudeCode
 from fido.codex import Codex, CodexAPI, CodexClient
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLI, CopilotCLIAPI, CopilotCLIClient
 from fido.provider import (
-    NullProviderStatsPublisher,
     PromptSession,
     Provider,
     ProviderAgent,
     ProviderAPI,
     ProviderID,
-    ProviderStatsPublisher,
 )
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 
 class DefaultProviderFactory:
@@ -50,13 +53,8 @@ class DefaultProviderFactory:
         work_dir: Path,
         repo_name: str,
         session: PromptSession | None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> Provider:
-        publisher: ProviderStatsPublisher = (
-            stats_publisher
-            if stats_publisher is not None
-            else NullProviderStatsPublisher()
-        )
         match repo_cfg.provider:
             case ProviderID.CLAUDE_CODE:
                 return ClaudeCode(
@@ -65,7 +63,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
-                        stats_publisher=publisher,
+                        state_updater=state_updater,
                     )
                 )
             case ProviderID.COPILOT_CLI:
@@ -79,7 +77,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
-                        stats_publisher=publisher,
+                        state_updater=state_updater,
                     ),
                 )
             case ProviderID.CODEX:
@@ -89,7 +87,7 @@ class DefaultProviderFactory:
                         work_dir=work_dir,
                         repo_name=repo_name,
                         session=session,
-                        stats_publisher=publisher,
+                        state_updater=state_updater,
                     )
                 )
             case _:

--- a/src/fido/rate_limit.py
+++ b/src/fido/rate_limit.py
@@ -24,7 +24,7 @@ from fido.github import GitHub
 from fido.provider import ProviderLimitWindow
 
 if TYPE_CHECKING:
-    from fido.registry import FidoState
+    from fido.appstate import FidoState
 
 log = logging.getLogger(__name__)
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -9,64 +9,31 @@ from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from frozendict import frozendict
-
+from fido.appstate import (
+    FidoState,
+    ProviderSnapshot,
+    RepoState,
+    ThreadSnapshot,
+    WebhookActivity,
+    WorkerActivity,
+    WorkerCrash,
+)
 from fido.atomic import AtomicUpdater
-from fido.atomic import create_atomic as _create_atomic
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import IssueTreeCache
 from fido.provider import PromptSession, Provider
-from fido.rate_limit import GitHubLimit
 from fido.rocq import handler_preemption as preemption_fsm
 from fido.rocq import worker_registry_crash as registry_fsm
 from fido.worker import WorkerThread
 
 if TYPE_CHECKING:
-    from fido.atomic import AtomicReader
     from fido.events import Dispatcher
 
 log = logging.getLogger(__name__)
 
 
-def _utcnow() -> datetime:
-    """Return the current UTC time as a timezone-aware datetime."""
-    return datetime.now(tz=timezone.utc)
-
-
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
-
-
-@dataclass(frozen=True, slots=True)
-class WorkerActivity:
-    """Snapshot of what one worker is currently doing.
-
-    Frozen so instances can be stored inside frozen :class:`RepoState`
-    without breaking the immutability guarantee of the atomic snapshot.
-    """
-
-    repo_name: str
-    what: str
-    busy: bool
-    last_progress_at: datetime
-
-
-@dataclass(frozen=True, slots=True)
-class WorkerCrash:
-    """Running record of unexpected worker deaths for one repo.
-
-    Frozen so instances can be stored inside frozen :class:`RepoState`
-    without breaking the immutability guarantee of the atomic snapshot.
-
-    The zero value (``_ZERO_CRASH``) represents "never crashed" — readers
-    check ``death_count == 0`` rather than testing for ``None``.
-    """
-
-    death_count: int
-    last_error: str
-    last_crash_time: datetime
-
-
 _ZERO_CRASH = WorkerCrash(death_count=0, last_error="", last_crash_time=_EPOCH)
 
 
@@ -81,163 +48,9 @@ def _zero_activity(repo_name: str) -> WorkerActivity:
     )
 
 
-@dataclass(frozen=True, slots=True)
-class WebhookActivity:
-    """One in-flight webhook handler running alongside the worker.
-
-    Created when ``_process_action`` starts handling a webhook action; removed
-    when that handler returns (success or failure).  Surfaced in ``fido
-    status`` as a sub-bullet under the repo so we can see what's being
-    handled beyond the worker's own task.
-
-    *thread_id* is :func:`threading.get_ident` captured at context entry so
-    status display can match this webhook to the active
-    :class:`~fido.provider.SessionTalker` (whose ``thread_id`` field is from
-    the same call) — letting the CLI attach claude stats to the specific
-    webhook line that's driving claude.
-
-    Frozen so instances can be stored inside frozen :class:`RepoState`
-    without breaking the immutability guarantee of the atomic snapshot.
-    """
-
-    handle_id: int
-    description: str
-    started_at: datetime
-    thread_id: int
-
-
-@dataclass(frozen=True, slots=True)
-class ProviderSnapshot:
-    """Immutable snapshot of one repo's provider (ClaudeSession) state.
-
-    Captures provider session metadata as primitive values at the moment of
-    each provider lifecycle event (session start, recovery).  Stored on
-    :class:`RepoState` so the SCADA display path reads stale-free values
-    without holding the provider lock.
-
-    Fields mirror the public session properties on
-    :class:`~fido.worker.WorkerThread` that are read by the status display
-    path.  Published by :meth:`WorkerRegistry._publish_provider_snapshot`
-    at lifecycle boundaries where session state actually changes.
-    """
-
-    session_owner: str | None
-    session_alive: bool
-    session_pid: int | None
-    session_dropped_count: int
-    session_sent_count: int
-    session_received_count: int
-
-
-@dataclass(frozen=True, slots=True)
-class RepoState:
-    """Per-repo sub-snapshot within :class:`FidoState`.
-
-    *key* is the repo slug (e.g. ``"rhencke/confusio"``), matching the key
-    under which this record is stored in :attr:`FidoState.repos`.
-
-    *started_at* is the UTC timestamp when the most recent
-    :class:`~fido.worker.WorkerThread` for this repo was started.
-
-    *activity* is the current :class:`WorkerActivity` for this repo.
-    Initialised to the zero sentinel (``what=""``) by :meth:`start`; the
-    worker replaces it on its first :meth:`report_activity` call.
-
-    *crash_record* is the accumulated :class:`WorkerCrash` history for this
-    repo.  Initialised to ``_ZERO_CRASH`` (``death_count=0``) by
-    :meth:`start`; the watchdog replaces it on each crash.
-
-    *webhook_activities* is the tuple of in-flight webhook handlers for this
-    repo.  Published from the authoritative ``_webhook_activities`` dict on
-    :class:`WorkerRegistry` via :meth:`~WorkerRegistry._publish_webhook_activities`; starts empty.
-
-    *thread* is the immutable :class:`ThreadSnapshot` for the repo's
-    :class:`~fido.worker.WorkerThread`.  ``None`` until the first
-    :meth:`~WorkerRegistry.start` call; refreshed by
-    :meth:`~WorkerRegistry._publish_thread_snapshot` immediately after the
-    thread is started.  No mutable thread reference is stored here — the
-    snapshot captures primitive values only.
-
-    *provider* is the immutable :class:`ProviderSnapshot` for the repo's
-    provider (ClaudeSession).  ``None`` until the first
-    :meth:`~WorkerRegistry.start` call; refreshed by
-    :meth:`~WorkerRegistry._publish_provider_snapshot` at provider lifecycle
-    events (session start, recovery).
-
-    As subsequent lock-free PRs migrate fields out of the per-lock dicts in
-    :class:`WorkerRegistry`, those fields grow here (e.g. ``rescoping``).
-    Each migration removes the corresponding lock and dict from
-    ``WorkerRegistry.__init__``.
-    """
-
-    key: str
-    started_at: datetime
-    activity: WorkerActivity
-    crash_record: WorkerCrash
-    webhook_activities: tuple[WebhookActivity, ...]
-    thread: "ThreadSnapshot | None" = None
-    provider: "ProviderSnapshot | None" = None
-
-
-@dataclass(frozen=True, slots=True)
-class ThreadSnapshot:
-    """Immutable snapshot of one :class:`~fido.worker.WorkerThread`'s lifecycle state.
-
-    Captures thread lifecycle metadata as primitive values — no handles to the
-    mutable :class:`~fido.worker.WorkerThread` object itself.  Stored inside
-    the frozen :class:`FidoState` so the SCADA display invariant is preserved:
-    a snapshot reader can never reach through to a live thread and observe
-    partial mutations.
-
-    Provider session state (session_owner, session_alive, session_pid, and
-    the message counters) lives on :class:`ProviderSnapshot` instead so it can
-    be published independently at provider lifecycle boundaries.
-    """
-
-    is_alive: bool
-    was_stopped: bool
-    crash_error: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class FidoState:
-    """Atomically-swapped coordination snapshot.
-
-    ``repos`` maps each repo slug to its :class:`RepoState` snapshot.  It is
-    a :class:`frozendict` so stale readers that hold a reference to an old
-    snapshot can never accidentally mutate the mapping — the immutability
-    guarantee holds even on the free-threaded (no-GIL) build.  Each
-    :class:`RepoState` carries a :class:`ThreadSnapshot` at its ``thread``
-    field — an immutable copy of the thread's observable state at the last
-    :meth:`WorkerRegistry.start` call.
-
-    The atomic cell is owned by the composition root (``run()`` in
-    ``server.py``), not by :class:`WorkerRegistry`.  The root creates both
-    faces via :func:`~fido.atomic.create_atomic`, passes the
-    :class:`~fido.atomic.AtomicUpdater` to ``WorkerRegistry`` and
-    :class:`~fido.rate_limit.RateLimitMonitor`, and passes the
-    :class:`~fido.atomic.AtomicReader` to the status serialisation path.
-
-    **Convergence target**: ``FidoState`` is intended to grow to cover all
-    coordination fields currently scattered across the per-lock dicts in
-    :class:`WorkerRegistry` (worker activities, crash records, webhook
-    activities, rescoping flags, …).  As each field migrates here, the
-    corresponding lock disappears.
-
-    **Replaces FidoStatus long-term**: :class:`~fido.status.FidoStatus` in
-    ``status.py`` is a display-oriented dataclass shaped by the old
-    ``/status.json`` schema.  The end-state is to serialise ``FidoState``
-    directly to JSON — even where that changes the wire format — and retire
-    ``FidoStatus``.  The ``./fido status`` CLI output serves as the living
-    requirement: whatever ``FidoState`` carries must be sufficient to render
-    everything that ``./fido status`` currently shows.
-    """
-
-    repos: frozendict[str, RepoState]
-    github_limits: GitHubLimit
-
-
-_EMPTY_FIDO_STATE = FidoState(repos=frozendict(), github_limits=GitHubLimit())
+def _utcnow() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime."""
+    return datetime.now(tz=timezone.utc)
 
 
 @dataclass(frozen=True, slots=True)
@@ -960,20 +773,6 @@ class WorkerRegistry:
         """
         with self._issue_cache_lock:
             return list(self._issue_caches.values())
-
-
-def create_fido_atomic() -> tuple[
-    "AtomicReader[FidoState]", "AtomicUpdater[FidoState]"
-]:
-    """Create the atomic cell for :class:`FidoState` and return both faces.
-
-    Thin wrapper around :func:`~fido.atomic.create_atomic` with the correct
-    initial value.  Call this once at the composition root (``run()``), pass
-    the updater to :class:`WorkerRegistry` and
-    :class:`~fido.rate_limit.RateLimitMonitor`, and keep the reader in the
-    composition root for the status serialisation path.
-    """
-    return _create_atomic(_EMPTY_FIDO_STATE)
 
 
 def _make_thread(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -82,7 +82,7 @@ class WorkerRegistry:
 
     Usage::
 
-        state_reader, state_updater = create_fido_atomic()
+        state_reader, state_updater = create_atomic(FidoState(repos=frozendict(), github_limits=GitHubLimit()))
         registry = WorkerRegistry(my_factory, state_updater)
         registry.start(repo_cfg)   # create + start thread
         registry.wake("owner/repo")  # nudge thread to check for work
@@ -820,7 +820,7 @@ def make_registry(
 
     Uses :func:`_make_thread` as the factory; all threads share the provided
     :class:`~fido.github.GitHub` client.  The caller (composition root) is
-    responsible for creating the atomic cell via :func:`create_fido_atomic`
+    responsible for creating the atomic cell via :func:`~fido.atomic.create_atomic`
     and passing the updater face here.  Pass a custom registry directly
     (with a mock factory) in tests instead of calling this.
     """

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -22,6 +22,7 @@ from xml.etree.ElementTree import Element, SubElement, register_namespace, tostr
 import requests
 
 from fido import provider
+from fido.appstate import FidoState, create_fido_atomic
 from fido.atomic import AtomicReader, AtomicUpdater
 from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
@@ -50,10 +51,8 @@ from fido.provider import ProviderLimitWindow
 from fido.provider_factory import DefaultProviderFactory
 from fido.rate_limit import GitHubLimit, RateLimitMonitor
 from fido.registry import (
-    FidoState,
     WebhookActivityHandle,
     WorkerRegistry,
-    create_fido_atomic,
     make_registry,
 )
 from fido.rocq import self_restart as restart_fsm

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -20,10 +20,11 @@ from urllib.parse import urlparse
 from xml.etree.ElementTree import Element, SubElement, register_namespace, tostring
 
 import requests
+from frozendict import frozendict
 
 from fido import provider
-from fido.appstate import FidoState, create_fido_atomic
-from fido.atomic import AtomicReader, AtomicUpdater
+from fido.appstate import FidoState
+from fido.atomic import AtomicReader, create_atomic
 from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.events import (
@@ -1512,9 +1513,6 @@ def run(
     _preflight_gh_auth: Callable[..., None] = preflight_gh_auth,
     _GitHub: type[GitHub] = GitHub,
     _bootstrap_issue_caches: Callable[..., None] = bootstrap_issue_caches,
-    _create_fido_atomic: Callable[
-        [], tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]
-    ] = create_fido_atomic,
 ) -> None:
     config = _from_args()
 
@@ -1582,7 +1580,9 @@ def run(
     # (write-only) and to the rate-limit monitor; the reader stays here and
     # is placed on WebhookHandler so the status serialisation path can read
     # without going through the registry at all.
-    state_reader, state_updater = _create_fido_atomic()
+    state_reader, state_updater = create_atomic(
+        FidoState(repos=frozendict(), github_limits=GitHubLimit())
+    )
     registry = _make_registry(
         config.repos, gh, config, dispatchers=dispatchers, state_updater=state_updater
     )

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -47,6 +47,11 @@ class SessionBackedAgent:
         )
 
     @property
+    def stats_publisher(self) -> ProviderStatsPublisher:
+        """Return the injected :class:`~fido.provider.ProviderStatsPublisher`."""
+        return self._stats_publisher
+
+    @property
     def session(self) -> PromptSession | None:
         with self._session_lock:
             return self._session

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
+    NullProviderStatsPublisher,
     PromptSession,
     ProviderModel,
+    ProviderStatsPublisher,
     TurnSessionMode,
 )
 
@@ -30,6 +32,7 @@ class SessionBackedAgent:
         work_dir: Path | str | None,
         repo_name: str | None,
         session: PromptSession | None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> None:
         self._session_fn = session_fn
         self._session_system_file = session_system_file
@@ -37,6 +40,11 @@ class SessionBackedAgent:
         self._repo_name = repo_name
         self._session_lock = threading.Lock()
         self._session: PromptSession | None = session
+        self._stats_publisher: ProviderStatsPublisher = (
+            stats_publisher
+            if stats_publisher is not None
+            else NullProviderStatsPublisher()
+        )
 
     @property
     def session(self) -> PromptSession | None:

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -5,8 +5,8 @@ import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
@@ -14,9 +14,6 @@ from fido.provider import (
     ProviderModel,
     TurnSessionMode,
 )
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +32,7 @@ class SessionBackedAgent:
         work_dir: Path | str | None,
         repo_name: str | None,
         session: PromptSession | None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> None:
         self._session_fn = session_fn
         self._session_system_file = session_system_file
@@ -43,10 +40,10 @@ class SessionBackedAgent:
         self._repo_name = repo_name
         self._session_lock = threading.Lock()
         self._session: PromptSession | None = session
-        self._state_updater: "AtomicUpdater[FidoState] | None" = state_updater
+        self._state_updater: AtomicUpdater[FidoState] | None = state_updater
 
     @property
-    def state_updater(self) -> "AtomicUpdater[FidoState] | None":
+    def state_updater(self) -> AtomicUpdater[FidoState] | None:
         """Return the injected :class:`~fido.atomic.AtomicUpdater`, if any."""
         return self._state_updater
 

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -5,15 +5,18 @@ import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from fido.atomic import AtomicUpdater
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
-    NullProviderStatsPublisher,
     PromptSession,
     ProviderModel,
-    ProviderStatsPublisher,
     TurnSessionMode,
 )
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +35,7 @@ class SessionBackedAgent:
         work_dir: Path | str | None,
         repo_name: str | None,
         session: PromptSession | None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> None:
         self._session_fn = session_fn
         self._session_system_file = session_system_file
@@ -40,16 +43,12 @@ class SessionBackedAgent:
         self._repo_name = repo_name
         self._session_lock = threading.Lock()
         self._session: PromptSession | None = session
-        self._stats_publisher: ProviderStatsPublisher = (
-            stats_publisher
-            if stats_publisher is not None
-            else NullProviderStatsPublisher()
-        )
+        self._state_updater: "AtomicUpdater[FidoState] | None" = state_updater
 
     @property
-    def stats_publisher(self) -> ProviderStatsPublisher:
-        """Return the injected :class:`~fido.provider.ProviderStatsPublisher`."""
-        return self._stats_publisher
+    def state_updater(self) -> "AtomicUpdater[FidoState] | None":
+        """Return the injected :class:`~fido.atomic.AtomicUpdater`, if any."""
+        return self._state_updater
 
     @property
     def session(self) -> PromptSession | None:

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -17,8 +17,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fido import provider
+from fido.appstate import create_fido_atomic
 from fido.provider_factory import DefaultProviderFactory
-from fido.registry import WorkerRegistry, create_fido_atomic
+from fido.registry import WorkerRegistry
 from fido.tasks import (
     _merge_thread_lineage,
     _review_thread_contains_comment,

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -15,10 +15,13 @@ from typing import Never
 from unittest.mock import MagicMock, patch
 
 import pytest
+from frozendict import frozendict
 
 from fido import provider
-from fido.appstate import create_fido_atomic
+from fido.appstate import FidoState
+from fido.atomic import create_atomic
 from fido.provider_factory import DefaultProviderFactory
+from fido.rate_limit import GitHubLimit
 from fido.registry import WorkerRegistry
 from fido.tasks import (
     _merge_thread_lineage,
@@ -64,7 +67,9 @@ class TestWorkerRegistryPreemptionHelpers:
     def _registry(self) -> WorkerRegistry:
         # WorkerRegistry takes a thread factory callable; tests don't
         # need real WorkerThreads, so a no-op factory is fine.
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         return WorkerRegistry(MagicMock(), updater)
 
     def test_note_provider_interrupt_requested(self) -> None:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,9 +1,11 @@
+import dataclasses
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
 
 from fido.provider import (
+    NullProviderStatsPublisher,
     ProviderID,
     ProviderInterruptTimeout,
     ProviderLimitSnapshot,
@@ -274,3 +276,49 @@ class TestSafeVoiceTurn:
         _, kwargs = agent.run_turn.call_args
         assert kwargs["model"] == model
         assert kwargs["system_prompt"] == "be brief"
+
+
+class TestProviderStatsPublisherBoundary:
+    """Structural invariants for the ProviderStatsPublisher boundary."""
+
+    def test_null_publisher_publish_is_a_no_op(self) -> None:
+        """Calling NullProviderStatsPublisher.publish() raises nothing."""
+        NullProviderStatsPublisher().publish()
+
+    def test_provider_modules_do_not_import_worker_registry(self) -> None:
+        """Provider and session modules must not reach through to WorkerRegistry."""
+        import fido.claude as claude_mod
+        import fido.codex as codex_mod
+        import fido.copilotcli as copilotcli_mod
+        import fido.provider_factory as factory_mod
+        import fido.session_agent as session_agent_mod
+
+        for mod in (
+            claude_mod,
+            codex_mod,
+            copilotcli_mod,
+            factory_mod,
+            session_agent_mod,
+        ):
+            assert not hasattr(mod, "WorkerRegistry"), (
+                f"{mod.__name__} must not import WorkerRegistry"
+            )
+
+    def test_provider_snapshot_holds_only_primitive_values(self) -> None:
+        """ProviderSnapshot must contain only primitive types — no live session refs."""
+        from fido.registry import ProviderSnapshot
+
+        snap = ProviderSnapshot(
+            session_owner="worker",
+            session_alive=True,
+            session_pid=42,
+            session_dropped_count=1,
+            session_sent_count=5,
+            session_received_count=3,
+        )
+        for field in dataclasses.fields(snap):
+            value = getattr(snap, field.name)
+            assert isinstance(value, (str, int, bool, type(None))), (
+                f"ProviderSnapshot.{field.name} = {value!r} is not a primitive — "
+                "live session references must not appear in status snapshots"
+            )

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -301,7 +301,7 @@ class TestProviderModuleBoundary:
 
     def test_provider_snapshot_holds_only_primitive_values(self) -> None:
         """ProviderSnapshot must contain only primitive types — no live session refs."""
-        from fido.registry import ProviderSnapshot
+        from fido.appstate import ProviderSnapshot
 
         snap = ProviderSnapshot(
             session_owner="worker",

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.provider import (
-    NullProviderStatsPublisher,
     ProviderID,
     ProviderInterruptTimeout,
     ProviderLimitSnapshot,
@@ -278,12 +277,8 @@ class TestSafeVoiceTurn:
         assert kwargs["system_prompt"] == "be brief"
 
 
-class TestProviderStatsPublisherBoundary:
-    """Structural invariants for the ProviderStatsPublisher boundary."""
-
-    def test_null_publisher_publish_is_a_no_op(self) -> None:
-        """Calling NullProviderStatsPublisher.publish() raises nothing."""
-        NullProviderStatsPublisher().publish()
+class TestProviderModuleBoundary:
+    """Structural invariants for the provider module boundary."""
 
     def test_provider_modules_do_not_import_worker_registry(self) -> None:
         """Provider and session modules must not reach through to WorkerRegistry."""

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLIAPI, CopilotCLIClient
-from fido.provider import ProviderID
+from fido.provider import NullProviderStatsPublisher, ProviderID
 from fido.provider_factory import DefaultProviderFactory
 
 
@@ -195,3 +195,49 @@ class TestProviderSessionIdExtraction:
             )
             == "codex-sess"
         )
+
+
+class TestProviderStatsPublisherWiring:
+    """create_provider threads ProviderStatsPublisher through to every agent type."""
+
+    def test_default_publisher_is_null_for_all_providers(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        for provider_id in (
+            ProviderID.CLAUDE_CODE,
+            ProviderID.CODEX,
+            ProviderID.COPILOT_CLI,
+        ):
+            prov = factory.create_provider(
+                RepoConfig(name="owner/repo", work_dir=tmp_path, provider=provider_id),
+                work_dir=tmp_path,
+                repo_name="owner/repo",
+                session=None,
+            )
+            assert isinstance(prov.agent.stats_publisher, NullProviderStatsPublisher), (
+                f"{provider_id}: expected NullProviderStatsPublisher by default"
+            )
+
+    def test_injected_publisher_reachable_on_all_agent_types(
+        self, tmp_path: Path
+    ) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        factory = DefaultProviderFactory(session_system_file=system_file)
+        for provider_id in (
+            ProviderID.CLAUDE_CODE,
+            ProviderID.CODEX,
+            ProviderID.COPILOT_CLI,
+        ):
+            fake = NullProviderStatsPublisher()
+            prov = factory.create_provider(
+                RepoConfig(name="owner/repo", work_dir=tmp_path, provider=provider_id),
+                work_dir=tmp_path,
+                repo_name="owner/repo",
+                session=None,
+                stats_publisher=fake,
+            )
+            assert prov.agent.stats_publisher is fake, (
+                f"{provider_id}: injected publisher not reachable on agent"
+            )

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from fido.atomic import AtomicUpdater
 from fido.config import RepoConfig
 from fido.copilotcli import CopilotCLIAPI, CopilotCLIClient
-from fido.provider import NullProviderStatsPublisher, ProviderID
+from fido.provider import ProviderID
 from fido.provider_factory import DefaultProviderFactory
 
 
@@ -197,10 +199,10 @@ class TestProviderSessionIdExtraction:
         )
 
 
-class TestProviderStatsPublisherWiring:
-    """create_provider threads ProviderStatsPublisher through to every agent type."""
+class TestProviderStateUpdaterWiring:
+    """create_provider threads AtomicUpdater[FidoState] through to every agent type."""
 
-    def test_default_publisher_is_null_for_all_providers(self, tmp_path: Path) -> None:
+    def test_default_updater_is_none_for_all_providers(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         factory = DefaultProviderFactory(session_system_file=system_file)
@@ -215,11 +217,11 @@ class TestProviderStatsPublisherWiring:
                 repo_name="owner/repo",
                 session=None,
             )
-            assert isinstance(prov.agent.stats_publisher, NullProviderStatsPublisher), (
-                f"{provider_id}: expected NullProviderStatsPublisher by default"
+            assert prov.agent.state_updater is None, (
+                f"{provider_id}: expected None state_updater by default"
             )
 
-    def test_injected_publisher_reachable_on_all_agent_types(
+    def test_injected_updater_reachable_on_all_agent_types(
         self, tmp_path: Path
     ) -> None:
         system_file = tmp_path / "persona.md"
@@ -230,14 +232,14 @@ class TestProviderStatsPublisherWiring:
             ProviderID.CODEX,
             ProviderID.COPILOT_CLI,
         ):
-            fake = NullProviderStatsPublisher()
+            fake: AtomicUpdater = MagicMock(spec=AtomicUpdater)
             prov = factory.create_provider(
                 RepoConfig(name="owner/repo", work_dir=tmp_path, provider=provider_id),
                 work_dir=tmp_path,
                 repo_name="owner/repo",
                 session=None,
-                stats_publisher=fake,
+                state_updater=fake,
             )
-            assert prov.agent.stats_publisher is fake, (
-                f"{provider_id}: injected publisher not reachable on agent"
+            assert prov.agent.state_updater is fake, (
+                f"{provider_id}: injected state_updater not reachable on agent"
             )

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from frozendict import frozendict
 
+from fido.appstate import FidoState
 from fido.atomic import AtomicReader, AtomicUpdater, create_atomic
 from fido.provider import ProviderLimitWindow
 from fido.rate_limit import (
@@ -15,12 +16,11 @@ from fido.rate_limit import (
     RateLimitMonitor,
     _parse_window,  # noqa: PLC2701
 )
-from fido.registry import FidoState
 
 
 def _make_state() -> tuple[AtomicReader[FidoState], AtomicUpdater[FidoState]]:
     """Return a fresh ``(reader, updater)`` pair seeded with an empty
-    :class:`~fido.registry.FidoState` for use in monitor tests."""
+    :class:`~fido.appstate.FidoState` for use in monitor tests."""
     return create_atomic(
         FidoState(
             repos=frozendict(),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -8,15 +8,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fido.config import RepoConfig as _RepoConfig
-from fido.provider import ProviderID
-from fido.registry import (
+from fido.appstate import (
     ProviderSnapshot,
     ThreadSnapshot,
     WorkerCrash,
+    create_fido_atomic,
+)
+from fido.config import RepoConfig as _RepoConfig
+from fido.provider import ProviderID
+from fido.registry import (
     WorkerRegistry,
     _make_thread,
-    create_fido_atomic,
     make_registry,
 )
 from fido.rocq import worker_registry_crash as registry_fsm

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,15 +7,13 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from frozendict import frozendict
 
-from fido.appstate import (
-    ProviderSnapshot,
-    ThreadSnapshot,
-    WorkerCrash,
-    create_fido_atomic,
-)
+from fido.appstate import FidoState, ProviderSnapshot, ThreadSnapshot, WorkerCrash
+from fido.atomic import create_atomic
 from fido.config import RepoConfig as _RepoConfig
 from fido.provider import ProviderID
+from fido.rate_limit import GitHubLimit
 from fido.registry import (
     WorkerRegistry,
     _make_thread,
@@ -44,7 +42,9 @@ class TestWorkerRegistry:
         self, *, repos: list[str] | None = None
     ) -> tuple[WorkerRegistry, MagicMock, object]:
         factory = MagicMock()
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         if repos:
             for name in repos:
@@ -62,7 +62,9 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         # First start — no prior thread
@@ -92,7 +94,9 @@ class TestWorkerRegistry:
         mock_provider = MagicMock()
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
@@ -108,7 +112,9 @@ class TestWorkerRegistry:
         """No provider rescue when the old thread exited via orderly stop()."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
@@ -149,7 +155,9 @@ class TestWorkerRegistry:
 
     def test_stop_all_calls_stop_on_every_thread(self, tmp_path: Path) -> None:
         factory = MagicMock(side_effect=[MagicMock(), MagicMock()])
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
@@ -168,7 +176,9 @@ class TestWorkerRegistry:
     def test_stop_all_calls_stop_count(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
@@ -223,7 +233,9 @@ class TestWorkerRegistry:
         self, tmp_path: Path
     ) -> None:
         """recover_provider() refreshes the ProviderSnapshot after recovery."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -248,7 +260,9 @@ class TestWorkerRegistry:
 
     def test_publish_provider_snapshot_updates_fido_state(self, tmp_path: Path) -> None:
         """publish_provider_snapshot() publishes a fresh ProviderSnapshot into FidoState."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -472,8 +486,8 @@ class TestWorkerRegistry:
 
         assert max_concurrent == 1
 
-    def test_create_fido_atomic_reader_sees_state(self) -> None:
-        """create_fido_atomic reader reflects writes made via the updater."""
+    def test_atomic_reader_sees_registry_writes(self) -> None:
+        """Atomic reader reflects writes made via the updater."""
         reg, _, reader = self._make_registry(repos=["foo/bar"])
         # reader sees the repo populated by start()
         assert "foo/bar" in reader.get().repos
@@ -547,7 +561,9 @@ class TestWorkerRegistry:
         """crash_record is preserved across start() so history accumulates."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
@@ -563,7 +579,9 @@ class TestWorkerRegistry:
     def test_start_replaces_existing_thread_entry(self, tmp_path: Path) -> None:
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = _repo("foo/bar", tmp_path)
         reg.start(cfg)
@@ -580,13 +598,17 @@ class TestWorkerRegistry:
     # ── ThreadSnapshot / RepoState.thread ────────────────────────────────
 
     def test_thread_snapshot_none_before_any_start(self) -> None:
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         WorkerRegistry(MagicMock(), updater)
         assert reader.get().repos == {}
 
     def test_start_publishes_thread_snapshot(self, tmp_path: Path) -> None:
         """start() sets thread on the repo's RepoState in FidoState."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -604,7 +626,9 @@ class TestWorkerRegistry:
         assert isinstance(snap, ThreadSnapshot)
 
     def test_thread_snapshot_is_alive_field(self, tmp_path: Path) -> None:
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -622,7 +646,9 @@ class TestWorkerRegistry:
         assert snap.is_alive is True
 
     def test_thread_snapshot_was_stopped_field(self, tmp_path: Path) -> None:
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = False
         factory.return_value.was_stopped = True
@@ -640,7 +666,9 @@ class TestWorkerRegistry:
         assert snap.was_stopped is True
 
     def test_provider_snapshot_fields(self, tmp_path: Path) -> None:
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -664,7 +692,9 @@ class TestWorkerRegistry:
         assert provider.session_received_count == 5
 
     def test_thread_snapshot_crash_error_field(self, tmp_path: Path) -> None:
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = False
         factory.return_value.was_stopped = False
@@ -683,7 +713,9 @@ class TestWorkerRegistry:
 
     def test_thread_snapshot_no_mutable_thread_ref(self, tmp_path: Path) -> None:
         """ThreadSnapshot stores only primitive values — no WorkerThread handle."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -724,7 +756,9 @@ class TestWorkerRegistry:
             t.session_received_count = 0
             t.crash_error = None
         factory = MagicMock(side_effect=threads)
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         reg.start(_repo("foo/bar", tmp_path))
         reg.start(_repo("foo/baz", tmp_path))
@@ -736,7 +770,9 @@ class TestWorkerRegistry:
         """ThreadSnapshot is frozen — stored safely inside frozen FidoState."""
         import dataclasses
 
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -757,7 +793,9 @@ class TestWorkerRegistry:
 
     def test_record_crash_republishes_thread_snapshot(self, tmp_path: Path) -> None:
         """record_crash refreshes the ThreadSnapshot so is_alive and crash_error reflect the crash."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -781,7 +819,9 @@ class TestWorkerRegistry:
 
     def test_stop_and_join_republishes_thread_snapshot(self, tmp_path: Path) -> None:
         """stop_and_join refreshes the ThreadSnapshot so is_alive and was_stopped reflect the stop."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         factory.return_value.is_alive.return_value = True
         factory.return_value.was_stopped = False
@@ -805,7 +845,9 @@ class TestWorkerRegistry:
 
     def test_stop_and_join_unknown_repo_skips_snapshot(self) -> None:
         """stop_and_join on an unknown repo must not attempt to publish a snapshot."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         factory = MagicMock()
         reg = WorkerRegistry(factory, updater)
         reg.stop_and_join("unknown/repo")  # must not raise
@@ -899,7 +941,9 @@ class TestMakeRegistry:
     def test_returns_worker_registry(self, tmp_path: Path) -> None:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         result = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
@@ -914,7 +958,9 @@ class TestMakeRegistry:
         cfg2 = _repo("foo/baz", tmp_path)
         mock_thread = MagicMock()
         mock_factory = MagicMock(return_value=mock_thread)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         make_registry(
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
@@ -926,7 +972,9 @@ class TestMakeRegistry:
         assert mock_thread.start.call_count == 2
 
     def test_empty_repos_returns_empty_registry(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         result = make_registry({}, MagicMock(), dispatchers={}, state_updater=updater)
         assert isinstance(result, WorkerRegistry)
         assert result.is_alive("anything") is False
@@ -935,7 +983,9 @@ class TestMakeRegistry:
         cfg = _repo("foo/bar", tmp_path)
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = True
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
@@ -958,7 +1008,9 @@ class TestMakeRegistry:
             sub_dir=tmp_path,
         )
         mock_factory = MagicMock(return_value=MagicMock())
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         make_registry(
             {"foo/bar": cfg},
             MagicMock(),
@@ -972,7 +1024,9 @@ class TestMakeRegistry:
 
 class TestWebhookActivity:
     def test_registers_and_unregisters(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         assert reg.get_webhook_activities("foo/bar") == []
@@ -985,7 +1039,9 @@ class TestWebhookActivity:
     def test_unregisters_on_exception(self, tmp_path: Path) -> None:
         import pytest as _pytest
 
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with _pytest.raises(RuntimeError):
@@ -994,7 +1050,9 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_multiple_concurrent_activities(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "first"):
@@ -1006,7 +1064,9 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_activities_isolated_per_repo(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("a/b", tmp_path))
         reg.start(_repo("c/d", tmp_path))
@@ -1018,12 +1078,16 @@ class TestWebhookActivity:
                 assert [x.description for x in c] == ["work-cd"]
 
     def test_unknown_repo_returns_empty_list(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_handle_can_update_description(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
@@ -1032,7 +1096,9 @@ class TestWebhookActivity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "triaging"
 
     def test_handle_update_after_exit_is_noop(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling") as activity:
@@ -1041,7 +1107,9 @@ class TestWebhookActivity:
         assert reg.get_webhook_activities("foo/bar") == []
 
     def test_unknown_handle_update_is_noop(self, tmp_path: Path) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
@@ -1049,14 +1117,18 @@ class TestWebhookActivity:
             assert reg.get_webhook_activities("foo/bar")[0].description == "handling"
 
     def test_unknown_repo_handle_update_is_noop(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.set_webhook_description("ghost/repo", 1, "triaging")
         assert reg.get_webhook_activities("ghost/repo") == []
 
     def test_publishes_to_fido_state_when_repo_started(self, tmp_path: Path) -> None:
         """webhook_activity publishes activities into FidoState when start() has run."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "handling"):
@@ -1067,7 +1139,9 @@ class TestWebhookActivity:
 
     def test_publishes_description_update_to_fido_state(self, tmp_path: Path) -> None:
         """set_webhook_description publishes the update into FidoState."""
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.start(_repo("foo/bar", tmp_path))
         with reg.webhook_activity("foo/bar", "original") as handle:
@@ -1079,25 +1153,33 @@ class TestWebhookActivity:
 
 class TestRescoping:
     def test_is_rescoping_false_for_unknown_repo(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         assert reg.is_rescoping("unknown/repo") is False
 
     def test_set_rescoping_true(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
 
     def test_set_rescoping_false_clears_flag(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         reg.set_rescoping("foo/bar", False)
         assert reg.is_rescoping("foo/bar") is False
 
     def test_rescoping_is_per_repo(self) -> None:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         reg.set_rescoping("foo/bar", True)
         assert reg.is_rescoping("foo/bar") is True
@@ -1105,7 +1187,9 @@ class TestRescoping:
 
     def test_rescoping_is_threadsafe(self) -> None:
         """Concurrent set_rescoping and is_rescoping calls must not corrupt state."""
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(MagicMock(), updater)
         errors: list[Exception] = []
 
@@ -1138,7 +1222,9 @@ class TestUntriagedInbox:
     """Tests for the per-repo untriaged-webhook inbox (fix #1067)."""
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         return WorkerRegistry(MagicMock(), updater)
 
     # ── has_untriaged ─────────────────────────────────────────────────────
@@ -1369,7 +1455,9 @@ class TestPreemptionFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         return WorkerRegistry(MagicMock(), updater)
 
     # ── worker_blocked_when_nonempty ─────────────────────────────────────
@@ -1595,7 +1683,9 @@ class TestRegistryFsmOracle:
     """
 
     def _reg(self) -> WorkerRegistry:
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         return WorkerRegistry(MagicMock(), updater)
 
     def _cfg(self, tmp_path: Path, name: str = "foo/bar") -> RepoConfig:
@@ -1683,7 +1773,9 @@ class TestRegistryFsmOracle:
         """start() after crash fires ThreadDies then Rescue: Active → Crashed → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
@@ -1706,7 +1798,9 @@ class TestRegistryFsmOracle:
         """start() after orderly stop fires ThreadStops then Launch: Active → Stopped → Active."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
@@ -1730,7 +1824,9 @@ class TestRegistryFsmOracle:
         """
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         cfg = self._cfg(tmp_path)
         reg.start(cfg)
@@ -1743,7 +1839,9 @@ class TestRegistryFsmOracle:
         """FSM state is independent for each repo — no cross-repo contamination."""
         threads = [MagicMock(), MagicMock()]
         factory = MagicMock(side_effect=threads)
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         reg = WorkerRegistry(factory, updater)
         reg.start(_repo("org/a", tmp_path))
         reg.start(_repo("org/b", tmp_path))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1853,8 +1853,9 @@ class TestProcessAction:
         mock_gh.add_reaction.assert_not_called()
 
     def test_issue_comment_webhook_activity_tracks_phase(self, tmp_path: Path) -> None:
+        from fido.appstate import create_fido_atomic
         from fido.events import Action
-        from fido.registry import WorkerRegistry, create_fido_atomic
+        from fido.registry import WorkerRegistry
 
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)
@@ -2097,8 +2098,9 @@ class TestProcessAction:
         """
         from contextlib import contextmanager
 
+        from fido.appstate import ProviderSnapshot, create_fido_atomic
         from fido.events import Action
-        from fido.registry import ProviderSnapshot, WorkerRegistry, create_fido_atomic
+        from fido.registry import WorkerRegistry
 
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)
@@ -2197,8 +2199,9 @@ class TestProcessAction:
         """
         from contextlib import contextmanager
 
+        from fido.appstate import ProviderSnapshot, create_fido_atomic
         from fido.events import Action
-        from fido.registry import ProviderSnapshot, WorkerRegistry, create_fido_atomic
+        from fido.registry import WorkerRegistry
 
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1853,14 +1853,17 @@ class TestProcessAction:
         mock_gh.add_reaction.assert_not_called()
 
     def test_issue_comment_webhook_activity_tracks_phase(self, tmp_path: Path) -> None:
-        from fido.appstate import create_fido_atomic
+        from fido.appstate import FidoState
+        from fido.atomic import create_atomic
         from fido.events import Action
         from fido.registry import WorkerRegistry
 
         cfg = _config(tmp_path)
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         handler.registry = WorkerRegistry(MagicMock(), updater)
         handler.registry.start(cfg.repos["owner/repo"])
         handler.gh = MagicMock()
@@ -2098,7 +2101,8 @@ class TestProcessAction:
         """
         from contextlib import contextmanager
 
-        from fido.appstate import ProviderSnapshot, create_fido_atomic
+        from fido.appstate import FidoState, ProviderSnapshot
+        from fido.atomic import create_atomic
         from fido.events import Action
         from fido.registry import WorkerRegistry
 
@@ -2106,7 +2110,9 @@ class TestProcessAction:
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
 
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
 
         # Build a mock thread with known, non-default session field values so
         # we can verify the snapshot contains exactly these values.
@@ -2199,7 +2205,8 @@ class TestProcessAction:
         """
         from contextlib import contextmanager
 
-        from fido.appstate import ProviderSnapshot, create_fido_atomic
+        from fido.appstate import FidoState, ProviderSnapshot
+        from fido.atomic import create_atomic
         from fido.events import Action
         from fido.registry import WorkerRegistry
 
@@ -2207,7 +2214,9 @@ class TestProcessAction:
         handler = WebhookHandler.__new__(WebhookHandler)
         handler.config = cfg
 
-        reader, updater = create_fido_atomic()
+        reader, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
 
         # Use session_owner=None to exercise the provider-returns-None path
         # (providers filter out non-worker talkers; clearing stale worker info
@@ -3682,7 +3691,7 @@ class TestRun:
             _RateLimitMonitor=mock_rl_cls,
         )
 
-        # The state_updater is the second element returned by _create_fido_atomic().
+        # The state_updater is the second element returned by create_atomic(...).
         # RateLimitMonitor must be wired with the same updater that was passed to
         # make_registry — verify positional args rather than the updater value.
         assert mock_rl_cls.call_count == 1

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -1,18 +1,15 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
+from fido.appstate import FidoState
 from fido.atomic import AtomicUpdater
 from fido.provider import (
     ProviderModel,
     TurnSessionMode,
 )
 from fido.session_agent import SessionBackedAgent
-
-if TYPE_CHECKING:
-    from fido.registry import FidoState
 
 
 class _FakeAgent(SessionBackedAgent):
@@ -28,7 +25,7 @@ class _FakeAgent(SessionBackedAgent):
         repo_name: str | None = None,
         session: object = None,
         session_factory: object = None,
-        state_updater: "AtomicUpdater[FidoState] | None" = None,
+        state_updater: AtomicUpdater[FidoState] | None = None,
     ) -> None:
         self._session_factory = (
             MagicMock() if session_factory is None else session_factory

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fido.provider import ProviderModel, TurnSessionMode
+from fido.provider import (
+    NullProviderStatsPublisher,
+    ProviderModel,
+    ProviderStatsPublisher,
+    TurnSessionMode,
+)
 from fido.session_agent import SessionBackedAgent
 
 
@@ -20,6 +25,7 @@ class _FakeAgent(SessionBackedAgent):
         repo_name: str | None = None,
         session: object = None,
         session_factory: object = None,
+        stats_publisher: ProviderStatsPublisher | None = None,
     ) -> None:
         self._session_factory = (
             MagicMock() if session_factory is None else session_factory
@@ -30,6 +36,7 @@ class _FakeAgent(SessionBackedAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
+            stats_publisher=stats_publisher,
         )
 
     def _spawn_owned_session(
@@ -266,3 +273,12 @@ class TestSessionBackedAgent:
         agent = _FakeAgent(session=session)
         assert agent.run_turn("hi", retry_on_preempt=True) == "done"
         assert session.prompt.call_count == 2
+
+    def test_stats_publisher_defaults_to_null_publisher(self) -> None:
+        agent = _FakeAgent()
+        assert isinstance(agent.stats_publisher, NullProviderStatsPublisher)
+
+    def test_stats_publisher_stores_injected_publisher(self) -> None:
+        fake = NullProviderStatsPublisher()
+        agent = _FakeAgent(stats_publisher=fake)
+        assert agent.stats_publisher is fake

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -1,15 +1,18 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
+from fido.atomic import AtomicUpdater
 from fido.provider import (
-    NullProviderStatsPublisher,
     ProviderModel,
-    ProviderStatsPublisher,
     TurnSessionMode,
 )
 from fido.session_agent import SessionBackedAgent
+
+if TYPE_CHECKING:
+    from fido.registry import FidoState
 
 
 class _FakeAgent(SessionBackedAgent):
@@ -25,7 +28,7 @@ class _FakeAgent(SessionBackedAgent):
         repo_name: str | None = None,
         session: object = None,
         session_factory: object = None,
-        stats_publisher: ProviderStatsPublisher | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
     ) -> None:
         self._session_factory = (
             MagicMock() if session_factory is None else session_factory
@@ -36,7 +39,7 @@ class _FakeAgent(SessionBackedAgent):
             work_dir=work_dir,
             repo_name=repo_name,
             session=session,
-            stats_publisher=stats_publisher,
+            state_updater=state_updater,
         )
 
     def _spawn_owned_session(
@@ -274,11 +277,11 @@ class TestSessionBackedAgent:
         assert agent.run_turn("hi", retry_on_preempt=True) == "done"
         assert session.prompt.call_count == 2
 
-    def test_stats_publisher_defaults_to_null_publisher(self) -> None:
+    def test_state_updater_defaults_to_none(self) -> None:
         agent = _FakeAgent()
-        assert isinstance(agent.stats_publisher, NullProviderStatsPublisher)
+        assert agent.state_updater is None
 
-    def test_stats_publisher_stores_injected_publisher(self) -> None:
-        fake = NullProviderStatsPublisher()
-        agent = _FakeAgent(stats_publisher=fake)
-        assert agent.stats_publisher is fake
+    def test_state_updater_stores_injected_updater(self) -> None:
+        fake: AtomicUpdater[FidoState] = MagicMock()
+        agent = _FakeAgent(state_updater=fake)
+        assert agent.state_updater is fake

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -800,7 +800,8 @@ class TestWorker:
         self, tmp_path: Path
     ) -> None:
         """Concurrent set_status calls on different workers sharing a registry serialize."""
-        from fido.registry import WorkerRegistry, create_fido_atomic
+        from fido.appstate import create_fido_atomic
+        from fido.registry import WorkerRegistry
 
         _, updater = create_fido_atomic()
         registry = WorkerRegistry(MagicMock(), updater)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -800,10 +800,16 @@ class TestWorker:
         self, tmp_path: Path
     ) -> None:
         """Concurrent set_status calls on different workers sharing a registry serialize."""
-        from fido.appstate import create_fido_atomic
+        from frozendict import frozendict
+
+        from fido.appstate import FidoState
+        from fido.atomic import create_atomic
+        from fido.rate_limit import GitHubLimit
         from fido.registry import WorkerRegistry
 
-        _, updater = create_fido_atomic()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
         registry = WorkerRegistry(MagicMock(), updater)
         # Prepopulate FidoState so report_activity can lens-write into it.
         for i in range(3):


### PR DESCRIPTION
Fixes #1598.

Extracts `FidoState` and its associated dataclasses (`ProviderSnapshot`, `RepoState`, `ThreadSnapshot`, etc.) from `registry.py` into a new `fido.appstate` leaf module, then injects `AtomicUpdater[FidoState]` through `SessionBackedAgent.__init__` and `DefaultProviderFactory.create_provider`. All three provider agents (Claude, Codex, CopilotCLI) import directly from `fido.atomic` and `fido.appstate` with no back-reference to the registry — no `TYPE_CHECKING` workarounds needed. The composition root calls `create_atomic` inline rather than wrapping it in a helper.

Fixes #1598.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Remove create_fido_atomic() and _EMPTY_FIDO_STATE from appstate.py. Remove the 'create_atomic as _create_atomic' alias import (and the AtomicUpdater import used only for the return annotation) from appstate.py. In server.py, inline the call as create_atomic(FidoState(repos=frozendict(), github_limits=GitHubLimit())). Update all tests that imported create_fido_atomic from fido.appstate to import create_atomic from fido.atomic instead.](https://github.com/FidoCanCode/home/pull/1602#discussion_r3219374198) <!-- type:thread -->
- [x] [Extract FidoState and all its associated dataclasses (ProviderSnapshot, RepoState, ThreadSnapshot, etc.) from registry.py into a new fido.state module. Update registry.py and all other importers accordingly. Provider modules (claude.py, codex.py, copilotcli.py, session_agent.py, provider_factory.py) then import AtomicUpdater from fido.atomic and FidoState from fido.state directly, eliminating the TYPE_CHECKING workarounds.](https://github.com/FidoCanCode/home/pull/1602#discussion_r3219088959) <!-- type:thread -->
- [x] [Replace ProviderStatsPublisher Protocol with AtomicUpdater[FidoState] passed through the constructor chain. Use TYPE_CHECKING import for FidoState in provider modules. Remove NullProviderStatsPublisher.](https://github.com/FidoCanCode/home/pull/1602#issuecomment-4417262023) <!-- type:thread -->
- [x] Inject publisher into SessionBackedAgent and provider factory <!-- type:spec -->
- [x] Add unit tests for the injected publisher boundary <!-- type:spec -->
- [x] Define ProviderStatsPublisher protocol in provider.py <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->