### PR TITLE
Provider stats: live-publish sent counts after provider sends (closes #1599)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -482,7 +482,7 @@ class ClaudeSession(OwnedSession):
         repo_name: str | None = None,
         session_id: str | None = None,
         tools: str | None = None,
-        on_metrics_changed: Callable[[], None] | None = None,
+        snapshot_publisher: provider.SnapshotPublisher | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -501,7 +501,7 @@ class ClaudeSession(OwnedSession):
         # which respawns the subprocess while keeping ``--resume`` so
         # conversation context survives the mode transition (#1042).
         self._tools: str | None = tools
-        self._on_metrics_changed = on_metrics_changed
+        self._snapshot_publisher = snapshot_publisher
         # Latest session_id seen in a stream-json event.  Updated inside
         # :meth:`iter_events` so :meth:`recover`, :meth:`reset`, and
         # :meth:`switch_model` can pass ``--resume <sid>``
@@ -889,8 +889,21 @@ class ClaudeSession(OwnedSession):
         self._proc.stdin.flush()
         with self._metrics_lock:
             self._sent_count += 1
-        if self._on_metrics_changed is not None:
-            self._on_metrics_changed()
+        self._notify_snapshot_publisher()
+
+    def _notify_snapshot_publisher(self) -> None:
+        """Push current metrics to the :class:`~fido.provider.SnapshotPublisher`."""
+        pub = self._snapshot_publisher
+        if pub is None:
+            return
+        pub.publish_metrics(
+            owner=self.owner,
+            alive=self.is_alive(),
+            pid=self.pid,
+            dropped_count=self.dropped_session_count,
+            sent_count=self.sent_count,
+            received_count=self.received_count,
+        )
 
     def _drain_to_boundary(self, deadline: float = 10.0) -> None:
         """Abort the in-flight turn and read events until ``type=result`` /
@@ -1711,7 +1724,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             repo_name=self._repo_name,
             model=model,
             session_id=session_id,
-            on_metrics_changed=self._publish_provider_snapshot,
+            snapshot_publisher=self,
         )
 
     def ensure_session(

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -482,6 +482,7 @@ class ClaudeSession(OwnedSession):
         repo_name: str | None = None,
         session_id: str | None = None,
         tools: str | None = None,
+        on_metrics_changed: Callable[[], None] | None = None,
     ) -> None:
         self._idle_timeout = idle_timeout
         self._selector = selector
@@ -500,6 +501,7 @@ class ClaudeSession(OwnedSession):
         # which respawns the subprocess while keeping ``--resume`` so
         # conversation context survives the mode transition (#1042).
         self._tools: str | None = tools
+        self._on_metrics_changed = on_metrics_changed
         # Latest session_id seen in a stream-json event.  Updated inside
         # :meth:`iter_events` so :meth:`recover`, :meth:`reset`, and
         # :meth:`switch_model` can pass ``--resume <sid>``
@@ -887,6 +889,8 @@ class ClaudeSession(OwnedSession):
         self._proc.stdin.flush()
         with self._metrics_lock:
             self._sent_count += 1
+        if self._on_metrics_changed is not None:
+            self._on_metrics_changed()
 
     def _drain_to_boundary(self, deadline: float = 10.0) -> None:
         """Abort the in-flight turn and read events until ``type=result`` /
@@ -1707,6 +1711,7 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             repo_name=self._repo_name,
             model=model,
             session_id=session_id,
+            on_metrics_changed=self._publish_provider_snapshot,
         )
 
     def ensure_session(

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -672,7 +672,7 @@ class CodexSession(OwnedSession):
         session_id: str | None = None,
         turn_idle_timeout: float = _CODEX_TURN_IDLE_TIMEOUT,
         clock: Callable[[], float] = time.monotonic,
-        on_metrics_changed: Callable[[], None] | None = None,
+        snapshot_publisher: provider.SnapshotPublisher | None = None,
     ) -> None:
         self._work_dir = Path(work_dir).resolve()
         self._repo_name = repo_name
@@ -684,7 +684,7 @@ class CodexSession(OwnedSession):
         self._model = coerce_provider_model(model)
         self._turn_idle_timeout = turn_idle_timeout
         self._clock = clock
-        self._on_metrics_changed = on_metrics_changed
+        self._snapshot_publisher = snapshot_publisher
         self._state_lock = threading.Lock()
         self._session_id: str | None = None
         self._turn_lock = threading.Lock()
@@ -783,8 +783,21 @@ class CodexSession(OwnedSession):
             self._active_turn_id = turn_id
         with self._state_lock:
             self._sent_count += 1
-        if self._on_metrics_changed is not None:
-            self._on_metrics_changed()
+        self._notify_snapshot_publisher()
+
+    def _notify_snapshot_publisher(self) -> None:
+        """Push current metrics to the :class:`~fido.provider.SnapshotPublisher`."""
+        pub = self._snapshot_publisher
+        if pub is None:
+            return
+        pub.publish_metrics(
+            owner=self.owner,
+            alive=self.is_alive(),
+            pid=self.pid,
+            dropped_count=self.dropped_session_count,
+            sent_count=self.sent_count,
+            received_count=self.received_count,
+        )
 
     def consume_until_result(self) -> str:
         with self._turn_lock:
@@ -1181,7 +1194,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             model=model,
             repo_name=self._repo_name,
             session_id=session_id,
-            on_metrics_changed=self._publish_provider_snapshot,
+            snapshot_publisher=self,
         )
 
     def _prompt_failure_is_passthrough(self, exc: Exception) -> bool:

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -672,6 +672,7 @@ class CodexSession(OwnedSession):
         session_id: str | None = None,
         turn_idle_timeout: float = _CODEX_TURN_IDLE_TIMEOUT,
         clock: Callable[[], float] = time.monotonic,
+        on_metrics_changed: Callable[[], None] | None = None,
     ) -> None:
         self._work_dir = Path(work_dir).resolve()
         self._repo_name = repo_name
@@ -683,6 +684,7 @@ class CodexSession(OwnedSession):
         self._model = coerce_provider_model(model)
         self._turn_idle_timeout = turn_idle_timeout
         self._clock = clock
+        self._on_metrics_changed = on_metrics_changed
         self._state_lock = threading.Lock()
         self._session_id: str | None = None
         self._turn_lock = threading.Lock()
@@ -781,6 +783,8 @@ class CodexSession(OwnedSession):
             self._active_turn_id = turn_id
         with self._state_lock:
             self._sent_count += 1
+        if self._on_metrics_changed is not None:
+            self._on_metrics_changed()
 
     def consume_until_result(self) -> str:
         with self._turn_lock:
@@ -1177,6 +1181,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             model=model,
             repo_name=self._repo_name,
             session_id=session_id,
+            on_metrics_changed=self._publish_provider_snapshot,
         )
 
     def _prompt_failure_is_passthrough(self, exc: Exception) -> bool:

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -948,7 +948,7 @@ class CopilotCLISession(OwnedSession):
         runtime: CopilotACPRuntime | None = None,
         runtime_factory: Callable[..., CopilotACPRuntime] | None = None,
         session_id: str | None = None,
-        on_metrics_changed: Callable[[], None] | None = None,
+        snapshot_publisher: provider.SnapshotPublisher | None = None,
     ) -> None:
         self._work_dir = Path(work_dir)
         self._repo_name = repo_name
@@ -965,7 +965,7 @@ class CopilotCLISession(OwnedSession):
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
-        self._on_metrics_changed = on_metrics_changed
+        self._snapshot_publisher = snapshot_publisher
         # _metrics_lock guards both counters: they are written by the worker
         # thread (send / prompt) and read from other threads (status,
         # registry).  Python 3.14t has no GIL, so += is not atomic.
@@ -1173,8 +1173,7 @@ class CopilotCLISession(OwnedSession):
         )
         with self._metrics_lock:
             self._sent_count += 1
-        if self._on_metrics_changed is not None:
-            self._on_metrics_changed()
+        self._notify_snapshot_publisher()
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
             prompt,
@@ -1202,6 +1201,20 @@ class CopilotCLISession(OwnedSession):
         if cancelled:
             return ""
         return result
+
+    def _notify_snapshot_publisher(self) -> None:
+        """Push current metrics to the :class:`~fido.provider.SnapshotPublisher`."""
+        pub = self._snapshot_publisher
+        if pub is None:
+            return
+        pub.publish_metrics(
+            owner=self.owner,
+            alive=self.is_alive(),
+            pid=self.pid,
+            dropped_count=self.dropped_session_count,
+            sent_count=self.sent_count,
+            received_count=self.received_count,
+        )
 
 
 class CopilotCLIAPI(ProviderAPI):
@@ -1330,7 +1343,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             model=model,
             repo_name=self._repo_name,
             session_id=session_id,
-            on_metrics_changed=self._publish_provider_snapshot,
+            snapshot_publisher=self,
         )
 
     def _should_retry_prompt_failure(

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -948,6 +948,7 @@ class CopilotCLISession(OwnedSession):
         runtime: CopilotACPRuntime | None = None,
         runtime_factory: Callable[..., CopilotACPRuntime] | None = None,
         session_id: str | None = None,
+        on_metrics_changed: Callable[[], None] | None = None,
     ) -> None:
         self._work_dir = Path(work_dir)
         self._repo_name = repo_name
@@ -964,6 +965,7 @@ class CopilotCLISession(OwnedSession):
         self._pending_content: str | None = None
         self._last_turn_cancelled = False
         self._model = coerce_provider_model(model)
+        self._on_metrics_changed = on_metrics_changed
         # _metrics_lock guards both counters: they are written by the worker
         # thread (send / prompt) and read from other threads (status,
         # registry).  Python 3.14t has no GIL, so += is not atomic.
@@ -1171,6 +1173,8 @@ class CopilotCLISession(OwnedSession):
         )
         with self._metrics_lock:
             self._sent_count += 1
+        if self._on_metrics_changed is not None:
+            self._on_metrics_changed()
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
             prompt,
@@ -1326,6 +1330,7 @@ class CopilotCLIClient(SessionBackedAgent, ProviderAgent):
             model=model,
             repo_name=self._repo_name,
             session_id=session_id,
+            on_metrics_changed=self._publish_provider_snapshot,
         )
 
     def _should_retry_prompt_failure(

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -298,6 +298,29 @@ GLOBAL_DISALLOWED_TOOLS = (
 )
 
 
+class SnapshotPublisher(Protocol):
+    """Typed callback for sessions to publish metrics to the status cell.
+
+    Sessions accept an optional ``SnapshotPublisher`` at construction time
+    and call :meth:`publish_metrics` after incrementing counters.  The agent
+    (or test double) implements this protocol — sessions never import
+    :class:`~fido.appstate.ProviderSnapshot` or :class:`~fido.atomic.AtomicUpdater`.
+    """
+
+    def publish_metrics(
+        self,
+        *,
+        owner: str | None,
+        alive: bool,
+        pid: int | None,
+        dropped_count: int,
+        sent_count: int,
+        received_count: int,
+    ) -> None:
+        """Publish a fresh provider metrics snapshot."""
+        ...
+
+
 class PromptSession(Protocol):
     """Persistent prompt/session collaborator owned by a repo worker thread."""
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -784,6 +784,7 @@ def _make_thread(
     session_issue: int | None = None,
     config: Config | None = None,
     dispatchers: "dict[str, Dispatcher]",
+    state_updater: AtomicUpdater[FidoState] | None = None,
     _WorkerThread: type[WorkerThread] = WorkerThread,
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client.
@@ -804,6 +805,7 @@ def _make_thread(
         repo_cfg=repo_cfg,
         dispatcher=dispatchers[repo_cfg.name],
         issue_cache=registry.get_issue_cache(repo_cfg.name),
+        state_updater=state_updater,
     )
 
 
@@ -839,6 +841,7 @@ def make_registry(
             session_issue=session_issue,
             config=config,
             dispatchers=dispatchers,
+            state_updater=state_updater,
         )
 
     registry = WorkerRegistry(factory, state_updater)

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -6,7 +6,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from fido.appstate import FidoState
+from fido.appstate import FidoState, ProviderSnapshot
 from fido.atomic import AtomicUpdater
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
@@ -46,6 +46,31 @@ class SessionBackedAgent:
     def state_updater(self) -> AtomicUpdater[FidoState] | None:
         """Return the injected :class:`~fido.atomic.AtomicUpdater`, if any."""
         return self._state_updater
+
+    def _publish_provider_snapshot(self) -> None:
+        """Build and publish a fresh :class:`~fido.appstate.ProviderSnapshot`.
+
+        Reads the current session properties and installs a new
+        :class:`~fido.appstate.ProviderSnapshot` at
+        ``repos[repo_name].provider`` in the atomic state cell via
+        :attr:`_state_updater`.
+
+        No-op when :attr:`_state_updater` or :attr:`_repo_name` is ``None``
+        — the agent was either constructed without state-publish wiring
+        (tests, standalone use) or without a known repo identity.
+        """
+        if self._state_updater is None or self._repo_name is None:
+            return
+        snapshot = ProviderSnapshot(
+            session_owner=self.session_owner,
+            session_alive=self.session_alive,
+            session_pid=self.session_pid,
+            session_dropped_count=self.session_dropped_count,
+            session_sent_count=self.session_sent_count,
+            session_received_count=self.session_received_count,
+        )
+        _name = self._repo_name
+        self._state_updater.update(lambda root: root.repos[_name].provider, snapshot)
 
     @property
     def session(self) -> PromptSession | None:

--- a/src/fido/session_agent.py
+++ b/src/fido/session_agent.py
@@ -12,13 +12,14 @@ from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
     PromptSession,
     ProviderModel,
+    SnapshotPublisher,
     TurnSessionMode,
 )
 
 log = logging.getLogger(__name__)
 
 
-class SessionBackedAgent:
+class SessionBackedAgent(SnapshotPublisher):
     """Common session attachment and lifecycle logic for provider agents."""
 
     voice_model: ProviderModel
@@ -47,11 +48,20 @@ class SessionBackedAgent:
         """Return the injected :class:`~fido.atomic.AtomicUpdater`, if any."""
         return self._state_updater
 
-    def _publish_provider_snapshot(self) -> None:
-        """Build and publish a fresh :class:`~fido.appstate.ProviderSnapshot`.
+    def publish_metrics(
+        self,
+        *,
+        owner: str | None,
+        alive: bool,
+        pid: int | None,
+        dropped_count: int,
+        sent_count: int,
+        received_count: int,
+    ) -> None:
+        """Publish a fresh :class:`~fido.appstate.ProviderSnapshot`.
 
-        Reads the current session properties and installs a new
-        :class:`~fido.appstate.ProviderSnapshot` at
+        Called by provider sessions after incrementing counters.  Installs a
+        new :class:`~fido.appstate.ProviderSnapshot` at
         ``repos[repo_name].provider`` in the atomic state cell via
         :attr:`_state_updater`.
 
@@ -62,12 +72,12 @@ class SessionBackedAgent:
         if self._state_updater is None or self._repo_name is None:
             return
         snapshot = ProviderSnapshot(
-            session_owner=self.session_owner,
-            session_alive=self.session_alive,
-            session_pid=self.session_pid,
-            session_dropped_count=self.session_dropped_count,
-            session_sent_count=self.session_sent_count,
-            session_received_count=self.session_received_count,
+            session_owner=owner,
+            session_alive=alive,
+            session_pid=pid,
+            session_dropped_count=dropped_count,
+            session_sent_count=sent_count,
+            session_received_count=received_count,
         )
         _name = self._repo_name
         self._state_updater.update(lambda root: root.repos[_name].provider, snapshot)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from fido.appstate import FidoState
+    from fido.atomic import AtomicUpdater
     from fido.events import Action, Dispatcher
 
 import requests as _requests
@@ -1219,6 +1221,7 @@ class Worker:
         provider_factory: DefaultProviderFactory | None = None,
         first_iteration: bool = False,
         nudges: Nudges | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -1252,6 +1255,7 @@ class Worker:
             if provider_factory is None
             else provider_factory
         )
+        self._state_updater: "AtomicUpdater[FidoState] | None" = state_updater
         self._bootstrap_session: PromptSession | None = session
         if provider is not None:
             self._provider = provider
@@ -1265,6 +1269,7 @@ class Worker:
                 work_dir=work_dir,
                 repo_name=repo_name,
                 session=session,
+                state_updater=state_updater,
             )
         else:
             self._provider = None
@@ -1282,6 +1287,7 @@ class Worker:
                 work_dir=self.work_dir,
                 repo_name=self._repo_name,
                 session=self._bootstrap_session,
+                state_updater=self._state_updater,
             )
             self._provider = provider
         return provider
@@ -4494,6 +4500,7 @@ class WorkerThread(threading.Thread):
         config: Config | None = None,
         repo_cfg: RepoConfig | None = None,
         provider_factory: DefaultProviderFactory | None = None,
+        state_updater: "AtomicUpdater[FidoState] | None" = None,
         *,
         dispatcher: "Dispatcher",
         issue_cache: IssueTreeCache,
@@ -4524,6 +4531,7 @@ class WorkerThread(threading.Thread):
             if provider_factory is None
             else provider_factory
         )
+        self._state_updater: "AtomicUpdater[FidoState] | None" = state_updater
         self._provider: Provider | None
         if provider is not None:
             self._provider = provider
@@ -4535,6 +4543,7 @@ class WorkerThread(threading.Thread):
                 work_dir=work_dir,
                 repo_name=repo_name,
                 session=session,
+                state_updater=state_updater,
             )
         else:
             self._provider = None
@@ -4686,6 +4695,7 @@ class WorkerThread(threading.Thread):
                     work_dir=self.work_dir,
                     repo_name=self._repo_name,
                     session=self._bootstrap_session,
+                    state_updater=self._state_updater,
                 )
                 self._provider = provider
             return provider
@@ -4827,6 +4837,7 @@ class WorkerThread(threading.Thread):
                     first_iteration=self._is_first_iteration,
                     dispatcher=self._dispatcher,
                     issue_cache=self._issue_cache,
+                    state_updater=self._state_updater,
                 )
                 worker._provider = provider  # pyright: ignore[reportPrivateUsage]
                 worker._provider_agent = provider.agent  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -912,6 +912,36 @@ class TestClaudeSessionMessageCounts:
         assert session.sent_count == 1
         assert session.received_count == 1
 
+    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+        import json as _json
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc(
+            [_json.dumps({"type": "result", "result": "ok"}) + "\n"]
+        )
+        calls: list[int] = []
+        session = ClaudeSession(
+            system_file,
+            work_dir=tmp_path,
+            popen=MagicMock(return_value=proc),
+            selector=MagicMock(return_value=([proc.stdout], [], [])),
+            on_metrics_changed=lambda: calls.append(session.sent_count),
+        )
+        session.send("hello")
+        assert calls == [1]
+
+    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+        import json as _json
+
+        proc = _make_session_proc(
+            [_json.dumps({"type": "result", "result": "ok"}) + "\n"]
+        )
+        session = _make_session(tmp_path, proc)
+        # No callback — send must not raise.
+        session.send("hello")
+        assert session.sent_count == 1
+
 
 class TestClaudeSessionDrainToBoundary:
     def test_returns_early_when_proc_dead(self, tmp_path: Path) -> None:
@@ -2791,6 +2821,7 @@ class TestClaudeClientSessionAttachment:
             repo_name=None,
             model="claude-opus-4-6",
             session_id=None,
+            on_metrics_changed=client._publish_provider_snapshot,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -912,7 +912,7 @@ class TestClaudeSessionMessageCounts:
         assert session.sent_count == 1
         assert session.received_count == 1
 
-    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_fires_after_send(self, tmp_path: Path) -> None:
         import json as _json
 
         system_file = tmp_path / "system.md"
@@ -920,25 +920,31 @@ class TestClaudeSessionMessageCounts:
         proc = _make_session_proc(
             [_json.dumps({"type": "result", "result": "ok"}) + "\n"]
         )
-        calls: list[int] = []
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
         session = ClaudeSession(
             system_file,
             work_dir=tmp_path,
             popen=MagicMock(return_value=proc),
             selector=MagicMock(return_value=([proc.stdout], [], [])),
-            on_metrics_changed=lambda: calls.append(session.sent_count),
+            snapshot_publisher=Recorder(),
         )
         session.send("hello")
-        assert calls == [1]
+        assert len(published) == 1
+        assert published[0]["sent_count"] == 1
 
-    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         import json as _json
 
         proc = _make_session_proc(
             [_json.dumps({"type": "result", "result": "ok"}) + "\n"]
         )
         session = _make_session(tmp_path, proc)
-        # No callback — send must not raise.
+        # No publisher — send must not raise.
         session.send("hello")
         assert session.sent_count == 1
 
@@ -2821,7 +2827,7 @@ class TestClaudeClientSessionAttachment:
             repo_name=None,
             model="claude-opus-4-6",
             session_id=None,
-            on_metrics_changed=client._publish_provider_snapshot,
+            snapshot_publisher=client,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -862,7 +862,7 @@ class TestCodexSession:
         assert params["threadId"] == "thread-new"
         assert params["excludeTurns"] is True
 
-    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_fires_after_send(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("base")
         fake = _FakeAppServer()
@@ -885,18 +885,24 @@ class TestCodexSession:
                 },
             ]
         )
-        calls: list[int] = []
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
         session = CodexSession(
             system_file,
             work_dir=tmp_path,
             model=ProviderModel("gpt-5.5", "medium"),
             client_factory=lambda **_: fake,
-            on_metrics_changed=lambda: calls.append(session.sent_count),
+            snapshot_publisher=Recorder(),
         )
         assert session.prompt("hello") == "ok"
-        assert calls == [1]
+        assert len(published) == 1
+        assert published[0]["sent_count"] == 1
 
-    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("base")
         fake = _FakeAppServer()
@@ -925,7 +931,7 @@ class TestCodexSession:
             model=ProviderModel("gpt-5.5", "medium"),
             client_factory=lambda **_: fake,
         )
-        # No callback — prompt must not raise.
+        # No publisher — prompt must not raise.
         assert session.prompt("hello") == "ok"
         assert session.sent_count == 1
 
@@ -959,7 +965,7 @@ class TestCodexClient:
             model=client.voice_model,
             repo_name="owner/repo",
             session_id="thread-1",
-            on_metrics_changed=client._publish_provider_snapshot,
+            snapshot_publisher=client,
         )
         assert client.session is session
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -862,6 +862,73 @@ class TestCodexSession:
         assert params["threadId"] == "thread-new"
         assert params["excludeTurns"] is True
 
+    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "ok"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        calls: list[int] = []
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model=ProviderModel("gpt-5.5", "medium"),
+            client_factory=lambda **_: fake,
+            on_metrics_changed=lambda: calls.append(session.sent_count),
+        )
+        assert session.prompt("hello") == "ok"
+        assert calls == [1]
+
+    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "ok"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model=ProviderModel("gpt-5.5", "medium"),
+            client_factory=lambda **_: fake,
+        )
+        # No callback — prompt must not raise.
+        assert session.prompt("hello") == "ok"
+        assert session.sent_count == 1
+
 
 class TestCodexClient:
     def test_model_slots_and_provider_id(self) -> None:
@@ -892,6 +959,7 @@ class TestCodexClient:
             model=client.voice_model,
             repo_name="owner/repo",
             session_id="thread-1",
+            on_metrics_changed=client._publish_provider_snapshot,
         )
         assert client.session is session
 

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1264,23 +1264,29 @@ class TestCopilotCLISession:
         assert "persona\n\n---\n\nsystem\n\n---\n\ntask" in caplog.text
         assert "copilot result >>>\ndone\n<<< copilot result" in caplog.text
 
-    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_fires_after_send(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         runtime = FakeRuntime()
         runtime.next_prompt = ("ok", "end_turn", "sess-2")
-        calls: list[int] = []
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
         session = CopilotCLISession(
             system_file,
             work_dir=tmp_path,
             model=CopilotCLIClient.voice_model,
             runtime=runtime,
-            on_metrics_changed=lambda: calls.append(session.sent_count),
+            snapshot_publisher=Recorder(),
         )
         session.prompt("hello", model=None, system_prompt=None)
-        assert calls == [1]
+        assert len(published) == 1
+        assert published[0]["sent_count"] == 1
 
-    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+    def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")
         runtime = FakeRuntime()
@@ -1291,7 +1297,7 @@ class TestCopilotCLISession:
             model=CopilotCLIClient.voice_model,
             runtime=runtime,
         )
-        # No callback — prompt must not raise.
+        # No publisher — prompt must not raise.
         session.prompt("hello", model=None, system_prompt=None)
         assert session.sent_count == 1
 
@@ -1525,7 +1531,7 @@ class TestCopilotCLIClient:
             model=client.voice_model,
             repo_name=None,
             session_id=None,
-            on_metrics_changed=client._publish_provider_snapshot,
+            snapshot_publisher=client,
         )
         session.reset.assert_called_once_with(client.work_model)
         session.switch_model.assert_not_called()
@@ -1562,7 +1568,7 @@ class TestCopilotCLIClient:
             model=client.voice_model,
             repo_name=None,
             session_id=None,
-            on_metrics_changed=client._publish_provider_snapshot,
+            snapshot_publisher=client,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1264,6 +1264,37 @@ class TestCopilotCLISession:
         assert "persona\n\n---\n\nsystem\n\n---\n\ntask" in caplog.text
         assert "copilot result >>>\ndone\n<<< copilot result" in caplog.text
 
+    def test_on_metrics_changed_fires_after_send(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        runtime.next_prompt = ("ok", "end_turn", "sess-2")
+        calls: list[int] = []
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.voice_model,
+            runtime=runtime,
+            on_metrics_changed=lambda: calls.append(session.sent_count),
+        )
+        session.prompt("hello", model=None, system_prompt=None)
+        assert calls == [1]
+
+    def test_on_metrics_changed_none_is_noop(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        runtime.next_prompt = ("ok", "end_turn", "sess-2")
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.voice_model,
+            runtime=runtime,
+        )
+        # No callback — prompt must not raise.
+        session.prompt("hello", model=None, system_prompt=None)
+        assert session.sent_count == 1
+
 
 class TestIsCopilotQuotaError:
     @pytest.mark.parametrize(
@@ -1494,6 +1525,7 @@ class TestCopilotCLIClient:
             model=client.voice_model,
             repo_name=None,
             session_id=None,
+            on_metrics_changed=client._publish_provider_snapshot,
         )
         session.reset.assert_called_once_with(client.work_model)
         session.switch_model.assert_not_called()
@@ -1530,6 +1562,7 @@ class TestCopilotCLIClient:
             model=client.voice_model,
             repo_name=None,
             session_id=None,
+            on_metrics_changed=client._publish_provider_snapshot,
         )
         session.reset.assert_not_called()
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -883,6 +883,7 @@ class TestMakeThread:
             repo_cfg=cfg,
             dispatcher=fake_dispatcher,
             issue_cache=mock_registry.get_issue_cache.return_value,
+            state_updater=None,
         )
         mock_registry.get_issue_cache.assert_called_once_with("foo/bar")
         assert result is mock_wt_cls.return_value
@@ -935,6 +936,36 @@ class TestMakeThread:
             _WorkerThread=mock_wt_cls,
         )
         assert mock_wt_cls.call_args.kwargs["repo_cfg"] is cfg
+
+    def test_state_updater_forwarded_to_worker_thread(self, tmp_path: Path) -> None:
+        """_make_thread passes state_updater through to WorkerThread."""
+        cfg = _repo("foo/bar", tmp_path)
+        mock_wt_cls = MagicMock()
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        _make_thread(
+            cfg,
+            MagicMock(),
+            gh=MagicMock(),
+            dispatchers={"foo/bar": _FakeDispatcher()},
+            state_updater=updater,
+            _WorkerThread=mock_wt_cls,
+        )
+        assert mock_wt_cls.call_args.kwargs["state_updater"] is updater
+
+    def test_state_updater_defaults_to_none(self, tmp_path: Path) -> None:
+        """_make_thread passes state_updater=None when not provided."""
+        cfg = _repo("foo/bar", tmp_path)
+        mock_wt_cls = MagicMock()
+        _make_thread(
+            cfg,
+            MagicMock(),
+            gh=MagicMock(),
+            dispatchers={"foo/bar": _FakeDispatcher()},
+            _WorkerThread=mock_wt_cls,
+        )
+        assert mock_wt_cls.call_args.kwargs["state_updater"] is None
 
 
 class TestMakeRegistry:
@@ -1020,6 +1051,22 @@ class TestMakeRegistry:
             _thread_factory=mock_factory,
         )
         assert mock_factory.call_args.kwargs["config"] is config
+
+    def test_state_updater_forwarded_to_thread_factory(self, tmp_path: Path) -> None:
+        """make_registry passes state_updater through to the thread factory."""
+        cfg = _repo("foo/bar", tmp_path)
+        mock_factory = MagicMock(return_value=MagicMock())
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        make_registry(
+            {"foo/bar": cfg},
+            MagicMock(),
+            dispatchers={},
+            state_updater=updater,
+            _thread_factory=mock_factory,
+        )
+        assert mock_factory.call_args.kwargs["state_updater"] is updater
 
 
 class TestWebhookActivity:

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -1,15 +1,43 @@
+import datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from frozendict import frozendict
 
-from fido.appstate import FidoState
-from fido.atomic import AtomicUpdater
+from fido.appstate import (
+    FidoState,
+    ProviderSnapshot,
+    RepoState,
+    WorkerActivity,
+    WorkerCrash,
+)
+from fido.atomic import AtomicUpdater, create_atomic
 from fido.provider import (
     ProviderModel,
     TurnSessionMode,
 )
+from fido.rate_limit import GitHubLimit
 from fido.session_agent import SessionBackedAgent
+
+_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+def _make_fido_state_with_repo(repo_name: str) -> FidoState:
+    """Return a minimal :class:`FidoState` with one pre-initialised repo entry."""
+    repo = RepoState(
+        key=repo_name,
+        started_at=_EPOCH,
+        activity=WorkerActivity(
+            repo_name=repo_name, what="", busy=False, last_progress_at=_EPOCH
+        ),
+        crash_record=WorkerCrash(death_count=0, last_error="", last_crash_time=_EPOCH),
+        webhook_activities=(),
+    )
+    return FidoState(
+        repos=frozendict({repo_name: repo}),
+        github_limits=GitHubLimit(),
+    )
 
 
 class _FakeAgent(SessionBackedAgent):
@@ -282,3 +310,86 @@ class TestSessionBackedAgent:
         fake: AtomicUpdater[FidoState] = MagicMock()
         agent = _FakeAgent(state_updater=fake)
         assert agent.state_updater is fake
+
+    # ── _publish_provider_snapshot ─────────────────────────────────────────
+
+    def test_publish_provider_snapshot_noop_without_updater(self) -> None:
+        """_publish_provider_snapshot does nothing when state_updater is None."""
+        session = MagicMock(
+            owner="worker",
+            pid=42,
+            session_id="s1",
+            dropped_session_count=0,
+            sent_count=3,
+            received_count=1,
+        )
+        session.is_alive.return_value = True
+        agent = _FakeAgent(session=session, repo_name="test/repo")
+        # No state_updater → must not raise.
+        agent._publish_provider_snapshot()
+
+    def test_publish_provider_snapshot_noop_without_repo_name(self) -> None:
+        """_publish_provider_snapshot does nothing when repo_name is None."""
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        session = MagicMock(sent_count=5)
+        session.is_alive.return_value = True
+        agent = _FakeAgent(session=session, state_updater=updater)
+        # repo_name is None → must not raise (no lens path to navigate).
+        agent._publish_provider_snapshot()
+
+    def test_publish_provider_snapshot_writes_snapshot_fields(self) -> None:
+        """_publish_provider_snapshot installs a ProviderSnapshot with correct fields."""
+        repo_name = "owner/myrepo"
+        reader, updater = create_atomic(_make_fido_state_with_repo(repo_name))
+        session = MagicMock(
+            owner="worker-thread",
+            pid=99,
+            session_id="sess-xyz",
+            dropped_session_count=1,
+            sent_count=7,
+            received_count=4,
+        )
+        session.is_alive.return_value = True
+        agent = _FakeAgent(
+            session=session,
+            repo_name=repo_name,
+            state_updater=updater,
+        )
+        agent._publish_provider_snapshot()
+        provider = reader.get().repos[repo_name].provider
+        assert provider is not None
+        assert isinstance(provider, ProviderSnapshot)
+        assert provider.session_owner == "worker-thread"
+        assert provider.session_alive is True
+        assert provider.session_pid == 99
+        assert provider.session_dropped_count == 1
+        assert provider.session_sent_count == 7
+        assert provider.session_received_count == 4
+
+    def test_publish_provider_snapshot_reflects_updated_sent_count(self) -> None:
+        """A second publish after the count changes reflects the new value."""
+        repo_name = "owner/myrepo"
+        reader, updater = create_atomic(_make_fido_state_with_repo(repo_name))
+        session = MagicMock(
+            owner=None,
+            pid=None,
+            session_id=None,
+            dropped_session_count=0,
+            sent_count=0,
+            received_count=0,
+        )
+        session.is_alive.return_value = True
+        agent = _FakeAgent(
+            session=session,
+            repo_name=repo_name,
+            state_updater=updater,
+        )
+        agent._publish_provider_snapshot()
+        assert reader.get().repos[repo_name].provider is not None
+        assert reader.get().repos[repo_name].provider.session_sent_count == 0  # type: ignore[union-attr]
+
+        session.sent_count = 3
+        agent._publish_provider_snapshot()
+        assert reader.get().repos[repo_name].provider.session_sent_count == 3  # type: ignore[union-attr]

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -311,53 +311,53 @@ class TestSessionBackedAgent:
         agent = _FakeAgent(state_updater=fake)
         assert agent.state_updater is fake
 
-    # ── _publish_provider_snapshot ─────────────────────────────────────────
+    # ── publish_metrics (SnapshotPublisher) ─────────────────────────────────
 
-    def test_publish_provider_snapshot_noop_without_updater(self) -> None:
-        """_publish_provider_snapshot does nothing when state_updater is None."""
-        session = MagicMock(
+    def test_publish_metrics_noop_without_updater(self) -> None:
+        """publish_metrics does nothing when state_updater is None."""
+        agent = _FakeAgent(repo_name="test/repo")
+        # No state_updater → must not raise.
+        agent.publish_metrics(
             owner="worker",
+            alive=True,
             pid=42,
-            session_id="s1",
-            dropped_session_count=0,
+            dropped_count=0,
             sent_count=3,
             received_count=1,
         )
-        session.is_alive.return_value = True
-        agent = _FakeAgent(session=session, repo_name="test/repo")
-        # No state_updater → must not raise.
-        agent._publish_provider_snapshot()
 
-    def test_publish_provider_snapshot_noop_without_repo_name(self) -> None:
-        """_publish_provider_snapshot does nothing when repo_name is None."""
+    def test_publish_metrics_noop_without_repo_name(self) -> None:
+        """publish_metrics does nothing when repo_name is None."""
         _, updater = create_atomic(
             FidoState(repos=frozendict(), github_limits=GitHubLimit())
         )
-        session = MagicMock(sent_count=5)
-        session.is_alive.return_value = True
-        agent = _FakeAgent(session=session, state_updater=updater)
+        agent = _FakeAgent(state_updater=updater)
         # repo_name is None → must not raise (no lens path to navigate).
-        agent._publish_provider_snapshot()
+        agent.publish_metrics(
+            owner=None,
+            alive=True,
+            pid=None,
+            dropped_count=0,
+            sent_count=5,
+            received_count=0,
+        )
 
-    def test_publish_provider_snapshot_writes_snapshot_fields(self) -> None:
-        """_publish_provider_snapshot installs a ProviderSnapshot with correct fields."""
+    def test_publish_metrics_writes_snapshot_fields(self) -> None:
+        """publish_metrics installs a ProviderSnapshot with correct fields."""
         repo_name = "owner/myrepo"
         reader, updater = create_atomic(_make_fido_state_with_repo(repo_name))
-        session = MagicMock(
-            owner="worker-thread",
-            pid=99,
-            session_id="sess-xyz",
-            dropped_session_count=1,
-            sent_count=7,
-            received_count=4,
-        )
-        session.is_alive.return_value = True
         agent = _FakeAgent(
-            session=session,
             repo_name=repo_name,
             state_updater=updater,
         )
-        agent._publish_provider_snapshot()
+        agent.publish_metrics(
+            owner="worker-thread",
+            alive=True,
+            pid=99,
+            dropped_count=1,
+            sent_count=7,
+            received_count=4,
+        )
         provider = reader.get().repos[repo_name].provider
         assert provider is not None
         assert isinstance(provider, ProviderSnapshot)
@@ -368,28 +368,31 @@ class TestSessionBackedAgent:
         assert provider.session_sent_count == 7
         assert provider.session_received_count == 4
 
-    def test_publish_provider_snapshot_reflects_updated_sent_count(self) -> None:
-        """A second publish after the count changes reflects the new value."""
+    def test_publish_metrics_reflects_updated_sent_count(self) -> None:
+        """A second publish with a new count reflects the new value."""
         repo_name = "owner/myrepo"
         reader, updater = create_atomic(_make_fido_state_with_repo(repo_name))
-        session = MagicMock(
-            owner=None,
-            pid=None,
-            session_id=None,
-            dropped_session_count=0,
-            sent_count=0,
-            received_count=0,
-        )
-        session.is_alive.return_value = True
         agent = _FakeAgent(
-            session=session,
             repo_name=repo_name,
             state_updater=updater,
         )
-        agent._publish_provider_snapshot()
+        agent.publish_metrics(
+            owner=None,
+            alive=True,
+            pid=None,
+            dropped_count=0,
+            sent_count=0,
+            received_count=0,
+        )
         assert reader.get().repos[repo_name].provider is not None
         assert reader.get().repos[repo_name].provider.session_sent_count == 0  # type: ignore[union-attr]
 
-        session.sent_count = 3
-        agent._publish_provider_snapshot()
+        agent.publish_metrics(
+            owner=None,
+            alive=True,
+            pid=None,
+            dropped_count=0,
+            sent_count=3,
+            received_count=0,
+        )
         assert reader.get().repos[repo_name].provider.session_sent_count == 3  # type: ignore[union-attr]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1041,6 +1041,59 @@ class TestWorker:
         assert worker._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert agent is worker._provider.agent  # pyright: ignore[reportPrivateUsage]
 
+    def test_state_updater_passed_to_create_provider_in_ensure_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """Worker._ensure_provider passes state_updater to create_provider."""
+        from frozendict import frozendict
+
+        from fido.appstate import FidoState, GitHubLimit
+        from fido.atomic import create_atomic
+
+        cfg = _default_repo_cfg(tmp_path, repo_name="owner/repo")
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        mock_factory = MagicMock()
+        mock_factory.create_provider.return_value = MagicMock()
+        worker = Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=cfg,
+            provider_factory=mock_factory,
+            state_updater=updater,
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        # Force _ensure_provider to create a new provider (clear existing).
+        worker._provider = None  # pyright: ignore[reportPrivateUsage]
+        worker._ensure_provider()  # pyright: ignore[reportPrivateUsage]
+        assert mock_factory.create_provider.call_args.kwargs["state_updater"] is updater
+
+    def test_state_updater_passed_to_create_provider_at_init(
+        self, tmp_path: Path
+    ) -> None:
+        """Worker.__init__ passes state_updater to create_provider when repo_cfg is given."""
+        from frozendict import frozendict
+
+        from fido.appstate import FidoState, GitHubLimit
+        from fido.atomic import create_atomic
+
+        cfg = _default_repo_cfg(tmp_path, repo_name="owner/repo")
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        mock_factory = MagicMock()
+        mock_factory.create_provider.return_value = MagicMock()
+        Worker(
+            tmp_path,
+            MagicMock(),
+            repo_cfg=cfg,
+            provider_factory=mock_factory,
+            state_updater=updater,
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        assert mock_factory.create_provider.call_args.kwargs["state_updater"] is updater
+
     def test_ensure_provider_requires_repo_cfg(self, tmp_path: Path) -> None:
         worker = Worker(
             tmp_path,
@@ -16383,10 +16436,17 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
+            state_updater: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del (
+                provider_factory,
+                dispatcher,
+                first_iteration,
+                issue_cache,
+                state_updater,
+            )
             captured.append(abort_task)
             self_w.work_dir = work_dir
             self_w.gh = gh
@@ -16601,10 +16661,17 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
+            state_updater: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del (
+                provider_factory,
+                dispatcher,
+                first_iteration,
+                issue_cache,
+                state_updater,
+            )
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -16656,10 +16723,17 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
+            state_updater: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del (
+                provider_factory,
+                dispatcher,
+                first_iteration,
+                issue_cache,
+                state_updater,
+            )
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -17117,10 +17191,17 @@ class TestWorkerThread:
             repo_cfg: object = None,
             provider_factory: object = None,
             first_iteration: bool = False,
+            state_updater: object = None,
             dispatcher: object = None,
             issue_cache: object = None,
         ) -> None:
-            del provider_factory, dispatcher, first_iteration, issue_cache
+            del (
+                provider_factory,
+                dispatcher,
+                first_iteration,
+                issue_cache,
+                state_updater,
+            )
             self_w.work_dir = work_dir
             self_w.gh = gh
             self_w._abort_task = abort_task
@@ -17141,6 +17222,94 @@ class TestWorkerThread:
 
         assert received_config == [config]
         assert received_repo_cfg == [cfg]
+
+    def test_state_updater_forwarded_to_worker(self, tmp_path: Path) -> None:
+        """WorkerThread passes state_updater to Worker on each loop iteration."""
+        from frozendict import frozendict
+
+        from fido.appstate import FidoState, GitHubLimit
+        from fido.atomic import create_atomic
+
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+            state_updater=updater,
+        )
+        wt._wake = MagicMock()
+        received_updaters: list = []
+
+        def fake_worker_init(
+            self_w: object,
+            work_dir: Path,
+            gh: MagicMock,
+            abort_task: object = None,
+            repo_name: str = "",
+            registry: object = None,
+            membership: object = None,
+            session: object = None,
+            session_issue: int | None = None,
+            config: object = None,
+            repo_cfg: object = None,
+            provider_factory: object = None,
+            first_iteration: bool = False,
+            state_updater: object = None,
+            dispatcher: object = None,
+            issue_cache: object = None,
+        ) -> None:
+            del provider_factory, dispatcher, first_iteration, issue_cache
+            self_w.work_dir = work_dir
+            self_w.gh = gh
+            self_w._abort_task = abort_task
+            self_w._bootstrap_session = session  # pyright: ignore[reportPrivateUsage]
+            self_w._session_issue = session_issue
+            received_updaters.append(state_updater)
+
+        def fake_worker_run(self_w: object) -> int:
+            wt._stop.set()
+            return 0
+
+        with (
+            patch.object(Worker, "__init__", fake_worker_init),
+            patch.object(Worker, "run", fake_worker_run),
+        ):
+            self._run_thread(wt)
+
+        assert len(received_updaters) == 1
+        assert received_updaters[0] is updater
+
+    def test_state_updater_passed_to_create_provider_in_ensure_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """WorkerThread._ensure_provider passes state_updater to create_provider."""
+        from frozendict import frozendict
+
+        from fido.appstate import FidoState, GitHubLimit
+        from fido.atomic import create_atomic
+
+        cfg = _default_repo_cfg(tmp_path, repo_name="owner/repo")
+        _, updater = create_atomic(
+            FidoState(repos=frozendict(), github_limits=GitHubLimit())
+        )
+        mock_factory = MagicMock()
+        mock_factory.create_provider.return_value = MagicMock()
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+            repo_cfg=cfg,
+            provider_factory=mock_factory,
+            state_updater=updater,
+        )
+        # Force _ensure_provider to create a new provider (clear existing).
+        wt._provider = None  # pyright: ignore[reportPrivateUsage]
+        wt._ensure_provider()  # pyright: ignore[reportPrivateUsage]
+        assert mock_factory.create_provider.call_args.kwargs["state_updater"] is updater
 
 
 class TestIsLeakedTaskComment:


### PR DESCRIPTION
Fixes #1599.

After a provider session increments its sent counter, immediately publish a fresh `ProviderSnapshot` so `fido status` reflects the new value without waiting for the next worker/webhook boundary. A new `SnapshotPublisher` protocol gives the concept a proper name and type — sessions call `publish_metrics()` with their own field values, and `SessionBackedAgent` implements the protocol to build and publish the snapshot. Sessions never import `FidoState`, `ProviderSnapshot`, or `AtomicUpdater`. Production wiring plumbs `state_updater` through the full construction path (`_make_thread` → `WorkerThread` → `Worker` → `provider_factory.create_provider` → agent classes).

Fixes #1599.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (6)</summary>

- [x] [Push the existing commit a7090fe on branch live-publish-sent-counts to origin.](https://github.com/FidoCanCode/home/pull/1621#issuecomment-4425246063) <!-- type:thread -->
- [x] [Replace on_metrics_changed callback with typed SnapshotPublisher protocol](https://github.com/FidoCanCode/home/pull/1621#discussion_r3221578460) <!-- type:thread -->
- [x] [Plumb state_updater from the registry through _make_thread → WorkerThread → Worker → provider_factory.create_provider so that provider agents receive a non-None state_updater in production and _publish_provider_snapshot actually publishes.](https://github.com/FidoCanCode/home/pull/1621#discussion_r3220177537) <!-- type:thread -->
- [x] Add self-publish ProviderSnapshot method to SessionBackedAgent <!-- type:spec -->
- [x] Wire sent-count publish callbacks in all three provider sessions <!-- type:spec -->
- [x] [PR top-level comment on #1621 by chatgpt-codex-connector[bot] (bot): To use Codex here, [create a Codex account and connect to github](https://chatgpt.com/codex/cloud/settings/connectors).](https://github.com/FidoCanCode/home/pull/1621#issuecomment-4422059955) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->