### PR TITLE
Provider stats: live-publish received counts as provider output is consumed (closes #1600)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -1382,6 +1382,7 @@ class ClaudeSession(OwnedSession):
                 self._log_event(obj)
                 with self._metrics_lock:
                     self._received_count += 1
+                self._notify_snapshot_publisher()
                 idle_deadline.reset()
                 # First non-empty event after Send transitions Sending →
                 # AwaitingReply.  Other states (AwaitingReply, Draining,

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -846,6 +846,7 @@ class CodexSession(OwnedSession):
                     final_text = text
                     with self._state_lock:
                         self._received_count += 1
+                    self._notify_snapshot_publisher()
             completed = (
                 _extract_completed_turn(params) if method == "turn/completed" else None
             )

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1181,6 +1181,7 @@ class CopilotCLISession(OwnedSession):
         )
         with self._metrics_lock:
             self._received_count += 1
+        self._notify_snapshot_publisher()
         self._session_id = session_id
         if model is not None:
             self._model = coerce_provider_model(model)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -937,6 +937,38 @@ class TestClaudeSessionMessageCounts:
         assert len(published) == 1
         assert published[0]["sent_count"] == 1
 
+    def test_snapshot_publisher_fires_after_receive(self, tmp_path: Path) -> None:
+        import json as _json
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        lines = [
+            _json.dumps({"type": "assistant", "text": "chunk"}) + "\n",
+            _json.dumps({"type": "result", "result": "done"}) + "\n",
+        ]
+        proc = _make_session_proc(lines)
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
+        session = ClaudeSession(
+            system_file,
+            work_dir=tmp_path,
+            popen=MagicMock(return_value=proc),
+            selector=MagicMock(return_value=([proc.stdout], [], [])),
+            snapshot_publisher=Recorder(),
+        )
+        session.send("hello")
+        published.clear()  # ignore the send publication
+        list(session.iter_events())
+        # Two events received → two snapshot publications, each with the
+        # incremented received_count already visible.
+        assert len(published) == 2
+        assert published[0]["received_count"] == 1
+        assert published[1]["received_count"] == 2
+
     def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         import json as _json
 

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -899,8 +899,55 @@ class TestCodexSession:
             snapshot_publisher=Recorder(),
         )
         assert session.prompt("hello") == "ok"
-        assert len(published) == 1
+        # sent publication fires first, then received publication after the
+        # item/completed event increments the counter.
+        assert len(published) == 2
         assert published[0]["sent_count"] == 1
+        assert published[0]["received_count"] == 0
+        assert published[1]["sent_count"] == 1
+        assert published[1]["received_count"] == 1
+
+    def test_snapshot_publisher_fires_after_receive(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "ok"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model=ProviderModel("gpt-5.5", "medium"),
+            client_factory=lambda **_: fake,
+            snapshot_publisher=Recorder(),
+        )
+        assert session.prompt("hello") == "ok"
+        # The receive publication must reflect the incremented received_count.
+        receive_pubs = [p for p in published if p.get("received_count", 0) > 0]
+        assert len(receive_pubs) >= 1
+        assert receive_pubs[0]["received_count"] == 1
 
     def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -907,48 +907,6 @@ class TestCodexSession:
         assert published[1]["sent_count"] == 1
         assert published[1]["received_count"] == 1
 
-    def test_snapshot_publisher_fires_after_receive(self, tmp_path: Path) -> None:
-        system_file = tmp_path / "system.md"
-        system_file.write_text("base")
-        fake = _FakeAppServer()
-        fake.notifications.extend(
-            [
-                {
-                    "method": "item/completed",
-                    "params": {
-                        "threadId": "thread-new",
-                        "turnId": "turn-1",
-                        "item": {"type": "agentMessage", "text": "ok"},
-                    },
-                },
-                {
-                    "method": "turn/completed",
-                    "params": {
-                        "threadId": "thread-new",
-                        "turn": {"id": "turn-1", "status": "completed"},
-                    },
-                },
-            ]
-        )
-        published: list[dict[str, object]] = []
-
-        class Recorder:
-            def publish_metrics(self, **kwargs: object) -> None:
-                published.append(kwargs)
-
-        session = CodexSession(
-            system_file,
-            work_dir=tmp_path,
-            model=ProviderModel("gpt-5.5", "medium"),
-            client_factory=lambda **_: fake,
-            snapshot_publisher=Recorder(),
-        )
-        assert session.prompt("hello") == "ok"
-        # The receive publication must reflect the incremented received_count.
-        receive_pubs = [p for p in published if p.get("received_count", 0) > 0]
-        assert len(receive_pubs) >= 1
-        assert receive_pubs[0]["received_count"] == 1
-
     def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
         system_file.write_text("base")

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1291,30 +1291,6 @@ class TestCopilotCLISession:
         assert published[1]["sent_count"] == 1
         assert published[1]["received_count"] == 1
 
-    def test_snapshot_publisher_fires_after_receive(self, tmp_path: Path) -> None:
-        system_file = tmp_path / "persona.md"
-        system_file.write_text("")
-        runtime = FakeRuntime()
-        runtime.next_prompt = ("ok", "end_turn", "sess-2")
-        published: list[dict[str, object]] = []
-
-        class Recorder:
-            def publish_metrics(self, **kwargs: object) -> None:
-                published.append(kwargs)
-
-        session = CopilotCLISession(
-            system_file,
-            work_dir=tmp_path,
-            model=CopilotCLIClient.voice_model,
-            runtime=runtime,
-            snapshot_publisher=Recorder(),
-        )
-        session.prompt("hello", model=None, system_prompt=None)
-        # The receive publication must reflect the incremented received_count.
-        receive_pubs = [p for p in published if p.get("received_count", 0) > 0]
-        assert len(receive_pubs) >= 1
-        assert receive_pubs[0]["received_count"] == 1
-
     def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"
         system_file.write_text("")

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -1283,8 +1283,37 @@ class TestCopilotCLISession:
             snapshot_publisher=Recorder(),
         )
         session.prompt("hello", model=None, system_prompt=None)
-        assert len(published) == 1
+        # sent publication fires first, then received publication after the
+        # runtime.prompt() call increments the counter.
+        assert len(published) == 2
         assert published[0]["sent_count"] == 1
+        assert published[0]["received_count"] == 0
+        assert published[1]["sent_count"] == 1
+        assert published[1]["received_count"] == 1
+
+    def test_snapshot_publisher_fires_after_receive(self, tmp_path: Path) -> None:
+        system_file = tmp_path / "persona.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        runtime.next_prompt = ("ok", "end_turn", "sess-2")
+        published: list[dict[str, object]] = []
+
+        class Recorder:
+            def publish_metrics(self, **kwargs: object) -> None:
+                published.append(kwargs)
+
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.voice_model,
+            runtime=runtime,
+            snapshot_publisher=Recorder(),
+        )
+        session.prompt("hello", model=None, system_prompt=None)
+        # The receive publication must reflect the incremented received_count.
+        receive_pubs = [p for p in published if p.get("received_count", 0) > 0]
+        assert len(receive_pubs) >= 1
+        assert receive_pubs[0]["received_count"] == 1
 
     def test_snapshot_publisher_none_is_noop(self, tmp_path: Path) -> None:
         system_file = tmp_path / "persona.md"

--- a/tests/test_session_agent.py
+++ b/tests/test_session_agent.py
@@ -396,3 +396,32 @@ class TestSessionBackedAgent:
             received_count=0,
         )
         assert reader.get().repos[repo_name].provider.session_sent_count == 3  # type: ignore[union-attr]
+
+    def test_publish_metrics_reflects_updated_received_count(self) -> None:
+        """A second publish with a new received count reflects the new value."""
+        repo_name = "owner/myrepo"
+        reader, updater = create_atomic(_make_fido_state_with_repo(repo_name))
+        agent = _FakeAgent(
+            repo_name=repo_name,
+            state_updater=updater,
+        )
+        agent.publish_metrics(
+            owner=None,
+            alive=True,
+            pid=None,
+            dropped_count=0,
+            sent_count=0,
+            received_count=0,
+        )
+        assert reader.get().repos[repo_name].provider is not None
+        assert reader.get().repos[repo_name].provider.session_received_count == 0  # type: ignore[union-attr]
+
+        agent.publish_metrics(
+            owner=None,
+            alive=True,
+            pid=None,
+            dropped_count=0,
+            sent_count=0,
+            received_count=5,
+        )
+        assert reader.get().repos[repo_name].provider.session_received_count == 5  # type: ignore[union-attr]


### PR DESCRIPTION
Fixes #1600.

Add `_notify_snapshot_publisher()` after every `_received_count += 1` in Claude, Codex, and Copilot CLI sessions, mirroring the sent-count publication pattern so `fido status` reflects receive progress during long provider turns. Align test structure with the sent-count commit's style — one focused test per distinct code path, no near-duplicate tests, and a matching `test_publish_metrics_reflects_updated_received_count` in `test_session_agent.py`.

Fixes #1600.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] [Inspect the most recent sent-count publication commit and align the received-count implementation (in claude.py, codex.py, copilotcli.py) and its tests to match that commit's exact style and structure.](https://github.com/FidoCanCode/home/pull/1631#issuecomment-4425376984) <!-- type:thread -->
- [x] Live-publish received counts after each increment in all providers <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->