### PR TITLE
Bug: create_task lineage dedup blocks new tasks when a completed task shares the lineage — #1188 sibling, opposite layer (closes #1246)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1125,30 +1125,57 @@ class Tasks(JsonFileStore):
             existing = lock.read()
             for t in existing:
                 existing_thread = t.get("thread") or {}
+                existing_comment_id = existing_thread.get("comment_id")
                 existing_lineage_key = _thread_lineage_key(existing_thread)
-                if lineage_key is not None and lineage_key == existing_lineage_key:
+
+                # Same comment: always dedup, regardless of status.
+                if comment_id is not None and existing_comment_id == comment_id:
                     if _merge_thread_lineage(existing_thread, thread or {}):
                         t["thread"] = existing_thread
                         lock.write(existing)
                     log.info(
-                        "task already exists for lineage %s (status: %s)",
-                        lineage_key,
+                        "task already exists for comment_id %s (status: %s)",
+                        comment_id,
                         t["status"],
                     )
                     return t
-                if comment_id is not None:
-                    # Never re-create a task for the same comment, regardless of status.
-                    if existing_thread.get("comment_id") == comment_id:
+
+                # Same lineage, different comment: dedup only when the sibling
+                # task is in-progress, or when the new comment's lineage overlaps
+                # the existing task's lineage (replies to the same review thread).
+                # A completed or pending task with non-overlapping lineage
+                # represents independent work and must not block new task creation.
+                if lineage_key is not None and lineage_key == existing_lineage_key:
+                    new_lineage_ids = set(_thread_lineage_comment_ids(thread))
+                    existing_lineage_ids = set(
+                        _thread_lineage_comment_ids(existing_thread)
+                    )
+                    lineage_overlaps = bool(new_lineage_ids & existing_lineage_ids)
+                    if t["status"] == TaskStatus.IN_PROGRESS or lineage_overlaps:
                         if _merge_thread_lineage(existing_thread, thread or {}):
                             t["thread"] = existing_thread
                             lock.write(existing)
-                        log.info(
-                            "task already exists for comment_id %s (status: %s)",
-                            comment_id,
-                            t["status"],
-                        )
+                        if (
+                            t["status"] == TaskStatus.IN_PROGRESS
+                            and not lineage_overlaps
+                        ):
+                            log.info(
+                                "task already in progress for lineage %s — coalescing",
+                                lineage_key,
+                            )
+                        else:
+                            log.info(
+                                "task already exists for lineage %s (status: %s)",
+                                lineage_key,
+                                t["status"],
+                            )
                         return t
-                elif t["status"] == TaskStatus.PENDING and t["title"] == title:
+
+                if (
+                    comment_id is None
+                    and t["status"] == TaskStatus.PENDING
+                    and t["title"] == title
+                ):
                     log.info("task already exists: %s", title[:80])
                     return t
             existing.append(task)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -433,6 +433,75 @@ class TestAddTask:
         assert t1["id"] != t2["id"]
         assert len(Tasks(tmp_path).list()) == 2
 
+    def test_completed_lineage_does_not_block_new_task_with_different_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: completed task with shared lineage_key must not dedup
+        a new task from a different comment (#1246, sibling of #1188)."""
+        thread_a = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 100,
+            "lineage_key": "issues:r/r:1",
+        }
+        thread_b = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 200,
+            "lineage_key": "issues:r/r:1",
+        }
+
+        t1 = Tasks(tmp_path).add(
+            title="do first thing",
+            task_type=TaskType.THREAD,
+            thread=thread_a,
+        )
+        Tasks(tmp_path).complete_by_id(t1["id"])
+
+        t2 = Tasks(tmp_path).add(
+            title="do second thing",
+            task_type=TaskType.THREAD,
+            thread=thread_b,
+        )
+
+        assert t1["id"] != t2["id"], "new comment must produce a new task"
+        tasks = Tasks(tmp_path).list()
+        assert len(tasks) == 2
+
+    def test_in_progress_lineage_deduplicates_new_task_with_different_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """An in-progress sibling task in the same lineage should coalesce
+        the new task — one active worker is already on it."""
+        thread_a = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 100,
+            "lineage_key": "issues:r/r:1",
+        }
+        thread_b = {
+            "repo": "r/r",
+            "pr": 1,
+            "comment_id": 200,
+            "lineage_key": "issues:r/r:1",
+        }
+
+        t1 = Tasks(tmp_path).add(
+            title="do first thing",
+            task_type=TaskType.THREAD,
+            thread=thread_a,
+        )
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+
+        t2 = Tasks(tmp_path).add(
+            title="do second thing",
+            task_type=TaskType.THREAD,
+            thread=thread_b,
+        )
+
+        assert t1["id"] == t2["id"], "in-progress sibling must coalesce"
+        assert len(Tasks(tmp_path).list()) == 1
+
     def test_task_type_required(self, tmp_path: Path) -> None:
         import pytest
 


### PR DESCRIPTION
## Summary

- Fix over-broad lineage dedup in `Tasks.add()` that silently drops new thread tasks when a completed task shares the same `lineage_key` (e.g. same PR, different comment)
- Restructure the dedup loop: comment_id match always deduplicates, lineage_key match only deduplicates when the existing task is in-progress
- Same flaw shape as #1188 (reply claim layer), now fixed in the task creation layer

## Why

Every `issue_comment` on a PR shares the lineage key `issues:<repo>:<number>`. Once any thread task on that PR completes, all subsequent `create_task` calls for new comments on the same PR get silently rejected. Observed live in #1242 — triage worked, reply posted, but both resulting tasks were dropped.

Fixes #1246.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Fix lineage dedup to only block in-progress siblings, add regression tests <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->