### PR TITLE
Feature: post 'eyes' reaction immediately on comment receipt; swap to final reaction when reply lands (closes #1243)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -46,7 +46,7 @@ from fido.worker import ActivityReporter
 
 log = logging.getLogger(__name__)
 
-_FIDO_LOGINS = frozenset({"fidocancode", "fido-can-code"})
+FIDO_LOGINS = frozenset({"fidocancode", "fido-can-code"})
 
 
 class _BackgroundRescopeTrigger:
@@ -1532,27 +1532,8 @@ def reply_to_comment(
     # replies posted by concurrent handlers during the synthesis window
     # (compared against the re-fetched thread below).
     initial_fido_ids: set[int] = {
-        c["id"] for c in thread_comments if c.get("author", "").lower() in _FIDO_LOGINS
+        c["id"] for c in thread_comments if c.get("author", "").lower() in FIDO_LOGINS
     }
-
-    # Add eyes reaction immediately at pickup to signal work-in-progress.
-    # Best-effort: never fail the reply if the reaction post fails.
-    _eyes_posted = False
-    if info.get("repo") and info.get("comment_id"):
-        try:
-            gh.add_reaction(
-                info["repo"],
-                "pulls",
-                info["comment_id"],
-                "eyes",
-            )
-            log.info("added eyes reaction to comment %s", info["comment_id"])
-            _eyes_posted = True
-        except Exception:
-            log.exception(
-                "failed to add eyes reaction to comment %s — continuing",
-                info["comment_id"],
-            )
 
     issue_ctx, pr_ctx = _load_active_context_for_rescope(
         repo_cfg.work_dir, repo_cfg.name, gh
@@ -1574,7 +1555,7 @@ def reply_to_comment(
         gh,
         rescope=rescope_trigger,
         insight_filer=_GitHubInsightFiler(gh),
-        fido_logins=_FIDO_LOGINS,
+        fido_logins=FIDO_LOGINS,
     )
     target: CommentTarget | None = None
     if isinstance(info.get("comment_id"), int):
@@ -1614,7 +1595,7 @@ def reply_to_comment(
             # Even the fallback explanation exhausted retries.  Best-effort
             # clear the eyes reaction so it does not sit forever as a false
             # "Fido is looking" signal, then re-raise.
-            if _eyes_posted and target is not None:
+            if target is not None:
                 executor.remove_eyes_reaction(target)
             raise
     log.info(
@@ -1657,7 +1638,7 @@ def reply_to_comment(
     current_fido_target_ids: set[int] = {
         c["id"]
         for c in thread_comments
-        if c.get("author", "").lower() in _FIDO_LOGINS
+        if c.get("author", "").lower() in FIDO_LOGINS
         and c.get("in_reply_to_id") == target_id
     }
     if current_fido_target_ids - initial_fido_ids:
@@ -1857,20 +1838,7 @@ def reply_to_issue_comment(
     if conversation_context:
         context["conversation"] = conversation_context
 
-    # Add eyes reaction immediately at pickup to signal work-in-progress.
-    # Best-effort: never fail the reply if the reaction post fails.
-    _eyes_posted_issue = False
     _cid = context.get("comment_id")
-    if _cid and repo_full:
-        try:
-            gh.add_reaction(repo_full, "issues", _cid, "eyes")
-            log.info("added eyes reaction to issue comment %s on PR #%s", _cid, number)
-            _eyes_posted_issue = True
-        except Exception:
-            log.exception(
-                "failed to add eyes reaction to issue comment %s — continuing", _cid
-            )
-
     issue_ctx, pr_ctx = _load_active_context_for_rescope(
         repo_cfg.work_dir, repo_cfg.name, gh
     )
@@ -1891,7 +1859,7 @@ def reply_to_issue_comment(
         gh,
         rescope=rescope_trigger,
         insight_filer=_GitHubInsightFiler(gh),
-        fido_logins=_FIDO_LOGINS,
+        fido_logins=FIDO_LOGINS,
     )
     issue_target: CommentTarget | None = None
     if _cid and repo_full:
@@ -1928,7 +1896,7 @@ def reply_to_issue_comment(
             # Even the fallback explanation exhausted retries.  Best-effort
             # clear the eyes reaction so it does not sit forever as a false
             # "Fido is looking" signal, then re-raise.
-            if _eyes_posted_issue and issue_target is not None:
+            if issue_target is not None:
                 executor.remove_eyes_reaction(issue_target)
             raise
     log.info(
@@ -2506,7 +2474,7 @@ def _resolved_thread_comment_author_for_oracle(
 ) -> thread_resolve_oracle.ThreadCommentAuthor:
     return thread_comment_author_for_auto_resolve_oracle(
         login,
-        fido_logins=_FIDO_LOGINS,
+        fido_logins=FIDO_LOGINS,
         owner=owner,
         collaborators=collaborators,
         allowed_bots=allowed_bots,

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -28,6 +28,7 @@ from fido.atomic import AtomicReader, create_atomic
 from fido.claude import kill_active_children
 from fido.config import Config, RepoConfig, RepoMembership
 from fido.events import (
+    FIDO_LOGINS,
     Action,
     Dispatcher,
     WebhookIngressOracle,
@@ -62,6 +63,7 @@ from fido.state import State
 from fido.static_files import StaticFiles
 from fido.status import provider_statuses_for_repo_configs
 from fido.store import FidoStore, ReplyPromiseRecord
+from fido.synthesis_executor import CommentTarget, SynthesisExecutor
 from fido.tasks import Tasks
 from fido.watchdog import (  # noqa: PLC2701
     _STALE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
@@ -1050,8 +1052,16 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # list (via :meth:`~fido.registry.WorkerRegistry.webhook_activity`).
         # Writing here would clobber the worker thread's own state, which is
         # what caused the old ``Doing: handling webhook action`` display bug.
+        gh = cast(GitHub, self.gh)  # always set by serve() before first request
+        # Determine which comment (if any) will receive the eyes reaction.
+        # Resolved before the try block so both the main path and the
+        # recoverable-exception handler can reference _eyes_comment_info.
+        _eyes_comment_info: dict[str, Any] | None = None
+        if action.reply_to:
+            _eyes_comment_info = action.reply_to
+        elif action.comment_body and action.thread:
+            _eyes_comment_info = action.thread
         try:
-            gh = cast(GitHub, self.gh)  # always set by serve() before first request
             handled = False
             category: str | None = None
             titles: list[str] = []
@@ -1063,11 +1073,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # Best-effort — a failed reaction must never abort the handler.
             # Skipped for bot-authored actions (don't react to other bots).
             _eyes_posted = False
-            _eyes_comment_info: dict[str, Any] | None = None
-            if action.reply_to:
-                _eyes_comment_info = action.reply_to
-            elif action.comment_body and action.thread:
-                _eyes_comment_info = action.thread
             if not action.is_bot and _eyes_comment_info is not None:
                 _eyes_repo = _eyes_comment_info.get("repo")
                 _eyes_ctype = str(_eyes_comment_info.get("comment_type", "issues"))
@@ -1088,6 +1093,10 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 if promise is None:
                     handled = True
                     category, titles = None, []
+                    # Dedup skip — another handler owns this comment.  Clean up
+                    # the eyes reaction posted above so it doesn't linger.
+                    if _eyes_comment_info is not None:
+                        self._remove_eyes_best_effort(gh, _eyes_comment_info)
                 else:
                     activity.set_description("triaging review comment")
                     try:
@@ -1136,6 +1145,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 promise = self._prepare_reply(repo_cfg, action)
                 if promise is None:
                     category, titles = None, []
+                    # Dedup skip — clean up the eyes reaction posted above.
+                    if _eyes_comment_info is not None:
+                        self._remove_eyes_best_effort(gh, _eyes_comment_info)
                 else:
                     activity.set_description("triaging PR comment")
                     try:
@@ -1200,7 +1212,38 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # Logic bugs (KeyError, TypeError, AttributeError, etc.) are NOT
             # caught here — they propagate and crash the thread loudly.
             log.exception("error processing action")
+            if _eyes_comment_info is not None:
+                self._remove_eyes_best_effort(gh, _eyes_comment_info)
             self._signal_action_error(action)
+
+    def _remove_eyes_best_effort(
+        self,
+        gh: GitHub,
+        eyes_comment_info: dict[str, Any],
+    ) -> None:
+        """Remove Fido's eyes reaction from a comment (best-effort).
+
+        Builds a minimal :class:`~fido.synthesis_executor.CommentTarget` from
+        *eyes_comment_info* and delegates to
+        :meth:`~fido.synthesis_executor.SynthesisExecutor.remove_eyes_reaction`,
+        which lists reactions, finds Fido's ``eyes`` entries, and deletes them.
+        Called on all non-reply exit paths in :meth:`_process_action_inner` so
+        the eyes reaction never lingers when no reply is posted.
+
+        Silently no-ops if the required fields are absent.
+        """
+        repo = eyes_comment_info.get("repo")
+        comment_id = eyes_comment_info.get("comment_id")
+        comment_type = str(eyes_comment_info.get("comment_type", "issues"))
+        if not repo or not isinstance(comment_id, int):
+            return
+        target = CommentTarget(
+            repo=str(repo),
+            pr=0,
+            comment_id=comment_id,
+            comment_type=comment_type,
+        )
+        SynthesisExecutor(gh, fido_logins=FIDO_LOGINS).remove_eyes_reaction(target)
 
     def _signal_action_error(self, action: Action) -> None:
         """Post a 'confused' reaction on the triggering comment, if any.

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1059,7 +1059,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         _eyes_comment_info: dict[str, Any] | None = None
         if action.reply_to:
             _eyes_comment_info = action.reply_to
-        elif action.comment_body and action.thread:
+        elif action.thread:
             _eyes_comment_info = action.thread
         try:
             handled = False

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1057,6 +1057,32 @@ class WebhookHandler(BaseHTTPRequestHandler):
             titles: list[str] = []
             queued_tasks = 0
 
+            # Post eyes reaction immediately to signal work-in-progress.
+            # Fires before any triage / rescope / reply work so the comment
+            # author sees acknowledgement within ~1s of their comment (#1243).
+            # Best-effort — a failed reaction must never abort the handler.
+            # Skipped for bot-authored actions (don't react to other bots).
+            _eyes_posted = False
+            _eyes_comment_info: dict[str, Any] | None = None
+            if action.reply_to:
+                _eyes_comment_info = action.reply_to
+            elif action.comment_body and action.thread:
+                _eyes_comment_info = action.thread
+            if not action.is_bot and _eyes_comment_info is not None:
+                _eyes_repo = _eyes_comment_info.get("repo")
+                _eyes_ctype = str(_eyes_comment_info.get("comment_type", "issues"))
+                _eyes_cid = _eyes_comment_info.get("comment_id")
+                if _eyes_repo and isinstance(_eyes_cid, int):
+                    try:
+                        gh.add_reaction(_eyes_repo, _eyes_ctype, _eyes_cid, "eyes")
+                        log.info("eyes reaction posted for comment %d", _eyes_cid)
+                        _eyes_posted = True
+                    except Exception:
+                        log.exception(
+                            "failed to post eyes reaction for comment %d — continuing",
+                            _eyes_cid,
+                        )
+
             if action.reply_to:
                 promise = self._prepare_reply(repo_cfg, action)
                 if promise is None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2698,9 +2698,6 @@ class TestReplyToCommentSynthesisFallback:
         mock_gh.fetch_comment_thread.return_value = [
             {"id": 556, "author": "rhencke", "body": "please rephrase"},
         ]
-        # Eyes reaction posted successfully so the failure-path cleanup is
-        # exercised.
-        mock_gh.add_reaction.return_value = None
 
         with (
             patch(
@@ -2768,38 +2765,6 @@ class TestReplyToCommentSynthesisFallback:
         assert mock_gh.comment_issue.called
         body = mock_gh.comment_issue.call_args.args[2]
         assert "please rephrase" in body
-
-    def test_issue_comment_continues_when_eyes_add_fails(self, tmp_path: Path) -> None:
-        # events.py:1765-1766 — gh.add_reaction raising for the eyes
-        # reaction must not abort the synthesis turn, just log + continue.
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="PR top-level comment on #7 by owner:\n\nplease fix",
-            comment_body="please fix",
-            is_bot=False,
-            context={"pr_title": "My PR", "comment_id": 701},
-        )
-
-        mock_gh = MagicMock()
-        mock_gh.get_repo_info.return_value = "owner/repo"
-        mock_gh.comment_issue.return_value = {"id": 8889}
-        mock_gh.add_reaction.side_effect = RuntimeError("eyes failed")
-
-        with patch(
-            "fido.events.call_synthesis",
-            return_value=_synthesis_response("ok"),
-        ):
-            cat, _titles = reply_to_issue_comment(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
-            )
-        assert cat == "ANSWER"
-        # Reply still posted despite eyes-add failure.
-        assert mock_gh.comment_issue.called
 
 
 class TestReplyToIssueComment:
@@ -6073,158 +6038,6 @@ class TestReplyToCommentElseBranch:
         assert cat == "ACT"
         assert titles == ["Fix it"]
         mock_gh.reply_to_review_comment.assert_not_called()
-
-
-class TestReplyToCommentEyesReaction:
-    """Eyes reaction lifecycle in reply_to_comment."""
-
-    def _cfg(self, tmp_path: Path) -> Config:
-        return Config(
-            port=9000,
-            secret=b"test",
-            repos={},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-
-    def _repo_cfg(self, tmp_path: Path) -> RepoConfig:
-        return RepoConfig(name="owner/repo", work_dir=tmp_path)
-
-    def test_eyes_reaction_added_before_synthesis(self, tmp_path: Path) -> None:
-        """Eyes reaction is added immediately at comment pickup, before synthesis."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="comment",
-            reply_to={"repo": "owner/repo", "pr": 5, "comment_id": 200},
-            comment_body="please add logging",
-            is_bot=False,
-        )
-        call_order: list[str] = []
-
-        mock_gh = MagicMock()
-        mock_gh.fetch_comment_thread.return_value = []
-        mock_gh.reply_to_review_comment.return_value = {"id": 999}
-        mock_gh.add_reaction.side_effect = lambda *a, **kw: call_order.append(
-            "reaction"
-        )
-
-        def capture_synthesis(*args: object, **kwargs: object) -> object:
-            call_order.append("synthesis")
-            return _synthesis_response("On it!")
-
-        with patch("fido.events.call_synthesis", side_effect=capture_synthesis):
-            reply_to_comment(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
-            )
-
-        # Eyes reaction must come before synthesis
-        assert "reaction" in call_order
-        assert "synthesis" in call_order
-        reaction_idx = next(i for i, v in enumerate(call_order) if v == "reaction")
-        synthesis_idx = next(i for i, v in enumerate(call_order) if v == "synthesis")
-        assert reaction_idx < synthesis_idx
-
-    def test_eyes_reaction_uses_correct_args(self, tmp_path: Path) -> None:
-        """Eyes reaction is posted with the correct repo, comment_type, and comment_id."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="comment",
-            reply_to={"repo": "owner/repo", "pr": 5, "comment_id": 200},
-            comment_body="please add logging",
-            is_bot=False,
-        )
-
-        mock_gh = MagicMock()
-        mock_gh.fetch_comment_thread.return_value = []
-        mock_gh.reply_to_review_comment.return_value = {"id": 999}
-
-        with patch(
-            "fido.events.call_synthesis",
-            return_value=_synthesis_response("On it!"),
-        ):
-            reply_to_comment(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
-            )
-
-        # First add_reaction call should be the eyes reaction
-        first_reaction_call = mock_gh.add_reaction.call_args_list[0]
-        args = first_reaction_call.args
-        assert args[0] == "owner/repo"
-        assert args[1] == "pulls"
-        assert args[2] == 200
-        assert args[3] == "eyes"
-
-    def test_eyes_reaction_failure_does_not_block_reply(self, tmp_path: Path) -> None:
-        """Eyes reaction failure is swallowed; reply still posts."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="comment",
-            reply_to={"repo": "owner/repo", "pr": 5, "comment_id": 201},
-            comment_body="please add logging",
-            is_bot=False,
-        )
-
-        mock_gh = MagicMock()
-        mock_gh.fetch_comment_thread.return_value = []
-        mock_gh.reply_to_review_comment.return_value = {"id": 999}
-        mock_gh.add_reaction.side_effect = RuntimeError("API down")
-
-        with patch(
-            "fido.events.call_synthesis",
-            return_value=_synthesis_response("On it!"),
-        ):
-            cat, titles = reply_to_comment(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
-            )
-
-        # Reply still posted despite reaction failure
-        mock_gh.reply_to_review_comment.assert_called()
-        assert cat == "ANSWER"
-
-    def test_no_eyes_reaction_without_comment_id(self, tmp_path: Path) -> None:
-        """No eyes reaction when comment_id is None."""
-        cfg = self._cfg(tmp_path)
-        action = Action(
-            prompt="comment",
-            reply_to={"repo": "owner/repo", "pr": 5, "comment_id": None},
-            comment_body="please add logging",
-            is_bot=False,
-        )
-
-        mock_gh = MagicMock()
-        mock_gh.fetch_comment_thread.return_value = []
-        mock_gh.reply_to_review_comment.return_value = {"id": 999}
-
-        with patch(
-            "fido.events.call_synthesis",
-            return_value=_synthesis_response("On it!"),
-        ):
-            reply_to_comment(
-                action,
-                cfg,
-                self._repo_cfg(tmp_path),
-                mock_gh,
-                agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
-            )
-
-        mock_gh.add_reaction.assert_not_called()
 
 
 # ── reply_to_comment: thread re-fetch before posting ─────────────────────────

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2755,6 +2755,30 @@ class TestProcessActionInner:
         # Eyes must be removed before the confused reaction is signalled
         assert remove_order == ["remove_eyes", "signal_error"]
 
+    def test_eyes_reaction_posted_for_queued_comment_action(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """Queued comment actions (thread set, comment_body=None, preempts_worker=True)
+        get the immediate eyes reaction — the production shape from the dispatcher."""
+        action = Action(
+            prompt="Queued review comment on PR #1 by owner (human/owner)",
+            preempts_worker=True,
+            is_bot=False,
+            thread={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 444,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            # comment_body intentionally None — matches _queued_pr_comment_action shape
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        handler.gh.add_reaction.assert_any_call("owner/repo", "pulls", 444, "eyes")
+
     def test_remove_eyes_best_effort_noop_with_missing_fields(
         self, cfg: Config
     ) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2552,6 +2552,114 @@ class TestProcessActionInner:
             "owner/repo", "issues", 500, "confused"
         )
 
+    def test_eyes_reaction_posted_for_review_comment(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """review-comment action → eyes posted before triage begins (#1243)."""
+        action = Action(
+            prompt="review comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 101,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="please fix this",
+            is_bot=False,
+        )
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        handler.gh.add_reaction.assert_any_call("owner/repo", "pulls", 101, "eyes")
+
+    def test_eyes_reaction_posted_for_top_level_pr_comment(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """top-level PR comment action → eyes posted before triage begins (#1243)."""
+        action = Action(
+            prompt="issue comment",
+            thread={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 301,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "issues",
+            },
+            comment_body="any thoughts?",
+            is_bot=False,
+        )
+        WebhookHandler._fn_reply_to_issue_comment = MagicMock(
+            return_value=("ANSWER", [])
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        handler.gh.add_reaction.assert_any_call("owner/repo", "issues", 301, "eyes")
+
+    def test_eyes_reaction_skipped_for_bot_action(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """is_bot=True → eyes reaction must not be posted."""
+        action = Action(
+            prompt="bot comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 201,
+                "url": "https://example.com",
+                "author": "somebot[bot]",
+                "comment_type": "pulls",
+            },
+            comment_body="automated feedback",
+            is_bot=True,
+        )
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        for call in handler.gh.add_reaction.call_args_list:
+            assert call.args[3] != "eyes", f"eyes was posted for bot action: {call}"
+
+    def test_eyes_reaction_skipped_for_non_comment_action(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """Non-comment webhook actions (no reply_to, no comment_body) → no reaction."""
+        action = Action(prompt="push event")
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        handler.gh.add_reaction.assert_not_called()
+
+    def test_eyes_reaction_failure_does_not_abort_handler(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """add_reaction failure for eyes must not abort the webhook handler."""
+        import requests
+
+        action = Action(
+            prompt="review comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 102,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="please fix",
+            is_bot=False,
+        )
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler.gh.add_reaction.side_effect = requests.RequestException("network down")
+        # Should not raise — eyes failure is best-effort.
+        handler._process_action_inner(action, repo_cfg, self._activity())
+
     def test_describe_action_handles_each_action_shape(self, cfg: Config) -> None:
         """Cover all branches of _describe_action."""
         handler = self._handler(cfg)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2660,6 +2660,115 @@ class TestProcessActionInner:
         # Should not raise — eyes failure is best-effort.
         handler._process_action_inner(action, repo_cfg, self._activity())
 
+    def test_eyes_removed_on_review_comment_dedup_skip(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """When _prepare_reply returns None (dedup skip), the eyes reaction is
+        removed so it doesn't linger on a comment that won't receive a reply."""
+        action = Action(
+            prompt="review comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 111,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="please fix",
+            is_bot=False,
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        # Simulate dedup skip: _prepare_reply returns None
+        with patch.object(handler, "_prepare_reply", return_value=None):
+            with patch(
+                "fido.server.SynthesisExecutor.remove_eyes_reaction"
+            ) as mock_remove:
+                handler._process_action_inner(action, repo_cfg, self._activity())
+        mock_remove.assert_called_once()
+
+    def test_eyes_removed_on_pr_comment_dedup_skip(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """When _prepare_reply returns None for a top-level PR comment (dedup skip),
+        the eyes reaction is removed."""
+        action = Action(
+            prompt="pr comment",
+            comment_body="please fix",
+            thread={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 222,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "issues",
+            },
+            is_bot=False,
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        with patch.object(handler, "_prepare_reply", return_value=None):
+            with patch(
+                "fido.server.SynthesisExecutor.remove_eyes_reaction"
+            ) as mock_remove:
+                handler._process_action_inner(action, repo_cfg, self._activity())
+        mock_remove.assert_called_once()
+
+    def test_eyes_removed_on_recoverable_exception(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """When a recoverable exception is raised during action processing, the
+        eyes reaction is removed before signalling the confused reaction."""
+        import requests
+
+        action = Action(
+            prompt="review comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 333,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="please fix",
+            is_bot=False,
+        )
+        WebhookHandler._fn_reply_to_comment = MagicMock(
+            side_effect=requests.RequestException("network down")
+        )
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        remove_order: list[str] = []
+        with patch(
+            "fido.server.SynthesisExecutor.remove_eyes_reaction",
+            side_effect=lambda _t: remove_order.append("remove_eyes"),
+        ):
+            with patch.object(
+                handler,
+                "_signal_action_error",
+                side_effect=lambda _a: remove_order.append("signal_error"),
+            ):
+                # Recoverable exception — should not propagate
+                handler._process_action_inner(action, repo_cfg, self._activity())
+        # Eyes must be removed before the confused reaction is signalled
+        assert remove_order == ["remove_eyes", "signal_error"]
+
+    def test_remove_eyes_best_effort_noop_with_missing_fields(
+        self, cfg: Config
+    ) -> None:
+        """_remove_eyes_best_effort is a no-op when repo or comment_id is absent."""
+        handler = self._handler(cfg)
+        # Missing repo — should not call remove_eyes_reaction at all.
+        with patch("fido.server.SynthesisExecutor.remove_eyes_reaction") as mock_remove:
+            handler._remove_eyes_best_effort(handler.gh, {"comment_id": 99})
+        mock_remove.assert_not_called()
+        # Missing comment_id — same.
+        with patch("fido.server.SynthesisExecutor.remove_eyes_reaction") as mock_remove:
+            handler._remove_eyes_best_effort(handler.gh, {"repo": "owner/repo"})
+        mock_remove.assert_not_called()
+
     def test_describe_action_handles_each_action_shape(self, cfg: Config) -> None:
         """Cover all branches of _describe_action."""
         handler = self._handler(cfg)


### PR DESCRIPTION
Fixes #1243.

Move the `eyes` reaction from deep inside the reply functions to the server webhook handler entry point so it lands within ~1s of comment receipt, remove the now-redundant eyes-posting from `events.py`, and ensure eyes cleanup on all non-reply exit paths (dedup skip, error, queued-action wake). Also fix the eyes-targeting condition so queued comment actions (which carry `thread` but not `comment_body` on the Action) get the immediate acknowledgement too.

Fixes #1243.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (3)</summary>

- [x] [Change the eyes-targeting condition in _process_action_inner from `elif action.comment_body and action.thread` to just `elif action.thread`, so queued comment actions (which have thread but not comment_body on the Action) also get eyes posted immediately. Add a test for the queued-action path (preempts_worker=True, thread set, comment_body=None).](https://github.com/FidoCanCode/home/pull/1637#discussion_r3222761036) <!-- type:thread -->
- [x] Post eyes reaction at webhook handler entry point <!-- type:spec -->
- [x] Remove redundant eyes-posting from reply functions and ensure cleanup on all exit paths <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->