### PR TITLE
Bug: copilot CLI 'Info: transient API error' chatter leaks into Fido replies (closes #1216)

### DIFF
--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -100,11 +100,38 @@ def _is_cancel_sentinel(text: str) -> bool:
 # #1216: Copilot CLI emits "Info: ...", "Warning: ...", "Error: ..." as
 # agent_message_chunk events when retrying API calls.  These get prepended to
 # the real assistant reply text.  Strip them before the result leaves the
-# session boundary.  The cancel sentinel is excluded from stripping so
-# _is_cancel_sentinel still fires correctly when stop_reason is not set.
+# session boundary.
+#
+# Two-layer defence:
+#   1. Chunk-level: drop diagnostic chunks in record_session_update before they
+#      enter _prompt_chunks.  Each diagnostic line arrives as a complete chunk
+#      so this handles both newline-terminated and non-newline-terminated shapes.
+#   2. Assembled-text fallback: _strip_copilot_chatter strips any leading run of
+#      newline-terminated chatter lines from the joined text, catching anything
+#      that slips through (e.g. a partial chunk spanning a diagnostic prefix).
+#
+# The cancel sentinel ("Info: Operation cancelled by user") is excluded from
+# both layers so _is_cancel_sentinel still fires when stop_reason is not set.
+_COPILOT_CHATTER_CHUNK_RE = re.compile(r"^(?:Info|Warning|Error): ")
 _COPILOT_CHATTER_LINE_RE = re.compile(
     r"(?:Info|Warning|Error): (?!Operation cancelled by user)[^\n]*\n"
 )
+
+
+def _is_copilot_chatter_chunk(text: str) -> bool:
+    """Return True when *text* is a standalone Copilot CLI diagnostic chunk.
+
+    The CLI emits ``Info:``, ``Warning:``, and ``Error:`` status lines as
+    individual ``agent_message_chunk`` events.  Each such chunk is a complete
+    diagnostic message that should not appear in the final reply body.
+
+    The cancel sentinel ``"Info: Operation cancelled by user"`` is excluded so
+    :func:`_is_cancel_sentinel` still fires when the stop_reason is not
+    ``"cancelled"``.
+    """
+    if not _COPILOT_CHATTER_CHUNK_RE.match(text):
+        return False
+    return not text.startswith(_COPILOT_CANCEL_SENTINEL)
 
 
 def _strip_copilot_chatter(text: str) -> str:
@@ -718,7 +745,12 @@ class CopilotACPRuntime:
         if update_type == "agent_message_chunk":
             content = getattr(update, "content", None)
             text = getattr(content, "text", None)
-            if isinstance(text, str):
+            # #1216: drop diagnostic chatter chunks before they enter
+            # _prompt_chunks.  Each "Info: / Warning: / Error: " status line
+            # arrives as a complete standalone chunk; filter at this boundary
+            # so even non-newline-terminated chatter never reaches the reply.
+            # The cancel sentinel is preserved so _is_cancel_sentinel fires.
+            if isinstance(text, str) and not _is_copilot_chatter_chunk(text):
                 self._prompt_chunks.append(text)
             return
         if update_type == "tool_call":

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -97,6 +97,37 @@ def _is_cancel_sentinel(text: str) -> bool:
     )
 
 
+# #1216: Copilot CLI emits "Info: ...", "Warning: ...", "Error: ..." as
+# agent_message_chunk events when retrying API calls.  These get prepended to
+# the real assistant reply text.  Strip them before the result leaves the
+# session boundary.  The cancel sentinel is excluded from stripping so
+# _is_cancel_sentinel still fires correctly when stop_reason is not set.
+_COPILOT_CHATTER_LINE_RE = re.compile(
+    r"(?:Info|Warning|Error): (?!Operation cancelled by user)[^\n]*\n"
+)
+
+
+def _strip_copilot_chatter(text: str) -> str:
+    """Strip Copilot CLI diagnostic prefix lines from assembled reply text.
+
+    The CLI emits ``Info:``, ``Warning:``, and ``Error:`` status lines as
+    ``agent_message_chunk`` events that are concatenated before the real
+    assistant reply.  Strip any leading run of such newline-terminated lines
+    so they do not appear in GitHub comment bodies.
+
+    The cancel sentinel ``"Info: Operation cancelled by user"`` is preserved
+    so :func:`_is_cancel_sentinel` continues to fire when the stop_reason
+    is not ``"cancelled"``.
+    """
+    result = text
+    while True:
+        m = _COPILOT_CHATTER_LINE_RE.match(result)
+        if m is None:
+            break
+        result = result[m.end() :]
+    return result
+
+
 def _iter_jsonl(output: str) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for line in output.splitlines():
@@ -1185,6 +1216,9 @@ class CopilotCLISession(OwnedSession):
         self._session_id = session_id
         if model is not None:
             self._model = coerce_provider_model(model)
+        # #1216: strip diagnostic chatter ("Info: ...", "Warning: ...",
+        # "Error: ...") that the CLI prepends when retrying API calls.
+        result = _strip_copilot_chatter(result)
         cancelled = stop_reason == "cancelled" or _is_cancel_sentinel(result)
         self._last_turn_cancelled = cancelled
         _log_for_repo(

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -28,6 +28,7 @@ from fido.copilotcli import (
     _combine_prompt,
     _CopilotACPClient,
     _is_cancel_sentinel,
+    _is_copilot_chatter_chunk,
     _is_copilot_quota_error,
     _is_line_limit_overrun_error,
     _normalize_model,
@@ -424,6 +425,104 @@ class TestStripCopilotChatter:
         )
         result = session.prompt("do the thing")
         assert result == "You're right, the fix is straightforward."
+
+
+class TestIsCopilotChatterChunk:
+    def test_info_chunk_is_chatter(self) -> None:
+        assert _is_copilot_chatter_chunk(
+            "Info: Request failed due to a transient API error. Retrying..."
+        )
+
+    def test_warning_chunk_is_chatter(self) -> None:
+        assert _is_copilot_chatter_chunk("Warning: degraded service")
+
+    def test_error_chunk_is_chatter(self) -> None:
+        assert _is_copilot_chatter_chunk("Error: connection reset")
+
+    def test_cancel_sentinel_is_not_chatter(self) -> None:
+        # The cancel sentinel must survive so _is_cancel_sentinel still fires.
+        assert not _is_copilot_chatter_chunk("Info: Operation cancelled by user")
+
+    def test_real_content_is_not_chatter(self) -> None:
+        assert not _is_copilot_chatter_chunk("You're right, I missed those details.")
+
+    def test_info_not_at_start_is_not_chatter(self) -> None:
+        # Only chunks that *start* with the prefix are diagnostic.
+        assert not _is_copilot_chatter_chunk("Here is some info: background")
+
+    def test_empty_string_is_not_chatter(self) -> None:
+        assert not _is_copilot_chatter_chunk("")
+
+
+class TestChunkLevelChatterFiltering:
+    def test_chatter_chunks_not_in_prompt_result(self, tmp_path: Path) -> None:
+        # Regression for #1216 (no-newline case): chatter chunks without
+        # trailing \n are filtered at the chunk level in record_session_update
+        # before they enter _prompt_chunks.
+        connection = FakeConnection(load_supported=True)
+
+        async def _prompt_with_chatter(prompt: list[object], session_id: str) -> object:
+            del prompt
+            assert connection.client is not None
+            runtime = connection.client._runtime
+            for chunk_text in [
+                "Info: Request failed due to a transient API error. Retrying...",
+                "Info: Request failed due to a transient API error. Retrying...",
+                "You're right, the fix is straightforward.",
+            ]:
+                runtime.record_session_update(
+                    session_id,
+                    SimpleNamespace(
+                        session_update="agent_message_chunk",
+                        content=SimpleNamespace(text=chunk_text),
+                    ),
+                )
+            return SimpleNamespace(stop_reason="end_turn")
+
+        connection.prompt = _prompt_with_chatter  # type: ignore[method-assign]
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            session_id = runtime.ensure_session(None, None)
+            text, stop_reason, _ = runtime.prompt(session_id, "hello", None)
+            assert text == "You're right, the fix is straightforward."
+            assert stop_reason == "end_turn"
+        finally:
+            runtime.stop()
+
+    def test_cancel_sentinel_chunk_preserved(self, tmp_path: Path) -> None:
+        # The cancel sentinel must pass through chunk filtering so
+        # _is_cancel_sentinel can detect cancelled turns when stop_reason
+        # is not "cancelled" (#666).
+        connection = FakeConnection(load_supported=True)
+
+        async def _prompt_with_sentinel(
+            prompt: list[object], session_id: str
+        ) -> object:
+            del prompt
+            assert connection.client is not None
+            connection.client._runtime.record_session_update(
+                session_id,
+                SimpleNamespace(
+                    session_update="agent_message_chunk",
+                    content=SimpleNamespace(text="Info: Operation cancelled by user"),
+                ),
+            )
+            return SimpleNamespace(stop_reason="end_turn")
+
+        connection.prompt = _prompt_with_sentinel  # type: ignore[method-assign]
+        runtime = CopilotACPRuntime(
+            work_dir=tmp_path,
+            spawn_agent_process=_spawn_factory(connection),
+        )
+        try:
+            session_id = runtime.ensure_session(None, None)
+            text, _, _ = runtime.prompt(session_id, "hello", None)
+            assert text == "Info: Operation cancelled by user"
+        finally:
+            runtime.stop()
 
 
 class TestTerminalManager:

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -32,6 +32,7 @@ from fido.copilotcli import (
     _is_line_limit_overrun_error,
     _normalize_model,
     _preview_log_value,
+    _strip_copilot_chatter,
     _TerminalManager,
     _tool_input_preview,
     extract_result_text,
@@ -361,6 +362,68 @@ class TestHelpers:
         client = CopilotCLIClient(runner=runner, work_dir=tmp_path)
         client._run_cli_prompt("body", model="gpt-5", timeout=1)
         assert "gpt-5" in runner.call_args.args[0]
+
+
+class TestStripCopilotChatter:
+    def test_strips_double_info_prefix(self) -> None:
+        # Regression for #1216: two retry-info lines before the real reply.
+        text = (
+            "Info: Request failed due to a transient API error. Retrying...\n"
+            "Info: Request failed due to a transient API error. Retrying...\n"
+            "You're right, I missed those details on the first pass."
+        )
+        assert (
+            _strip_copilot_chatter(text)
+            == "You're right, I missed those details on the first pass."
+        )
+
+    def test_strips_warning_and_error_prefix_lines(self) -> None:
+        text = "Warning: something degraded\nError: retry failed\nReal reply here."
+        assert _strip_copilot_chatter(text) == "Real reply here."
+
+    def test_clean_text_passes_through_unchanged(self) -> None:
+        text = "You're right, no chatter here."
+        assert _strip_copilot_chatter(text) == text
+
+    def test_info_in_middle_not_stripped(self) -> None:
+        # Only leading chatter is stripped; Info: that appears after real
+        # content is part of the assistant reply and must be preserved.
+        text = "Real content\nInfo: some status\nMore content"
+        assert _strip_copilot_chatter(text) == text
+
+    def test_empty_string_passes_through(self) -> None:
+        assert _strip_copilot_chatter("") == ""
+
+    def test_chatter_only_returns_empty(self) -> None:
+        text = "Info: Request failed due to a transient API error. Retrying...\n"
+        assert _strip_copilot_chatter(text) == ""
+
+    def test_cancel_sentinel_not_stripped(self) -> None:
+        # The cancel sentinel must survive stripping so _is_cancel_sentinel
+        # still fires when stop_reason is not "cancelled" (#666).
+        text = "Info: Operation cancelled by user\n"
+        assert _strip_copilot_chatter(text) == text
+
+    def test_session_prompt_strips_chatter_prefix(self, tmp_path: Path) -> None:
+        # Integration: chatter emitted by FakeRuntime is stripped before
+        # _prompt_locked returns the result to the caller.
+        system_file = tmp_path / "system.md"
+        system_file.write_text("")
+        runtime = FakeRuntime()
+        runtime.next_prompt = (
+            "Info: Request failed due to a transient API error. Retrying...\n"
+            "You're right, the fix is straightforward.",
+            "end_turn",
+            "sess-next",
+        )
+        session = CopilotCLISession(
+            system_file,
+            work_dir=tmp_path,
+            model=CopilotCLIClient.work_model,
+            runtime=runtime,
+        )
+        result = session.prompt("do the thing")
+        assert result == "You're right, the fix is straightforward."
 
 
 class TestTerminalManager:


### PR DESCRIPTION
Fixes #1216.

Copilot CLI emits `Info:` / `Warning:` / `Error:` diagnostic chatter as `agent_message_chunk` events during API retries, and these get concatenated into the assembled reply text that Fido posts to GitHub. This PR filters diagnostic chunks at two levels: dropping chatter chunks in `record_session_update` before they enter `_prompt_chunks` (preserving the cancel sentinel), and stripping any remaining newline-terminated chatter lines from the assembled text as a belt-and-suspenders fallback.

Fixes #1216.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (2)</summary>

- [x] [Make _strip_copilot_chatter handle chatter that is not newline-terminated. Preferred approach: filter diagnostic chunks at the chunk level in record_session_update (drop agent_message_chunk text that starts with Info:/Warning:/Error: but preserve the cancel sentinel), as a complement to or replacement for the assembled-text regex.](https://github.com/FidoCanCode/home/pull/1640#discussion_r3223271241) <!-- type:thread -->
- [x] Strip copilot CLI diagnostic chatter from ACP reply text <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->