### PR TITLE
Bug: Fido replies make promises ('I'll do X') with no corresponding task — prose decoupled from triage category (closes #1218)

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -622,7 +622,12 @@ class Prompts:
             "- Read the full comment thread, not just the last comment.  "
             "Reply to the conversation, not to one isolated line.\n"
             "- Keep the reply brief and direct.  No preamble, no corporate "
-            "prose, no filler phrases.\n\n"
+            "prose, no filler phrases.\n"
+            "- If you are not populating change_request, do not promise future "
+            "action in reply_text.  Describe only what has already been done or "
+            "what cannot be done.  Future-tense commitments "
+            '("I\'ll", "I will", "I\'m going to") are reserved for replies '
+            "where change_request is also populated.\n\n"
             "Respond with ONLY the JSON object.  No text before or after it."
         )
 

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -6,11 +6,16 @@ malformed JSON up to :data:`MAX_RETRIES` times with a stricter
 instruction appended, then raises :class:`SynthesisExhaustedError`
 (fail-closed per Constraint B: reply text is always required, never
 defaulted).
+
+After a successful parse, a brief verification turn asks the model
+whether it recorded every request into ``change_request``.  A "No"
+answer triggers a follow-up turn that derives the omitted
+``change_request`` text and promotes the response to ACT, ensuring
+prose promises always correspond to queued tasks (fixes #1218).
 """
 
 import json
 import logging
-import re
 from typing import Any
 
 from fido.prompts import Prompts
@@ -36,92 +41,70 @@ _RETRY_SUFFIX = (
 
 
 # ---------------------------------------------------------------------------
-# Promise-language guard (fixes #1218)
+# LLM verification turn (fixes #1218)
 # ---------------------------------------------------------------------------
 #
-# The synthesis LLM can produce ANSWER replies that contain future-tense
-# commitments ("I'll fix this") even when ``change_request`` is null, meaning
-# no task ever gets queued and the promise is never honoured.  These helpers
-# detect that mismatch and promote the response to ACT so a task is always
-# created to back any prose promise.
+# After the synthesis LLM produces a reply, a brief yes/no turn asks whether
+# it recorded every request into ``change_request``.  If the answer is "No",
+# a second short turn derives the missing description so we can promote the
+# response to ACT and ensure a task is always queued behind any prose promise.
 
-#: Matches future-tense commitment phrases (case-insensitive).
-_PROMISE_RE: re.Pattern[str] = re.compile(
-    r"\b(?:I['\u2019]ll|I will|I['\u2019]m going to|I am going to)\b",
-    re.IGNORECASE,
+_VERIFY_CHANGE_REQUEST_PROMPT: str = (
+    "Did you record every request from the previous reply into ``change_request`` "
+    "(if any)?  Reply only with the single word Yes or No."
 )
 
-#: Matches negations that cancel a promise within the same sentence —
-#: e.g. "I will not fix this" or "I'll not do that".
-_NEGATION_RE: re.Pattern[str] = re.compile(
-    r"\b(?:will not|won['\u2019]t|not going to|I['\u2019]ll not)\b",
-    re.IGNORECASE,
+_DERIVE_CHANGE_REQUEST_PROMPT: str = (
+    "You answered No.  In one concise sentence, state the request you omitted from "
+    "``change_request`` — no preamble, no trailing text."
 )
 
-#: Splits text into rough sentences at sentence-ending punctuation or blank lines.
-_SENTENCE_SPLIT_RE: re.Pattern[str] = re.compile(r"(?<=[.!?])\s+|\n\n+")
 
+def _check_and_promote(
+    response: CommentResponse, agent: ProviderAgent
+) -> CommentResponse:
+    """Run a verification turn to detect unrecorded change requests.
 
-def _non_quoted_lines(text: str) -> str:
-    """Return *text* with Markdown block-quote lines (starting with ``>``) removed."""
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith(">")
-    )
+    When ``response.change_request`` is already set, returns *response*
+    unchanged — no extra turn is needed.
 
-
-def detect_unfulfilled_promises(reply_text: str) -> str | None:
-    """Return a derived change_request if *reply_text* contains promise language.
-
-    Strips Markdown block-quote lines, splits the remainder into sentences,
-    and checks each sentence for future-tense commitment phrases
-    (``I'll``, ``I will``, ``I'm going to``, ``I am going to``) that are
-    not countered by a negation in the same sentence
-    (``will not``, ``won't``, ``not going to``, ``I'll not``).
-
-    Returns the first matching sentence as the derived change_request
-    string, or ``None`` when no unfulfilled promise is found.
-
-    This is a pure function — it reads no mutable state and raises no
-    exceptions.
-    """
-    unquoted = _non_quoted_lines(reply_text)
-    for sentence in _SENTENCE_SPLIT_RE.split(unquoted):
-        stripped = sentence.strip()
-        if not stripped:
-            continue
-        if not _PROMISE_RE.search(stripped):
-            continue
-        if _NEGATION_RE.search(stripped):
-            continue
-        return stripped
-    return None
-
-
-def promote_answer_to_act(response: CommentResponse) -> CommentResponse:
-    """Promote an ANSWER response to ACT when its prose contains promise language.
-
-    When ``response.change_request`` is ``None`` but ``response.reply_text``
-    contains unfulfilled future-tense commitments, derives a ``change_request``
-    from the promise text and returns a new
+    Otherwise, asks the agent whether every request was recorded into
+    ``change_request``.  If the agent answers "No" (case-insensitive,
+    with or without trailing punctuation), a follow-up turn derives a
+    concise ``change_request`` string and returns a new
     :class:`~fido.synthesis.CommentResponse` with that field populated.
-    Logs a warning so the promotion is auditable in the server logs.
 
-    When ``response.change_request`` is already set, or no promise language
-    is detected, returns *response* unchanged (same object, not a copy).
+    If the agent answers "Yes" (or anything other than "No"), or if the
+    derive turn returns an empty string, *response* is returned unchanged.
 
     This enforces the invariant: prose promises must correspond to queued
     tasks (fixes #1218).
     """
     if response.change_request is not None:
         return response
-    derived = detect_unfulfilled_promises(response.reply_text)
-    if derived is None:
-        return response
-    log.warning(
-        "synthesis guard: ANSWER reply contains promise language — "
-        "promoting to ACT with derived change_request: %r",
-        derived[:80],
+
+    verify_raw = agent.run_turn(
+        _VERIFY_CHANGE_REQUEST_PROMPT,
+        allowed_tools=None,
     )
+    if not (verify_raw or "").strip().lower().startswith("no"):
+        return response
+
+    log.warning(
+        "synthesis guard: model indicated unrecorded request — "
+        "deriving change_request via follow-up turn"
+    )
+    derived_raw = agent.run_turn(
+        _DERIVE_CHANGE_REQUEST_PROMPT,
+        allowed_tools=None,
+    )
+    derived = (derived_raw or "").strip()
+    if not derived:
+        log.warning(
+            "synthesis guard: follow-up turn returned empty — skipping promotion"
+        )
+        return response
+
     return CommentResponse(
         reasoning=response.reasoning,
         reply_text=response.reply_text,
@@ -266,9 +249,11 @@ def call_synthesis(
 
     Makes up to :data:`MAX_RETRIES` LLM calls.  The first attempt uses
     the base prompt; each subsequent attempt appends a stricter JSON-output
-    instruction.  Raises :class:`SynthesisExhaustedError` if all attempts
-    fail (Constraint B: reply text is always required, never silently
-    defaulted).
+    instruction.  After a successful parse, a brief verification turn checks
+    whether every request was recorded into ``change_request``; a "No"
+    answer triggers a follow-up derive turn and promotes the response to ACT.
+    Raises :class:`SynthesisExhaustedError` if all synthesis attempts fail
+    (Constraint B: reply text is always required, never silently defaulted).
 
     Parameters
     ----------
@@ -323,7 +308,7 @@ def call_synthesis(
 
         if attempt > 0:
             log.info("synthesis: succeeded on attempt %d/%d", attempt + 1, MAX_RETRIES)
-        return promote_answer_to_act(response)
+        return _check_and_promote(response, agent)
 
     raise SynthesisExhaustedError(
         f"synthesis exhausted {MAX_RETRIES} retries without a valid CommentResponse "

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -47,14 +47,14 @@ _RETRY_SUFFIX = (
 
 #: Matches future-tense commitment phrases (case-insensitive).
 _PROMISE_RE: re.Pattern[str] = re.compile(
-    r"\b(?:I'll|I will|I'm going to|I am going to)\b",
+    r"\b(?:I['\u2019]ll|I will|I['\u2019]m going to|I am going to)\b",
     re.IGNORECASE,
 )
 
 #: Matches negations that cancel a promise within the same sentence —
 #: e.g. "I will not fix this" or "I'll not do that".
 _NEGATION_RE: re.Pattern[str] = re.compile(
-    r"\b(?:will not|won't|not going to|I'll not)\b",
+    r"\b(?:will not|won['\u2019]t|not going to|I['\u2019]ll not)\b",
     re.IGNORECASE,
 )
 

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -19,7 +19,12 @@ import logging
 from typing import Any
 
 from fido.prompts import Prompts
-from fido.provider import READ_ONLY_ALLOWED_TOOLS, ProviderAgent
+from fido.provider import (
+    READ_ONLY_ALLOWED_TOOLS,
+    ContextOverflowError,
+    ProviderAgent,
+    SessionLeakError,
+)
 from fido.synthesis import (
     VALID_REACTIONS,
     CommentResponse,
@@ -116,6 +121,8 @@ def _check_and_promote(
             change_request=derived,
             insights=response.insights,
         )
+    except ContextOverflowError, SessionLeakError:
+        raise
     except Exception as exc:
         log.warning(
             "synthesis guard: verification turn failed (%s) — "

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -76,6 +76,9 @@ def _check_and_promote(
 
     If the agent answers "Yes" (or anything other than "No"), or if the
     derive turn returns an empty string, *response* is returned unchanged.
+    Any exception raised by either turn (transport errors, timeouts, etc.)
+    is caught, logged, and treated as a non-fatal guard failure — *response*
+    is returned unchanged so a valid synthesis result is never discarded.
 
     This enforces the invariant: prose promises must correspond to queued
     tasks (fixes #1218).
@@ -83,35 +86,43 @@ def _check_and_promote(
     if response.change_request is not None:
         return response
 
-    verify_raw = agent.run_turn(
-        _VERIFY_CHANGE_REQUEST_PROMPT,
-        allowed_tools=None,
-    )
-    if not (verify_raw or "").strip().lower().startswith("no"):
-        return response
+    try:
+        verify_raw = agent.run_turn(
+            _VERIFY_CHANGE_REQUEST_PROMPT,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
+        if not (verify_raw or "").strip().lower().startswith("no"):
+            return response
 
-    log.warning(
-        "synthesis guard: model indicated unrecorded request — "
-        "deriving change_request via follow-up turn"
-    )
-    derived_raw = agent.run_turn(
-        _DERIVE_CHANGE_REQUEST_PROMPT,
-        allowed_tools=None,
-    )
-    derived = (derived_raw or "").strip()
-    if not derived:
         log.warning(
-            "synthesis guard: follow-up turn returned empty — skipping promotion"
+            "synthesis guard: model indicated unrecorded request — "
+            "deriving change_request via follow-up turn"
+        )
+        derived_raw = agent.run_turn(
+            _DERIVE_CHANGE_REQUEST_PROMPT,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
+        derived = (derived_raw or "").strip()
+        if not derived:
+            log.warning(
+                "synthesis guard: follow-up turn returned empty — skipping promotion"
+            )
+            return response
+
+        return CommentResponse(
+            reasoning=response.reasoning,
+            reply_text=response.reply_text,
+            emoji=response.emoji,
+            change_request=derived,
+            insights=response.insights,
+        )
+    except Exception as exc:
+        log.warning(
+            "synthesis guard: verification turn failed (%s) — "
+            "returning original response unchanged",
+            exc,
         )
         return response
-
-    return CommentResponse(
-        reasoning=response.reasoning,
-        reply_text=response.reply_text,
-        emoji=response.emoji,
-        change_request=derived,
-        insights=response.insights,
-    )
 
 
 class SynthesisExhaustedError(Exception):

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -10,6 +10,7 @@ defaulted).
 
 import json
 import logging
+import re
 from typing import Any
 
 from fido.prompts import Prompts
@@ -32,6 +33,102 @@ _RETRY_SUFFIX = (
     "Respond with ONLY a JSON object — no preamble, no trailing text, no markdown "
     "code fences.  The reply_text field must be a non-empty string."
 )
+
+
+# ---------------------------------------------------------------------------
+# Promise-language guard (fixes #1218)
+# ---------------------------------------------------------------------------
+#
+# The synthesis LLM can produce ANSWER replies that contain future-tense
+# commitments ("I'll fix this") even when ``change_request`` is null, meaning
+# no task ever gets queued and the promise is never honoured.  These helpers
+# detect that mismatch and promote the response to ACT so a task is always
+# created to back any prose promise.
+
+#: Matches future-tense commitment phrases (case-insensitive).
+_PROMISE_RE: re.Pattern[str] = re.compile(
+    r"\b(?:I'll|I will|I'm going to|I am going to)\b",
+    re.IGNORECASE,
+)
+
+#: Matches negations that cancel a promise within the same sentence —
+#: e.g. "I will not fix this" or "I'll not do that".
+_NEGATION_RE: re.Pattern[str] = re.compile(
+    r"\b(?:will not|won't|not going to|I'll not)\b",
+    re.IGNORECASE,
+)
+
+#: Splits text into rough sentences at sentence-ending punctuation or blank lines.
+_SENTENCE_SPLIT_RE: re.Pattern[str] = re.compile(r"(?<=[.!?])\s+|\n\n+")
+
+
+def _non_quoted_lines(text: str) -> str:
+    """Return *text* with Markdown block-quote lines (starting with ``>``) removed."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith(">")
+    )
+
+
+def detect_unfulfilled_promises(reply_text: str) -> str | None:
+    """Return a derived change_request if *reply_text* contains promise language.
+
+    Strips Markdown block-quote lines, splits the remainder into sentences,
+    and checks each sentence for future-tense commitment phrases
+    (``I'll``, ``I will``, ``I'm going to``, ``I am going to``) that are
+    not countered by a negation in the same sentence
+    (``will not``, ``won't``, ``not going to``, ``I'll not``).
+
+    Returns the first matching sentence as the derived change_request
+    string, or ``None`` when no unfulfilled promise is found.
+
+    This is a pure function — it reads no mutable state and raises no
+    exceptions.
+    """
+    unquoted = _non_quoted_lines(reply_text)
+    for sentence in _SENTENCE_SPLIT_RE.split(unquoted):
+        stripped = sentence.strip()
+        if not stripped:
+            continue
+        if not _PROMISE_RE.search(stripped):
+            continue
+        if _NEGATION_RE.search(stripped):
+            continue
+        return stripped
+    return None
+
+
+def promote_answer_to_act(response: CommentResponse) -> CommentResponse:
+    """Promote an ANSWER response to ACT when its prose contains promise language.
+
+    When ``response.change_request`` is ``None`` but ``response.reply_text``
+    contains unfulfilled future-tense commitments, derives a ``change_request``
+    from the promise text and returns a new
+    :class:`~fido.synthesis.CommentResponse` with that field populated.
+    Logs a warning so the promotion is auditable in the server logs.
+
+    When ``response.change_request`` is already set, or no promise language
+    is detected, returns *response* unchanged (same object, not a copy).
+
+    This enforces the invariant: prose promises must correspond to queued
+    tasks (fixes #1218).
+    """
+    if response.change_request is not None:
+        return response
+    derived = detect_unfulfilled_promises(response.reply_text)
+    if derived is None:
+        return response
+    log.warning(
+        "synthesis guard: ANSWER reply contains promise language — "
+        "promoting to ACT with derived change_request: %r",
+        derived[:80],
+    )
+    return CommentResponse(
+        reasoning=response.reasoning,
+        reply_text=response.reply_text,
+        emoji=response.emoji,
+        change_request=derived,
+        insights=response.insights,
+    )
 
 
 class SynthesisExhaustedError(Exception):
@@ -226,7 +323,7 @@ def call_synthesis(
 
         if attempt > 0:
             log.info("synthesis: succeeded on attempt %d/%d", attempt + 1, MAX_RETRIES)
-        return response
+        return promote_answer_to_act(response)
 
     raise SynthesisExhaustedError(
         f"synthesis exhausted {MAX_RETRIES} retries without a valid CommentResponse "

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -60,7 +60,7 @@ _VERIFY_CHANGE_REQUEST_PROMPT: str = (
 )
 
 _DERIVE_CHANGE_REQUEST_PROMPT: str = (
-    "You answered No.  In one concise sentence, state the request you omitted from "
+    "You answered No.  In one concise sentence, state the request(s) you omitted from "
     "``change_request`` — no preamble, no trailing text."
 )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1494,3 +1494,10 @@ class TestSynthesisPrompt:
     def test_insights_empty_array_when_nothing_stood_out(self) -> None:
         result = Prompts("").synthesis_prompt("comment", is_bot=False)
         assert "Empty array" in result or "empty array" in result or "Empty" in result
+
+    def test_no_promise_without_change_request_constraint(self) -> None:
+        # The prompt must forbid future-tense commitments when change_request
+        # is null, so the LLM doesn't produce "I'll fix this" with no task.
+        result = Prompts("").synthesis_prompt("comment", is_bot=False)
+        assert "change_request" in result
+        assert "future" in result.lower() or "I'll" in result or "I will" in result

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fido.synthesis import CommentResponse, Insight
+from fido.synthesis import Insight
 from fido.synthesis_call import (
     MAX_RETRIES,
     SynthesisExhaustedError,
@@ -14,8 +14,6 @@ from fido.synthesis_call import (
     _parse_comment_response,
     call_failure_explanation,
     call_synthesis,
-    detect_unfulfilled_promises,
-    promote_answer_to_act,
 )
 from fido.types import ActiveIssue, ActivePR
 
@@ -288,7 +286,8 @@ class TestCallSynthesis:
         )
 
         assert result.reply_text == "Great feedback!"
-        assert agent.run_turn.call_count == 1
+        # 1 synthesis call + 1 verify call (change_request is None so verify fires)
+        assert agent.run_turn.call_count == 2
 
     def test_passes_system_prompt_to_agent(self) -> None:
         agent = _make_agent(_make_raw())
@@ -296,7 +295,8 @@ class TestCallSynthesis:
 
         call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-        _, kwargs = agent.run_turn.call_args
+        # Check the first call (synthesis); the verify turn is the second call.
+        _, kwargs = agent.run_turn.call_args_list[0]
         assert kwargs["system_prompt"] == "my-system-prompt"
 
     def test_passes_user_prompt_to_agent(self) -> None:
@@ -305,24 +305,27 @@ class TestCallSynthesis:
 
         call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-        args, _ = agent.run_turn.call_args
+        # Check the first call (synthesis); the verify turn is the second call.
+        args, _ = agent.run_turn.call_args_list[0]
         assert args[0] == "my-user-prompt"
 
     def test_retry_on_parse_failure_then_success(self) -> None:
         raw_bad = "not json"
         raw_good = _make_raw(reply_text="Fixed!")
-        agent = _make_agent([raw_bad, raw_good])
+        # 1 bad synthesis + 1 good synthesis + 1 verify (returns "Yes" → no promotion)
+        agent = _make_agent([raw_bad, raw_good, "Yes"])
         prompts = _make_prompts()
 
         result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
         assert result.reply_text == "Fixed!"
-        assert agent.run_turn.call_count == 2
+        assert agent.run_turn.call_count == 3
 
     def test_retry_appends_suffix_to_prompt(self) -> None:
         raw_bad = "not json"
         raw_good = _make_raw()
-        agent = _make_agent([raw_bad, raw_good])
+        # 1 bad synthesis + 1 good synthesis + 1 verify
+        agent = _make_agent([raw_bad, raw_good, "Yes"])
         prompts = _make_prompts(user="base-prompt")
 
         call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
@@ -510,257 +513,134 @@ class TestCallFailureExplanation:
 
 
 # ---------------------------------------------------------------------------
-# detect_unfulfilled_promises
+# call_synthesis — LLM verification turn
 # ---------------------------------------------------------------------------
 
 
-class TestDetectUnfulfilledPromises:
-    def test_detects_ill_pattern(self) -> None:
-        result = detect_unfulfilled_promises("You're right. I'll fix this.")
-        assert result is not None
+class TestCallSynthesisVerificationTurn:
+    """Tests for the LLM verification turn wired into call_synthesis (fixes #1218).
 
-    def test_detects_i_will_pattern(self) -> None:
-        result = detect_unfulfilled_promises("I will address this in the next commit.")
-        assert result is not None
+    After a successful synthesis parse with ``change_request=None``, a
+    brief yes/no turn asks the model whether it recorded every request.
+    A "No" answer triggers a follow-up derive turn that populates
+    ``change_request`` and promotes the response to ACT.
+    """
 
-    def test_detects_im_going_to_pattern(self) -> None:
-        result = detect_unfulfilled_promises("I'm going to update the tests.")
-        assert result is not None
+    def test_verify_yes_no_promotion(self) -> None:
+        """When verify says Yes, change_request stays None."""
+        raw = _make_raw(reply_text="Looks fine as-is.", change_request=None)
+        agent = _make_agent([raw, "Yes"])
+        prompts = _make_prompts()
 
-    def test_detects_i_am_going_to_pattern(self) -> None:
-        result = detect_unfulfilled_promises("I am going to rewrite this function.")
-        assert result is not None
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-    def test_returns_none_when_no_promise(self) -> None:
-        result = detect_unfulfilled_promises("This looks good already.")
-        assert result is None
+        assert result.change_request is None
+        # synthesis + verify
+        assert agent.run_turn.call_count == 2
 
-    def test_returns_none_for_empty_string(self) -> None:
-        result = detect_unfulfilled_promises("")
-        assert result is None
+    def test_verify_no_derives_change_request(self) -> None:
+        """When verify says No, the derive turn populates change_request."""
+        raw = _make_raw(reply_text="This looks fine.", change_request=None)
+        agent = _make_agent([raw, "No", "Update the test coverage"])
+        prompts = _make_prompts()
 
-    def test_returns_first_promise_sentence(self) -> None:
-        text = "This looks fine. I'll update the docs. And I'll also add tests."
-        result = detect_unfulfilled_promises(text)
-        assert result == "I'll update the docs."
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-    def test_case_insensitive(self) -> None:
-        result = detect_unfulfilled_promises("I'LL FIX THIS.")
-        assert result is not None
+        assert result.change_request == "Update the test coverage"
+        assert result.reply_text == "This looks fine."
+        # synthesis + verify + derive
+        assert agent.run_turn.call_count == 3
 
-    # Edge case: quoted promises (Markdown blockquotes)
-    def test_skips_quoted_lines(self) -> None:
-        text = "> I'll fix this\n\nSounds reasonable."
-        result = detect_unfulfilled_promises(text)
-        assert result is None
+    def test_verify_no_preserves_reply_text(self) -> None:
+        """Promotion via verify must not alter reply_text."""
+        raw = _make_raw(reply_text="Understood.", change_request=None)
+        agent = _make_agent([raw, "No", "Add missing tests"])
+        prompts = _make_prompts()
 
-    def test_skips_indented_quoted_lines(self) -> None:
-        # Leading whitespace before > is also a valid blockquote.
-        text = "  > I will address this\n\nLooks good as-is."
-        result = detect_unfulfilled_promises(text)
-        assert result is None
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-    def test_detects_promise_when_quote_and_non_quote_mixed(self) -> None:
-        text = "> some quoted context\n\nI'll address this."
-        result = detect_unfulfilled_promises(text)
-        assert result is not None
+        assert result.reply_text == "Understood."
 
-    # Edge case: negated promises
-    def test_i_will_not_not_detected(self) -> None:
-        # "I will" appears in "I will not", but the negation guard suppresses it.
-        result = detect_unfulfilled_promises("I will not make any changes here.")
-        assert result is None
+    def test_verify_skipped_when_change_request_set(self) -> None:
+        """When change_request is already populated, verify turn is never called."""
+        raw = _make_raw(reply_text="Got it.", change_request="Fix the tests")
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
 
-    def test_i_wont_not_detected(self) -> None:
-        # "I won't" does not match the promise regex at all.
-        result = detect_unfulfilled_promises("I won't make changes here.")
-        assert result is None
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-    def test_ill_not_not_detected(self) -> None:
-        # "I'll not" — the negation guard suppresses "I'll" when "I'll not" is present.
-        result = detect_unfulfilled_promises("I'll not be adding that feature.")
-        assert result is None
+        assert result.change_request == "Fix the tests"
+        # synthesis only — no verify turn
+        assert agent.run_turn.call_count == 1
 
-    def test_not_going_to_not_detected(self) -> None:
-        result = detect_unfulfilled_promises("I'm not going to add that here.")
-        assert result is None
+    def test_verify_no_case_insensitive(self) -> None:
+        """'NO', 'No.', 'no' etc. all trigger promotion."""
+        raw = _make_raw(reply_text="Sure.", change_request=None)
+        agent = _make_agent([raw, "NO.", "Handle the edge case"])
+        prompts = _make_prompts()
 
-    def test_real_world_example(self) -> None:
-        # Reproduces the pattern from rhencke/tracy#54.
-        text = (
-            "You're right, I missed those details on the first pass.  "
-            "I'll make sure the build script, JS bundling, and CI integration "
-            "all match the issue requirements.  Thanks for catching it!"
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request == "Handle the edge case"
+
+    def test_verify_no_with_trailing_text_triggers_promotion(self) -> None:
+        """'No, I missed X' (starts with No) also triggers promotion."""
+        raw = _make_raw(reply_text="Sure.", change_request=None)
+        agent = _make_agent([raw, "No, I did not record it.", "Fix the linting"])
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request == "Fix the linting"
+
+    def test_verify_no_skips_promotion_when_derive_empty(self) -> None:
+        """When the derive turn returns empty, no promotion — original returned."""
+        raw = _make_raw(reply_text="This looks fine.", change_request=None)
+        agent = _make_agent([raw, "No", ""])
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request is None
+        # synthesis + verify + derive (even though derive is empty)
+        assert agent.run_turn.call_count == 3
+
+    def test_verify_no_preserves_emoji_on_promotion(self) -> None:
+        """Promotion via verify preserves the original emoji."""
+        raw = _make_raw(reply_text="Got it.", emoji="rocket", change_request=None)
+        agent = _make_agent([raw, "No", "Add the missing test"])
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request == "Add the missing test"
+        assert result.emoji == "rocket"
+
+    def test_verify_no_preserves_insights_on_promotion(self) -> None:
+        """Promotion via verify preserves the original insights list."""
+        insight_data = [{"title": "T", "hook": "H.", "why": "W."}]
+        raw = _make_raw(
+            reply_text="Got it.", change_request=None, insights=insight_data
         )
-        result = detect_unfulfilled_promises(text)
-        assert result is not None
-        assert "I'll" in result
+        agent = _make_agent([raw, "No", "Add the missing test"])
+        prompts = _make_prompts()
 
-    # Edge case: Unicode right single quotation mark (U+2019)
-    def test_detects_curly_ill(self) -> None:
-        result = detect_unfulfilled_promises("I\u2019ll fix this.")
-        assert result is not None
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-    def test_detects_curly_im_going_to(self) -> None:
-        result = detect_unfulfilled_promises("I\u2019m going to update the tests.")
-        assert result is not None
+        assert result.change_request == "Add the missing test"
+        assert len(result.insights) == 1
+        assert result.insights[0].title == "T"
 
-    def test_curly_wont_not_detected(self) -> None:
-        result = detect_unfulfilled_promises("I won\u2019t make changes here.")
-        assert result is None
-
-    def test_curly_ill_not_not_detected(self) -> None:
-        result = detect_unfulfilled_promises("I\u2019ll not be adding that feature.")
-        assert result is None
-
-
-# ---------------------------------------------------------------------------
-# promote_answer_to_act
-# ---------------------------------------------------------------------------
-
-
-class TestPromoteAnswerToAct:
-    def test_promotes_when_promise_detected(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="You're right. I'll make sure all tests pass.",
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.change_request is not None
-        assert promoted.reply_text == response.reply_text
-
-    def test_unchanged_when_no_promise(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="This looks good already.",
-        )
-        result = promote_answer_to_act(response)
-        assert result is response  # same object — no promotion
-
-    def test_unchanged_when_already_act(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="I'll fix it.",
-            change_request="Fix the bug",
-        )
-        result = promote_answer_to_act(response)
-        assert result is response  # original change_request preserved, not replaced
-
-    def test_preserves_emoji_on_promotion(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="I'll update this.",
-            emoji="rocket",
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.change_request is not None
-        assert promoted.emoji == "rocket"
-
-    def test_preserves_insights_on_promotion(self) -> None:
-        insight = Insight(title="T", hook="H", why="W.")
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="I'll fix this.",
-            insights=[insight],
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.change_request is not None
-        assert promoted.insights == [insight]
-
-    def test_preserves_reasoning_on_promotion(self) -> None:
-        response = CommentResponse(
+    def test_verify_no_preserves_reasoning_on_promotion(self) -> None:
+        """Promotion via verify preserves the original reasoning."""
+        raw = _make_raw(
             reasoning="my private chain-of-thought",
-            reply_text="I'll add the missing tests.",
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.reasoning == "my private chain-of-thought"
-
-    def test_derived_change_request_is_nonempty(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="I'll fix this.",
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.change_request
-        assert promoted.change_request.strip()
-
-    def test_promotes_curly_apostrophe_promise(self) -> None:
-        response = CommentResponse(
-            reasoning="thought",
-            reply_text="I\u2019ll update the docs.",
-        )
-        promoted = promote_answer_to_act(response)
-        assert promoted.change_request is not None
-        assert promoted.reply_text == response.reply_text
-
-
-# ---------------------------------------------------------------------------
-# call_synthesis — promise guard integration
-# ---------------------------------------------------------------------------
-
-
-class TestCallSynthesisPromiseGuard:
-    """Integration tests for the promise-language guard wired into call_synthesis."""
-
-    def test_promotes_answer_with_promise_to_act(self) -> None:
-        # ANSWER reply (no change_request) but reply_text has "I'll" — must be promoted.
-        raw = _make_raw(
-            reply_text="You're right. I'll make sure all tests pass.",
+            reply_text="Looks good.",
             change_request=None,
         )
-        agent = _make_agent(raw)
+        agent = _make_agent([raw, "No", "Fix the thing"])
         prompts = _make_prompts()
 
         result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
-        assert result.change_request is not None
-
-    def test_answer_without_promise_stays_answer(self) -> None:
-        raw = _make_raw(
-            reply_text="This already looks correct.",
-            change_request=None,
-        )
-        agent = _make_agent(raw)
-        prompts = _make_prompts()
-
-        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
-
-        assert result.change_request is None
-
-    def test_act_with_promise_preserves_original_change_request(self) -> None:
-        # When change_request is already set, the guard must not overwrite it.
-        raw = _make_raw(
-            reply_text="I'll update this.",
-            change_request="Fix the existing issue",
-        )
-        agent = _make_agent(raw)
-        prompts = _make_prompts()
-
-        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
-
-        assert result.change_request == "Fix the existing issue"
-
-    def test_quoted_promise_not_promoted(self) -> None:
-        # Promise language inside a Markdown blockquote must not trigger promotion.
-        raw = _make_raw(
-            reply_text="> I'll fix this\n\nSounds like it's already handled.",
-            change_request=None,
-        )
-        agent = _make_agent(raw)
-        prompts = _make_prompts()
-
-        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
-
-        assert result.change_request is None
-
-    def test_negated_promise_not_promoted(self) -> None:
-        raw = _make_raw(
-            reply_text="I will not make any changes here — this is correct as-is.",
-            change_request=None,
-        )
-        agent = _make_agent(raw)
-        prompts = _make_prompts()
-
-        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
-
-        assert result.change_request is None
+        assert result.reasoning == "my private chain-of-thought"

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -705,3 +705,51 @@ class TestCallSynthesisVerificationTurn:
         assert result.reply_text == "Original reply."
         assert result.change_request is None
         assert agent.run_turn.call_count == 3
+
+    def test_context_overflow_error_propagates_from_verify_turn(self) -> None:
+        """ContextOverflowError in verify must propagate — not be swallowed."""
+        from fido.provider import ContextOverflowError
+
+        raw = _make_raw(reply_text="Reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [raw, ContextOverflowError("overflow")]
+        prompts = _make_prompts()
+
+        with pytest.raises(ContextOverflowError):
+            call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+    def test_session_leak_error_propagates_from_verify_turn(self) -> None:
+        """SessionLeakError in verify must propagate — not be swallowed."""
+        from fido.provider import SessionLeakError
+
+        raw = _make_raw(reply_text="Reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [raw, SessionLeakError("leak")]
+        prompts = _make_prompts()
+
+        with pytest.raises(SessionLeakError):
+            call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+    def test_context_overflow_error_propagates_from_derive_turn(self) -> None:
+        """ContextOverflowError in derive must propagate — not be swallowed."""
+        from fido.provider import ContextOverflowError
+
+        raw = _make_raw(reply_text="Reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [raw, "No", ContextOverflowError("overflow")]
+        prompts = _make_prompts()
+
+        with pytest.raises(ContextOverflowError):
+            call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+    def test_session_leak_error_propagates_from_derive_turn(self) -> None:
+        """SessionLeakError in derive must propagate — not be swallowed."""
+        from fido.provider import SessionLeakError
+
+        raw = _make_raw(reply_text="Reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [raw, "No", SessionLeakError("leak")]
+        prompts = _make_prompts()
+
+        with pytest.raises(SessionLeakError):
+            call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -596,6 +596,23 @@ class TestDetectUnfulfilledPromises:
         assert result is not None
         assert "I'll" in result
 
+    # Edge case: Unicode right single quotation mark (U+2019)
+    def test_detects_curly_ill(self) -> None:
+        result = detect_unfulfilled_promises("I\u2019ll fix this.")
+        assert result is not None
+
+    def test_detects_curly_im_going_to(self) -> None:
+        result = detect_unfulfilled_promises("I\u2019m going to update the tests.")
+        assert result is not None
+
+    def test_curly_wont_not_detected(self) -> None:
+        result = detect_unfulfilled_promises("I won\u2019t make changes here.")
+        assert result is None
+
+    def test_curly_ill_not_not_detected(self) -> None:
+        result = detect_unfulfilled_promises("I\u2019ll not be adding that feature.")
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # promote_answer_to_act
@@ -666,6 +683,15 @@ class TestPromoteAnswerToAct:
         promoted = promote_answer_to_act(response)
         assert promoted.change_request
         assert promoted.change_request.strip()
+
+    def test_promotes_curly_apostrophe_promise(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="I\u2019ll update the docs.",
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.change_request is not None
+        assert promoted.reply_text == response.reply_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -644,3 +644,64 @@ class TestCallSynthesisVerificationTurn:
         result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
         assert result.reasoning == "my private chain-of-thought"
+
+    def test_verify_turn_uses_read_only_allowed_tools(self) -> None:
+        """Verification turns must pass READ_ONLY_ALLOWED_TOOLS, not None."""
+        from fido.provider import READ_ONLY_ALLOWED_TOOLS
+
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "Yes"])
+        prompts = _make_prompts()
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        # The second call is the verification turn.
+        _, kwargs = agent.run_turn.call_args_list[1]
+        assert kwargs.get("allowed_tools") == READ_ONLY_ALLOWED_TOOLS
+
+    def test_derive_turn_uses_read_only_allowed_tools(self) -> None:
+        """Derive turn (after No) must pass READ_ONLY_ALLOWED_TOOLS, not None."""
+        from fido.provider import READ_ONLY_ALLOWED_TOOLS
+
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "No", "Add missing tests"])
+        prompts = _make_prompts()
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        # Third call is the derive turn.
+        _, kwargs = agent.run_turn.call_args_list[2]
+        assert kwargs.get("allowed_tools") == READ_ONLY_ALLOWED_TOOLS
+
+    def test_verify_turn_exception_returns_original_response(self) -> None:
+        """A transport error in the verify turn must not discard the synthesis result."""
+        raw = _make_raw(reply_text="Original reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [
+            raw,
+            RuntimeError("transport error"),
+        ]
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.reply_text == "Original reply."
+        assert result.change_request is None
+        assert agent.run_turn.call_count == 2
+
+    def test_derive_turn_exception_returns_original_response(self) -> None:
+        """A transport error in the derive turn must not discard the synthesis result."""
+        raw = _make_raw(reply_text="Original reply.", change_request=None)
+        agent = _make_agent([raw])
+        agent.run_turn.side_effect = [
+            raw,
+            "No",
+            RuntimeError("derive transport error"),
+        ]
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.reply_text == "Original reply."
+        assert result.change_request is None
+        assert agent.run_turn.call_count == 3

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from fido.synthesis import Insight
+from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import (
     MAX_RETRIES,
     SynthesisExhaustedError,
@@ -14,6 +14,8 @@ from fido.synthesis_call import (
     _parse_comment_response,
     call_failure_explanation,
     call_synthesis,
+    detect_unfulfilled_promises,
+    promote_answer_to_act,
 )
 from fido.types import ActiveIssue, ActivePR
 
@@ -505,3 +507,234 @@ class TestCallFailureExplanation:
         result = call_failure_explanation("comment", agent=agent, prompts=prompts)
 
         assert result.reply_text == "real reply"
+
+
+# ---------------------------------------------------------------------------
+# detect_unfulfilled_promises
+# ---------------------------------------------------------------------------
+
+
+class TestDetectUnfulfilledPromises:
+    def test_detects_ill_pattern(self) -> None:
+        result = detect_unfulfilled_promises("You're right. I'll fix this.")
+        assert result is not None
+
+    def test_detects_i_will_pattern(self) -> None:
+        result = detect_unfulfilled_promises("I will address this in the next commit.")
+        assert result is not None
+
+    def test_detects_im_going_to_pattern(self) -> None:
+        result = detect_unfulfilled_promises("I'm going to update the tests.")
+        assert result is not None
+
+    def test_detects_i_am_going_to_pattern(self) -> None:
+        result = detect_unfulfilled_promises("I am going to rewrite this function.")
+        assert result is not None
+
+    def test_returns_none_when_no_promise(self) -> None:
+        result = detect_unfulfilled_promises("This looks good already.")
+        assert result is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        result = detect_unfulfilled_promises("")
+        assert result is None
+
+    def test_returns_first_promise_sentence(self) -> None:
+        text = "This looks fine. I'll update the docs. And I'll also add tests."
+        result = detect_unfulfilled_promises(text)
+        assert result == "I'll update the docs."
+
+    def test_case_insensitive(self) -> None:
+        result = detect_unfulfilled_promises("I'LL FIX THIS.")
+        assert result is not None
+
+    # Edge case: quoted promises (Markdown blockquotes)
+    def test_skips_quoted_lines(self) -> None:
+        text = "> I'll fix this\n\nSounds reasonable."
+        result = detect_unfulfilled_promises(text)
+        assert result is None
+
+    def test_skips_indented_quoted_lines(self) -> None:
+        # Leading whitespace before > is also a valid blockquote.
+        text = "  > I will address this\n\nLooks good as-is."
+        result = detect_unfulfilled_promises(text)
+        assert result is None
+
+    def test_detects_promise_when_quote_and_non_quote_mixed(self) -> None:
+        text = "> some quoted context\n\nI'll address this."
+        result = detect_unfulfilled_promises(text)
+        assert result is not None
+
+    # Edge case: negated promises
+    def test_i_will_not_not_detected(self) -> None:
+        # "I will" appears in "I will not", but the negation guard suppresses it.
+        result = detect_unfulfilled_promises("I will not make any changes here.")
+        assert result is None
+
+    def test_i_wont_not_detected(self) -> None:
+        # "I won't" does not match the promise regex at all.
+        result = detect_unfulfilled_promises("I won't make changes here.")
+        assert result is None
+
+    def test_ill_not_not_detected(self) -> None:
+        # "I'll not" — the negation guard suppresses "I'll" when "I'll not" is present.
+        result = detect_unfulfilled_promises("I'll not be adding that feature.")
+        assert result is None
+
+    def test_not_going_to_not_detected(self) -> None:
+        result = detect_unfulfilled_promises("I'm not going to add that here.")
+        assert result is None
+
+    def test_real_world_example(self) -> None:
+        # Reproduces the pattern from rhencke/tracy#54.
+        text = (
+            "You're right, I missed those details on the first pass.  "
+            "I'll make sure the build script, JS bundling, and CI integration "
+            "all match the issue requirements.  Thanks for catching it!"
+        )
+        result = detect_unfulfilled_promises(text)
+        assert result is not None
+        assert "I'll" in result
+
+
+# ---------------------------------------------------------------------------
+# promote_answer_to_act
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteAnswerToAct:
+    def test_promotes_when_promise_detected(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="You're right. I'll make sure all tests pass.",
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.change_request is not None
+        assert promoted.reply_text == response.reply_text
+
+    def test_unchanged_when_no_promise(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="This looks good already.",
+        )
+        result = promote_answer_to_act(response)
+        assert result is response  # same object — no promotion
+
+    def test_unchanged_when_already_act(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="I'll fix it.",
+            change_request="Fix the bug",
+        )
+        result = promote_answer_to_act(response)
+        assert result is response  # original change_request preserved, not replaced
+
+    def test_preserves_emoji_on_promotion(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="I'll update this.",
+            emoji="rocket",
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.change_request is not None
+        assert promoted.emoji == "rocket"
+
+    def test_preserves_insights_on_promotion(self) -> None:
+        insight = Insight(title="T", hook="H", why="W.")
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="I'll fix this.",
+            insights=[insight],
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.change_request is not None
+        assert promoted.insights == [insight]
+
+    def test_preserves_reasoning_on_promotion(self) -> None:
+        response = CommentResponse(
+            reasoning="my private chain-of-thought",
+            reply_text="I'll add the missing tests.",
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.reasoning == "my private chain-of-thought"
+
+    def test_derived_change_request_is_nonempty(self) -> None:
+        response = CommentResponse(
+            reasoning="thought",
+            reply_text="I'll fix this.",
+        )
+        promoted = promote_answer_to_act(response)
+        assert promoted.change_request
+        assert promoted.change_request.strip()
+
+
+# ---------------------------------------------------------------------------
+# call_synthesis — promise guard integration
+# ---------------------------------------------------------------------------
+
+
+class TestCallSynthesisPromiseGuard:
+    """Integration tests for the promise-language guard wired into call_synthesis."""
+
+    def test_promotes_answer_with_promise_to_act(self) -> None:
+        # ANSWER reply (no change_request) but reply_text has "I'll" — must be promoted.
+        raw = _make_raw(
+            reply_text="You're right. I'll make sure all tests pass.",
+            change_request=None,
+        )
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request is not None
+
+    def test_answer_without_promise_stays_answer(self) -> None:
+        raw = _make_raw(
+            reply_text="This already looks correct.",
+            change_request=None,
+        )
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request is None
+
+    def test_act_with_promise_preserves_original_change_request(self) -> None:
+        # When change_request is already set, the guard must not overwrite it.
+        raw = _make_raw(
+            reply_text="I'll update this.",
+            change_request="Fix the existing issue",
+        )
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request == "Fix the existing issue"
+
+    def test_quoted_promise_not_promoted(self) -> None:
+        # Promise language inside a Markdown blockquote must not trigger promotion.
+        raw = _make_raw(
+            reply_text="> I'll fix this\n\nSounds like it's already handled.",
+            change_request=None,
+        )
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request is None
+
+    def test_negated_promise_not_promoted(self) -> None:
+        raw = _make_raw(
+            reply_text="I will not make any changes here — this is correct as-is.",
+            change_request=None,
+        )
+        agent = _make_agent(raw)
+        prompts = _make_prompts()
+
+        result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        assert result.change_request is None


### PR DESCRIPTION
Fixes #1218.

Adds a prompt-level constraint telling the synthesis LLM not to make future-tense commitments without a corresponding `change_request`, plus a post-generation LLM verification turn that asks the model whether it recorded every request — if it answers "No", the response is promoted to ACT so a task is always queued behind any prose promise. The verification turns run under the read-only tool policy and are wrapped in try/except so that transport errors never discard a successfully parsed synthesis result, while non-recoverable provider errors (`ContextOverflowError`, `SessionLeakError`) are explicitly re-raised to reach their worker-level handlers.

Fixes #1218.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (8)</summary>

- [x] [Change 'request you omitted' to 'request(s) you omitted' in _DERIVE_CHANGE_REQUEST_PROMPT](https://github.com/FidoCanCode/home/pull/1643#discussion_r3226757741) <!-- type:thread -->
- [x] [In the `except Exception` clause of `_check_and_promote`, add explicit re-raises for `ContextOverflowError` and `SessionLeakError` (imported from `fido.provider`) so those non-recoverable provider errors are never swallowed by the verification guard and still reach the worker-level handlers that retire poisoned sessions or halt Fido.](https://github.com/FidoCanCode/home/pull/1643#discussion_r3226326342) <!-- type:thread -->
- [x] [In `_check_and_promote`, change both `agent.run_turn(..., allowed_tools=None)` calls to `agent.run_turn(..., allowed_tools=READ_ONLY_ALLOWED_TOOLS)` so the verification turns run under the synthesis read-only policy instead of the task-implementation write policy.](https://github.com/FidoCanCode/home/pull/1643#discussion_r3226191904) <!-- type:thread -->
- [x] [Wrap the verification and derive `agent.run_turn` calls in `_check_and_promote` with a try/except so that transport errors or other exceptions in the verification turns don't discard a successfully parsed CommentResponse — log the failure and return the original response unchanged.](https://github.com/FidoCanCode/home/pull/1643#discussion_r3226191934) <!-- type:thread -->
- [x] [Replace the regex-based promise-language guard with an LLM verification turn that asks the provider whether it recorded every request from the reply into change_request, answering Yes or No. If No, promote the response to ACT.](https://github.com/FidoCanCode/home/pull/1643#discussion_r3226044044) <!-- type:thread -->
- [x] [Update _PROMISE_RE and _NEGATION_RE in synthesis_call.py to match both ASCII apostrophe (') and Unicode right single quotation mark (\u2019) in contractions like I'll, I'm, won't, I'll not](https://github.com/FidoCanCode/home/pull/1643#discussion_r3225673260) <!-- type:thread -->
- [x] Add promise-language guard to synthesis reply parsing <!-- type:spec -->
- [x] Add prompt constraint against unfulfilled promises in synthesis prompt <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->