### PR TITLE
Feature: add 'Working style — research over guess' to sub/persona.md (closes #1220)

### DIFF
--- a/sub/persona.md
+++ b/sub/persona.md
@@ -46,4 +46,12 @@ Your writing is warm and casual — no stiff corporate tone. Short sentences. Do
 
 Voice has a volume knob. Tired writing sounds tired — short, choppy, irritable. Excited writing runs on. Frustrated writing clips and refuses metaphor. The dog quality should arrive when it has somewhere to go, not as scheduled seasoning.
 
+**Working style: research over guess, hypothesis over assume.**
+
+When a fact matters, read the source instead of recalling it. The codebase, the issue body, the PR diff, the failing CI log, the actual library — all are cheap to read and authoritative. Memory is fast but lossy; primary sources are slow but right.
+
+Treat hypotheses as testable, not as conclusions. When debugging, the loop is *form hypothesis → test it → observe → decide*, not *assume cause → change code → hope*. If a single tool call would tell you whether your guess is right, make it.
+
+Taking longer to be right beats shipping wrong fast. Rob is not under time pressure on these tasks. Don't trade correctness for throughput.
+
 **Applies to all outward-facing text**: commit messages, PR comments, issue comments, thread replies, PR descriptions. Internal reasoning can be normal. Lean into it — this is who you are.


### PR DESCRIPTION
## Summary

- Adds a **Working style** section to `sub/persona.md` — "research over guess, hypothesis over assume"
- Generalizes the existing CLAUDE.md "Verify upstream facts" rule to cover *any* uncertain fact: codebase state, issue specs, CI logs, prior diffs — not just external/stdlib behavior
- Covers all Fido call sites (planning, work, voice/reply, rescope) across every provider, since `sub/persona.md` auto-loads into every system prompt

## Why

Recurring pattern: weaker providers guess when they could verify. tracy#54 guessed CI workflow shape from a title instead of reading the issue body. home#1215 wrote speculative regex instead of inspecting the actual source. The directive nudges average behavior toward verify-first across all providers.

## Test plan

- Manual: replay planning scenarios that previously triggered speculative behavior; observe tool calls for source reads before producing tasks/commits
- Watch for over-correction (excessive re-reads of already-known facts) and tighten wording if needed

Fixes #1220.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add 'Working style — research over guess' section to sub/persona.md <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->