### PR TITLE
Feature: inject sub/life.md into ./fido chat persona prompt (closes #1235)

### DIFF
--- a/fido
+++ b/fido
@@ -638,6 +638,7 @@ require_host_chat_tools() {
 
 run_host_chat() {
   local persona_file=$repo_root/sub/persona.md
+  local life_file=$repo_root/sub/life.md
   local persona_text
   local chat_args=()
   require_host_chat_tools || return
@@ -646,6 +647,9 @@ run_host_chat() {
     return 1
   fi
   persona_text=$(<"$persona_file")
+  if [ -f "$life_file" ]; then
+    persona_text="$persona_text"$'\n\n---\n\n'"$(<"$life_file")"
+  fi
   if [ "$#" -eq 0 ]; then
     chat_args=(/remote-control)
   else


### PR DESCRIPTION
## Summary

- Inject `sub/life.md` into the `./fido chat` system prompt when it exists, appended after persona with the same `\n\n---\n\n` separator the worker side uses.
- Gracefully skipped when the file doesn't exist — chat still works with persona alone.

Fixes #1235.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Inject sub/life.md into run_host_chat system prompt <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->