### PR TITLE
Bug: use --permission-mode dontAsk so handler --allowedTools is enforced (closes #1669)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -634,20 +634,29 @@ class ClaudeSession(OwnedSession):
             "--output-format",
             "stream-json",
             "--verbose",
-            # `dontAsk` makes `--allowedTools` the actual gate: anything not
-            # in the allowlist is silently denied without an interactive
-            # prompt.  `--dangerously-skip-permissions` would bypass the
-            # allowlist entirely, letting handler/synthesis phases call
-            # Edit/Write/Bash regardless of the read-only restriction (#1669).
-            "--permission-mode",
-            "dontAsk",
             "--model",
             self._model,
             "--system-prompt-file",
             str(self._system_file),
         ]
+        # Per-phase permission mode (#1669).  Handler/synthesis/rescope/voice
+        # phases pass an explicit allowlist; pair it with `--permission-mode
+        # dontAsk` so anything outside the allowlist is silently denied —
+        # that's the gate that keeps synthesis turns away from
+        # Edit/Write/arbitrary Bash.  Worker phase passes `_tools=None` and
+        # keeps `--dangerously-skip-permissions` so it retains full
+        # implementation access; `dontAsk` without an allowlist would deny
+        # everything and break the worker.  `GLOBAL_DISALLOWED_TOOLS` still
+        # applies on top in both phases.
         if self._tools is not None:
-            cmd += ["--allowedTools", self._tools]
+            cmd += [
+                "--permission-mode",
+                "dontAsk",
+                "--allowedTools",
+                self._tools,
+            ]
+        else:
+            cmd += ["--dangerously-skip-permissions"]
         # GLOBAL_DISALLOWED_TOOLS applies to every spawn regardless of
         # which phase's allowlist is active — these are tools no phase can
         # legitimately use (harness owns commit/push, bypass-prone Agent /
@@ -1835,14 +1844,20 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             "--output-format",
             "stream-json",
             "--verbose",
-            "--permission-mode",
-            "dontAsk",
             "--system-prompt-file",
             str(system_file),
             "--print",
         ]
+        # Per-phase permission mode — see _spawn for the full rationale (#1669).
         if allowed_tools is not None:
-            cmd += ["--allowedTools", allowed_tools]
+            cmd += [
+                "--permission-mode",
+                "dontAsk",
+                "--allowedTools",
+                allowed_tools,
+            ]
+        else:
+            cmd += ["--dangerously-skip-permissions"]
         cmd += ["--disallowedTools", GLOBAL_DISALLOWED_TOOLS]
         output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)
@@ -1871,14 +1886,20 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             "--output-format",
             "stream-json",
             "--verbose",
-            "--permission-mode",
-            "dontAsk",
             "--resume",
             session_id,
             "--print",
         ]
+        # Per-phase permission mode — see _spawn for the full rationale (#1669).
         if allowed_tools is not None:
-            cmd += ["--allowedTools", allowed_tools]
+            cmd += [
+                "--permission-mode",
+                "dontAsk",
+                "--allowedTools",
+                allowed_tools,
+            ]
+        else:
+            cmd += ["--dangerously-skip-permissions"]
         cmd += ["--disallowedTools", GLOBAL_DISALLOWED_TOOLS]
         output = "".join(
             self._streaming_runner(cmd, prompt_file, idle_timeout, cwd=cwd)

--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -634,7 +634,13 @@ class ClaudeSession(OwnedSession):
             "--output-format",
             "stream-json",
             "--verbose",
-            "--dangerously-skip-permissions",
+            # `dontAsk` makes `--allowedTools` the actual gate: anything not
+            # in the allowlist is silently denied without an interactive
+            # prompt.  `--dangerously-skip-permissions` would bypass the
+            # allowlist entirely, letting handler/synthesis phases call
+            # Edit/Write/Bash regardless of the read-only restriction (#1669).
+            "--permission-mode",
+            "dontAsk",
             "--model",
             self._model,
             "--system-prompt-file",
@@ -1829,7 +1835,8 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             "--output-format",
             "stream-json",
             "--verbose",
-            "--dangerously-skip-permissions",
+            "--permission-mode",
+            "dontAsk",
             "--system-prompt-file",
             str(system_file),
             "--print",
@@ -1864,7 +1871,8 @@ class ClaudeClient(SessionBackedAgent, ProviderAgent):
             "--output-format",
             "stream-json",
             "--verbose",
-            "--dangerously-skip-permissions",
+            "--permission-mode",
+            "dontAsk",
             "--resume",
             session_id,
             "--print",

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -716,10 +716,45 @@ class TestClaudeSessionInit:
         assert "--output-format" in cmd
         assert "stream-json" in cmd[cmd.index("--output-format") + 1]
         assert "--verbose" in cmd
-        assert "--permission-mode" in cmd
-        assert cmd[cmd.index("--permission-mode") + 1] == "dontAsk"
+        # Default ClaudeSession has _tools=None (worker phase) — keeps
+        # full implementation access via --dangerously-skip-permissions
+        # so Edit/Write/Bash all work for code-implementing turns (#1669).
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--permission-mode" not in cmd
+        assert "--allowedTools" not in cmd
         assert "--system-prompt-file" in cmd
         assert str(system_file) in cmd
+
+    def test_spawns_with_dontask_when_handler_allowlist_passed(
+        self, tmp_path: Path
+    ) -> None:
+        """Handler/synthesis phase (tools=READ_ONLY) → dontAsk + allowlist.
+
+        --permission-mode dontAsk makes --allowedTools the actual gate;
+        anything outside the allowlist is silently denied.  This is what
+        keeps synthesis turns away from Edit/Write/arbitrary Bash (#1669).
+        """
+        from fido.provider import READ_ONLY_ALLOWED_TOOLS
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("sys")
+        proc = _make_session_proc([])
+        fake_popen = MagicMock(return_value=proc)
+        fake_selector = MagicMock(return_value=([], [], []))
+        ClaudeSession(
+            system_file,
+            work_dir=tmp_path,
+            popen=fake_popen,
+            selector=fake_selector,
+            tools=READ_ONLY_ALLOWED_TOOLS,
+        )
+        cmd = fake_popen.call_args.args[0]
+        assert "--permission-mode" in cmd
+        assert cmd[cmd.index("--permission-mode") + 1] == "dontAsk"
+        assert "--allowedTools" in cmd
+        assert cmd[cmd.index("--allowedTools") + 1] == READ_ONLY_ALLOWED_TOOLS
+        # Worker-only flag must NOT appear in handler mode.
+        assert "--dangerously-skip-permissions" not in cmd
 
     def test_opens_stdin_stdout_pipes(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"
@@ -3327,6 +3362,24 @@ class TestClaudeClientPrintPromptFromFile:
         )
         assert mock_stream.call_args[0][2] == 600.0
 
+    def test_uses_dangerous_skip_when_allowed_tools_none(self, tmp_path: Path) -> None:
+        """Worker phase (allowed_tools=None) keeps full implementation access.
+
+        --permission-mode dontAsk without an allowlist would deny everything;
+        worker turns need Edit/Write/Bash, so this path uses
+        --dangerously-skip-permissions instead (#1669).
+        """
+        sys, prompt = self._files(tmp_path)
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.print_prompt_from_file(
+            sys, prompt, "claude-sonnet-4-6", allowed_tools=None
+        )
+        cmd = mock_stream.call_args[0][0]
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--permission-mode" not in cmd
+        assert "--allowedTools" not in cmd
+
     def test_passes_cwd(self, tmp_path: Path) -> None:
         sys, prompt = self._files(tmp_path)
         mock_stream = MagicMock(return_value=iter(["out"]))
@@ -3416,6 +3469,20 @@ class TestClaudeClientResumeSession:
         assert "--resume" in cmd
         assert "sess-123" in cmd
         assert "--print" in cmd
+
+    def test_uses_dangerous_skip_when_allowed_tools_none(self, tmp_path: Path) -> None:
+        """Worker phase resume — keeps full implementation access (#1669)."""
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("continue")
+        mock_stream = MagicMock(return_value=iter(["out"]))
+        client = ClaudeClient(streaming_runner=mock_stream)
+        client.resume_session(
+            "sess-123", prompt_file, "claude-sonnet-4-6", allowed_tools=None
+        )
+        cmd = mock_stream.call_args[0][0]
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--permission-mode" not in cmd
+        assert "--allowedTools" not in cmd
 
     def test_raises_on_provider_error_output(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "prompt.txt"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -716,7 +716,8 @@ class TestClaudeSessionInit:
         assert "--output-format" in cmd
         assert "stream-json" in cmd[cmd.index("--output-format") + 1]
         assert "--verbose" in cmd
-        assert "--dangerously-skip-permissions" in cmd
+        assert "--permission-mode" in cmd
+        assert cmd[cmd.index("--permission-mode") + 1] == "dontAsk"
         assert "--system-prompt-file" in cmd
         assert str(system_file) in cmd
 
@@ -1967,7 +1968,8 @@ class TestClaudeSessionIsAliveAndReset:
         session.reset("claude-sonnet-4-6")
         assert session._proc is new_proc
         assert fake_popen.call_count == 2
-        assert fake_popen.call_args.args[0][8] == "claude-sonnet-4-6"
+        cmd = fake_popen.call_args.args[0]
+        assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-6"
 
     def test_reset_registers_new_proc_in_active_children(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"


### PR DESCRIPTION
Fixes #1669.

`--dangerously-skip-permissions` was bypassing `--allowedTools` entirely. Synthesis / handler / rescope / voice / status phases pass `allowed_tools=READ_ONLY_ALLOWED_TOOLS` per call, but the spawn flag overrode it — letting the model call `Edit`, `Write`, and arbitrary `Bash` even though those tools are absent from the allowlist.

Live evidence on PR #1658: a synthesis turn that drifted after a `compact_boundary` went on to write actual edits to `test_status.py` because `Edit` was reachable.

Replace `--dangerously-skip-permissions` with `--permission-mode dontAsk` in all three `claude.py` spawn paths. In `dontAsk` mode, `--allowedTools` is the actual gate: anything not listed is silently denied (no prompt, no bypass).

**Per-phase behavior preserved:**

- **Worker phase** (`allowed_tools=None` → no `--allowedTools` flag → broadest set, `--disallowedTools` denies commit/push/Agent/Skill etc.): unchanged effective permissions. Worker keeps `Edit`, `Write`, `Bash`, all the implementation tools.
- **Synthesis / rescope / handler / voice / status phases** (`allowed_tools=READ_ONLY_ALLOWED_TOOLS`): allowlist now actually fires. `Edit`, `Write`, `NotebookEdit`, arbitrary `Bash` → silently denied.

Also rewrites `test_reset_spawns_new_process` to use index-based command lookup instead of hard-coded position `[8]` — the position would shift again with any future spawn-flag change.

## Test plan

- [x] `./fido ci` — 4245 passed, 100% coverage
- [ ] Smoke: restart Fido, verify worker still does Edit/Write/Bash on a real implementation task
- [ ] Smoke: trigger a synthesis turn, verify Edit attempts return "tool not allowed" (not a successful edit)