### PR TITLE
Bug: post eager eyes only when no other open comment for the repo (closes #1662)

### DIFF
--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1072,21 +1072,37 @@ class WebhookHandler(BaseHTTPRequestHandler):
             # author sees acknowledgement within ~1s of their comment (#1243).
             # Best-effort — a failed reaction must never abort the handler.
             # Skipped for bot-authored actions (don't react to other bots).
+            #
+            # Skipped for batch arrivals (#1662): if there's any other open
+            # comment for this repo (pending or in-progress), this comment is
+            # part of a batch — the worker posts eyes on claim instead, so at
+            # most one comment per repo carries eyes at a time.  Solo comments
+            # (no other open work) still get the sub-1s ack.
             _eyes_posted = False
             if not action.is_bot and _eyes_comment_info is not None:
                 _eyes_repo = _eyes_comment_info.get("repo")
                 _eyes_ctype = str(_eyes_comment_info.get("comment_type", "issues"))
                 _eyes_cid = _eyes_comment_info.get("comment_id")
                 if _eyes_repo and isinstance(_eyes_cid, int):
-                    try:
-                        gh.add_reaction(_eyes_repo, _eyes_ctype, _eyes_cid, "eyes")
-                        log.info("eyes reaction posted for comment %d", _eyes_cid)
-                        _eyes_posted = True
-                    except Exception:
-                        log.exception(
-                            "failed to post eyes reaction for comment %d — continuing",
+                    if FidoStore(repo_cfg.work_dir).has_other_open_pr_comments(
+                        repo=_eyes_repo, exclude_comment_id=_eyes_cid
+                    ):
+                        log.debug(
+                            "eager eyes skipped for comment %d — repo has "
+                            "other open comments; worker posts eyes on claim",
                             _eyes_cid,
                         )
+                    else:
+                        try:
+                            gh.add_reaction(_eyes_repo, _eyes_ctype, _eyes_cid, "eyes")
+                            log.info("eyes reaction posted for comment %d", _eyes_cid)
+                            _eyes_posted = True
+                        except Exception:
+                            log.exception(
+                                "failed to post eyes reaction for comment %d "
+                                "— continuing",
+                                _eyes_cid,
+                            )
 
             if action.reply_to:
                 promise = self._prepare_reply(repo_cfg, action)

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -647,6 +647,31 @@ class FidoStore:
         """Return whether *repo* has currently retryable queued comments."""
         return bool(self.pending_pr_comments(repo=repo, pr_number=pr_number))
 
+    def has_other_open_pr_comments(self, *, repo: str, exclude_comment_id: int) -> bool:
+        """Return whether *repo* has any other open queue entries.
+
+        "Open" means ``state IN ('pending', 'in_progress', 'retryable_failed')``
+        — anything that isn't completed.  Used by the dispatcher's eager-eyes
+        path to detect batch-arrival vs. solo: if there's any other open
+        comment for the same repo, this comment is part of a batch and the
+        worker will post eyes when it claims the comment in pickup order
+        (#1662).
+        """
+        self.ensure_schema()
+        with closing(self._connect()) as conn:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM pr_comment_queue
+                WHERE repo = ?
+                  AND comment_id != ?
+                  AND state IN ('pending', 'in_progress', 'retryable_failed')
+                LIMIT 1
+                """,
+                (repo, int(exclude_comment_id)),
+            ).fetchone()
+        return row is not None
+
     def claim_next_pr_comment(
         self, *, owner: str, repo: str | None = None, pr_number: int | None = None
     ) -> PRCommentQueueRecord | None:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2584,6 +2584,26 @@ class Worker:
         repo_cfg = self._repo_cfg
         if config is None or repo_cfg is None:
             raise RuntimeError("queued comment handling requires explicit config")
+        # Post eyes on claim so the comment carries the work-in-progress
+        # signal exactly while it's being processed.  Covers comments that
+        # the dispatcher skipped because the repo had other open work at
+        # webhook time (#1662).  Idempotent at GitHub: re-posting the same
+        # reaction is a no-op.  Bot-authored comments don't get eyes
+        # (matches dispatcher behaviour).
+        if not queued.is_bot:
+            try:
+                self.gh.add_reaction(
+                    repo_ctx.repo,
+                    queued.comment_type,
+                    queued.comment_id,
+                    "eyes",
+                )
+                log.info("eyes reaction posted for comment %d", queued.comment_id)
+            except Exception:
+                log.exception(
+                    "failed to post eyes reaction for comment %d — continuing",
+                    queued.comment_id,
+                )
         pr_data = self.gh.get_pr(repo_ctx.repo, queued.pr_number)
         pr_title = pr_data["title"]
         pr_body = pr_data["body"] or ""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2600,6 +2600,54 @@ class TestProcessActionInner:
         handler._process_action_inner(action, repo_cfg, self._activity())
         handler.gh.add_reaction.assert_any_call("owner/repo", "issues", 301, "eyes")
 
+    def test_eyes_reaction_skipped_when_other_open_comment_in_queue(
+        self, cfg: Config, repo_cfg: RepoConfig
+    ) -> None:
+        """Batch arrival: another pending comment in queue → eager eyes skipped.
+
+        With #1662, when a second comment arrives for a repo that already
+        has an open queued or in-progress comment, the dispatcher does not
+        post eager eyes — the worker posts eyes when claiming each comment
+        in pickup order, so at most one comment per repo carries eyes at a
+        time.
+        """
+        from fido.store import FidoStore
+
+        # Pre-populate the queue with another pending comment for the
+        # same repo — simulates a sibling in a multi-comment review.
+        FidoStore(repo_cfg.work_dir).enqueue_pr_comment(
+            delivery_id="delivery-sibling",
+            repo="owner/repo",
+            pr_number=1,
+            comment_type="pulls",
+            comment_id=400,
+            author="owner",
+            is_bot=False,
+            body="sibling comment",
+            github_created_at="2026-04-30T10:00:00Z",
+        )
+        action = Action(
+            prompt="batch review comment",
+            reply_to={
+                "repo": "owner/repo",
+                "pr": 1,
+                "comment_id": 401,
+                "url": "https://example.com",
+                "author": "owner",
+                "comment_type": "pulls",
+            },
+            comment_body="please fix this",
+            is_bot=False,
+        )
+        WebhookHandler._fn_reply_to_comment = MagicMock(return_value=("ANSWER", []))
+        WebhookHandler._fn_launch_worker = MagicMock()
+        handler = self._handler(cfg)
+        handler._process_action_inner(action, repo_cfg, self._activity())
+        for call in handler.gh.add_reaction.call_args_list:
+            assert call.args[3] != "eyes", (
+                f"eyes was posted despite sibling open comment: {call}"
+            )
+
     def test_eyes_reaction_skipped_for_bot_action(
         self, cfg: Config, repo_cfg: RepoConfig
     ) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -767,6 +767,168 @@ def test_claim_next_pr_comment_marks_oldest_in_progress(tmp_path: Path) -> None:
     assert store.pending_pr_comments(repo="owner/repo") == [newer]
 
 
+def test_has_other_open_pr_comments_false_when_only_excluded(
+    tmp_path: Path,
+) -> None:
+    """Solo arrival: only the excluded comment is queued → no other open work."""
+    store = FidoStore(tmp_path)
+    only = store.enqueue_pr_comment(
+        delivery_id="delivery-only",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=500,
+        author="rob",
+        is_bot=False,
+        body="solo",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo", exclude_comment_id=only.comment_id
+        )
+        is False
+    )
+
+
+def test_has_other_open_pr_comments_true_when_other_pending(tmp_path: Path) -> None:
+    """Batch arrival: another pending entry for same repo → True."""
+    store = FidoStore(tmp_path)
+    store.enqueue_pr_comment(
+        delivery_id="delivery-sibling",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=600,
+        author="rob",
+        is_bot=False,
+        body="sibling",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    just_arrived = store.enqueue_pr_comment(
+        delivery_id="delivery-just-arrived",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=601,
+        author="rob",
+        is_bot=False,
+        body="just arrived",
+        github_created_at="2026-04-30T10:00:01Z",
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo", exclude_comment_id=just_arrived.comment_id
+        )
+        is True
+    )
+
+
+def test_has_other_open_pr_comments_true_when_other_in_progress(
+    tmp_path: Path,
+) -> None:
+    """Worker is already processing another comment → True."""
+    store = FidoStore(tmp_path)
+    sibling = store.enqueue_pr_comment(
+        delivery_id="delivery-claimed",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=700,
+        author="rob",
+        is_bot=False,
+        body="being processed",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    store.claim_next_pr_comment(owner="worker", repo="owner/repo")
+    just_arrived = store.enqueue_pr_comment(
+        delivery_id="delivery-arrived",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=701,
+        author="rob",
+        is_bot=False,
+        body="just arrived",
+        github_created_at="2026-04-30T10:00:01Z",
+    )
+    del sibling
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo", exclude_comment_id=just_arrived.comment_id
+        )
+        is True
+    )
+
+
+def test_has_other_open_pr_comments_ignores_completed(tmp_path: Path) -> None:
+    """A completed sibling does not count as 'other open'."""
+    store = FidoStore(tmp_path)
+    completed = store.enqueue_pr_comment(
+        delivery_id="delivery-done",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=800,
+        author="rob",
+        is_bot=False,
+        body="already done",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    store.claim_next_pr_comment(owner="worker", repo="owner/repo")
+    store.complete_pr_comment(completed.queue_id)
+    just_arrived = store.enqueue_pr_comment(
+        delivery_id="delivery-arrived-after",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=801,
+        author="rob",
+        is_bot=False,
+        body="just arrived",
+        github_created_at="2026-04-30T10:00:01Z",
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo", exclude_comment_id=just_arrived.comment_id
+        )
+        is False
+    )
+
+
+def test_has_other_open_pr_comments_scopes_by_repo(tmp_path: Path) -> None:
+    """A pending comment in a different repo does not count."""
+    store = FidoStore(tmp_path)
+    store.enqueue_pr_comment(
+        delivery_id="delivery-other-repo",
+        repo="owner/other-repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=900,
+        author="rob",
+        is_bot=False,
+        body="different repo",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    just_arrived = store.enqueue_pr_comment(
+        delivery_id="delivery-this-repo",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=901,
+        author="rob",
+        is_bot=False,
+        body="this repo",
+        github_created_at="2026-04-30T10:00:01Z",
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo", exclude_comment_id=just_arrived.comment_id
+        )
+        is False
+    )
+
+
 def test_recover_in_progress_pr_comments_requeues_abandoned_claim(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10054,6 +10054,120 @@ class TestHandleQueuedComments:
             payload_json="{}",
         )
 
+    def test_posts_eyes_on_claim_for_human_comment(self, tmp_path: Path) -> None:
+        """When the worker claims a comment, it posts the eyes reaction.
+
+        Covers comments that the dispatcher skipped because the repo had
+        other open work at webhook time (#1662).  Idempotent at GitHub —
+        re-posting the same reaction is a no-op, so the dispatcher's eager
+        eyes (when it does fire on a solo arrival) plus the worker's
+        on-claim post don't double-react.
+        """
+        worker, gh = self._make_worker(tmp_path)
+        self._enqueue(tmp_path, comment_type="pulls", comment_id=501)
+        gh.get_pr.return_value = {"title": "My PR", "body": "Body"}
+        gh.get_pull_comment.return_value = {
+            "id": 501,
+            "body": "please fix",
+            "user": {"login": "owner"},
+            "html_url": "https://github.com/owner/repo/pull/7#discussion_r501",
+            "path": "x.py",
+            "line": 5,
+            "diff_hunk": "@@",
+        }
+
+        with (
+            patch("fido.events.reply_to_comment", return_value=("ANSWER", [])),
+            patch("fido.tasks.sync_tasks_background"),
+        ):
+            worker.handle_queued_comments(
+                self._fido_dir(tmp_path), self._repo_ctx(), 7, "branch"
+            )
+
+        gh.add_reaction.assert_any_call("owner/repo", "pulls", 501, "eyes")
+
+    def test_skips_eyes_on_claim_for_bot_comment(self, tmp_path: Path) -> None:
+        """Bot-authored comments do not get the eyes reaction on claim.
+
+        Matches the dispatcher's bot-skip behaviour — Fido doesn't react
+        to other bots (#1662).
+        """
+        worker, gh = self._make_worker(tmp_path)
+        FidoStore(tmp_path).enqueue_pr_comment(
+            delivery_id="delivery-bot",
+            repo="owner/repo",
+            pr_number=7,
+            comment_type="pulls",
+            comment_id=502,
+            author="dependabot[bot]",
+            is_bot=True,
+            body="bumped a dep",
+            github_created_at="2026-04-30T12:00:00Z",
+            payload_json="{}",
+        )
+        gh.get_pr.return_value = {"title": "My PR", "body": "Body"}
+        gh.get_pull_comment.return_value = {
+            "id": 502,
+            "body": "bumped a dep",
+            "user": {"login": "dependabot[bot]"},
+            "html_url": "https://github.com/owner/repo/pull/7#discussion_r502",
+            "path": "x.py",
+            "line": 5,
+            "diff_hunk": "@@",
+        }
+
+        with (
+            patch("fido.events.reply_to_comment", return_value=("ANSWER", [])),
+            patch("fido.tasks.sync_tasks_background"),
+        ):
+            worker.handle_queued_comments(
+                self._fido_dir(tmp_path), self._repo_ctx(), 7, "branch"
+            )
+
+        for reaction_call in gh.add_reaction.call_args_list:
+            assert reaction_call.args[3] != "eyes", (
+                f"eyes was posted for bot comment on claim: {reaction_call}"
+            )
+
+    def test_eyes_post_failure_on_claim_does_not_abort(self, tmp_path: Path) -> None:
+        """A failed eyes post on claim is best-effort — claim continues.
+
+        Mirrors the dispatcher's eager-eyes failure handling (#1662).
+        """
+        worker, gh = self._make_worker(tmp_path)
+        self._enqueue(tmp_path, comment_type="pulls", comment_id=503)
+        gh.get_pr.return_value = {"title": "My PR", "body": "Body"}
+        gh.get_pull_comment.return_value = {
+            "id": 503,
+            "body": "please fix",
+            "user": {"login": "owner"},
+            "html_url": "https://github.com/owner/repo/pull/7#discussion_r503",
+            "path": "x.py",
+            "line": 5,
+            "diff_hunk": "@@",
+        }
+
+        # Fail the eyes call; subsequent reactions should still work.
+        def add_reaction_side_effect(
+            *args: object, **_kwargs: object
+        ) -> dict[str, str]:
+            if len(args) >= 4 and args[3] == "eyes":
+                raise RuntimeError("github transient")
+            return {"id": "ok"}
+
+        gh.add_reaction.side_effect = add_reaction_side_effect
+
+        with (
+            patch("fido.events.reply_to_comment", return_value=("ANSWER", [])),
+            patch("fido.tasks.sync_tasks_background"),
+        ):
+            result = worker.handle_queued_comments(
+                self._fido_dir(tmp_path), self._repo_ctx(), 7, "branch"
+            )
+
+        assert result is True
+        assert FidoStore(tmp_path).claim_state(503) == "completed"
+
     def test_drains_issue_comment_and_queues_tasks(self, tmp_path: Path) -> None:
         worker, gh = self._make_worker(tmp_path)
         self._enqueue(tmp_path, comment_type="issues", comment_id=301)


### PR DESCRIPTION
Fixes #1662.

When a single review submission produced multiple inline comments, the dispatcher fired eager eyes on each one within ~1s. Visually the PR showed Fido committed to all of them simultaneously, but processing was strictly serial — minutes per comment — leaving the queue depth invisible. The pre-#1243 pattern was honest about this: only the comment currently being worked carried eyes.

**Fix:** skip the dispatcher's eager eyes when the repo already has any other open queued or in-progress comment. Solo arrivals still get the sub-1s ack from the dispatcher; batch arrivals get eyes only when the worker claims each comment in pickup order — at most one comment per repo carries eyes at a time.

Worker also posts eyes on claim (idempotent at GitHub) so any comment the dispatcher skipped still picks up the work-in-progress signal at the moment work actually starts. Bot-authored comments stay eyes-free, matching the existing dispatcher behaviour.

## Implementation

- `FidoStore.has_other_open_pr_comments(repo, exclude_comment_id)` — backs the dispatcher's batch-detect; checks for any pending / in_progress / retryable_failed entry for the repo with a different comment_id.
- `server.py` dispatcher: before the existing `gh.add_reaction(..., "eyes")` call, check the new store method; if True, skip and log debug.
- `worker.py` `_handle_queued_comment`: at start of processing, post eyes (best-effort, skips bots).

## Test plan

- [x] `./fido ci` — 4254 passed, 100% coverage
- [x] New tests cover: store method (5 cases — solo, batch-pending, batch-in-progress, ignores-completed, repo-scope), dispatcher skip-on-batch, worker eyes-on-claim, worker bot-skip, worker eyes-failure-tolerant
- [ ] Smoke after merge: arriving review with N inline comments shows eyes only on the comment Fido is actively processing, swapping as he progresses