### PR TITLE
Bug: deny top-level PR/issue comment posts at the capability layer (closes #1675)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -169,9 +169,14 @@ Pull conversations from the day's PRs — review comments are durably stored and
 fully recoverable:
 
 ```bash
-gh api repos/<owner>/<repo>/issues/<n>/comments
-gh api repos/<owner>/<repo>/pulls/<n>/comments
+gh issue view <n> --repo <owner>/<repo> --json comments    # top-level
+gh api repos/<owner>/<repo>/pulls/<n>/comments              # review-thread
 ```
+
+The `gh api repos/.../issues/<n>/comments` REST endpoint is denied at the
+capability layer (#1675) — the harness owns top-level reply posting, and
+denying the path also blocks GET on it.  Use `gh issue view --json comments`
+instead for top-level comment context.
 
 **Keep the research invisible.** Fido doesn't "know" he ran a script — he just
 *remembers* the day. Never write "I ran the stats" or "I checked the Activities

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -292,6 +292,15 @@ GLOBAL_DISALLOWED_TOOLS = (
     " Bash(git reset *)"
     " Bash(git checkout *)"
     " Bash(./fido task *)"
+    # Top-level PR / issue comment posting.  The harness owns reply
+    # delivery via the synthesis path (`_handle_queued_comment`); the
+    # model must not reach for `gh api .../issues/<n>/comments` to post
+    # acknowledgements directly.  `sub/task.md` line 104 already says
+    # "Never post a top-level PR comment" but the model has been
+    # observed doing it anyway via the unrestricted Bash tool — capability-
+    # layer enforcement (#1675) closes the gap that prompt rules can't.
+    # Read paths still work via `gh issue view`/`gh pr view --comments`.
+    " Bash(gh api *issues/*/comments*)"
     " Agent"
     " Skill"
     " TaskCreate TaskUpdate TaskList TodoWrite TodoRead"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.provider import (
+    GLOBAL_DISALLOWED_TOOLS,
     ProviderID,
     ProviderInterruptTimeout,
     ProviderLimitSnapshot,
@@ -14,6 +15,22 @@ from fido.provider import (
     is_recoverable_provider_wedge,
     safe_voice_turn,
 )
+
+
+class TestGlobalDisallowedTools:
+    def test_denies_top_level_pr_comment_post(self) -> None:
+        """Top-level PR/issue comment posting must be denied at the
+        capability layer — the harness owns reply delivery via the
+        synthesis path, and `sub/task.md`'s "Never post a top-level PR
+        comment" prompt rule isn't enough on its own (#1675)."""
+        assert "Bash(gh api *issues/*/comments*)" in GLOBAL_DISALLOWED_TOOLS
+
+    def test_review_thread_reply_path_not_denied(self) -> None:
+        """The review-thread reply path
+        (`gh api .../pulls/<n>/comments`) must remain available — that's
+        the prescribed channel for `sub/task.md`'s "PR comment:" task
+        instructions."""
+        assert "pulls/" not in GLOBAL_DISALLOWED_TOOLS
 
 
 class TestProviderLimitWindow:


### PR DESCRIPTION
Fixes #1675.

`sub/task.md` line 104 already says *"Never post a top-level PR comment (`gh api .../issues/<n>/comments`) about task status"* — but the model has been observed doing it anyway during pre-task work via unrestricted Bash. Live evidence on PR #1658 (15:21 / 15:22): two top-level Fido comments posted ~25 minutes after the initial dispatcher-driven replies to Rob's SRP and free-functions comments, created via `gh api repos/.../issues/1658/comments`.

Same family as **#1574** ("LLM behavioral constraints need capability-layer enforcement, not just prompt rules"). Now that PR #1671 made `--disallowedTools` actually enforced, tightening `GLOBAL_DISALLOWED_TOOLS` actually closes the gap.

## Change

Adds one pattern to `GLOBAL_DISALLOWED_TOOLS` in `provider.py`:

```
Bash(gh api *issues/*/comments*)
```

- Denies POST and GET on the issue-comment REST endpoint specifically
- Alternative read paths (`gh issue view --json comments`, `gh pr view --comments`) remain available
- The **review-thread reply path** (`gh api .../pulls/<n>/comments`) — the prescribed channel for "PR comment:" task replies per `sub/task.md` — is untouched

## Test plan

- [x] `./fido ci` — 4259 passed, 100% coverage
- [x] Two new tests confirm the deny rule is present and the review-thread path isn't caught
- [ ] Smoke after merge: trigger a worker turn that previously freelanced a top-level comment via `gh api`; observe tool denial instead of a posted comment