### PR TITLE
Bug: per-phase sandbox for codex — synthesis/handler runs read-only (closes #1672)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -169,9 +169,14 @@ Pull conversations from the day's PRs — review comments are durably stored and
 fully recoverable:
 
 ```bash
-gh api repos/<owner>/<repo>/issues/<n>/comments
-gh api repos/<owner>/<repo>/pulls/<n>/comments
+gh issue view <n> --repo <owner>/<repo> --json comments    # top-level
+gh api repos/<owner>/<repo>/pulls/<n>/comments              # review-thread
 ```
+
+The `gh api repos/.../issues/<n>/comments` REST endpoint is denied at the
+capability layer (#1675) — the harness owns top-level reply posting, and
+denying the path also blocks GET on it.  Use `gh issue view --json comments`
+instead for top-level comment context.
 
 **Keep the research invisible.** Fido doesn't "know" he ran a script — he just
 *remembers* the day. Never write "I ran the stats" or "I checked the Activities

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -47,6 +47,33 @@ _CODEX_CLIENT_INFO = {
 }
 
 
+def _sandbox_acp_policy_for_phase(allowed_tools: str | None) -> dict[str, str]:
+    """Return the ACP-protocol ``sandboxPolicy`` for a turn based on phase.
+
+    Codex's app-server takes a ``sandboxPolicy`` field per ``turn/start``.
+    We use it to apply the same per-phase tool restriction the claude
+    provider gets from ``--allowedTools``: handler / synthesis / rescope /
+    voice / status phases pass an explicit allowlist (any non-None value)
+    and run with read-only sandbox so they cannot Edit/Write/Bash; worker
+    phase passes ``allowed_tools=None`` and keeps full implementation
+    access (#1672).
+    """
+    if allowed_tools is None:
+        return {"type": "dangerFullAccess"}
+    return {"type": "readOnly"}
+
+
+def _sandbox_cli_value_for_phase(allowed_tools: str | None) -> str:
+    """Return the ``--sandbox`` CLI value for a one-shot codex invocation.
+
+    Mirrors :func:`_sandbox_acp_policy_for_phase` for the non-persistent
+    exec paths (``run_codex_exec`` and ``run_codex_exec_resume``).
+    """
+    if allowed_tools is None:
+        return "danger-full-access"
+    return "read-only"
+
+
 class CodexCLIError(RuntimeError):
     """Raised when the Codex CLI process exits unsuccessfully."""
 
@@ -743,24 +770,40 @@ class CodexSession(OwnedSession):
         content: str,
         *,
         model: ProviderModel | None = None,
-        allowed_tools: str | None = None,  # see comment below
+        allowed_tools: str | None = None,
         system_prompt: str | None = None,
     ) -> str:
         # ``allowed_tools`` is part of the ``PromptSession`` protocol (closes
-        # #1413), but Codex's runtime has no equivalent of ``--allowedTools``
-        # so the kwarg is informational here.  Default differs from the
-        # protocol's READ_ONLY default because there's nothing to enforce.
-        del allowed_tools
+        # #1413).  Codex has no per-tool primitive but it does have
+        # per-turn sandbox modes — we translate the protocol's allowlist
+        # into a sandbox policy: any non-None value means "handler /
+        # synthesis / rescope / voice / status" and gets read-only;
+        # ``None`` is "worker phase" and keeps full implementation access
+        # (#1672).
+        sandbox_policy = _sandbox_acp_policy_for_phase(allowed_tools)
         with self:
             if model is not None:
                 self.switch_model(model)
-            self.send(_combine_prompt(content, self._base_system_prompt, system_prompt))
+            self.send(
+                _combine_prompt(content, self._base_system_prompt, system_prompt),
+                sandbox_policy=sandbox_policy,
+            )
             return self.consume_until_result()
 
-    def send(self, content: str) -> None:
+    def send(
+        self,
+        content: str,
+        *,
+        sandbox_policy: dict[str, str] | None = None,
+    ) -> None:
         thread_id = self._require_thread_id()
         with self._state_lock:
             self._last_turn_cancelled = False
+        # Default to full-access when no policy is provided so direct
+        # ``send`` callers (rare; ``prompt`` is the normal entry point)
+        # behave the same as today.
+        if sandbox_policy is None:
+            sandbox_policy = {"type": "dangerFullAccess"}
         result = self._client.request(
             "turn/start",
             {
@@ -772,7 +815,7 @@ class CodexSession(OwnedSession):
                 "effort": self._model.efforts[0] if self._model.efforts else None,
                 "cwd": str(self._work_dir),
                 "approvalPolicy": "never",
-                "sandboxPolicy": {"type": "dangerFullAccess"},
+                "sandboxPolicy": sandbox_policy,
             },
         )
         turn = result.get("turn") if isinstance(result, dict) else None
@@ -1081,8 +1124,14 @@ def run_codex_exec(
     timeout: int = 30,
     cwd: Path | str = ".",
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    allowed_tools: str | None = None,
 ) -> str:
-    """Run one non-persistent Codex exec turn and return raw JSONL output."""
+    """Run one non-persistent Codex exec turn and return raw JSONL output.
+
+    ``allowed_tools`` selects the per-phase sandbox: ``None`` (worker phase)
+    runs with ``danger-full-access``; any non-None value (handler /
+    synthesis / rescope / voice / status) runs with ``read-only`` (#1672).
+    """
     work_dir = Path(cwd).resolve()
     completed = _codex(
         "exec",
@@ -1090,7 +1139,7 @@ def run_codex_exec(
         "--model",
         model_name(model),
         "--sandbox",
-        "danger-full-access",
+        _sandbox_cli_value_for_phase(allowed_tools),
         "--ask-for-approval",
         "never",
         "--skip-git-repo-check",
@@ -1116,8 +1165,13 @@ def run_codex_exec_resume(
     timeout: int = 300,
     cwd: Path | str = ".",
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    allowed_tools: str | None = None,
 ) -> str:
-    """Run one non-persistent Codex exec resume turn and return raw JSONL output."""
+    """Run one non-persistent Codex exec resume turn and return raw JSONL output.
+
+    ``allowed_tools`` selects the per-phase sandbox — see
+    :func:`run_codex_exec` for the mapping.
+    """
     work_dir = Path(cwd).resolve()
     completed = _codex(
         "exec",
@@ -1125,7 +1179,7 @@ def run_codex_exec_resume(
         "--model",
         model_name(model),
         "--sandbox",
-        "danger-full-access",
+        _sandbox_cli_value_for_phase(allowed_tools),
         "--ask-for-approval",
         "never",
         "--skip-git-repo-check",
@@ -1213,9 +1267,9 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
         *,
-        allowed_tools: str | None = None,  # informational; Codex has no equivalent
+        allowed_tools: str | None = None,
     ) -> str:
-        del idle_timeout, allowed_tools
+        del idle_timeout
         prompt = _combine_prompt(prompt_file.read_text(), system_file.read_text(), None)
         return run_codex_exec(
             prompt,
@@ -1223,6 +1277,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             timeout=timeout,
             cwd=cwd,
             runner=self._runner,
+            allowed_tools=allowed_tools,
         )
 
     def resume_session(
@@ -1234,9 +1289,9 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
         idle_timeout: float = 1800.0,
         cwd: Path | str = ".",
         *,
-        allowed_tools: str | None = None,  # informational; Codex has no equivalent
+        allowed_tools: str | None = None,
     ) -> str:
-        del idle_timeout, allowed_tools
+        del idle_timeout
         return run_codex_exec_resume(
             session_id,
             prompt_file.read_text(),
@@ -1244,6 +1299,7 @@ class CodexClient(SessionBackedAgent, ProviderAgent):
             timeout=timeout,
             cwd=cwd,
             runner=self._runner,
+            allowed_tools=allowed_tools,
         )
 
     def extract_session_id(self, output: str) -> str:

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -292,6 +292,15 @@ GLOBAL_DISALLOWED_TOOLS = (
     " Bash(git reset *)"
     " Bash(git checkout *)"
     " Bash(./fido task *)"
+    # Top-level PR / issue comment posting.  The harness owns reply
+    # delivery via the synthesis path (`_handle_queued_comment`); the
+    # model must not reach for `gh api .../issues/<n>/comments` to post
+    # acknowledgements directly.  `sub/task.md` line 104 already says
+    # "Never post a top-level PR comment" but the model has been
+    # observed doing it anyway via the unrestricted Bash tool — capability-
+    # layer enforcement (#1675) closes the gap that prompt rules can't.
+    # Read paths still work via `gh issue view`/`gh pr view --comments`.
+    " Bash(gh api *issues/*/comments*)"
     " Agent"
     " Skill"
     " TaskCreate TaskUpdate TaskList TodoWrite TodoRead"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -244,6 +244,21 @@ class TestRunCodexExec:
         assert mock_run.call_args.kwargs["timeout"] == 17
         assert mock_run.call_args.kwargs["cwd"] == tmp_path.resolve()
 
+    def test_handler_phase_uses_read_only_sandbox(self, tmp_path: Path) -> None:
+        """Non-persistent exec with allowed_tools set runs read-only (#1672)."""
+        from fido.provider import READ_ONLY_ALLOWED_TOOLS
+
+        mock_run = MagicMock(return_value=_completed(_fixture("normal.jsonl")))
+        run_codex_exec(
+            "hello",
+            model="gpt-5.5",
+            cwd=tmp_path,
+            runner=mock_run,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
+        cmd = mock_run.call_args.args[0]
+        assert cmd[cmd.index("--sandbox") + 1] == "read-only"
+
     def test_normalizes_relative_work_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -622,6 +637,56 @@ class TestCodexSession:
         ]
         assert session.sent_count == 1
         assert session.received_count == 1
+
+    def test_prompt_with_allowed_tools_uses_read_only_sandbox(
+        self, tmp_path: Path
+    ) -> None:
+        """Handler / synthesis / rescope / voice / status phases pass an
+        explicit allowlist; codex's per-turn sandbox runs read-only so
+        the model cannot Edit/Write/Bash even though the codex runtime
+        has no `--allowedTools` primitive (#1672)."""
+        from fido.provider import READ_ONLY_ALLOWED_TOOLS
+
+        system_file = tmp_path / "system.md"
+        system_file.write_text("base")
+        fake = _FakeAppServer()
+        fake.notifications.extend(
+            [
+                {
+                    "method": "turn/started",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "inProgress"},
+                    },
+                },
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turnId": "turn-1",
+                        "item": {"type": "agentMessage", "text": "reply"},
+                    },
+                },
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-new",
+                        "turn": {"id": "turn-1", "status": "completed"},
+                    },
+                },
+            ]
+        )
+        session = CodexSession(
+            system_file,
+            work_dir=tmp_path,
+            model=ProviderModel("gpt-5.5", "medium"),
+            client_factory=lambda **_: fake,
+        )
+        assert session.prompt("hello", allowed_tools=READ_ONLY_ALLOWED_TOOLS) == (
+            "reply"
+        )
+        turn_params = fake.requests[1][1]
+        assert turn_params["sandboxPolicy"] == {"type": "readOnly"}
 
     def test_resumes_persisted_thread_id(self, tmp_path: Path) -> None:
         system_file = tmp_path / "system.md"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.provider import (
+    GLOBAL_DISALLOWED_TOOLS,
     ProviderID,
     ProviderInterruptTimeout,
     ProviderLimitSnapshot,
@@ -14,6 +15,22 @@ from fido.provider import (
     is_recoverable_provider_wedge,
     safe_voice_turn,
 )
+
+
+class TestGlobalDisallowedTools:
+    def test_denies_top_level_pr_comment_post(self) -> None:
+        """Top-level PR/issue comment posting must be denied at the
+        capability layer — the harness owns reply delivery via the
+        synthesis path, and `sub/task.md`'s "Never post a top-level PR
+        comment" prompt rule isn't enough on its own (#1675)."""
+        assert "Bash(gh api *issues/*/comments*)" in GLOBAL_DISALLOWED_TOOLS
+
+    def test_review_thread_reply_path_not_denied(self) -> None:
+        """The review-thread reply path
+        (`gh api .../pulls/<n>/comments`) must remain available — that's
+        the prescribed channel for `sub/task.md`'s "PR comment:" task
+        instructions."""
+        assert "pulls/" not in GLOBAL_DISALLOWED_TOOLS
 
 
 class TestProviderLimitWindow:


### PR DESCRIPTION
Fixes #1672.

Codex's runtime has no `--allowedTools` equivalent, but it does have a real OS-level sandbox via the per-turn `sandboxPolicy` field (ACP `turn/start`) and the `--sandbox <mode>` CLI flag. Up to now Codex unconditionally used `dangerFullAccess` everywhere — handler / synthesis / rescope / voice / status turns had the same write access as the worker phase, so a runaway synthesis turn could `Edit`/`Write`/`Bash` regardless of `allowed_tools=READ_ONLY_ALLOWED_TOOLS` being passed at the application layer.

## Fix

Map the existing `allowed_tools` kwarg to a sandbox value:

| `allowed_tools` | ACP policy | CLI value |
|---|---|---|
| `None` (worker phase) | `dangerFullAccess` | `danger-full-access` |
| non-None (handler/synthesis/...) | `readOnly` | `read-only` |

Real OS-level enforcement — Seatbelt on macOS, namespaces + seccomp on Linux. Filesystem write syscalls fail in `read-only`, regardless of what the model "decides" to do.

## Threaded through

- `CodexSession.send` accepts a per-call `sandbox_policy`
- `CodexSession.prompt` translates `allowed_tools` via the new `_sandbox_acp_policy_for_phase` helper
- `run_codex_exec` / `run_codex_exec_resume` accept `allowed_tools` and translate via `_sandbox_cli_value_for_phase`
- `CodexClient.print_prompt_from_file` / `resume_session` pass `allowed_tools` through (no more `del allowed_tools`)

## Known follow-up

Read-only sandbox blocks **disk writes** but allows **network calls**. A clever turn could still post a comment via raw `curl -X POST https://api.github.com/repos/.../issues/.../comments`, bypassing both the codex sandbox and the gh-api deny rule from PR #1677. Filing that as a separate issue — fix likely involves either a stricter sandbox mode (e.g. `workspace-write-no-network` + a separate network proxy for legit reads) or banning `curl` outright in handler-phase tool patterns.

## Test plan

- [x] `./fido ci` — 4261 passed, 100% coverage
- [x] New tests cover the read-only path on both persistent and non-persistent entry points
- [x] Existing default-path tests still pass with `dangerFullAccess`
- [ ] Smoke after merge on tracy: synthesis turn → write attempts fail; worker turn → Edit/Write/Bash still work