### PR TITLE
Bug: deny raw curl to close the comment-posting loophole below #1675/#1672 (closes #1679)

### DIFF
--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -301,6 +301,14 @@ GLOBAL_DISALLOWED_TOOLS = (
     # layer enforcement (#1675) closes the gap that prompt rules can't.
     # Read paths still work via `gh issue view`/`gh pr view --comments`.
     " Bash(gh api *issues/*/comments*)"
+    # Raw curl is the same loophole one layer down: banning `gh api ...
+    # POST` plus codex's read-only sandbox blocks disk and the high-level
+    # GitHub helper, but `curl -X POST https://api.github.com/...`
+    # bypasses both because it's a different binary and codex's
+    # read-only mode allows network (#1679).  The model uses `gh` for
+    # GitHub interactions; curl is rarely necessary and the rare cases
+    # don't justify the loophole.
+    " Bash(curl *)"
     " Agent"
     " Skill"
     " TaskCreate TaskUpdate TaskList TodoWrite TodoRead"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -32,6 +32,14 @@ class TestGlobalDisallowedTools:
         instructions."""
         assert "pulls/" not in GLOBAL_DISALLOWED_TOOLS
 
+    def test_denies_raw_curl(self) -> None:
+        """Raw curl is the loophole one layer below the gh-api deny:
+        `curl -X POST https://api.github.com/...` bypasses both the
+        gh-api pattern (different binary) and codex's read-only sandbox
+        (network is allowed).  Capability-layer enforcement closes it
+        (#1679)."""
+        assert "Bash(curl *)" in GLOBAL_DISALLOWED_TOOLS
+
 
 class TestProviderLimitWindow:
     def test_pressure_returns_ratio(self) -> None:


### PR DESCRIPTION
Fixes #1679.

PR #1677 (closes #1675) added \`Bash(gh api *issues/*/comments*)\` to \`GLOBAL_DISALLOWED_TOOLS\`. PR #1678 (closes #1672) made codex's handler phase run OS-level read-only sandbox. Both leave a network-only loophole — raw \`curl\`:

\`\`\`bash
curl -X POST -H "Authorization: Bearer $GH_TOKEN" \\
  https://api.github.com/repos/<owner>/<repo>/issues/<n>/comments \\
  -d '{"body": "..."}'
\`\`\`

That bypasses both fixes: different binary (gh-api patterns don't match), no disk writes (codex read-only allows network), and \`$GH_TOKEN\` is in the model's env.

## Fix

Add \`Bash(curl *)\` to \`GLOBAL_DISALLOWED_TOOLS\`. The model uses \`gh\` for GitHub interactions; raw curl is rarely necessary. Same capability-layer enforcement pattern as #1675 (the **#1574** Insight: prompt rules aren't enough).

## Test plan

- [x] \`./fido ci\` — 4262 passed, 100% coverage
- [x] New test confirms the deny rule is in place
- [ ] Smoke after merge: a handler-phase turn that attempts \`curl\` is denied at the tool layer