### PR TITLE
Bug: notify thread commenter only on title change, not pure-description rewrites (closes #1388)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -841,7 +841,7 @@ def _compute_thread_changes(
     result: list[dict[str, Any]],
     original_ids: frozenset[str],
 ) -> list[dict[str, Any]]:
-    """Return change records for thread tasks that were completed or modified.
+    """Return change records for thread tasks that were completed or materially modified.
 
     Only tasks in *original_ids* (those Opus knew about) with a ``thread``
     attachment are reported.  Already-completed tasks are excluded.
@@ -849,6 +849,13 @@ def _compute_thread_changes(
     Each record is one of:
     - ``{"task": ..., "kind": "completed"}`` — Opus omitted or marked it done
     - ``{"task": ..., "kind": "modified", "new_title": ..., "new_description": ...}``
+      — the **title** changed.  Title is the contract Fido committed to in
+      its initial reply; a title change indicates the scope materially
+      shifted.  Pure description rewrites that preserve the title are
+      treated as internal rephrasing and produce no change record — the
+      reviewer's mental model is "I gave feedback, Fido replied, I'll see
+      them again when the work lands," and rescope-internal description
+      edits between those two events are noise (#1388).
 
     Note: the Rocq model (``TaskCompleted`` vs ``TaskCancelled``) distinguishes
     explicit completion from omission.  Here both map to ``"completed"`` because
@@ -871,9 +878,7 @@ def _compute_thread_changes(
         r = result_by_id.get(tid)
         if r is None or r.get("status") == TaskStatus.COMPLETED:
             changes.append({"task": t, "kind": "completed"})
-        elif r.get("title") != t.get("title") or r.get("description") != t.get(
-            "description"
-        ):
+        elif r.get("title") != t.get("title"):
             changes.append(
                 {
                     "task": t,
@@ -1032,9 +1037,12 @@ def reorder_tasks(
         lock.write(result)
 
     if _on_changes is not None:
-        changes = _compute_thread_changes(current, result, original_ids)
-        if changes:
-            _on_changes(changes)
+        # Always call with the (possibly empty) list — the production
+        # callback iterates and a no-change run is a no-op.  Avoids a
+        # branch that's hard to reach in tests now that title
+        # preservation by the reducer means rescope rarely produces a
+        # material change record (#1388).
+        _on_changes(_compute_thread_changes(current, result, original_ids))
 
     if inprogress_affected and _on_inprogress_affected is not None:
         assert inprogress is not None  # inprogress_affected is True

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1366,7 +1366,14 @@ class TestReorderTasks:
         task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
         assert task1["status"] == "pending"
 
-    def test_on_changes_called_when_thread_task_modified(self, tmp_path: Path) -> None:
+    def test_on_changes_skipped_when_only_description_changes(
+        self, tmp_path: Path
+    ) -> None:
+        """Pure description rewrites (title preserved) do not fire a
+        reply-back to the commenter.  The reducer currently preserves
+        titles across rescope, so Opus's "Changed title" gets dropped and
+        only the description update lands — that's an internal rephrasing,
+        not a contract change worth notifying the reviewer about (#1388)."""
         thread = {
             "repo": "r/r",
             "pr": 1,
@@ -1388,10 +1395,12 @@ class TestReorderTasks:
             agent=_client(raw),
             _on_changes=lambda changes: received.extend(changes),
         )
-        assert len(received) == 1
-        assert received[0]["kind"] == "modified"
-        assert received[0]["new_title"] == "Stable title"
-        assert received[0]["new_description"] == "new"
+        assert received == []
+        # The description still gets written; only the reply-back is
+        # suppressed.  Verify the task list reflects the description edit.
+        task1 = next(t for t in Tasks(tmp_path).list() if t["id"] == t1["id"])
+        assert task1["description"] == "new"
+        assert task1["title"] == "Stable title"
 
     def test_on_changes_not_called_when_no_thread_tasks_changed(
         self, tmp_path: Path
@@ -1755,13 +1764,15 @@ class TestComputeThreadChanges:
         assert changes[0]["kind"] == "modified"
         assert changes[0]["new_title"] == "New title"
 
-    def test_modified_description(self) -> None:
+    def test_description_only_change_is_silent(self) -> None:
+        """Pure description rewrites (title unchanged) are internal
+        rescope rephrasing — no change record, no reply-back to the
+        commenter.  Only title changes signal a material scope shift
+        worth notifying the reviewer about (#1388)."""
         original = [self._t("1", "Task", thread=self._thread(), description="old")]
         result = [self._t("1", "Task", thread=self._thread(), description="new")]
         changes = _compute_thread_changes(original, result, frozenset({"1"}))
-        assert len(changes) == 1
-        assert changes[0]["kind"] == "modified"
-        assert changes[0]["new_description"] == "new"
+        assert changes == []
 
     def test_unchanged_thread_task_not_reported(self) -> None:
         t = self._t("1", "Task", thread=self._thread())


### PR DESCRIPTION
Fixes #1388.

`_compute_thread_changes` previously fired a "modified" change record whenever EITHER the title OR description of a thread task differed. That caused chatty Fido — between the initial reply and the work landing, every internal Opus rewrite of a task description fired an "I've taken your input" reply on the originating review thread, even when the contract Fido committed to (the title) hadn't changed.

## Fix

Tighten the elif: only emit a "modified" record when the title differs. Description-only rewrites are internal rephrasing (rescope rewording, scope merges, re-running synthesis on the same comment) and produce no change record. The reviewer's mental model is "I gave feedback, Fido replied, I'll see them again when the work lands" — and now they will.

Title is the contract Fido committed to in its initial reply; a title change indicates the scope materially shifted in a reviewer-visible way. Description-only changes still get written to `tasks.json` — internal state evolves; only the reply-back is suppressed.

In-progress-abort logic (`_on_inprogress_affected`) still fires on either title or description change — worker-side concern distinct from the reviewer-side noise this targets.

Also drops the `if changes:` guard around `_on_changes` since the production callback iterates and a no-change list is a no-op. Keeps coverage simple now that title-preservation by the reducer means the integration path rarely produces non-empty change lists.

## Test plan

- [x] `./fido ci` — 4262 passed, 100% coverage
- [x] `test_description_only_change_is_silent` confirms the unit-level fix
- [x] `test_on_changes_skipped_when_only_description_changes` confirms the integration path stays quiet
- [ ] Smoke after merge: verify PR thread doesn't get re-replied during rescope cycles

## Related

- **#1675** (PR #1677, merged) — sibling top-level case fixed via capability-layer enforcement