### PR TITLE
Bug: pass retry_on_preempt=True so cancelled synthesis turns don't burn parse-failure retries (closes #1687)

### DIFF
--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -95,6 +95,7 @@ def _check_and_promote(
         verify_raw = agent.run_turn(
             _VERIFY_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            retry_on_preempt=True,
         )
         if not (verify_raw or "").strip().lower().startswith("no"):
             return response
@@ -106,6 +107,7 @@ def _check_and_promote(
         derived_raw = agent.run_turn(
             _DERIVE_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            retry_on_preempt=True,
         )
         derived = (derived_raw or "").strip()
         if not derived:
@@ -303,10 +305,20 @@ def call_synthesis(
         user_prompt = (
             base_user_prompt if attempt == 0 else base_user_prompt + _RETRY_SUFFIX
         )
+        # ``retry_on_preempt=True`` (#1687): a preempted (cancelled)
+        # turn returns an empty string from the drain.  Without this,
+        # ``_parse_comment_response`` below would raise "no JSON
+        # objects found", logged as "parse failure" — and three
+        # preemptions in a row would burn the retry budget and trip
+        # the failure-explanation fallback even though the model never
+        # got a chance to answer.  ``session_agent`` re-runs cancelled
+        # turns transparently, so the parse-failure branch only fires
+        # for genuine model misbehavior.
         raw = agent.run_turn(
             user_prompt,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
             system_prompt=system_prompt,
+            retry_on_preempt=True,
         )
         log.debug(
             "synthesis attempt %d/%d raw output: %r", attempt + 1, MAX_RETRIES, raw
@@ -367,6 +379,7 @@ def call_failure_explanation(
         raw = agent.run_turn(
             user_prompt + suffix,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            retry_on_preempt=True,
         )
         log.debug(
             "failure-explanation attempt %d/%d raw output: %r",

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -511,6 +511,20 @@ class TestCallFailureExplanation:
 
         assert result.reply_text == "real reply"
 
+    def test_uses_retry_on_preempt(self) -> None:
+        """Failure-explanation retry loop must also pass
+        ``retry_on_preempt=True`` (#1687) — otherwise three consecutive
+        cancellations would arrive here as empty strings, exhaust the
+        retry budget, and raise ``SynthesisExhaustedError`` even though
+        the model never produced a real failure."""
+        agent = _make_agent("Sorry, please try again.")
+        prompts = _make_failure_prompts()
+
+        call_failure_explanation("comment", agent=agent, prompts=prompts)
+
+        _, kwargs = agent.run_turn.call_args_list[0]
+        assert kwargs.get("retry_on_preempt") is True
+
 
 # ---------------------------------------------------------------------------
 # call_synthesis — LLM verification turn
@@ -644,6 +658,47 @@ class TestCallSynthesisVerificationTurn:
         result = call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
         assert result.reasoning == "my private chain-of-thought"
+
+    def test_synthesis_turn_uses_retry_on_preempt(self) -> None:
+        """Main synthesis turn passes ``retry_on_preempt=True`` so a
+        cancelled/preempted turn is transparently re-tried by the agent
+        instead of arriving here as an empty string and burning a
+        parse-failure retry slot — three consecutive preemptions used
+        to trip the failure-explanation fallback even though the model
+        never got a chance to answer (#1687)."""
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "Yes"])
+        prompts = _make_prompts()
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        # First call is the synthesis turn itself.
+        _, kwargs = agent.run_turn.call_args_list[0]
+        assert kwargs.get("retry_on_preempt") is True
+
+    def test_verify_turn_uses_retry_on_preempt(self) -> None:
+        """Verification turn (#1644 self-verification guard) is also
+        on the synthesis retry path — same preempt-eaten-as-empty bug
+        applies if not protected (#1687)."""
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "Yes"])
+        prompts = _make_prompts()
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        _, kwargs = agent.run_turn.call_args_list[1]
+        assert kwargs.get("retry_on_preempt") is True
+
+    def test_derive_turn_uses_retry_on_preempt(self) -> None:
+        """Derive turn (after a "No" verify) — same protection (#1687)."""
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "No", "Add missing tests"])
+        prompts = _make_prompts()
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        _, kwargs = agent.run_turn.call_args_list[2]
+        assert kwargs.get("retry_on_preempt") is True
 
     def test_verify_turn_uses_read_only_allowed_tools(self) -> None:
         """Verification turns must pass READ_ONLY_ALLOWED_TOOLS, not None."""


### PR DESCRIPTION
## What was happening

A preempted (cancelled mid-turn) `ClaudeSession` turn returns an empty
string from the drain. Synthesis was calling `agent.run_turn` without
`retry_on_preempt`, so the empty string flowed straight into
`_parse_comment_response`, raised `no JSON objects found`, and was
logged as a parse failure. Three preemptions in a row burned the
retry budget and tripped the failure-explanation fallback (`I had
trouble responding...`) even though the model never got a chance to
answer.

## Fix

Pass `retry_on_preempt=True` at all four synthesis call sites:

- main synthesis turn (`call_synthesis` retry loop)
- verify turn inside `_check_and_promote`
- derive turn inside `_check_and_promote`
- failure-explanation retry loop (`call_failure_explanation`)

`session_agent._prompt_with_recovery` already re-runs cancelled turns
transparently when this flag is set, so the parse-failure branch now
only fires for genuine model misbehavior.

## Tests

Added four assertions confirming `retry_on_preempt=True` is passed at
each of the four call sites, in the same style as the existing
`allowed_tools=READ_ONLY_ALLOWED_TOOLS` assertions.

## Coverage

100% maintained. Full suite green (4268 passed).