### PR TITLE
Bug: drain queued PR comments before rescope so synthesis-produced tasks are visible (closes #1689)

### DIFF
--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4434,6 +4434,15 @@ class Worker:
             if pr_is_fresh:
                 log.info("fresh PR — skipping CI/thread/rescope checks")
             else:
+                # Drain durable PR-comment FIFO before rescope so synthesis-
+                # produced tasks are visible when rescope rewrites the list
+                # (#1689).  Otherwise rescope spends an Opus call on a list
+                # that the queued comment is about to invalidate, and the
+                # human waits minutes for a reply that should arrive in
+                # seconds.  The drain is a single SQLite SELECT when the
+                # queue is empty, so this is cheap on the steady-state path.
+                if self.handle_queued_comments(ctx.fido_dir, repo_ctx, pr_number, slug):
+                    return 1
                 self.rescope_before_pick()
                 if self.handle_merge_conflict(
                     ctx.fido_dir,
@@ -4442,8 +4451,6 @@ class Worker:
                     slug,
                     issue_labels=issue_labels,
                 ):
-                    return 1
-                if self.handle_queued_comments(ctx.fido_dir, repo_ctx, pr_number, slug):
                     return 1
                 if self.handle_ci(
                     ctx.fido_dir,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1189,6 +1189,9 @@ class TestWorker:
             order.append("queued_comments")
             return False
 
+        def mark_rescope(*args: object, **kwargs: object) -> None:
+            order.append("rescope")
+
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1208,13 +1211,16 @@ class TestWorker:
             patch.object(
                 worker, "handle_queued_comments", side_effect=mark_queued_comments
             ),
+            patch.object(worker, "rescope_before_pick", side_effect=mark_rescope),
             patch.object(worker, "handle_ci", side_effect=mark_ci),
             patch.object(worker, "handle_threads", return_value=False),
             patch.object(worker, "execute_task", return_value=False),
             patch.object(worker, "handle_promote_merge", return_value=0),
         ):
             worker.run()
-        assert order[:3] == ["recover", "queued_comments", "ci"]
+        # Drain queued comments before rescope so synthesis-produced tasks
+        # are visible when rescope rewrites the list (#1689).
+        assert order[:4] == ["recover", "queued_comments", "rescope", "ci"]
 
     def test_run_does_not_switch_model_for_carry_over_session(
         self, tmp_path: Path
@@ -10789,8 +10795,12 @@ class TestRunRescopeIntegration:
             worker.run()
         mock_rescope.assert_called_once_with()
 
-    def test_rescope_called_before_queued_comments(self, tmp_path: Path) -> None:
-        """rescope_before_pick must execute before queued comments drain."""
+    def test_queued_comments_drained_before_rescope(self, tmp_path: Path) -> None:
+        """Queued PR comments must drain before rescope_before_pick (#1689)
+        so synthesis-produced tasks are visible when rescope rewrites the
+        list — otherwise rescope spends an Opus call on a stale list and
+        the human waits minutes for a reply that should arrive in seconds.
+        """
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
@@ -10823,7 +10833,7 @@ class TestRunRescopeIntegration:
             patch.object(worker, "execute_task", return_value=False),
         ):
             worker.run()
-        assert call_order == ["rescope", "handle_queued_comments"]
+        assert call_order == ["handle_queued_comments", "rescope"]
 
 
 class TestEnsurePushed:


### PR DESCRIPTION
## What was happening

When a human submitted a PR review with inline comments, both webhooks arrived ~1s apart:

1. `pull_request_review/submitted` — preempts the worker, yields
2. `pull_request_review_comment/created` — enqueues the comment in `FidoStore`

The worker re-entered its loop and called `rescope_before_pick()` first, which spawns Opus (model + tool respawn, 30-60s) and rewrites the task list. Only *after* that did it call `handle_queued_comments`, which synthesizes a reply and creates the task that captures the comment's change request.

Net effect: the human waited 2+ minutes for a reply that should arrive in seconds, and the rescope Opus call was spent on a list that was about to be invalidated.

## Fix

Move `handle_queued_comments` ahead of `rescope_before_pick` in the worker loop.

The drain is a single SQLite `SELECT` when the queue is empty, so steady state pays nothing. When the queue has work, synthesis produces the comment-derived tasks, the worker returns `1` to end the iteration, and the next iteration's rescope sees the new tasks instead of an about-to-be-stale list.

`handle_queued_comments`'s docstring already said _"drain durable PR-comment FIFO entries before normal worker turns"_ — the code now matches.

## Tests

- New `test_queued_comments_drained_before_rescope` (replaces the inverted `test_rescope_called_before_queued_comments` which asserted the old buggy order).
- Extended `test_run_recovers_reply_promises_before_normal_handlers` to also assert `rescope` lands after `queued_comments` in the recovered-promise path.

## Coverage

100% maintained. Full suite green (4268 passed).