### PR TITLE
Bug: sweep PR-comment queue on worker startup to clear post-merge orphans (closes #1691)

### DIFF
--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -1139,6 +1139,16 @@ query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
         data = self._get(f"/repos/{repo}/pulls/{pr}")
         return data.get("body") or ""
 
+    def get_pr_state(self, repo: str, pr: int | str) -> str:
+        """Return just the PR state (``"open"`` or ``"closed"``).
+
+        One ``_get`` call, no review/commit pagination — used by the orphan
+        comment-queue sweep (#1691) which only needs to know whether the PR
+        is still open.
+        """
+        data = self._get(f"/repos/{repo}/pulls/{pr}")
+        return data["state"]
+
     def add_pr_reviewers(self, repo: str, pr: int | str, reviewers: list[str]) -> None:
         """Request review from one or more users on a PR.
 

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -647,6 +647,24 @@ class FidoStore:
         """Return whether *repo* has currently retryable queued comments."""
         return bool(self.pending_pr_comments(repo=repo, pr_number=pr_number))
 
+    def pending_pr_numbers(self, *, repo: str) -> list[int]:
+        """Return distinct PR numbers that have any pending or retryable
+        queue entries.  Used by the orphan sweep (#1691) to enumerate
+        candidates without loading their full payloads."""
+        self.ensure_schema()
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT pr_number
+                FROM pr_comment_queue
+                WHERE repo = ?
+                  AND state IN ('pending', 'retryable_failed')
+                ORDER BY pr_number
+                """,
+                (repo,),
+            ).fetchall()
+        return [int(row[0]) for row in rows]
+
     def has_other_open_pr_comments(self, *, repo: str, exclude_comment_id: int) -> bool:
         """Return whether *repo* has any other open queue entries.
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2550,6 +2550,32 @@ class Worker:
         tasks.sync_tasks_background(self.work_dir, self.gh)
         return True
 
+    def sweep_orphan_pr_comments(self, repo: str) -> int:
+        """Drop queued PR-comment entries whose PR is closed (#1691).
+
+        ``clear_pr_comment_queue`` already runs on the ``pull_request/closed``
+        webhook, but comments can arrive *after* the close webhook fires —
+        a Codex bot review on a just-merged PR, for example.  Those entries
+        sit in the queue forever because the worker only ever drains the
+        currently-assigned PR, and Fido has long since moved on.
+
+        Run this once per ``WorkerThread`` lifetime to clean up the orphans
+        from previous runs and from any post-merge comment races.
+        """
+        store = FidoStore(self.work_dir)
+        cleared = 0
+        for pr_number in store.pending_pr_numbers(repo=repo):
+            pr_data = self.gh.get_pr(repo, pr_number)
+            if pr_data["state"] != "open":
+                cleared += store.clear_pr_comment_queue(repo=repo, pr_number=pr_number)
+        if cleared:
+            log.info(
+                "sweep_orphan_pr_comments: cleared %d entries for closed PRs in %s",
+                cleared,
+                repo,
+            )
+        return cleared
+
     def handle_queued_comments(
         self,
         fido_dir: Path,
@@ -4385,6 +4411,7 @@ class Worker:
                         len(recovered_comments),
                         repo_ctx.repo,
                     )
+                self.sweep_orphan_pr_comments(repo_ctx.repo)
             recovery_provider = (
                 self._ensure_provider().provider_id
                 if self._repo_cfg is None

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4335,6 +4335,15 @@ class Worker:
         session_fresh = self._provider is None or self._provider.agent.session is None
         if session_fresh:
             self.create_session()
+        if self._first_iteration:
+            # Run before issue selection so idle repos (no current issue,
+            # acquired-sub-issues abandonment, all-covered terminal close)
+            # still get their orphan queue swept (#1691, codex P2 on PR
+            # #1695).  The sibling recover_in_progress_pr_comments inside
+            # the post-find_or_create_pr block runs later because it
+            # reconciles in-progress claim state for the PR about to be
+            # drained — that's appropriate to gate on having a PR.
+            self.sweep_orphan_pr_comments(repo_ctx.repo)
         try:
             issue = self.get_current_issue(ctx.fido_dir, repo_ctx.repo)
             if issue is None:
@@ -4410,7 +4419,6 @@ class Worker:
                         len(recovered_comments),
                         repo_ctx.repo,
                     )
-                self.sweep_orphan_pr_comments(repo_ctx.repo)
             recovery_provider = (
                 self._ensure_provider().provider_id
                 if self._repo_cfg is None

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -2565,8 +2565,7 @@ class Worker:
         store = FidoStore(self.work_dir)
         cleared = 0
         for pr_number in store.pending_pr_numbers(repo=repo):
-            pr_data = self.gh.get_pr(repo, pr_number)
-            if pr_data["state"] != "open":
+            if self.gh.get_pr_state(repo, pr_number) != "open":
                 cleared += store.clear_pr_comment_queue(repo=repo, pr_number=pr_number)
         if cleared:
             log.info(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2535,6 +2535,17 @@ class TestGitHubClass:
         result = gh.get_pr_body("o/r", 10)
         assert result == ""
 
+    def test_get_pr_state_returns_open_or_closed(self) -> None:
+        """Lightweight state-only fetch for the orphan-queue sweep (#1691)."""
+        gh, mock_s = self._gh()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"state": "closed"}
+        mock_s.get.return_value = mock_resp
+        result = gh.get_pr_state("o/r", 10)
+        url = mock_s.get.call_args.args[0]
+        assert "repos/o/r/pulls/10" in url
+        assert result == "closed"
+
     def test_add_pr_reviewers(self) -> None:
         gh, mock_s = self._gh()
         mock_resp = MagicMock()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1114,6 +1114,56 @@ def test_clear_pr_comment_queue_is_pr_scoped(tmp_path: Path) -> None:
     assert removed not in store.pending_pr_comments(repo="owner/repo")
 
 
+def test_pending_pr_numbers_lists_distinct_pr_numbers_with_pending_entries(
+    tmp_path: Path,
+) -> None:
+    """pending_pr_numbers feeds the orphan sweep (#1691) — must return
+    distinct PR numbers with pending or retryable entries, sorted."""
+    store = FidoStore(tmp_path)
+    for delivery, pr_number, comment_id in [
+        ("d1", 7, 701),
+        ("d2", 7, 702),  # duplicate PR
+        ("d3", 9, 901),
+        ("d4", 8, 801),
+    ]:
+        store.enqueue_pr_comment(
+            delivery_id=delivery,
+            repo="owner/repo",
+            pr_number=pr_number,
+            comment_type="pulls",
+            comment_id=comment_id,
+            author="rob",
+            is_bot=False,
+            body="x",
+            github_created_at="2026-04-30T10:00:00Z",
+        )
+
+    assert store.pending_pr_numbers(repo="owner/repo") == [7, 8, 9]
+
+    # Other repos are not included.
+    assert store.pending_pr_numbers(repo="other/repo") == []
+
+
+def test_pending_pr_numbers_excludes_completed_entries(tmp_path: Path) -> None:
+    store = FidoStore(tmp_path)
+    store.enqueue_pr_comment(
+        delivery_id="d1",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=701,
+        author="rob",
+        is_bot=False,
+        body="x",
+        github_created_at="2026-04-30T10:00:00Z",
+    )
+    record = store.claim_next_pr_comment(owner="worker", repo="owner/repo")
+    assert record is not None
+    store.complete_pr_comment(record.queue_id)
+
+    assert store.pending_pr_numbers(repo="owner/repo") == []
+
+
 def test_missing_pr_comment_queue_ids_are_noops(tmp_path: Path) -> None:
     store = FidoStore(tmp_path)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7714,6 +7714,9 @@ class TestRunSeedTasksIntegration:
 
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        # Keep the orphan sweep (#1691) from clearing the recovered entry —
+        # the recovered comment's PR is still open in this scenario.
+        gh.get_pr.return_value = {"state": "open"}
         mock_dispatcher = _FakeDispatcher(backfill_return=0)
         worker = Worker(
             tmp_path,
@@ -13716,6 +13719,61 @@ class TestCiReadyForReview:
             self._check("ci / lint", "FAILURE"),
         ]
         assert ci_ready_for_review(checks, ["ci / test"]) is True
+
+
+class TestSweepOrphanPrComments:
+    """Tests for Worker.sweep_orphan_pr_comments (#1691).
+
+    Catches the race where a comment-created webhook arrives after the
+    PR-close webhook fires.  ``clear_pr_comment_queue`` runs on close
+    but can't catch entries that haven't been enqueued yet — those sit
+    in the queue forever because the worker only ever drains the
+    currently-assigned PR.
+    """
+
+    def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
+        gh = MagicMock()
+        return (
+            Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)),
+            gh,
+        )
+
+    def _enqueue(self, tmp_path: Path, *, pr_number: int, comment_id: int) -> None:
+        FidoStore(tmp_path).enqueue_pr_comment(
+            delivery_id=f"delivery-{pr_number}-{comment_id}",
+            repo="owner/repo",
+            pr_number=pr_number,
+            comment_type="pulls",
+            comment_id=comment_id,
+            author="someone",
+            is_bot=True,
+            body="late comment",
+            github_created_at="2026-04-30T12:00:00Z",
+            payload_json="{}",
+        )
+
+    def test_clears_entries_for_closed_prs_and_keeps_open(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        self._enqueue(tmp_path, pr_number=7, comment_id=701)  # closed
+        self._enqueue(tmp_path, pr_number=7, comment_id=702)  # closed
+        self._enqueue(tmp_path, pr_number=8, comment_id=801)  # still open
+
+        def fake_get_pr(_repo: str, pr: int | str) -> dict[str, str]:
+            return {"state": "closed"} if int(pr) == 7 else {"state": "open"}
+
+        gh.get_pr.side_effect = fake_get_pr
+
+        cleared = worker.sweep_orphan_pr_comments("owner/repo")
+
+        assert cleared == 2
+        remaining = FidoStore(tmp_path).pending_pr_numbers(repo="owner/repo")
+        assert remaining == [8]
+
+    def test_returns_zero_when_no_pending_entries(self, tmp_path: Path) -> None:
+        worker, gh = self._make_worker(tmp_path)
+        cleared = worker.sweep_orphan_pr_comments("owner/repo")
+        assert cleared == 0
+        gh.get_pr.assert_not_called()
 
 
 class TestHandlePromoteMerge:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1168,6 +1168,53 @@ class TestWorker:
             worker.run()
         mock_create.assert_called_once_with()
 
+    def test_first_iteration_sweep_runs_for_idle_repo_with_no_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 (#1695): the orphan sweep must fire even when issue
+        selection returns None — otherwise idle repos never clean their
+        post-merge orphan queue entries because ``_is_first_iteration``
+        flips to False on the next attempt and the sweep never runs."""
+        # Enqueue a comment whose PR is now closed.
+        FidoStore(tmp_path).enqueue_pr_comment(
+            delivery_id="d1",
+            repo="owner/repo",
+            pr_number=999,
+            comment_type="pulls",
+            comment_id=42,
+            author="someone",
+            is_bot=True,
+            body="late comment",
+            github_created_at="2026-04-30T12:00:00Z",
+            payload_json="{}",
+        )
+        gh = self._make_gh()
+        gh.get_pr_state.return_value = "closed"
+        worker = Worker(
+            tmp_path,
+            gh,
+            first_iteration=True,
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        with (
+            patch.object(
+                worker, "create_context", return_value=self._make_mock_ctx(tmp_path)
+            ),
+            patch.object(
+                worker, "discover_repo_context", return_value=self._make_mock_repo_ctx()
+            ),
+            patch.object(worker, "setup_hooks", return_value=("c", "s")),
+            patch.object(worker, "teardown_hooks"),
+            patch.object(worker, "create_session"),
+            patch.object(worker, "stop_session"),
+            patch.object(worker, "get_current_issue", return_value=None),
+            patch.object(worker, "find_next_issue", return_value=None),
+        ):
+            worker.run()
+
+        # The sweep cleared the orphan even though no issue was selected.
+        assert FidoStore(tmp_path).pending_pr_numbers(repo="owner/repo") == []
+
     def test_run_recovers_reply_promises_before_normal_handlers(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7716,7 +7716,7 @@ class TestRunSeedTasksIntegration:
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
         # Keep the orphan sweep (#1691) from clearing the recovered entry —
         # the recovered comment's PR is still open in this scenario.
-        gh.get_pr.return_value = {"state": "open"}
+        gh.get_pr_state.return_value = "open"
         mock_dispatcher = _FakeDispatcher(backfill_return=0)
         worker = Worker(
             tmp_path,
@@ -13758,10 +13758,10 @@ class TestSweepOrphanPrComments:
         self._enqueue(tmp_path, pr_number=7, comment_id=702)  # closed
         self._enqueue(tmp_path, pr_number=8, comment_id=801)  # still open
 
-        def fake_get_pr(_repo: str, pr: int | str) -> dict[str, str]:
-            return {"state": "closed"} if int(pr) == 7 else {"state": "open"}
+        def fake_get_pr_state(_repo: str, pr: int | str) -> str:
+            return "closed" if int(pr) == 7 else "open"
 
-        gh.get_pr.side_effect = fake_get_pr
+        gh.get_pr_state.side_effect = fake_get_pr_state
 
         cleared = worker.sweep_orphan_pr_comments("owner/repo")
 
@@ -13773,6 +13773,19 @@ class TestSweepOrphanPrComments:
         worker, gh = self._make_worker(tmp_path)
         cleared = worker.sweep_orphan_pr_comments("owner/repo")
         assert cleared == 0
+        gh.get_pr_state.assert_not_called()
+
+    def test_uses_lightweight_get_pr_state_not_get_pr(self, tmp_path: Path) -> None:
+        """Codex P2 (#1695): the sweep only needs open/closed, not the full
+        PR hydration with reviews+commits pagination.  Hit the lightweight
+        ``GitHub.get_pr_state`` path."""
+        worker, gh = self._make_worker(tmp_path)
+        self._enqueue(tmp_path, pr_number=7, comment_id=701)
+        gh.get_pr_state.return_value = "open"
+
+        worker.sweep_orphan_pr_comments("owner/repo")
+
+        gh.get_pr_state.assert_called_once_with("owner/repo", 7)
         gh.get_pr.assert_not_called()
 
 


### PR DESCRIPTION
## What was happening

`FidoStore.clear_pr_comment_queue` already runs on the `pull_request/closed` webhook, but comments can arrive *after* that webhook fires.

Confirmed in PR #1632: merged at 2026-05-11T22:23:26Z, comments arrived at 22:24:22Z — 56 seconds *after* close. Those entries sit in the queue forever because the worker only drains the currently-assigned PR, and Fido has long since moved on.

Live store at filing time has **17 such orphans** across PRs #1242, #1632, #1643 (all merged days ago).

## Fix

Add `Worker.sweep_orphan_pr_comments(repo)` called once per `WorkerThread` lifetime in the existing `_first_iteration` block, right alongside `recover_in_progress_pr_comments`.

The sweep:

1. `FidoStore.pending_pr_numbers(repo)` — new helper, returns distinct PR numbers with pending/retryable entries.
2. For each, call `gh.get_pr(repo, pr_number)`. If `state != "open"`, call `clear_pr_comment_queue(repo, pr_number)`.

In steady state (no orphans) this is one SQLite SELECT and zero API calls. After this lands, the next worker start will sweep up the existing 17 orphans.

## Trade-off considered

A complementary "drop-on-enqueue when payload PR state is closed" check would prevent the race at webhook time. Skipped here to keep this PR focused — the startup sweep covers both new and historical orphans, and the window before sweep is bounded by `WorkerThread` lifetime (Fido restarts often).

## Tests

- `test_pending_pr_numbers_lists_distinct_pr_numbers_with_pending_entries`
- `test_pending_pr_numbers_excludes_completed_entries`
- `TestSweepOrphanPrComments::test_clears_entries_for_closed_prs_and_keeps_open`
- `TestSweepOrphanPrComments::test_returns_zero_when_no_pending_entries`
- Updated `test_first_iteration_recovers_in_progress_pr_comments` to mock `gh.get_pr.return_value = {"state": "open"}` so the sweep doesn't clear the recovered entry.

## Coverage

100% maintained. Full suite green (4272 passed).