### PR TITLE
Bug: SessionLockWatchdog kills active turns — rewrite as send-arms / receive-disarms (closes #1709)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -905,6 +905,7 @@ class ClaudeSession(OwnedSession):
         assert self._proc.stdin is not None
         self._proc.stdin.write(msg + "\n")
         self._proc.stdin.flush()
+        self._mark_send_outstanding()
         with self._metrics_lock:
             self._sent_count += 1
         self._notify_snapshot_publisher()
@@ -1436,6 +1437,7 @@ class ClaudeSession(OwnedSession):
                 self._log_event(obj)
                 with self._metrics_lock:
                     self._received_count += 1
+                self._mark_received()
                 self._notify_snapshot_publisher()
                 idle_deadline.reset()
                 # First non-empty event after Send transitions Sending →

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -890,6 +890,13 @@ class CodexSession(OwnedSession):
             except TimeoutError:
                 continue
             idle_deadline.reset()
+            # Disarm the no-reply watchdog clock on every inbound turn
+            # event (turn/completed, item/completed, tool-only progress
+            # notifications, error frames, …), not just agent_message
+            # text — any data from the app-server proves the turn isn't
+            # wedged (#1710 codex P1).  The agent_message branch below
+            # only counts user-visible text for the metrics counters.
+            self._mark_received()
             method = notification.get("method")
             params = notification["params"]
             if method == "error":
@@ -910,7 +917,6 @@ class CodexSession(OwnedSession):
                     final_text = text
                     with self._state_lock:
                         self._received_count += 1
-                    self._mark_received()
                     self._notify_snapshot_publisher()
             completed = (
                 _extract_completed_turn(params) if method == "turn/completed" else None

--- a/src/fido/codex.py
+++ b/src/fido/codex.py
@@ -846,6 +846,7 @@ class CodexSession(OwnedSession):
             self._active_turn_id = turn_id
         with self._state_lock:
             self._sent_count += 1
+        self._mark_send_outstanding()
         self._notify_snapshot_publisher()
 
     def _notify_snapshot_publisher(self) -> None:
@@ -909,6 +910,7 @@ class CodexSession(OwnedSession):
                     final_text = text
                     with self._state_lock:
                         self._received_count += 1
+                    self._mark_received()
                     self._notify_snapshot_publisher()
             completed = (
                 _extract_completed_turn(params) if method == "turn/completed" else None

--- a/src/fido/copilotcli.py
+++ b/src/fido/copilotcli.py
@@ -1236,6 +1236,7 @@ class CopilotCLISession(OwnedSession):
         )
         with self._metrics_lock:
             self._sent_count += 1
+        self._mark_send_outstanding()
         self._notify_snapshot_publisher()
         result, stop_reason, session_id = self._runtime.prompt(
             self._session_id or "",
@@ -1244,6 +1245,7 @@ class CopilotCLISession(OwnedSession):
         )
         with self._metrics_lock:
             self._received_count += 1
+        self._mark_received()
         self._notify_snapshot_publisher()
         self._session_id = session_id
         if model is not None:

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -941,6 +941,15 @@ class OwnedSession:
                     f"{type(ev).__name__} rejected in state "
                     f"{type(self._fsm_state).__name__}"
                 )
+            # Disarm the no-reply watchdog clock as part of releasing
+            # the lock.  Tying ``outstanding_send_at`` to the lock
+            # lifecycle means any release path — orderly exit, the
+            # exception path inside :meth:`prompt`, force_release after
+            # wedge — leaves the session "no-send-pending" so the
+            # watchdog can't evict a stale armed timestamp inherited
+            # from an aborted turn (#1710 codex P2).
+            with self._outstanding_send_lock:
+                self._outstanding_send_at = None
             if self._handler_queue:
                 # Hand ownership directly to the next waiting handler.
                 waiter = self._handler_queue.pop(0)

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -1023,6 +1023,18 @@ class OwnedSession:
                     reason,
                 )
                 return False
+            # Disarm the no-reply watchdog clock as part of the
+            # eviction (#1710 codex round 2 P1).  The evicted holder's
+            # eventual ``__exit__`` returns early via the
+            # ``_evicted_tids`` guard in :meth:`_fsm_release` and so
+            # would skip the clear there — but a subsequent acquire
+            # could happen before that escape and inherit the stale
+            # armed timestamp, causing the watchdog to evict the new
+            # holder based on the prior turn's silence.  Clearing
+            # here, under the FSM lock, guarantees the clock is
+            # disarmed before any new holder can acquire.
+            with self._outstanding_send_lock:
+                self._outstanding_send_at = None
             # Capture the evicted holder's identity before mutating any
             # state.  ``_repo_name`` may be None on test stubs; in that
             # case there is no global talker to consult and we fall back

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -755,6 +755,45 @@ class OwnedSession:
         # consults this set under ``_fsm_cond`` and skips the normal
         # ``_fsm_release`` so the double-release does not raise.
         self._evicted_tids: set[int] = set()
+        # Per-prompt no-reply watchdog state (#1709).  Send arms the
+        # timer (sets :attr:`_outstanding_send_at` to now); receive
+        # disarms (clears to ``None``).  Multiple sends without a
+        # receive simply restart the clock — the latest send wins.
+        # The :class:`~fido.session_lock_watchdog.SessionLockWatchdog`
+        # polls :attr:`outstanding_send_at` and kills the session when
+        # it stays set for more than ``no_reply_seconds``.  ``None``
+        # means "no send awaiting reply" — idle sessions and sessions
+        # whose last send has been ack'd both look the same to the
+        # watchdog and are left alone forever.
+        self._outstanding_send_lock = threading.Lock()
+        self._outstanding_send_at: datetime | None = None
+
+    def _mark_send_outstanding(self) -> None:
+        """Arm (or restart) the no-reply watchdog clock.  Subclasses
+        call this every time they write a prompt to the provider
+        subprocess's stdin.  Multiple sends without an intervening
+        receive simply reset the clock — we only care about the most
+        recent unanswered send."""
+        with self._outstanding_send_lock:
+            self._outstanding_send_at = datetime.now(tz=timezone.utc)
+
+    def _mark_received(self) -> None:
+        """Disarm the no-reply watchdog clock.  Subclasses call this
+        from their receive loop on every line / message read from the
+        provider subprocess (sibling to bumping ``_received_count``).
+        Once any data arrives, the prior send is considered ACK'd and
+        the watchdog stops counting until the next send re-arms it
+        (closes #1709)."""
+        with self._outstanding_send_lock:
+            self._outstanding_send_at = None
+
+    @property
+    def outstanding_send_at(self) -> datetime | None:
+        """When the most recent unanswered send was issued, or ``None``
+        if nothing is awaiting a reply.  Read by
+        :class:`~fido.session_lock_watchdog.SessionLockWatchdog`."""
+        with self._outstanding_send_lock:
+            return self._outstanding_send_at
 
     def _bump_entry_depth(self) -> int:
         """Increment and return the new per-thread entry depth (1 at

--- a/src/fido/session_lock_watchdog.py
+++ b/src/fido/session_lock_watchdog.py
@@ -120,19 +120,23 @@ class SessionLockWatchdog:
             outstanding = session.outstanding_send_at
             if outstanding is None:
                 continue
+            # Require a current holder before evicting (#1710 codex P2).
+            # ``_fsm_release`` clears ``outstanding_send_at`` on every
+            # release path, but if a stale armed timestamp ever survived
+            # (race with concurrent acquire, future code change), this
+            # gate keeps the watchdog from evicting a freshly-acquired
+            # holder based on an aborted predecessor's silence.
+            talker = get_talker(repo_name)
+            if talker is None:
+                continue
             silent_for = (talker_now() - outstanding).total_seconds()
             if silent_for <= self.no_reply_seconds:
                 continue
-            talker = get_talker(repo_name)
-            label = (
-                f"tid={talker.thread_id} kind={talker.kind}, "
-                f"description={talker.description!r}"
-                if talker is not None
-                else "(no talker registered)"
-            )
             reason = (
                 f"no reply for {silent_for:.0f}s "
-                f"(deadline {self.no_reply_seconds:.0f}s, holder {label})"
+                f"(deadline {self.no_reply_seconds:.0f}s, "
+                f"holder tid={talker.thread_id} kind={talker.kind}, "
+                f"description={talker.description!r})"
             )
             log.warning(
                 "session-lock-watchdog[%s]: outstanding send past deadline — %s",

--- a/src/fido/session_lock_watchdog.py
+++ b/src/fido/session_lock_watchdog.py
@@ -6,25 +6,37 @@ but in earlier model revisions the only path out of an owned state was
 the holder firing its voluntary ``WorkerRelease`` / ``HandlerRelease``
 event.  When a holder thread parked inside
 :meth:`~fido.claude.ClaudeSession.consume_until_result` on a subprocess
-that streamed events forever (so ``idle_timeout`` never tripped) and
-never produced ``type=result``, the holder never returned from
-``with self:``, ``__exit__`` never ran, ``_fsm_release`` never fired,
-and the FSM lock leaked indefinitely (closes #1377).
+that wedged before producing ``type=result``, the holder never returned
+from ``with self:``, ``__exit__`` never ran, ``_fsm_release`` never
+fired, and the FSM lock leaked indefinitely (closes #1377).
 
 The model now also proves **liveness** via ``force_release_to_free``
 and ``every_state_reaches_free``: ``ForceRelease`` is accepted in every
 state and always lands in :class:`~fido.rocq.transition.Free`.  This
 watchdog is the runtime driver that fires that event when a holder
-has held the lock past a deadline — guarding the property that no
-acquire can wait forever for a holder that will never release.
+has held the lock without receiving any data from the provider
+subprocess for too long — guarding the property that no acquire can
+wait forever for a holder that will never release.
+
+Trigger semantics — **SYN without ACK** (closes #1709):
+
+* Send arms the clock — setting
+  :attr:`~fido.provider.OwnedSession.outstanding_send_at` to now.
+* Receive disarms it — clearing the field back to ``None``.
+* Multiple sends without an intervening receive simply restart the
+  clock; the most recent unanswered send wins.
+* Idle sessions never trigger (clock is ``None``).
+* Forever-streaming sessions never trigger (each receive disarms).
+* Only the **prompt-sent-no-reply** wedge fires: the clock has been
+  armed continuously for more than ``no_reply_seconds``.
 
 Per repo, every :data:`_WATCHDOG_INTERVAL` seconds:
 
-1. Read the current :class:`~fido.provider.SessionTalker` snapshot.
-2. If a holder is registered and ``now - talker.started_at >
-   hold_deadline_seconds``, log a warning and call
+1. Read :attr:`~fido.provider.OwnedSession.outstanding_send_at`.
+2. If it is not ``None`` and ``now - outstanding_send_at >
+   no_reply_seconds``, log a warning and call
    :meth:`~fido.provider.OwnedSession.force_release` with a reason
-   string identifying the evicted tid and the elapsed hold time.
+   string identifying the evicted tid and the silence duration.
 3. The provider's :meth:`_on_force_release` subclass hook (e.g.
    :meth:`~fido.claude.ClaudeSession._on_force_release`) knocks the
    wedged thread out of its parked IO call by killing the subprocess.
@@ -48,21 +60,26 @@ log = logging.getLogger(__name__)
 # ``_WATCHDOG_INTERVAL`` past the holder's deadline, in the worst case.
 _WATCHDOG_INTERVAL: float = 30.0
 
-# Default per-turn hold deadline.  A worker turn over this threshold is
-# already a code smell (typical legitimate turns finish in seconds to
-# a few minutes); past 15 minutes we assume the holder is wedged.
-# Configurable per session for tests and tightening over time.
-_DEFAULT_HOLD_DEADLINE_SECONDS: float = 900.0
+# Default no-reply deadline: kill the holder when an outstanding send
+# has been waiting for a receive for more than this long.  One hour is
+# generous — the in-process ``idle_timeout`` (30 min) is the first line
+# of defense for the totally-silent subprocess; this watchdog is the
+# safety net for the SYN-without-ACK case where the holder thread is
+# wedged outside of ``iter_events`` and the in-process kill never fires.
+# Forever-streaming sessions that keep producing data are intentionally
+# never killed (#1709).
+_DEFAULT_NO_REPLY_SECONDS: float = 3600.0
 
 
 class SessionLockWatchdog:
-    """Per-repo poller that evicts FSM lock holders past a deadline.
+    """Per-repo poller that evicts FSM lock holders past a no-reply
+    deadline.
 
     Accepts *registry* and *repos* via the constructor so tests can
     drive it directly with hand-rolled fakes (no MagicMock per
-    fido test conventions).  *hold_deadline_seconds* is configurable
+    fido test conventions).  *no_reply_seconds* is configurable
     per instance: tests use a tiny value so a single iteration triggers
-    eviction; production uses :data:`_DEFAULT_HOLD_DEADLINE_SECONDS`.
+    eviction; production uses :data:`_DEFAULT_NO_REPLY_SECONDS`.
     """
 
     def __init__(
@@ -70,45 +87,55 @@ class SessionLockWatchdog:
         registry: WorkerRegistry,
         repos: dict[str, RepoConfig],
         *,
-        hold_deadline_seconds: float = _DEFAULT_HOLD_DEADLINE_SECONDS,
+        no_reply_seconds: float = _DEFAULT_NO_REPLY_SECONDS,
     ) -> None:
         self.registry = registry
         self.repos = repos
-        self.hold_deadline_seconds = hold_deadline_seconds
+        self.no_reply_seconds = no_reply_seconds
 
     def run(self) -> int:
         """Run one watchdog iteration. Returns 0.
 
-        For each configured repo with an attached session and an
-        active holder, compute the hold age via
-        :func:`~fido.provider.talker_now` and the talker's
-        ``started_at`` timestamp.  If the age exceeds
-        :attr:`hold_deadline_seconds`, fire
-        :meth:`~fido.provider.OwnedSession.force_release` on the
-        session.
+        For each configured repo with an attached session, read
+        :attr:`~fido.provider.OwnedSession.outstanding_send_at`.  If
+        the clock is armed (not ``None``) and ``now -
+        outstanding_send_at`` exceeds :attr:`no_reply_seconds`, fire
+        :meth:`~fido.provider.OwnedSession.force_release`.
 
-        Repos without a session (provider not yet initialised, or a
-        registry stub during boot) and repos with no current holder
-        (FSM is :class:`~fido.rocq.transition.Free`) are silently
-        skipped — both are normal idle states.
+        * Idle sessions (clock is ``None``) are left alone forever.
+        * Active turns that keep receiving data disarm the clock on
+          every receive and so are left alone forever.
+        * Only the **prompt-sent-no-reply** wedge — clock armed,
+          no receive in too long — triggers a kill.
+
+        The ``talker`` snapshot is consulted only to label the kill
+        reason (which tid / kind / description is being evicted) — the
+        kill decision itself depends only on the session's send/receive
+        history.
         """
         for repo_name in self.repos:
             session = self._resolve_session(repo_name)
             if session is None:
                 continue
+            outstanding = session.outstanding_send_at
+            if outstanding is None:
+                continue
+            silent_for = (talker_now() - outstanding).total_seconds()
+            if silent_for <= self.no_reply_seconds:
+                continue
             talker = get_talker(repo_name)
-            if talker is None:
-                continue
-            held_for = (talker_now() - talker.started_at).total_seconds()
-            if held_for <= self.hold_deadline_seconds:
-                continue
+            label = (
+                f"tid={talker.thread_id} kind={talker.kind}, "
+                f"description={talker.description!r}"
+                if talker is not None
+                else "(no talker registered)"
+            )
             reason = (
-                f"held > {self.hold_deadline_seconds:.0f}s "
-                f"by tid={talker.thread_id} kind={talker.kind} "
-                f"(actual {held_for:.0f}s, description={talker.description!r})"
+                f"no reply for {silent_for:.0f}s "
+                f"(deadline {self.no_reply_seconds:.0f}s, holder {label})"
             )
             log.warning(
-                "session-lock-watchdog[%s]: holder past deadline — %s",
+                "session-lock-watchdog[%s]: outstanding send past deadline — %s",
                 repo_name,
                 reason,
             )
@@ -150,9 +177,7 @@ def run(
     registry: WorkerRegistry,
     repos: dict[str, RepoConfig],
     *,
-    hold_deadline_seconds: float = _DEFAULT_HOLD_DEADLINE_SECONDS,
+    no_reply_seconds: float = _DEFAULT_NO_REPLY_SECONDS,
 ) -> int:
     """Module-level entry point — create a watchdog and run one tick."""
-    return SessionLockWatchdog(
-        registry, repos, hold_deadline_seconds=hold_deadline_seconds
-    ).run()
+    return SessionLockWatchdog(registry, repos, no_reply_seconds=no_reply_seconds).run()

--- a/tests/test_session_lock_watchdog.py
+++ b/tests/test_session_lock_watchdog.py
@@ -432,6 +432,48 @@ def test_mark_received_clears_outstanding_send() -> None:
     assert session.outstanding_send_at is None
 
 
+def test_no_eviction_when_outstanding_set_but_no_talker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale ``outstanding_send_at`` without a current talker must not
+    fire eviction (#1710 codex P2).  The release path normally clears
+    the timestamp, but this gate is the safety net for any future
+    race where a stale armed value survives lock release."""
+    repo_name = "FidoCanCode/home"
+    sent_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = _RecordingSession(repo_name, outstanding_send_at=sent_at)
+    registry = _StubRegistry({repo_name: session})
+    # No register_talker call — get_talker(repo_name) returns None.
+    monkeypatch.setattr(
+        session_lock_watchdog,
+        "talker_now",
+        lambda: sent_at + timedelta(seconds=3600),
+    )
+    watchdog = SessionLockWatchdog(
+        registry,  # type: ignore[arg-type]
+        {repo_name: _repo_config(repo_name)},
+        no_reply_seconds=60.0,
+    )
+    watchdog.run()
+    assert session.force_release_calls == [], (
+        "watchdog must not evict when no talker is currently registered"
+    )
+
+
+def test_release_clears_outstanding_send_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_fsm_release`` clears ``outstanding_send_at`` so a stale armed
+    timestamp from an aborted turn never survives lock release (#1710
+    codex P2)."""
+    # Build a real OwnedSession with the FSM primed for a worker hold.
+    session = _RecordingSession("FidoCanCode/home")
+    session._mark_send_outstanding()  # noqa: SLF001
+    assert session.outstanding_send_at is not None
+    # Drive the FSM to OwnedByWorker so _fsm_release accepts WorkerRelease.
+    session._fsm_acquire_worker()  # noqa: SLF001
+    session._fsm_release()  # noqa: SLF001
+    assert session.outstanding_send_at is None, "release must disarm the no-reply clock"
+
+
 def test_multi_send_restarts_no_reply_clock() -> None:
     """Calling ``_mark_send_outstanding`` twice in a row resets the
     clock — only the most recent unanswered send matters."""

--- a/tests/test_session_lock_watchdog.py
+++ b/tests/test_session_lock_watchdog.py
@@ -460,6 +460,32 @@ def test_no_eviction_when_outstanding_set_but_no_talker(
     )
 
 
+def test_force_release_clears_outstanding_send_at() -> None:
+    """``force_release`` clears ``outstanding_send_at`` before any new
+    acquire can happen (#1710 codex round 2 P1).
+
+    The evicted holder's eventual ``__exit__`` skips the normal
+    ``_fsm_release`` via the ``_evicted_tids`` guard, so the clear
+    inside ``_fsm_release`` doesn't run for evicted holders.  Without
+    a clear in ``force_release`` itself, a new acquirer would inherit
+    the prior turn's stale timestamp and the watchdog could evict
+    them before they sent anything.
+    """
+    # Build a real OwnedSession in OwnedByWorker so ForceRelease has
+    # somewhere to evict from.
+    session = _RecordingSession("FidoCanCode/home")
+    session._fsm_acquire_worker()  # noqa: SLF001
+    session._mark_send_outstanding()  # noqa: SLF001
+    assert session.outstanding_send_at is not None
+    # Override the recording stub's force_release to call the real one
+    # (the recorder otherwise short-circuits to just append to its log).
+    OwnedSession.force_release(session, reason="test wedge")  # type: ignore[arg-type]
+    assert session.outstanding_send_at is None, (
+        "force_release must disarm the no-reply clock so a "
+        "freshly-acquired successor isn't evicted on stale silence"
+    )
+
+
 def test_release_clears_outstanding_send_at(monkeypatch: pytest.MonkeyPatch) -> None:
     """``_fsm_release`` clears ``outstanding_send_at`` so a stale armed
     timestamp from an aborted turn never survives lock release (#1710

--- a/tests/test_session_lock_watchdog.py
+++ b/tests/test_session_lock_watchdog.py
@@ -13,6 +13,7 @@ holder is present.
 from __future__ import annotations
 
 import threading
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -37,13 +38,23 @@ class _RecordingSession(OwnedSession):
     state directly, so a stub that records the calls is enough to
     assert "eviction fired with the expected reason" without spinning
     up a real provider session.
+
+    *outstanding_send_at* lets tests pin the no-reply clock; defaults
+    to ``None`` (idle, no send awaiting reply).  The production
+    session arms it on send and clears it on receive (#1709).
     """
 
     _repo_name: str | None
 
-    def __init__(self, repo_name: str) -> None:
+    def __init__(
+        self,
+        repo_name: str,
+        *,
+        outstanding_send_at: datetime | None = None,
+    ) -> None:
         self._repo_name = repo_name
         self._init_handler_reentry()
+        self._outstanding_send_at = outstanding_send_at
         self.force_release_calls: list[str] = []
 
     def _fire_worker_cancel(self) -> None:  # pragma: no cover — abstract hook
@@ -91,7 +102,7 @@ def test_run_skips_repo_without_session() -> None:
     watchdog = SessionLockWatchdog(
         registry,  # type: ignore[arg-type]
         {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
-        hold_deadline_seconds=0.01,
+        no_reply_seconds=0.01,
     )
     assert watchdog.run() == 0
 
@@ -103,7 +114,7 @@ def test_run_skips_repo_without_active_holder() -> None:
     watchdog = SessionLockWatchdog(
         registry,  # type: ignore[arg-type]
         {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
-        hold_deadline_seconds=0.01,
+        no_reply_seconds=0.01,
     )
     # No register_talker call → get_talker returns None.
     watchdog.run()
@@ -113,11 +124,11 @@ def test_run_skips_repo_without_active_holder() -> None:
 def test_run_skips_holder_within_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Holders that have not exceeded the deadline are left alone."""
+    """A send that's still within the no-reply deadline is left alone."""
     repo_name = "FidoCanCode/home"
-    session = _RecordingSession(repo_name)
+    sent_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = _RecordingSession(repo_name, outstanding_send_at=sent_at)
     registry = _StubRegistry({repo_name: session})
-    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     register_talker(
         SessionTalker(
             repo_name=repo_name,
@@ -125,21 +136,22 @@ def test_run_skips_holder_within_deadline(
             kind="worker",
             description="recent turn",
             subprocess_pid=1,
-            started_at=started_at,
+            started_at=sent_at,
         )
     )
     try:
-        # ``talker_now`` is the seam the watchdog uses to compute hold age.
-        # Set it to "5 seconds after started_at" so held_for = 5 s.
+        # ``talker_now`` is the seam the watchdog uses to compute the
+        # silence duration.  Set it to "5 seconds after sent_at" so
+        # the outstanding send has been waiting only 5 s.
         monkeypatch.setattr(
             session_lock_watchdog,
             "talker_now",
-            lambda: started_at + timedelta(seconds=5),
+            lambda: sent_at + timedelta(seconds=5),
         )
         watchdog = SessionLockWatchdog(
             registry,  # type: ignore[arg-type]
             {repo_name: _repo_config(repo_name)},
-            hold_deadline_seconds=10.0,
+            no_reply_seconds=10.0,
         )
         watchdog.run()
         assert session.force_release_calls == []
@@ -153,16 +165,16 @@ def test_run_skips_holder_within_deadline(
 
 
 def test_run_evicts_holder_past_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A holder whose age exceeds the deadline triggers ``force_release``.
+    """A send whose silence exceeds the deadline triggers ``force_release``.
 
-    The watchdog passes a reason string identifying the evicted tid
-    and the actual hold time so the production log makes the
-    eviction unambiguous in a postmortem.
+    The watchdog's reason string identifies the evicted tid and the
+    silence duration so the production log makes the eviction
+    unambiguous in a postmortem.
     """
     repo_name = "FidoCanCode/home"
-    session = _RecordingSession(repo_name)
+    sent_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = _RecordingSession(repo_name, outstanding_send_at=sent_at)
     registry = _StubRegistry({repo_name: session})
-    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     register_talker(
         SessionTalker(
             repo_name=repo_name,
@@ -170,19 +182,19 @@ def test_run_evicts_holder_past_deadline(monkeypatch: pytest.MonkeyPatch) -> Non
             kind="webhook",
             description="wedged synthesis turn",
             subprocess_pid=1,
-            started_at=started_at,
+            started_at=sent_at,
         )
     )
     try:
         monkeypatch.setattr(
             session_lock_watchdog,
             "talker_now",
-            lambda: started_at + timedelta(seconds=120),
+            lambda: sent_at + timedelta(seconds=120),
         )
         watchdog = SessionLockWatchdog(
             registry,  # type: ignore[arg-type]
             {repo_name: _repo_config(repo_name)},
-            hold_deadline_seconds=60.0,
+            no_reply_seconds=60.0,
         )
         watchdog.run()
     finally:
@@ -193,8 +205,8 @@ def test_run_evicts_holder_past_deadline(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "tid=99999" in reason
     assert "kind=webhook" in reason
     assert "wedged synthesis turn" in reason
-    # Reason carries both the threshold (60s) and the observed hold (120s)
-    # so a postmortem can tell what the watchdog actually saw.
+    # Reason carries both the threshold (60s) and the observed silence
+    # (120s) so a postmortem can tell what the watchdog actually saw.
     assert "60s" in reason
     assert "120s" in reason
 
@@ -203,9 +215,11 @@ def test_run_handles_multiple_repos_independently(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Watchdog evaluates each configured repo separately on the same tick."""
-    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    home = _RecordingSession("FidoCanCode/home")
-    confusio = _RecordingSession("rhencke/confusio")
+    sent_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    home = _RecordingSession("FidoCanCode/home", outstanding_send_at=sent_at)
+    confusio = _RecordingSession(
+        "rhencke/confusio", outstanding_send_at=sent_at + timedelta(seconds=55)
+    )
     registry = _StubRegistry({"FidoCanCode/home": home, "rhencke/confusio": confusio})
 
     register_talker(
@@ -215,7 +229,7 @@ def test_run_handles_multiple_repos_independently(
             kind="webhook",
             description="long",
             subprocess_pid=1,
-            started_at=started_at,
+            started_at=sent_at,
         )
     )
     register_talker(
@@ -225,14 +239,14 @@ def test_run_handles_multiple_repos_independently(
             kind="worker",
             description="short",
             subprocess_pid=1,
-            started_at=started_at + timedelta(seconds=55),
+            started_at=sent_at + timedelta(seconds=55),
         )
     )
     try:
         monkeypatch.setattr(
             session_lock_watchdog,
             "talker_now",
-            lambda: started_at + timedelta(seconds=60),
+            lambda: sent_at + timedelta(seconds=60),
         )
         watchdog = SessionLockWatchdog(
             registry,  # type: ignore[arg-type]
@@ -240,16 +254,16 @@ def test_run_handles_multiple_repos_independently(
                 "FidoCanCode/home": _repo_config("FidoCanCode/home"),
                 "rhencke/confusio": _repo_config("rhencke/confusio"),
             },
-            hold_deadline_seconds=10.0,
+            no_reply_seconds=10.0,
         )
         watchdog.run()
     finally:
         unregister_talker("FidoCanCode/home", 1)
         unregister_talker("rhencke/confusio", 2)
 
-    # home's holder has been held 60 s (> 10 s) → evicted.
+    # home's send has been outstanding 60 s (> 10 s) → evicted.
     assert len(home.force_release_calls) == 1
-    # confusio's holder has only been held 5 s → spared.
+    # confusio's send has only been outstanding 5 s → spared.
     assert confusio.force_release_calls == []
 
 
@@ -273,7 +287,7 @@ def test_run_skips_non_owned_session_returns() -> None:
     watchdog = SessionLockWatchdog(
         registry,  # type: ignore[arg-type]
         {"FidoCanCode/home": _repo_config("FidoCanCode/home")},
-        hold_deadline_seconds=0.01,
+        no_reply_seconds=0.01,
     )
     assert watchdog.run() == 0
 
@@ -299,7 +313,7 @@ def test_start_thread_returns_running_daemon_that_invokes_run() -> None:
     watchdog = _SignalingWatchdog(
         _StubRegistry({}),  # type: ignore[arg-type]
         {},
-        hold_deadline_seconds=999.0,
+        no_reply_seconds=999.0,
     )
     # Tiny interval so the daemon hits its first ``run`` quickly.  The
     # thread is a daemon — no join needed; process exit will reap it.
@@ -323,15 +337,60 @@ def test_module_level_run_evicts_past_deadline(
     from fido.session_lock_watchdog import run as run_watchdog
 
     repo_name = "FidoCanCode/home"
-    session = _RecordingSession(repo_name)
+    sent_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session = _RecordingSession(repo_name, outstanding_send_at=sent_at)
     registry = _StubRegistry({repo_name: session})
-    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     register_talker(
         SessionTalker(
             repo_name=repo_name,
             thread_id=7,
             kind="worker",
             description="wedged",
+            subprocess_pid=1,
+            started_at=sent_at,
+        )
+    )
+    try:
+        monkeypatch.setattr(
+            session_lock_watchdog,
+            "talker_now",
+            lambda: sent_at + timedelta(seconds=2),
+        )
+        result = run_watchdog(
+            registry,  # type: ignore[arg-type]
+            {repo_name: _repo_config(repo_name)},
+            no_reply_seconds=1.0,
+        )
+    finally:
+        unregister_talker(repo_name, 7)
+
+    assert result == 0
+    assert len(session.force_release_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Send/receive semantics (#1709): receive disarms the clock; multi-send
+# restarts it; idle never trips.
+# ---------------------------------------------------------------------------
+
+
+def test_idle_session_with_no_outstanding_send_is_left_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session whose ``outstanding_send_at`` is ``None`` (idle, or its
+    last send already received an ACK) is left alone forever — even with
+    a registered talker present and ``talker_now`` arbitrarily far ahead.
+    """
+    repo_name = "FidoCanCode/home"
+    session = _RecordingSession(repo_name)  # outstanding_send_at=None
+    registry = _StubRegistry({repo_name: session})
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    register_talker(
+        SessionTalker(
+            repo_name=repo_name,
+            thread_id=42,
+            kind="worker",
+            description="lock held but no send pending",
             subprocess_pid=1,
             started_at=started_at,
         )
@@ -340,15 +399,49 @@ def test_module_level_run_evicts_past_deadline(
         monkeypatch.setattr(
             session_lock_watchdog,
             "talker_now",
-            lambda: started_at + timedelta(seconds=2),
+            lambda: started_at + timedelta(hours=24),
         )
-        result = run_watchdog(
+        watchdog = SessionLockWatchdog(
             registry,  # type: ignore[arg-type]
             {repo_name: _repo_config(repo_name)},
-            hold_deadline_seconds=1.0,
+            no_reply_seconds=60.0,
         )
+        watchdog.run()
     finally:
-        unregister_talker(repo_name, 7)
+        unregister_talker(repo_name, 42)
 
-    assert result == 0
-    assert len(session.force_release_calls) == 1
+    assert session.force_release_calls == [], (
+        "watchdog must not fire when no send is awaiting a reply"
+    )
+
+
+def test_mark_received_clears_outstanding_send() -> None:
+    """The session's send / receive helpers compose:
+
+    1. ``_mark_send_outstanding()`` arms the clock.
+    2. ``_mark_received()`` disarms it.
+
+    After a receive the watchdog sees ``outstanding_send_at == None``
+    and skips, even though a send was outstanding moments earlier.
+    """
+    session = _RecordingSession("FidoCanCode/home")
+    assert session.outstanding_send_at is None
+    session._mark_send_outstanding()  # noqa: SLF001
+    assert session.outstanding_send_at is not None
+    session._mark_received()  # noqa: SLF001
+    assert session.outstanding_send_at is None
+
+
+def test_multi_send_restarts_no_reply_clock() -> None:
+    """Calling ``_mark_send_outstanding`` twice in a row resets the
+    clock — only the most recent unanswered send matters."""
+    session = _RecordingSession("FidoCanCode/home")
+    session._mark_send_outstanding()  # noqa: SLF001
+    first = session.outstanding_send_at
+    assert first is not None
+    # Force a measurable gap so the second timestamp is strictly later.
+    time.sleep(0.001)
+    session._mark_send_outstanding()  # noqa: SLF001
+    second = session.outstanding_send_at
+    assert second is not None
+    assert second > first


### PR DESCRIPTION
Closes #1709.

The watchdog measured wall-clock since ``talker.started_at`` and killed any holder past 15 min.  In practice that meant any legitimate large-task turn (e.g. the 75-site mock.patch migration on test_events.py) lost mid-progress claude work every 15 min and got rescued into the same wedge again — five forced kills on home in one hour, all matching the same pattern, all with claude actively producing tool_use events seconds before the kill.

The fix matches the SYN-without-ACK semantic Rob asked for in the issue:

- A send arms the no-reply clock (``OwnedSession._mark_send_outstanding()``).
- A receive disarms it (``OwnedSession._mark_received()``).
- Multi-send simply restarts the clock — the most recent unanswered send wins.
- Idle sessions never trip; forever-streaming sessions never trip; only the **prompt-sent-no-reply** wedge does.
- Threshold 900s → 3600s (1 hour). The in-process ``idle_timeout`` (30 min in iter_events) is still the first-line defense; the watchdog is the safety net for the holder-wedged-outside-iter_events case.

Renamed ``hold_deadline_seconds`` → ``no_reply_seconds`` (and ``_DEFAULT_HOLD_DEADLINE_SECONDS`` → ``_DEFAULT_NO_REPLY_SECONDS``).

## Test plan

- [x] All 4231 tests green at 100% coverage.
- [x] New unit tests cover: idle session left alone forever; ``_mark_received()`` clears an outstanding send; multi-send restarts the clock; receive-silence past deadline still evicts; reason string identifies tid/kind/description and reports actual silence.
- [ ] Eyeball ``./fido status`` after restart — claude on the test_events.py task should run uninterrupted past 15 min.