### PR TITLE
Bug: SessionLockWatchdog kills active turns — wait, no, that was a symptom; this fixes the actual livelock (closes #1711)

### DIFF
--- a/src/fido/claude.py
+++ b/src/fido/claude.py
@@ -36,6 +36,7 @@ from fido.provider import (
     ProviderLimitSnapshot,
     ProviderLimitWindow,
     ProviderModel,
+    ThreadKind,
     model_name,
 )
 from fido.rocq import claude_session as stream_fsm
@@ -398,7 +399,7 @@ def _run_streaming(
             provider.SessionTalker(
                 repo_name=repo_name,
                 thread_id=thread_id,
-                kind="webhook",
+                kind=ThreadKind.WEBHOOK,
                 description=f"one-shot claude --print (pid {proc.pid})",
                 subprocess_pid=proc.pid,
                 started_at=provider.talker_now(),

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2391,18 +2391,25 @@ def _reorder_tasks_background(
         current_intents: list[RescopeIntent] = list(intents or [])
         release_untriaged = 0
         iteration = 0
-        # Register as "webhook" so the session talker reflects the true nature of
-        # this thread: it is triggered by webhooks and should not be treated as the
-        # worker for preemption purposes.  Without this, current_thread_kind()
-        # defaults to "worker", causing real webhooks to fire _fire_worker_cancel
-        # against the reorder thread and misidentify it as the running worker (#955).
+        # Register as "background" so:
+        # 1. real webhooks see kind != "worker" on this thread and so
+        #    don't fire _fire_worker_cancel against the rescope thread
+        #    (the protection from #955), AND
+        # 2. THIS thread, when its session.prompt() consults
+        #    try_preempt_worker, identifies as background and so does
+        #    NOT preempt a running worker turn.  Background-as-webhook
+        #    triggered the livelock in #1711 — every rescope iteration
+        #    cancelled the worker mid-flight, the worker retried, the
+        #    next iteration cancelled again, indefinitely.  Background
+        #    rescope is system-internal and has no priority claim on
+        #    interrupting the worker.
         #
         # IMPORTANT: every line from here through the end of the finally must be
         # inside the try/finally — if a prelude line (set_thread_kind,
         # set_rescoping, etc.) raises, the finally still has to release the
         # inbox holds; otherwise the worker parks forever (#1280).
         try:
-            set_thread_kind("webhook")
+            set_thread_kind("background")
             set_thread_repo(repo_cfg.name)
             registry.set_rescoping(repo_cfg.name, True)
             log.info("rescope BG: starting (work_dir=%s)", work_dir)

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -16,6 +16,7 @@ from fido.prompts import NO_TOOLS_CLAUSE, Prompts
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
     ProviderAgent,
+    ThreadKind,
     safe_voice_turn,
     set_thread_kind,
     set_thread_repo,
@@ -2409,7 +2410,7 @@ def _reorder_tasks_background(
         # set_rescoping, etc.) raises, the finally still has to release the
         # inbox holds; otherwise the worker parks forever (#1280).
         try:
-            set_thread_kind("background")
+            set_thread_kind(ThreadKind.BACKGROUND)
             set_thread_repo(repo_cfg.name)
             registry.set_rescoping(repo_cfg.name, True)
             log.info("rescope BG: starting (work_dir=%s)", work_dir)

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -474,7 +474,7 @@ class SessionTalker:
 
     repo_name: str
     thread_id: int
-    kind: Literal["worker", "webhook"]
+    kind: Literal["worker", "webhook", "background"]
     description: str
     subprocess_pid: int | None
     started_at: datetime
@@ -537,15 +537,23 @@ def current_repo() -> str | None:
     return getattr(_thread_local, "repo_name", None)
 
 
-def set_thread_kind(kind: Literal["worker", "webhook"] | None) -> None:
+def set_thread_kind(kind: Literal["worker", "webhook", "background"] | None) -> None:
     """Set (or clear, with ``None``) the caller kind for this thread.
 
-    Workers call this with ``"worker"`` at :meth:`WorkerThread.run` entry; the
-    webhook handler calls it with ``"webhook"`` at ``_process_action`` entry.
-    :meth:`ClaudeSession.prompt` and :meth:`CopilotCLISession.__enter__`
-    consult it to decide whether their preempt signal should fire —
-    webhooks preempt workers; workers and webhooks never preempt a running
-    webhook (fix for #637).
+    Three kinds:
+
+    * ``"worker"`` — the per-repo :class:`~fido.worker.WorkerThread` set by
+      :meth:`WorkerThread.run` entry.
+    * ``"webhook"`` — a real, user-initiated webhook handler (set by
+      :meth:`WebhookHandler._process_action`).  Webhook callers may
+      preempt a running worker turn (fix for #637).
+    * ``"background"`` — an internal system trigger such as the
+      background rescope thread in :mod:`fido.events` (#1711).
+      Background callers identify as non-worker for OTHER threads'
+      preempt decisions (so real webhooks don't try to cancel a
+      rescope thinking it's the worker), but they themselves never
+      preempt a running worker — that would livelock long worker turns
+      against bursty rescope iterations.
     """
     if kind is None:
         if hasattr(_thread_local, "kind"):
@@ -554,7 +562,7 @@ def set_thread_kind(kind: Literal["worker", "webhook"] | None) -> None:
         _thread_local.kind = kind
 
 
-def current_thread_kind() -> Literal["worker", "webhook"]:
+def current_thread_kind() -> Literal["worker", "webhook", "background"]:
     """Return the caller kind for this thread.  Defaults to ``"worker"``
     when not set (non-entry code paths and tests)."""
     return getattr(_thread_local, "kind", "worker")
@@ -562,8 +570,8 @@ def current_thread_kind() -> Literal["worker", "webhook"]:
 
 def try_preempt_worker(
     repo_name: str | None, cancel_fn: Callable[[], None]
-) -> tuple[bool, Literal["worker", "webhook"] | None]:
-    """Invoke *cancel_fn* iff the calling thread is a webhook AND the
+) -> tuple[bool, Literal["worker", "webhook", "background"] | None]:
+    """Invoke *cancel_fn* iff the calling thread is a real webhook AND the
     session's current lock holder is a worker.  Otherwise do nothing.
 
     Returns ``(preempted, current_kind)`` — *preempted* is ``True`` only when
@@ -576,7 +584,10 @@ def try_preempt_worker(
     for claude, ACP ``cancel(session_id)`` for copilot), but the *decision*
     is identical and lives here.  Worker callers never preempt anyone;
     webhooks queue behind other webhooks (FIFO on the session lock) instead
-    of cancelling each other.
+    of cancelling each other.  ``"background"`` callers (e.g. the rescope
+    thread, #1711) also never preempt — that's the whole point of the
+    third kind: they're system-internal, not user-facing, so they have
+    no priority claim on interrupting in-flight worker turns.
     """
     caller_kind = current_thread_kind()
     current = get_talker(repo_name) if repo_name is not None else None

--- a/src/fido/provider.py
+++ b/src/fido/provider.py
@@ -64,6 +64,30 @@ class ProviderID(StrEnum):
     CODEX = "codex"
 
 
+class ThreadKind(StrEnum):
+    """Caller kind for the per-thread preempt-decision plumbing.
+
+    Tracked in :data:`_thread_local` and consulted by
+    :func:`try_preempt_worker` to decide whether the current thread may
+    cancel a running worker turn.
+
+    * :attr:`WORKER` — the per-repo :class:`~fido.worker.WorkerThread`.
+    * :attr:`WEBHOOK` — a real, user-initiated webhook handler (set by
+      :meth:`fido.server.WebhookHandler._process_action`).  Webhook
+      callers may preempt a running worker turn (#637).
+    * :attr:`BACKGROUND` — an internal system trigger such as the
+      background rescope thread in :mod:`fido.events` (#1711).
+      Background callers identify as non-worker so OTHER threads'
+      preempt decisions don't cancel them, but they themselves never
+      preempt a running worker — that would livelock long worker turns
+      against bursty rescope iterations.
+    """
+
+    WORKER = "worker"
+    WEBHOOK = "webhook"
+    BACKGROUND = "background"
+
+
 @dataclass(frozen=True)
 class ProviderPalette:
     """ANSI truecolor palette for a provider's status rendering.
@@ -474,7 +498,7 @@ class SessionTalker:
 
     repo_name: str
     thread_id: int
-    kind: Literal["worker", "webhook", "background"]
+    kind: ThreadKind
     description: str
     subprocess_pid: int | None
     started_at: datetime
@@ -537,7 +561,7 @@ def current_repo() -> str | None:
     return getattr(_thread_local, "repo_name", None)
 
 
-def set_thread_kind(kind: Literal["worker", "webhook", "background"] | None) -> None:
+def set_thread_kind(kind: ThreadKind | None) -> None:
     """Set (or clear, with ``None``) the caller kind for this thread.
 
     Three kinds:
@@ -562,15 +586,17 @@ def set_thread_kind(kind: Literal["worker", "webhook", "background"] | None) -> 
         _thread_local.kind = kind
 
 
-def current_thread_kind() -> Literal["worker", "webhook", "background"]:
-    """Return the caller kind for this thread.  Defaults to ``"worker"``
-    when not set (non-entry code paths and tests)."""
-    return getattr(_thread_local, "kind", "worker")
+def current_thread_kind() -> ThreadKind:
+    """Return the caller kind for this thread.  Defaults to
+    :attr:`ThreadKind.WORKER` when not set (non-entry code paths
+    and tests)."""
+    kind = getattr(_thread_local, "kind", None)
+    return kind if isinstance(kind, ThreadKind) else ThreadKind.WORKER
 
 
 def try_preempt_worker(
     repo_name: str | None, cancel_fn: Callable[[], None]
-) -> tuple[bool, Literal["worker", "webhook", "background"] | None]:
+) -> tuple[bool, ThreadKind | None]:
     """Invoke *cancel_fn* iff the calling thread is a real webhook AND the
     session's current lock holder is a worker.  Otherwise do nothing.
 

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -50,6 +50,7 @@ from fido.infra import (
     ProcessRunner,
     real_infra,
 )
+from fido.provider import ThreadKind
 from fido.provider_factory import DefaultProviderFactory
 from fido.provider_pressure import ProviderPressureMonitor
 from fido.rate_limit import RateLimitMonitor
@@ -625,7 +626,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             tid,
         )
         provider.set_thread_repo(repo_cfg.name)
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         session = self.registry.get_session(repo_cfg.name)
         needs_model = self._action_uses_model(action)
         preempts_worker = self._action_preempts_worker(action)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -44,6 +44,7 @@ from fido.provider import (
     ProviderModel,
     ProviderPressureStatus,
     SessionLeakError,
+    ThreadKind,
     TurnSessionMode,
     safe_voice_turn,
     set_thread_kind,
@@ -4905,7 +4906,7 @@ class WorkerThread(threading.Thread):
         """Main loop — runs until :meth:`stop` is called."""
         _thread_repo.repo_name = self._repo_name.split("/")[-1]
         set_thread_repo(self._repo_name)
-        set_thread_kind("worker")
+        set_thread_kind(ThreadKind.WORKER)
         try:
             while not self._stop.is_set():
                 if self._registry is not None:

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -37,6 +37,7 @@ from fido.provider import (
     ProviderID,
     ProviderLimitSnapshot,
     ProviderLimitWindow,
+    ThreadKind,
     TurnSessionMode,
 )
 
@@ -2161,7 +2162,7 @@ class TestClaudeSessionLock:
 
         proc = _make_session_proc([])
         session = _make_session(tmp_path, proc)
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         try:
             with (
                 patch(
@@ -2184,7 +2185,7 @@ class TestClaudeSessionLock:
         attribute that prompt() wrote and __enter__ read.  Cross-thread
         race: a webhook thread's "webhook" write could clobber a worker
         thread's "worker" write between the worker's prompt() and the
-        worker's __enter__, registering the worker with kind="webhook".
+        worker's __enter__, registering the worker with kind=ThreadKind.WEBHOOK.
 
         This test simulates that hazard directly: the *current thread* is
         a worker, but a session-level "webhook" annotation has been
@@ -2200,7 +2201,7 @@ class TestClaudeSessionLock:
         # no-op for the kind decision.
         session._pending_talker_kind = "webhook"  # type: ignore[attr-defined]
 
-        provider.set_thread_kind("worker")
+        provider.set_thread_kind(ThreadKind.WORKER)
         try:
             session.__enter__()
             talker = provider.get_talker(session._repo_name)
@@ -2478,7 +2479,7 @@ class TestClaudeSessionLock:
             SessionTalker(
                 repo_name="owner/repo",
                 thread_id=999,
-                kind="webhook",
+                kind=ThreadKind.WEBHOOK,
                 description="leaked",
                 subprocess_pid=555,
                 started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),

--- a/tests/test_claude_hold_for_handler.py
+++ b/tests/test_claude_hold_for_handler.py
@@ -8,7 +8,7 @@ import pytest
 
 from fido import provider
 from fido.claude import ClaudeSession
-from fido.provider import SessionTalker, talker_now
+from fido.provider import SessionTalker, ThreadKind, talker_now
 
 
 def _make_session_proc(lines: list[str]) -> MagicMock:
@@ -44,7 +44,7 @@ def test_hold_acquires_lock_and_registers_talker(tmp_path: Path) -> None:
     from fido.rocq.transition import Free, OwnedByHandler
 
     session = _setup_session(tmp_path)
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             talker = provider.get_talker("owner/repo")
@@ -73,7 +73,7 @@ def test_nested_with_inside_hold_does_not_double_register(
         real_register(talker)
 
     monkeypatch.setattr(provider, "register_talker", counting_register)
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             assert len(register_calls) == 1  # outer entry registered once
@@ -107,7 +107,7 @@ def test_hold_preempt_fires_cancel_when_worker_holds(
     monkeypatch.setattr(provider, "get_talker", lambda _repo: fake_talker("worker"))
     cancel_calls = []
     monkeypatch.setattr(session, "_fire_worker_cancel", lambda: cancel_calls.append(1))
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             pass
@@ -128,7 +128,7 @@ def test_hold_preempt_no_fire_when_no_worker_holder(
     monkeypatch.setattr(provider, "get_talker", lambda _repo: None)
     cancel_calls = []
     monkeypatch.setattr(session, "_fire_worker_cancel", lambda: cancel_calls.append(1))
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             pass
@@ -177,7 +177,7 @@ def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
     other_finished = threading.Event()
 
     def holder() -> None:
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         try:
             with session.hold_for_handler():
                 holder_entered.set()
@@ -186,7 +186,7 @@ def test_other_thread_blocks_while_held(tmp_path: Path) -> None:
             provider.set_thread_kind(None)
 
     def other() -> None:
-        provider.set_thread_kind("worker")
+        provider.set_thread_kind(ThreadKind.WORKER)
         try:
             with session:
                 other_acquired.set()
@@ -254,7 +254,7 @@ def test_webhook_preempts_worker_mid_turn(tmp_path: Path) -> None:
     webhook_done = threading.Event()
 
     def worker() -> None:
-        provider.set_thread_kind("worker")
+        provider.set_thread_kind(ThreadKind.WORKER)
         try:
             with session:
                 worker_in_turn.set()
@@ -265,7 +265,7 @@ def test_webhook_preempts_worker_mid_turn(tmp_path: Path) -> None:
             provider.set_thread_kind(None)
 
     def webhook() -> None:
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         try:
             # Wait until worker is actually blocked, then preempt.
             worker_blocked.wait(timeout=2.0)
@@ -343,7 +343,7 @@ def test_handler_prompt_runs_after_preempt_does_not_inherit_cancel(
         session, "_selector", MagicMock(return_value=([proc.stdout], [], []))
     )
 
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             # _fire_worker_cancel set _cancel.  Handler's first prompt() must
@@ -378,7 +378,7 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
     errors: list[Exception] = []
 
     def webhook_a() -> None:
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         try:
             with session.hold_for_handler():
                 webhook_a_holding.set()
@@ -396,7 +396,7 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
             provider.set_thread_kind(None)
 
     def webhook_b() -> None:
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         try:
             assert webhook_a_holding.wait(timeout=2.0), "webhook_a_holding timed out"
             webhook_b_queuing.set()
@@ -409,7 +409,7 @@ def test_queued_webhook_acquires_lock_before_worker_after_inner_prompt(
             provider.set_thread_kind(None)
 
     def worker() -> None:
-        provider.set_thread_kind("worker")
+        provider.set_thread_kind(ThreadKind.WORKER)
         try:
             assert webhook_b_queuing.wait(timeout=2.0), "webhook_b_queuing timed out"
             import time as _time
@@ -453,13 +453,13 @@ def test_hold_reraises_leak_error_and_releases_lock(
         SessionTalker(
             repo_name="owner/repo",
             thread_id=111_111,  # different tid — triggers leak
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="squatter",
             subprocess_pid=None,
             started_at=talker_now(),
         )
     )
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with pytest.raises(provider.SessionLeakError):
             with session.hold_for_handler():
@@ -671,7 +671,7 @@ def test_force_release_unblocks_wedged_holder_end_to_end(tmp_path: Path) -> None
         finally:
             holder_done.set()
 
-    provider.set_thread_kind("worker")
+    provider.set_thread_kind(ThreadKind.WORKER)
     try:
         t = threading.Thread(target=holder, daemon=True)
         t.start()

--- a/tests/test_claude_preempt_kind.py
+++ b/tests/test_claude_preempt_kind.py
@@ -18,5 +18,97 @@ def test_set_thread_kind_roundtrip() -> None:
     assert provider.current_thread_kind() == "webhook"
     provider.set_thread_kind("worker")
     assert provider.current_thread_kind() == "worker"
+    provider.set_thread_kind("background")
+    assert provider.current_thread_kind() == "background"
     provider.set_thread_kind(None)
     assert provider.current_thread_kind() == "worker"
+
+
+def test_try_preempt_worker_webhook_preempts_worker() -> None:
+    """A real webhook caller preempts a running worker."""
+    from datetime import datetime, timezone
+
+    repo = "owner/repo"
+    talker = provider.SessionTalker(
+        repo_name=repo,
+        thread_id=42,
+        kind="worker",
+        description="long worker turn",
+        subprocess_pid=1,
+        started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    try:
+        provider.register_talker(talker)
+        provider.set_thread_kind("webhook")
+        cancelled: list[bool] = []
+        preempted, current_kind = provider.try_preempt_worker(
+            repo, lambda: cancelled.append(True)
+        )
+        assert preempted is True
+        assert current_kind == "worker"
+        assert cancelled == [True]
+    finally:
+        provider.unregister_talker(repo, 42)
+        provider.set_thread_kind(None)
+
+
+def test_try_preempt_worker_background_does_not_preempt() -> None:
+    """Background callers (e.g. the rescope thread, #1711) do not
+    preempt a running worker — that's the whole point of the third
+    kind.  Without this, every rescope iteration would cancel the
+    worker mid-flight and livelock long worker turns."""
+    from datetime import datetime, timezone
+
+    repo = "owner/repo"
+    talker = provider.SessionTalker(
+        repo_name=repo,
+        thread_id=42,
+        kind="worker",
+        description="long worker turn",
+        subprocess_pid=1,
+        started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    try:
+        provider.register_talker(talker)
+        provider.set_thread_kind("background")
+        cancelled: list[bool] = []
+        preempted, current_kind = provider.try_preempt_worker(
+            repo, lambda: cancelled.append(True)
+        )
+        assert preempted is False
+        assert current_kind == "worker"
+        assert cancelled == []
+    finally:
+        provider.unregister_talker(repo, 42)
+        provider.set_thread_kind(None)
+
+
+def test_try_preempt_worker_background_holder_not_preempted_by_webhook() -> None:
+    """A real webhook caller does not preempt a background holder
+    (e.g. an in-flight rescope iteration).  Same shape as the
+    no-preempt-on-webhook protection from #955 — kind != \"worker\"
+    means \"don't preempt me\"."""
+    from datetime import datetime, timezone
+
+    repo = "owner/repo"
+    talker = provider.SessionTalker(
+        repo_name=repo,
+        thread_id=42,
+        kind="background",
+        description="rescope iteration in flight",
+        subprocess_pid=1,
+        started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    try:
+        provider.register_talker(talker)
+        provider.set_thread_kind("webhook")
+        cancelled: list[bool] = []
+        preempted, current_kind = provider.try_preempt_worker(
+            repo, lambda: cancelled.append(True)
+        )
+        assert preempted is False
+        assert current_kind == "background"
+        assert cancelled == []
+    finally:
+        provider.unregister_talker(repo, 42)
+        provider.set_thread_kind(None)

--- a/tests/test_claude_preempt_kind.py
+++ b/tests/test_claude_preempt_kind.py
@@ -9,16 +9,17 @@ paths live in ``test_claude_hold_for_handler.py`` and ``test_server.py``.
 """
 
 from fido import provider
+from fido.provider import ThreadKind
 
 
 def test_set_thread_kind_roundtrip() -> None:
     provider.set_thread_kind(None)
     assert provider.current_thread_kind() == "worker"
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     assert provider.current_thread_kind() == "webhook"
-    provider.set_thread_kind("worker")
+    provider.set_thread_kind(ThreadKind.WORKER)
     assert provider.current_thread_kind() == "worker"
-    provider.set_thread_kind("background")
+    provider.set_thread_kind(ThreadKind.BACKGROUND)
     assert provider.current_thread_kind() == "background"
     provider.set_thread_kind(None)
     assert provider.current_thread_kind() == "worker"
@@ -32,14 +33,14 @@ def test_try_preempt_worker_webhook_preempts_worker() -> None:
     talker = provider.SessionTalker(
         repo_name=repo,
         thread_id=42,
-        kind="worker",
+        kind=ThreadKind.WORKER,
         description="long worker turn",
         subprocess_pid=1,
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
     try:
         provider.register_talker(talker)
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         cancelled: list[bool] = []
         preempted, current_kind = provider.try_preempt_worker(
             repo, lambda: cancelled.append(True)
@@ -63,14 +64,14 @@ def test_try_preempt_worker_background_does_not_preempt() -> None:
     talker = provider.SessionTalker(
         repo_name=repo,
         thread_id=42,
-        kind="worker",
+        kind=ThreadKind.WORKER,
         description="long worker turn",
         subprocess_pid=1,
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
     try:
         provider.register_talker(talker)
-        provider.set_thread_kind("background")
+        provider.set_thread_kind(ThreadKind.BACKGROUND)
         cancelled: list[bool] = []
         preempted, current_kind = provider.try_preempt_worker(
             repo, lambda: cancelled.append(True)
@@ -94,14 +95,14 @@ def test_try_preempt_worker_background_holder_not_preempted_by_webhook() -> None
     talker = provider.SessionTalker(
         repo_name=repo,
         thread_id=42,
-        kind="background",
+        kind=ThreadKind.BACKGROUND,
         description="rescope iteration in flight",
         subprocess_pid=1,
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
     try:
         provider.register_talker(talker)
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         cancelled: list[bool] = []
         preempted, current_kind = provider.try_preempt_worker(
             repo, lambda: cancelled.append(True)

--- a/tests/test_copilot_hold_for_handler.py
+++ b/tests/test_copilot_hold_for_handler.py
@@ -6,6 +6,7 @@ import pytest
 
 from fido import provider
 from fido.copilotcli import CopilotCLIClient, CopilotCLISession
+from fido.provider import ThreadKind
 
 
 class FakeRuntime:
@@ -54,7 +55,7 @@ def test_hold_for_handler_allows_nested_with(tmp_path: Path) -> None:
     single talker registration across both entries (mirrors the claude
     behaviour in #658)."""
     session = _session(tmp_path)
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             assert provider.get_talker("owner/repo") is not None
@@ -72,7 +73,7 @@ def test_hold_for_handler_does_not_fire_runtime_cancel_when_free(
     """No holder + no ``preempt_worker=True`` → no runtime cancel."""
     session = _session(tmp_path)
     assert isinstance(session._runtime, FakeRuntime)
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             pass
@@ -94,14 +95,14 @@ def test_hold_for_handler_preempt_fires_runtime_cancel_on_worker_holder(
         return provider.SessionTalker(
             repo_name="owner/repo",
             thread_id=999_999,
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="fake-worker",
             subprocess_pid=None,
             started_at=provider.talker_now(),
         )
 
     monkeypatch.setattr(provider, "get_talker", fake_talker)
-    provider.set_thread_kind("webhook")
+    provider.set_thread_kind(ThreadKind.WEBHOOK)
     try:
         with session.hold_for_handler():
             pass

--- a/tests/test_copilotcli.py
+++ b/tests/test_copilotcli.py
@@ -43,6 +43,7 @@ from fido.provider import (
     ProviderID,
     ProviderLimitSnapshot,
     ProviderModel,
+    ThreadKind,
     TurnSessionMode,
 )
 
@@ -1211,11 +1212,11 @@ class TestCopilotCLISession:
         release = threading.Event()
 
         # Holder enters as worker so the shared talker registry reports it.
-        provider.set_thread_kind("worker")
+        provider.set_thread_kind(ThreadKind.WORKER)
         session.__enter__()
 
         def contender() -> None:
-            provider.set_thread_kind("webhook")
+            provider.set_thread_kind(ThreadKind.WEBHOOK)
             try:
                 with session:
                     acquired.set()
@@ -1256,11 +1257,11 @@ class TestCopilotCLISession:
         acquired = threading.Event()
         release = threading.Event()
 
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         session.__enter__()
 
         def contender() -> None:
-            provider.set_thread_kind("webhook")
+            provider.set_thread_kind(ThreadKind.WEBHOOK)
             try:
                 with session:
                     acquired.set()
@@ -1303,7 +1304,7 @@ class TestCopilotCLISession:
             provider.SessionTalker(
                 repo_name="owner/repo",
                 thread_id=999_999,
-                kind="worker",
+                kind=ThreadKind.WORKER,
                 description="squatter",
                 subprocess_pid=None,
                 started_at=provider.talker_now(),
@@ -1338,11 +1339,11 @@ class TestCopilotCLISession:
         acquired = threading.Event()
         release = threading.Event()
 
-        provider.set_thread_kind("webhook")
+        provider.set_thread_kind(ThreadKind.WEBHOOK)
         session.__enter__()
 
         def contender() -> None:
-            provider.set_thread_kind("worker")
+            provider.set_thread_kind(ThreadKind.WORKER)
             try:
                 with session:
                     acquired.set()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5121,12 +5121,16 @@ class TestReorderTasksBackground:
             self._run_thread(started)
         assert current_repo() is None
 
-    def test_sets_thread_kind_webhook_during_reorder(self, tmp_path: Path) -> None:
-        """Thread kind is set to 'webhook' while the reorder loop runs (#955).
+    def test_sets_thread_kind_background_during_reorder(self, tmp_path: Path) -> None:
+        """Thread kind is set to 'background' while the reorder loop runs (#1711).
 
-        The reorder thread must not register as 'worker' in the session talker —
-        real webhooks would fire the cancel mechanism against it thinking it is
-        the actual worker."""
+        Was 'webhook' originally (#955) — that protected the rescope thread
+        from being identified as the worker by OTHER webhooks, but it also
+        caused the rescope thread itself to preempt the worker on every
+        iteration, livelocking long worker turns.  The third kind
+        'background' preserves the #955 protection (kind != 'worker' still
+        means OTHER webhooks won't preempt this thread) without granting
+        preemption rights to the rescope thread itself."""
         from fido.provider import current_thread_kind
 
         started: list = []
@@ -5147,7 +5151,7 @@ class TestReorderTasksBackground:
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
-        assert seen == ["webhook"]
+        assert seen == ["background"]
 
     def test_clears_thread_kind_after_reorder(self, tmp_path: Path) -> None:
         """Thread kind is cleared in the finally block after the reorder loop."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -42,7 +42,7 @@ from fido.events import (
     reply_to_review,
     thread_lineage_comment_ids,
 )
-from fido.provider import ProviderID
+from fido.provider import ProviderID, ThreadKind
 from fido.rocq import replied_comment_claims as oracle
 from fido.state import State
 from fido.store import FidoStore, ReplyPromiseRecord
@@ -5160,7 +5160,9 @@ class TestReorderTasksBackground:
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
 
-        set_thread_kind("webhook")  # pre-set to confirm the finally block clears it
+        set_thread_kind(
+            ThreadKind.WEBHOOK
+        )  # pre-set to confirm the finally block clears it
         _reorder_tasks_background(
             tmp_path,
             "cs",

--- a/tests/test_session_lock_watchdog.py
+++ b/tests/test_session_lock_watchdog.py
@@ -25,6 +25,7 @@ from fido.provider import (
     OwnedSession,
     ProviderID,
     SessionTalker,
+    ThreadKind,
     register_talker,
     unregister_talker,
 )
@@ -133,7 +134,7 @@ def test_run_skips_holder_within_deadline(
         SessionTalker(
             repo_name=repo_name,
             thread_id=42,
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="recent turn",
             subprocess_pid=1,
             started_at=sent_at,
@@ -179,7 +180,7 @@ def test_run_evicts_holder_past_deadline(monkeypatch: pytest.MonkeyPatch) -> Non
         SessionTalker(
             repo_name=repo_name,
             thread_id=99999,
-            kind="webhook",
+            kind=ThreadKind.WEBHOOK,
             description="wedged synthesis turn",
             subprocess_pid=1,
             started_at=sent_at,
@@ -226,7 +227,7 @@ def test_run_handles_multiple_repos_independently(
         SessionTalker(
             repo_name="FidoCanCode/home",
             thread_id=1,
-            kind="webhook",
+            kind=ThreadKind.WEBHOOK,
             description="long",
             subprocess_pid=1,
             started_at=sent_at,
@@ -236,7 +237,7 @@ def test_run_handles_multiple_repos_independently(
         SessionTalker(
             repo_name="rhencke/confusio",
             thread_id=2,
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="short",
             subprocess_pid=1,
             started_at=sent_at + timedelta(seconds=55),
@@ -344,7 +345,7 @@ def test_module_level_run_evicts_past_deadline(
         SessionTalker(
             repo_name=repo_name,
             thread_id=7,
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="wedged",
             subprocess_pid=1,
             started_at=sent_at,
@@ -389,7 +390,7 @@ def test_idle_session_with_no_outstanding_send_is_left_alone(
         SessionTalker(
             repo_name=repo_name,
             thread_id=42,
-            kind="worker",
+            kind=ThreadKind.WORKER,
             description="lock held but no send pending",
             subprocess_pid=1,
             started_at=started_at,


### PR DESCRIPTION
Closes #1711.

Symptom: 6-comment review on home livelocked the worker — every rescope iteration cancelled the worker mid-flight, retry loop forever, ``result_len=0, cancelled=True`` for every turn.

Root cause: ``_reorder_tasks_background`` ran with ``thread_kind=\"webhook\"`` (set in #955 to keep OTHER webhooks from cancelling the rescope thread).  Side effect: the rescope thread also identified as a webhook to its OWN preempt path, so every iteration fired ``try_preempt_worker`` and cancelled the worker.

Fix: introduce a third thread kind ``\"background\"``.

* ``set_thread_kind`` / ``current_thread_kind`` accept and return ``worker | webhook | background``.
* ``try_preempt_worker`` only fires when caller is ``\"webhook\"`` — background callers never preempt.
* The existing gate already only fires when current_kind is ``\"worker\"``, so the #955 protection still holds (other webhooks won't cancel a rescope thread now identifying as ``\"background\"``).
* ``_reorder_tasks_background`` switches to ``set_thread_kind(\"background\")``.
* ``SessionTalker.kind`` widens to the same Literal so background callers register accurately.

## Test plan

- [x] CI green at 100% / 4237 tests
- [x] New ``test_claude_preempt_kind`` cases cover the 3 preempt matrix cells: ``webhook→worker`` preempts, ``background→worker`` doesn't, ``webhook→background`` doesn't
- [x] Updated ``test_events.test_sets_thread_kind_background_during_reorder`` for the new kind
- [ ] Eyeball ``./fido status`` after restart — long worker turns under bursty review traffic should run uninterrupted