### PR TITLE
Test: drop nested-docker extraction subprocess (closes #1726)

### DIFF
--- a/tests/test_extraction_diagnostics_catalogue.py
+++ b/tests/test_extraction_diagnostics_catalogue.py
@@ -1,8 +1,5 @@
 import json
-import os
 import re
-import subprocess
-import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -71,61 +68,40 @@ def test_structured_diagnostic_renderer_fields_are_present() -> None:
         assert f'field "{field}"' in source
 
 
-def test_structured_diagnostic_output_from_failed_extraction() -> None:
-    if os.environ.get("FIDO_SKIP_DOCKER_HELPER_TESTS") == "1":
-        pytest.skip("Docker helper is exercised outside the buildx pytest target")
-
-    script = textwrap.dedent(
-        """
-        cat > test/diagnostics_negative_tmp.v <<'EOF'
-        Declare ML Module "rocq-python-extraction".
-        Declare ML Module "rocq-runtime.plugins.extraction".
-        Extract Inductive nat => "int"
-          [ "0" "(lambda x: x + 1)" ]
-          "(lambda fO, fS, n: fO() if n == 0 else fS(n - 1))".
-        Definition bad_get (n : nat) : nat := n.
-        Extract Constant bad_get => "__PYMONAD_STATE_GET__".
-        Definition bad_monad_marker : nat := bad_get 0.
-        Python Extraction bad_monad_marker.
-        EOF
-        # Inject the new module before the closing ``))`` of the (modules ...)
-        # stanza.  Earlier this sed targeted the last-known module name
-        # (``source_maps``), which silently no-op'd whenever a later
-        # module was added — leaving dune unaware of the new file and
-        # the test failing without producing the extraction diagnostic
-        # it was meant to verify.  Anchoring on the closing ``))`` is
-        # robust to module additions.
-        sed -i '0,/))$/{s/))$/ diagnostics_negative_tmp))/}' test/dune
-        opam exec -- dune build test/diagnostics_negative_tmp.vo
-        """
+def test_structured_diagnostic_payload_shape_is_parseable() -> None:
+    # Hand-written fixture mirroring what the renderer in python.ml emits when
+    # a real extraction fails with PYEX010.  Earlier this test ran a docker
+    # subprocess that built a deliberately-broken .v file; under xdist that one
+    # 47-second subprocess starved the other workers and inflated unrelated
+    # FidoStore tests by ~50x.  The renderer-side guarantee — that python.ml
+    # actually emits this shape — lives in
+    # ``test_structured_diagnostic_renderer_fields_are_present`` (which scans
+    # python.ml for the field-emitting calls) and in the catalogue tests
+    # (which assert PYEX010 has the matching docs anchor).
+    line = "PYTHON_EXTRACTION_DIAGNOSTIC_JSON: " + json.dumps(
+        {
+            "version": 1,
+            "code": "PYEX010",
+            "title": "Monad marker arity mismatch",
+            "category": "Monad markers",
+            "message": (
+                "bad_monad_marker is tagged as a __PYMONAD_STATE_GET__ "
+                "marker but has arity 0"
+            ),
+            "remediation": (
+                "Reshape the body so the marker takes the expected argument."
+            ),
+            "docs": (
+                "rocq-python-extraction/DIAGNOSTICS.md"
+                "#pyex010-monad-marker-arity-mismatch"
+            ),
+            "symbol": "bad_monad_marker",
+            "detail": "expected arity >= 1, got 0",
+        }
     )
 
-    result = subprocess.run(
-        [
-            str(REPO_ROOT / "rocq-python-extraction" / "run_in_docker.sh"),
-            "rocq-python-extraction",
-            "bash",
-            "-euo",
-            "pipefail",
-            "-c",
-            script,
-        ],
-        check=False,
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-    )
-    output = result.stdout + result.stderr
-    json_line = next(
-        line.removeprefix("PYTHON_EXTRACTION_DIAGNOSTIC_JSON: ")
-        for line in output.splitlines()
-        if line.startswith("PYTHON_EXTRACTION_DIAGNOSTIC_JSON: ")
-    )
-    payload = json.loads(json_line)
+    payload = json.loads(line.removeprefix("PYTHON_EXTRACTION_DIAGNOSTIC_JSON: "))
 
-    assert result.returncode != 0
-    assert "Python ExtractionError [PYEX010]" in output
-    assert "Remediation:" in output
     assert payload["version"] == 1
     assert payload["code"] == "PYEX010"
     assert payload["remediation"]


### PR DESCRIPTION
## Summary
- Replace \`test_structured_diagnostic_output_from_failed_extraction\` with a hand-written JSON fixture that mirrors the wire format. No more nested-docker subprocess.
- Renderer-side coverage is unchanged: \`test_structured_diagnostic_renderer_fields_are_present\` still scans \`python.ml\` for the field-emitting calls; catalogue tests still assert PYEX010's docs anchor.

## Why this matters beyond just dropping 47s
That one subprocess pegged CPU + filesystem hard enough to starve the other three xdist workers. Removing it dropped the full suite from 64.9s -> 25.7s (~40s saved), and the next-slowest non-rocq-lsp test went from 18.9s to 0.5s. So the win is the 47s of the test itself **plus** un-starving the dozen other tests it was blocking.

## Test plan
- [x] \`./fido ci\` (ran via pre-commit hook)
- [x] \`./fido pytest tests/test_extraction_diagnostics_catalogue.py\` -> 48 passed in 1.68s (was ~50s)
- [x] Full suite -> 4237 passed in 25.72s (was 64.92s)