### PR TITLE
Rescope L1: add-boundary dedup uses exact comment replay only (closes #1665)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -167,13 +167,6 @@ def _review_thread_contains_comment(
     return False
 
 
-def _thread_lineage_key(thread: dict[str, Any] | None) -> str | None:
-    if not thread:
-        return None
-    key = thread.get("lineage_key")
-    return str(key) if key else None
-
-
 def _thread_lineage_comment_ids(thread: dict[str, Any] | None) -> list[int]:
     if not thread:
         return []
@@ -197,7 +190,15 @@ def _thread_lineage_comment_ids(thread: dict[str, Any] | None) -> list[int]:
 def _merge_thread_lineage(
     existing_thread: dict[str, Any], new_thread: dict[str, Any]
 ) -> bool:
-    """Merge related source comment ids into an existing task thread."""
+    """Merge related source-comment ids into an existing task thread.
+
+    ``lineage_comment_ids`` is the only lineage metadata that survives —
+    it answers "which comments contributed to this task" so a future
+    reply-back filter (#1256) can reach every commenter whose intent
+    materially shaped the task.  The legacy ``lineage_key`` join field
+    is dropped (#1665) — lineage is no longer a dedup key, so the
+    canonical chain identifier serves no purpose.
+    """
     merged = _thread_lineage_comment_ids(existing_thread)
     changed = False
     for comment_id in _thread_lineage_comment_ids(new_thread):
@@ -206,9 +207,6 @@ def _merge_thread_lineage(
             changed = True
     if changed:
         existing_thread["lineage_comment_ids"] = merged
-    if not existing_thread.get("lineage_key") and new_thread.get("lineage_key"):
-        existing_thread["lineage_key"] = new_thread["lineage_key"]
-        changed = True
     return changed
 
 
@@ -1230,14 +1228,20 @@ class Tasks(JsonFileStore):
         if thread:
             task["thread"] = thread
         comment_id = (thread or {}).get("comment_id")
-        lineage_key = _thread_lineage_key(thread)
         with self.modify() as existing:
             for t in existing:
                 existing_thread = t.get("thread") or {}
                 existing_comment_id = existing_thread.get("comment_id")
-                existing_lineage_key = _thread_lineage_key(existing_thread)
 
-                # Same comment: always dedup, regardless of status.
+                # Exact-comment-id replay protection: the only dedup at the
+                # add boundary (#1665).  Lineage stops being a join key —
+                # three distinct comments on the same PR thread produce
+                # three distinct tasks.  Lineage stays on the task as
+                # origin metadata via :func:`_merge_thread_lineage`,
+                # answering "which comments contributed to this task,"
+                # not "is this task the same as that one."  Combine /
+                # split / rewrite decisions move to the rescope reducer
+                # under #1340 (#1666 / #1667).
                 if comment_id is not None and existing_comment_id == comment_id:
                     if _merge_thread_lineage(existing_thread, thread or {}):
                         t["thread"] = existing_thread
@@ -1248,36 +1252,11 @@ class Tasks(JsonFileStore):
                     )
                     return t
 
-                # Same lineage, different comment: dedup only when the sibling
-                # task is in-progress, or when the new comment's lineage overlaps
-                # the existing task's lineage (replies to the same review thread).
-                # A completed or pending task with non-overlapping lineage
-                # represents independent work and must not block new task creation.
-                if lineage_key is not None and lineage_key == existing_lineage_key:
-                    new_lineage_ids = set(_thread_lineage_comment_ids(thread))
-                    existing_lineage_ids = set(
-                        _thread_lineage_comment_ids(existing_thread)
-                    )
-                    lineage_overlaps = bool(new_lineage_ids & existing_lineage_ids)
-                    if t["status"] == TaskStatus.IN_PROGRESS or lineage_overlaps:
-                        if _merge_thread_lineage(existing_thread, thread or {}):
-                            t["thread"] = existing_thread
-                        if (
-                            t["status"] == TaskStatus.IN_PROGRESS
-                            and not lineage_overlaps
-                        ):
-                            log.info(
-                                "task already in progress for lineage %s — coalescing",
-                                lineage_key,
-                            )
-                        else:
-                            log.info(
-                                "task already exists for lineage %s (status: %s)",
-                                lineage_key,
-                                t["status"],
-                            )
-                        return t
-
+                # Title-match dedup for non-comment-derived tasks (CI
+                # failures, spec setup): a pending task with the same
+                # title is the same work; don't double-add.  Comment-
+                # derived adds skip this — exact comment_id is the only
+                # dedup for them (#1665).
                 if (
                     comment_id is None
                     and t["status"] == TaskStatus.PENDING

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -27,10 +27,8 @@ from fido.atomic import create_atomic
 from fido.provider_factory import DefaultProviderFactory
 from fido.registry import WorkerRegistry
 from fido.tasks import (
-    _merge_thread_lineage,
     _review_thread_contains_comment,
     _thread_lineage_comment_ids,
-    _thread_lineage_key,
     _thread_task_for_auto_resolve_oracle,
     review_thread_for_auto_resolve_oracle,
 )
@@ -162,20 +160,6 @@ class TestTasksHelpers:
         """Cover the early-return for missing thread (tasks.py:169)."""
         assert _thread_lineage_comment_ids(None) == []
         assert _thread_lineage_comment_ids({}) == []
-
-    def test_thread_lineage_key_with_no_thread_returns_none(self) -> None:
-        """Cover _thread_lineage_key's None branch."""
-        assert _thread_lineage_key(None) is None
-        assert _thread_lineage_key({}) is None
-
-    def test_merge_thread_lineage_inherits_lineage_key(self) -> None:
-        """Cover the ``existing_thread["lineage_key"] = new_thread[...]``
-        branch (tasks.py:200)."""
-        existing = {"comment_id": 1}  # no lineage_key
-        incoming = {"comment_id": 1, "lineage_key": "k1"}
-        changed = _merge_thread_lineage(existing, incoming)
-        assert changed
-        assert existing["lineage_key"] == "k1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -385,21 +385,23 @@ class TestAddTask:
         assert t1["id"] == t2["id"]
         assert len(Tasks(tmp_path).list()) == 1
 
-    def test_deduplicates_by_comment_lineage_and_merges_sources(
+    def test_distinct_comments_in_same_lineage_produce_distinct_tasks(
         self, tmp_path: Path
     ) -> None:
+        """#1665: lineage stops being a join key.  Three distinct
+        comments on the same PR thread produce three distinct tasks
+        — combine / split decisions move to the rescope reducer
+        (#1666 / #1667), not the add boundary."""
         first_thread = {
             "repo": "r/r",
             "pr": 1,
             "comment_id": 101,
-            "lineage_key": "pulls:r/r:1:thread:100",
             "lineage_comment_ids": [100, 101],
         }
         second_thread = {
             "repo": "r/r",
             "pr": 1,
             "comment_id": 102,
-            "lineage_key": "pulls:r/r:1:thread:100",
             "lineage_comment_ids": [100, 102],
         }
 
@@ -414,11 +416,11 @@ class TestAddTask:
             thread=second_thread,
         )
 
-        assert first["id"] == second["id"]
+        assert first["id"] != second["id"]
         tasks = Tasks(tmp_path).list()
-        assert len(tasks) == 1
+        assert len(tasks) == 2
         assert tasks[0]["thread"]["comment_id"] == 101
-        assert tasks[0]["thread"]["lineage_comment_ids"] == [100, 101, 102]
+        assert tasks[1]["thread"]["comment_id"] == 102
 
     def test_different_comment_ids_are_not_deduplicated(self, tmp_path: Path) -> None:
         t1 = Tasks(tmp_path).add(
@@ -469,22 +471,22 @@ class TestAddTask:
         tasks = Tasks(tmp_path).list()
         assert len(tasks) == 2
 
-    def test_in_progress_lineage_deduplicates_new_task_with_different_comment(
+    def test_in_progress_sibling_does_not_block_new_distinct_comment(
         self, tmp_path: Path
     ) -> None:
-        """An in-progress sibling task in the same lineage should coalesce
-        the new task — one active worker is already on it."""
+        """#1665: even an in-progress sibling task in the same lineage
+        does not coalesce a new distinct comment.  The combine
+        decision moves to the rescope reducer (#1667) — at the add
+        boundary every distinct comment yields its own task."""
         thread_a = {
             "repo": "r/r",
             "pr": 1,
             "comment_id": 100,
-            "lineage_key": "issues:r/r:1",
         }
         thread_b = {
             "repo": "r/r",
             "pr": 1,
             "comment_id": 200,
-            "lineage_key": "issues:r/r:1",
         }
 
         t1 = Tasks(tmp_path).add(
@@ -500,8 +502,8 @@ class TestAddTask:
             thread=thread_b,
         )
 
-        assert t1["id"] == t2["id"], "in-progress sibling must coalesce"
-        assert len(Tasks(tmp_path).list()) == 1
+        assert t1["id"] != t2["id"]
+        assert len(Tasks(tmp_path).list()) == 2
 
     def test_task_type_required(self, tmp_path: Path) -> None:
         import pytest


### PR DESCRIPTION
Closes #1665.
Parent epic: #1340 — intent-driven rescope.

## Summary
- Drop the `lineage_key == existing_lineage_key` branch in `Tasks.add` and its merge-into-existing-task logic.
- Three distinct comments on the same PR thread now produce three distinct tasks. The only dedup at the add boundary is exact-comment_id replay protection (the same GitHub comment delivered twice).

## Why this change
Lineage stops being a join key for dedup. It stays on the task as origin metadata via `lineage_comment_ids` — answering "which comments contributed to this task," not "is this task the same as that one." Combine / split / rewrite decisions move to the rescope reducer in later phases of the epic (#1666 / #1667).

`lineage_key` is dropped from `_merge_thread_lineage`'s write path since it is no longer load-bearing. Callers (events.py) still attach it to thread metadata so historical traces stay intact until later phases of the epic clean it up.

## Test plan
- [x] `./fido ci` (ran via pre-commit hook) — 4235 tests, 100% coverage
- [x] Two former dedup-by-lineage tests rewritten to assert distinct tasks instead of coalescing
- [x] Two helper tests in test_coverage_fills.py removed because the helpers they covered (`_thread_lineage_key`, the `lineage_key` setter in `_merge_thread_lineage`) are gone

## Out of scope
Existing-task title/anchor rewrites (#1666), reducer mutation operations (#1667), prompt vocabulary (#1247), reply-back filtering (#1256). Each gets its own leaf PR.