### PR TITLE
Rescope L4: validate batch atomically before commit (closes #1715)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -897,6 +897,67 @@ def _make_new_tasks_from_opus(
     return new_tasks
 
 
+def _validate_rescope_batch(
+    current: list[dict[str, Any]],
+    ordered_items: list[Any],
+) -> list[str]:
+    """Validate a rescope batch atomically.  Empty list = valid (#1715).
+
+    Returns a list of error messages.  The whole batch is rejected if any
+    check fails — partial commits would leave ``tasks.json`` in a state
+    Opus didn't propose, defeating the snapshot/replay model.
+
+    Checks:
+
+    * Each item must be a dict.
+    * An item with a non-null ``id`` must reference a task that currently
+      exists in the queue (snapshot or post-snapshot).  An unknown id
+      means Opus is operating on a hallucinated row; reject and let the
+      next iteration retry against fresh state.
+    * No two items may share the same non-null ``id`` (duplicate output —
+      both would target the same task and the second would be silently
+      dropped today).
+    * A non-null ``id`` must be a non-empty string.
+
+    Items with ``id is None`` (or absent) are new-task proposals; their
+    own validation lives in :func:`_make_new_tasks_from_opus` (blank-title
+    skip, etc.) — they are not rejected here.
+
+    Forward-looking: when #1716/1717/1718 add explicit delete/merge/split
+    operations to the rescope vocabulary, this is where their lineage-
+    preservation rules will live (e.g. merge into target T must keep
+    every source's source_comment in T's lineage_comment_ids).
+    """
+    errors: list[str] = []
+    known_ids = {t["id"] for t in current if "id" in t}
+    seen_ids: set[str] = set()
+
+    for index, item in enumerate(ordered_items):
+        if not isinstance(item, dict):
+            errors.append(f"item[{index}]: not a dict, got {type(item).__name__}")
+            continue
+        item_id = item.get("id")
+        if item_id is None:
+            continue
+        if not isinstance(item_id, str) or not item_id:
+            errors.append(
+                f"item[{index}].id: must be non-empty string, got {item_id!r}"
+            )
+            continue
+        if item_id not in known_ids:
+            errors.append(
+                f"item[{index}].id={item_id!r}: unknown source id "
+                "(not in current task queue)"
+            )
+        if item_id in seen_ids:
+            errors.append(
+                f"item[{index}].id={item_id!r}: duplicate (already appears earlier)"
+            )
+        seen_ids.add(item_id)
+
+    return errors
+
+
 def _find_duplicate_titles(
     ordered_items: list[dict[str, Any]],
     existing_by_id: dict[str, str],
@@ -1163,51 +1224,73 @@ def reorder_tasks(
     # serialize on the same lock.
     inprogress_affected = False
     pre_rescope: list[dict[str, Any]] = []
+    result: list[dict[str, Any]] = []
+    inprogress: dict[str, Any] | None = None
+    rejected = False
     with tasks.modify() as current:
-        # Snapshot the pre-rescope list so _compute_thread_changes can
-        # diff against it after the in-place slice-assign below (codex
-        # P2 #1696: comparing post-rescope to itself suppresses
-        # _on_changes notifications for thread tasks Opus completed/
-        # modified).
-        pre_rescope = [dict(t) for t in current]
-        inprogress = next(
-            (t for t in current if t.get("status") == TaskStatus.IN_PROGRESS), None
-        )
-        result = _apply_reorder(current, ordered_items, original_ids, intents=intents)
-        if inprogress is not None:
-            # The omission ⇒ completed branch is gone (#1357 case A): the
-            # rescope reducer now uses KeepTask for omitted snapshot tasks,
-            # so the in-progress task always survives the rescope at its
-            # current status.  Triggers for _on_inprogress_affected are
-            # explicit modifications by Opus that change the task's
-            # contract: title, description, or — under #1714 — the
-            # source-comment anchor.  Anchor change is structural (it re-
-            # targets the reply destination), so a worker turn that began
-            # under the old anchor must not finish under the new one.
-            inprogress_in_result = next(
-                (t for t in result if t["id"] == inprogress["id"]), None
+        # #1715: validate the batch atomically before applying any of it.
+        # If validation fails, every error is logged and the with block
+        # exits without slice-assigning — JsonFileStore.modify writes
+        # back the same content, so the durable list is unchanged.
+        # Partial commits aren't safe: they'd leave tasks.json in a
+        # state Opus didn't propose, breaking snapshot/replay reasoning.
+        validation_errors = _validate_rescope_batch(current, ordered_items)
+        if validation_errors:
+            rejected = True
+            for error in validation_errors:
+                log.warning("reorder_tasks: rejecting batch — %s", error)
+        else:
+            # Snapshot the pre-rescope list so _compute_thread_changes can
+            # diff against it after the in-place slice-assign below (codex
+            # P2 #1696: comparing post-rescope to itself suppresses
+            # _on_changes notifications for thread tasks Opus completed/
+            # modified).
+            pre_rescope = [dict(t) for t in current]
+            inprogress = next(
+                (t for t in current if t.get("status") == TaskStatus.IN_PROGRESS), None
             )
-            # Compare anchors via _task_source_comment_for_oracle so a
-            # legacy ``'42'`` string in tasks.json compares equal to the
-            # oracle-materialized ``42`` (codex on #1731): int(comment_id)
-            # normalization on both sides means spurious type-mismatch
-            # aborts can't fire.
-            if inprogress_in_result is not None and (
-                inprogress_in_result.get("title") != inprogress.get("title")
-                or inprogress_in_result.get("description")
-                != inprogress.get("description")
-                or _task_source_comment_for_oracle(inprogress_in_result)
-                != _task_source_comment_for_oracle(inprogress)
-            ):
-                inprogress_affected = True
-                inprogress_in_result["status"] = str(TaskStatus.PENDING)
-                log.info(
-                    "reorder_tasks: in-progress task modified by Opus — reset to pending: %s",
-                    inprogress_in_result.get("title", "")[:60],
+            result = _apply_reorder(
+                current, ordered_items, original_ids, intents=intents
+            )
+            if inprogress is not None:
+                # The omission ⇒ completed branch is gone (#1357 case A): the
+                # rescope reducer now uses KeepTask for omitted snapshot tasks,
+                # so the in-progress task always survives the rescope at its
+                # current status.  Triggers for _on_inprogress_affected are
+                # explicit modifications by Opus that change the task's
+                # contract: title, description, or — under #1714 — the
+                # source-comment anchor.  Anchor change is structural (it re-
+                # targets the reply destination), so a worker turn that began
+                # under the old anchor must not finish under the new one.
+                inprogress_in_result = next(
+                    (t for t in result if t["id"] == inprogress["id"]), None
                 )
-        # Slice-assign so JsonFileStore.modify writes the recomputed
-        # list back (it persists the same dict/list object it yielded).
-        current[:] = result
+                # Compare anchors via _task_source_comment_for_oracle so a
+                # legacy ``'42'`` string in tasks.json compares equal to the
+                # oracle-materialized ``42`` (codex on #1731): int(comment_id)
+                # normalization on both sides means spurious type-mismatch
+                # aborts can't fire.
+                if inprogress_in_result is not None and (
+                    inprogress_in_result.get("title") != inprogress.get("title")
+                    or inprogress_in_result.get("description")
+                    != inprogress.get("description")
+                    or _task_source_comment_for_oracle(inprogress_in_result)
+                    != _task_source_comment_for_oracle(inprogress)
+                ):
+                    inprogress_affected = True
+                    inprogress_in_result["status"] = str(TaskStatus.PENDING)
+                    log.info(
+                        "reorder_tasks: in-progress task modified by Opus — reset to pending: %s",
+                        inprogress_in_result.get("title", "")[:60],
+                    )
+            # Slice-assign so JsonFileStore.modify writes the recomputed
+            # list back (it persists the same dict/list object it yielded).
+            current[:] = result
+
+    if rejected:
+        if _on_done is not None:
+            _on_done()
+        return
 
     if _on_changes is not None:
         # Always call with the (possibly empty) list — the production

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1288,8 +1288,10 @@ def reorder_tasks(
             current[:] = result
 
     if rejected:
-        if _on_done is not None:
-            _on_done()
+        # _on_done's contract is "post-successful reorder" — production wires
+        # it to sync_tasks (git push) and _rewrite_pr_description (GitHub API
+        # write).  Neither makes sense after a rejection: nothing committed,
+        # nothing to sync.  Skip every post-commit callback (codex on #1733).
         return
 
     if _on_changes is not None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -28,6 +28,7 @@ from fido.tasks import (
     _task_source_comment_for_oracle,
     _task_status_for_oracle,
     _task_store_for_oracle,
+    _validate_rescope_batch,
     reorder_tasks,
     review_thread_for_auto_resolve_oracle,
 )
@@ -1494,6 +1495,88 @@ class TestFindDuplicateTitles:
         assert _find_duplicate_titles(items, existing_by_id) == ["Alpha"]
 
 
+# ── _validate_rescope_batch ───────────────────────────────────────────────────
+
+
+class TestValidateRescopeBatch:
+    """#1715: rescope batch validation runs before any commit.  Errors
+    reject the whole batch atomically — partial commits would leave
+    tasks.json in a state Opus didn't propose."""
+
+    def _t(self, task_id: str, title: str = "") -> dict:
+        return {
+            "id": task_id,
+            "title": title,
+            "type": "spec",
+            "status": "pending",
+            "description": "",
+        }
+
+    def test_empty_batch_is_valid(self) -> None:
+        assert _validate_rescope_batch([self._t("1")], []) == []
+
+    def test_known_id_with_changes_is_valid(self) -> None:
+        current = [self._t("1", "A")]
+        items = [{"id": "1", "title": "A renamed", "description": "x"}]
+        assert _validate_rescope_batch(current, items) == []
+
+    def test_null_id_is_treated_as_new_task_not_rejected(self) -> None:
+        current = [self._t("1")]
+        items = [{"id": None, "title": "Brand new", "description": ""}]
+        assert _validate_rescope_batch(current, items) == []
+
+    def test_unknown_source_id_is_rejected(self) -> None:
+        current = [self._t("1")]
+        items = [{"id": "999", "title": "Hallucinated"}]
+        errors = _validate_rescope_batch(current, items)
+        assert len(errors) == 1
+        assert "999" in errors[0]
+        assert "unknown source id" in errors[0]
+
+    def test_duplicate_item_id_is_rejected(self) -> None:
+        current = [self._t("1")]
+        items = [
+            {"id": "1", "title": "first"},
+            {"id": "1", "title": "second"},
+        ]
+        errors = _validate_rescope_batch(current, items)
+        assert len(errors) == 1
+        assert "duplicate" in errors[0]
+
+    def test_blank_id_is_rejected(self) -> None:
+        current = [self._t("1")]
+        items = [{"id": "", "title": "blank id"}]
+        errors = _validate_rescope_batch(current, items)
+        assert any("non-empty string" in e for e in errors)
+
+    def test_non_string_id_is_rejected(self) -> None:
+        current = [self._t("1")]
+        items = [{"id": 42, "title": "int id"}]
+        errors = _validate_rescope_batch(current, items)
+        assert any("non-empty string" in e for e in errors)
+
+    def test_non_dict_item_is_rejected(self) -> None:
+        current = [self._t("1")]
+        items = ["not a dict"]
+        errors = _validate_rescope_batch(current, items)  # type: ignore[arg-type]
+        assert any("not a dict" in e for e in errors)
+
+    def test_mixed_valid_and_invalid_collects_all_errors(self) -> None:
+        # Validator runs to completion so the operator sees every problem
+        # in one log scan, not just the first.
+        current = [self._t("1"), self._t("2")]
+        items = [
+            {"id": "1", "title": "OK"},  # valid
+            {"id": "999", "title": "ghost"},  # unknown source
+            {"id": "1", "title": "dup"},  # duplicate of OK
+            {"id": None, "title": "new"},  # valid (null = new)
+        ]
+        errors = _validate_rescope_batch(current, items)
+        assert len(errors) == 2
+        assert any("999" in e and "unknown" in e for e in errors)
+        assert any("duplicate" in e for e in errors)
+
+
 # ── reorder_tasks ─────────────────────────────────────────────────────────────
 
 
@@ -1533,6 +1616,61 @@ class TestReorderTasks:
         result_before = Tasks(tmp_path).list()
         reorder_tasks(Tasks(tmp_path), "", agent=_client("not json"))
         assert Tasks(tmp_path).list() == result_before
+
+    def test_invalid_batch_leaves_durable_list_unchanged(self, tmp_path: Path) -> None:
+        # #1715: a mixed batch — one valid item and one referencing a
+        # hallucinated id — must reject the WHOLE batch.  The valid
+        # item's rename does not partially commit; tasks.json stays as
+        # it was before reorder_tasks ran.
+        t1 = self._add(tmp_path, "Original")
+        before = Tasks(tmp_path).list()
+        raw = self._response(
+            [
+                {"id": t1["id"], "title": "Renamed", "description": ""},
+                {"id": "ghost-999", "title": "hallucinated"},
+            ]
+        )
+        reorder_tasks(Tasks(tmp_path), "", agent=_client(raw))
+        # Durable list is byte-for-byte identical to pre-call state.
+        assert Tasks(tmp_path).list() == before
+
+    def test_invalid_batch_calls_on_done(self, tmp_path: Path) -> None:
+        # Even when validation rejects, _on_done still fires so callers
+        # can clean up (e.g. release a one-shot lock).  Only the commit
+        # and the post-commit notifications are skipped.
+        t1 = self._add(tmp_path, "Original")
+        raw = self._response([{"id": "ghost-999", "title": "hallucinated"}])
+        done_calls: list[int] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_done=lambda: done_calls.append(1),
+        )
+        assert done_calls == [1]
+        assert Tasks(tmp_path).list()[0]["title"] == t1["title"]
+
+    def test_invalid_batch_skips_on_changes_callback(self, tmp_path: Path) -> None:
+        # _on_changes is post-commit notification machinery; rejected
+        # batches mustn't fire it (there's no rescope to report on).
+        thread = {"repo": "r/r", "pr": 1, "comment_id": 99}
+        t1 = Tasks(tmp_path).add(
+            title="Thread task", task_type=TaskType.THREAD, thread=thread
+        )
+        raw = self._response(
+            [
+                {"id": t1["id"], "title": "Renamed", "description": ""},
+                {"id": "ghost-999", "title": "hallucinated"},
+            ]
+        )
+        received: list = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_changes=lambda changes: received.extend(changes),
+        )
+        assert received == []
 
     def test_preserves_snapshot_order_for_non_ci_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "First")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1634,10 +1634,11 @@ class TestReorderTasks:
         # Durable list is byte-for-byte identical to pre-call state.
         assert Tasks(tmp_path).list() == before
 
-    def test_invalid_batch_calls_on_done(self, tmp_path: Path) -> None:
-        # Even when validation rejects, _on_done still fires so callers
-        # can clean up (e.g. release a one-shot lock).  Only the commit
-        # and the post-commit notifications are skipped.
+    def test_invalid_batch_skips_on_done(self, tmp_path: Path) -> None:
+        # codex on #1733: _on_done's contract is "post-successful reorder."
+        # Production wires it to sync_tasks (git push) and
+        # _rewrite_pr_description (GitHub API write); firing on rejection
+        # would cause unnecessary churn for invalid Opus output.
         t1 = self._add(tmp_path, "Original")
         raw = self._response([{"id": "ghost-999", "title": "hallucinated"}])
         done_calls: list[int] = []
@@ -1647,7 +1648,7 @@ class TestReorderTasks:
             agent=_client(raw),
             _on_done=lambda: done_calls.append(1),
         )
-        assert done_calls == [1]
+        assert done_calls == []
         assert Tasks(tmp_path).list()[0]["title"] == t1["title"]
 
     def test_invalid_batch_skips_on_changes_callback(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1715.
Parent: #1667. Epic: #1340 — intent-driven rescope.

## Summary
- New \`_validate_rescope_batch\` runs inside the modify() lock before any rewrite. If any item fails, the whole batch is rejected — partial commits would leave \`tasks.json\` in a state Opus didn't propose, defeating the snapshot/replay model.
- On rejection: every error is logged, the durable list stays byte-for-byte identical, post-commit notifications are skipped, and \`_on_done\` still fires so callers can release one-shot locks.

## Validation rules
- Each item must be a dict.
- A non-null \`id\` must reference a task currently in the queue (snapshot or post-snapshot). Unknown id = Opus is operating on a hallucinated row → reject and let the next iteration try against fresh state.
- No two items may share the same non-null \`id\` (duplicate output — second would be silently dropped today).
- A non-null \`id\` must be a non-empty string.
- Items with \`id=None\` (new-task proposals) are not subject to these checks — their own validation lives in \`_make_new_tasks_from_opus\`.

## Forward-looking
The lineage-preservation rules for #1716 (delete), #1717 (merge), #1718 (split) will live here. Today's \`RewriteAnchor\` already preserves lineage in \`_materialize_rescope_oracle_result\`, so the lineage check needs no special-casing yet.

## Test plan
- [x] \`./fido ci\` (pre-commit hook) — 4262 tests, 100% coverage
- [x] Validator unit tests: empty/valid batch, valid + null-id, unknown source, duplicate id, blank/non-string id, non-dict item, mixed valid+invalid (collects ALL errors)
- [x] End-to-end: invalid batch leaves durable list unchanged; \`_on_done\` fires; \`_on_changes\` doesn't