### PR TITLE
Rescope L5: explicit task removal via item.status=completed (closes #1716)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -381,21 +381,33 @@ def _rescope_releases_for_oracle(
             new_description = (
                 item["description"] if "description" in item else existing_description
             )
-            # #1714: anchor change takes precedence over text rewrites when
-            # the task already has a thread — anchor is structural (re-
-            # targets the reply destination).  If Opus also asked for
-            # title/description rewrites alongside the anchor change, they
-            # ride the next rescope iteration.  An ``anchor_comment_id`` on
-            # a non-thread task is garbage and is ignored — fall through
-            # to the text path.  A non-positive or boolean value is also
-            # garbage (Python's ``bool`` is a subclass of ``int``; GitHub
-            # comment ids are positive 64-bit ints).  The materialization
-            # step preserves the previous anchor in lineage_comment_ids.
-            if (
+            # Op precedence (most structural first):
+            #   1. Explicit completion (#1716): item.status == "completed".
+            #      Removes the task — strictly more structural than any
+            #      metadata change, so it preempts the others.  Omission
+            #      still means keep-as-is (#1357), not delete.
+            #   2. Anchor rewrite (#1714): re-targets the reply destination.
+            #   3. Text rewrite (#1713): title/description.
+            #   4. KeepTask: nothing changed.
+            #
+            # The model carries one op per task per batch, so a combined
+            # request rides multiple rescope iterations — the highest-
+            # precedence change lands first.
+            if item.get("status") == str(TaskStatus.COMPLETED):
+                decision: rescope_oracle.RescopeOp = rescope_oracle.CompleteTask(
+                    oracle_id
+                )
+            elif (
                 isinstance(task.get("thread"), dict)
                 and _is_valid_anchor_id(item.get("anchor_comment_id"))
                 and item["anchor_comment_id"] != existing_anchor
             ):
+                # An ``anchor_comment_id`` on a non-thread task is garbage
+                # and is ignored — fall through to the text path.  A non-
+                # positive or boolean value is also garbage (Python's
+                # ``bool`` is a subclass of ``int``; GitHub comment ids
+                # are positive 64-bit ints).  The materialization step
+                # preserves the previous anchor in lineage_comment_ids.
                 decision = rescope_oracle.RewriteAnchor(
                     oracle_id, item["anchor_comment_id"]
                 )
@@ -1254,14 +1266,12 @@ def reorder_tasks(
             )
             if inprogress is not None:
                 # The omission ⇒ completed branch is gone (#1357 case A): the
-                # rescope reducer now uses KeepTask for omitted snapshot tasks,
-                # so the in-progress task always survives the rescope at its
-                # current status.  Triggers for _on_inprogress_affected are
-                # explicit modifications by Opus that change the task's
-                # contract: title, description, or — under #1714 — the
-                # source-comment anchor.  Anchor change is structural (it re-
-                # targets the reply destination), so a worker turn that began
-                # under the old anchor must not finish under the new one.
+                # rescope reducer now uses KeepTask for omitted snapshot
+                # tasks, so the in-progress task always survives the rescope
+                # at its current status.  Triggers for _on_inprogress_affected
+                # are explicit modifications by Opus that change the task's
+                # contract: title, description, source-comment anchor (#1714),
+                # or — under #1716 — explicit completion.
                 inprogress_in_result = next(
                     (t for t in result if t["id"] == inprogress["id"]), None
                 )
@@ -1270,19 +1280,37 @@ def reorder_tasks(
                 # oracle-materialized ``42`` (codex on #1731): int(comment_id)
                 # normalization on both sides means spurious type-mismatch
                 # aborts can't fire.
-                if inprogress_in_result is not None and (
-                    inprogress_in_result.get("title") != inprogress.get("title")
-                    or inprogress_in_result.get("description")
-                    != inprogress.get("description")
-                    or _task_source_comment_for_oracle(inprogress_in_result)
-                    != _task_source_comment_for_oracle(inprogress)
-                ):
-                    inprogress_affected = True
-                    inprogress_in_result["status"] = str(TaskStatus.PENDING)
-                    log.info(
-                        "reorder_tasks: in-progress task modified by Opus — reset to pending: %s",
-                        inprogress_in_result.get("title", "")[:60],
+                if inprogress_in_result is not None:
+                    completed_by_rescope = inprogress_in_result.get("status") == str(
+                        TaskStatus.COMPLETED
                     )
+                    text_or_anchor_changed = (
+                        inprogress_in_result.get("title") != inprogress.get("title")
+                        or inprogress_in_result.get("description")
+                        != inprogress.get("description")
+                        or _task_source_comment_for_oracle(inprogress_in_result)
+                        != _task_source_comment_for_oracle(inprogress)
+                    )
+                    if completed_by_rescope or text_or_anchor_changed:
+                        inprogress_affected = True
+                        if completed_by_rescope:
+                            # #1716: explicit completion — the task is done;
+                            # the worker just needs to abort its now-stale
+                            # turn.  Don't reset to pending.
+                            log.info(
+                                "reorder_tasks: in-progress task explicitly "
+                                "completed by Opus — aborting turn: %s",
+                                inprogress_in_result.get("title", "")[:60],
+                            )
+                        else:
+                            # Text/anchor change: reset to pending so the
+                            # worker re-picks under the new scope.
+                            inprogress_in_result["status"] = str(TaskStatus.PENDING)
+                            log.info(
+                                "reorder_tasks: in-progress task modified by "
+                                "Opus — reset to pending: %s",
+                                inprogress_in_result.get("title", "")[:60],
+                            )
             # Slice-assign so JsonFileStore.modify writes the recomputed
             # list back (it persists the same dict/list object it yielded).
             current[:] = result

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1193,6 +1193,70 @@ class TestApplyReorder:
         # Thread metadata stays put — no anchor change happened.
         assert result[0]["thread"] == thread
 
+    def test_explicit_completion_marks_task_completed(self) -> None:
+        # #1716: an item with status="completed" emits CompleteTask, which
+        # the reducer applies as a status flip to COMPLETED.  This is the
+        # only way rescope can remove a snapped task — omission still means
+        # keep-as-is (#1357).
+        current = [self._t("1", "Done work")]
+        items = [{"id": "1", "title": "Done work", "status": "completed"}]
+        result = _apply_reorder(current, items)
+        assert result[0]["status"] == str(TaskStatus.COMPLETED)
+
+    def test_explicit_completion_takes_precedence_over_text_and_anchor(
+        self,
+    ) -> None:
+        # CompleteTask is the most structural op — it removes the task.
+        # When an item asks for both completion and text/anchor changes,
+        # the adapter emits CompleteTask; the metadata changes are moot
+        # because the task is done.
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        t = self._t("1", "Old title", task_type="thread", description="old desc")
+        t["thread"] = thread
+        items = [
+            {
+                "id": "1",
+                "title": "New title",
+                "description": "new desc",
+                "anchor_comment_id": 99,
+                "status": "completed",
+            },
+        ]
+        result = _apply_reorder([t], items)
+        assert result[0]["status"] == str(TaskStatus.COMPLETED)
+        # Title/desc/anchor at the moment of completion are immaterial —
+        # the row is done.  Existing thread metadata isn't re-anchored.
+        assert result[0]["thread"]["comment_id"] == 42
+
+    def test_omitted_task_is_kept_not_completed(self) -> None:
+        # #1357 / #1716 invariant: omission ≠ deletion.  A pending task
+        # Opus omits from its output survives at its current status.
+        # Only an explicit status="completed" item triggers removal.
+        current = [self._t("1", "Keep me"), self._t("2", "Also keep")]
+        original_ids = frozenset({"1", "2"})
+        items = [self._item("1", "Keep me")]  # task "2" omitted
+        result = _apply_reorder(current, items, original_ids)
+        task2 = next(t for t in result if t["id"] == "2")
+        assert task2["status"] == str(TaskStatus.PENDING)
+        assert task2["title"] == "Also keep"
+
+    def test_explicit_completion_of_thread_task_fires_completed_change_record(
+        self,
+    ) -> None:
+        # _compute_thread_changes already keys completion records on
+        # result.status == COMPLETED, so the explicit completion path
+        # naturally produces "kind=completed" change records that
+        # reply-back consumers (#1256) will eventually filter and post.
+        thread = {"repo": "a/b", "pr": 1, "comment_id": 42}
+        t = self._t("1", "Thread task", task_type="thread")
+        t["thread"] = thread
+        items = [{"id": "1", "title": "Thread task", "status": "completed"}]
+        result = _apply_reorder([t], items)
+        changes = _compute_thread_changes([t], result, frozenset({"1"}))
+        assert len(changes) == 1
+        assert changes[0]["kind"] == "completed"
+        assert changes[0]["task"]["id"] == "1"
+
     def test_applies_duplicate_titles_at_apply_reorder_layer(self) -> None:
         # _apply_reorder is the low-level reducer; uniqueness is enforced
         # upstream by the rescope nudge loop in reorder_tasks(), not here
@@ -2041,6 +2105,37 @@ class TestReorderTasks:
         result = Tasks(tmp_path).list()
         assert result[0]["status"] == str(TaskStatus.PENDING)
         assert result[0]["thread"]["comment_id"] == 99
+
+    def test_on_inprogress_affected_called_when_explicitly_completed(
+        self, tmp_path: Path
+    ) -> None:
+        # #1716: when Opus explicitly completes the in-progress task, the
+        # worker turn must abort.  Unlike text/anchor changes, the task is
+        # NOT reset to pending — it's done.  The callback fires so the
+        # worker can stop running on a now-completed task.
+        t1 = self._add(tmp_path, "Active task")
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [
+                {
+                    "id": t1["id"],
+                    "title": "Active task",
+                    "description": "",
+                    "status": "completed",
+                },
+            ]
+        )
+        affected: list[str] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_inprogress_affected=lambda task_id: affected.append(task_id),
+        )
+        assert affected == [t1["id"]]
+        # Task stays completed — not reset to pending.
+        result = Tasks(tmp_path).list()
+        assert result[0]["status"] == str(TaskStatus.COMPLETED)
 
     def test_on_inprogress_affected_not_called_when_no_inprogress_task(
         self, tmp_path: Path


### PR DESCRIPTION
Closes #1716.
Parent: #1667. Epic: #1340 — intent-driven rescope.

## Summary
- Wires the explicit-removal path the rocq model has had since L1: when a rescope item carries \`status="completed"\`, the adapter emits \`CompleteTask\`, the reducer flips the row to \`StatusCompleted\`, and the materialization step persists \`status="completed"\`.
- This is the only way rescope can remove a snapped task — omission still means keep-as-is (#1357), the strict invariant of #1716.

## Op precedence (most structural first)
1. \`CompleteTask\` — #1716, \`item.status == "completed"\`
2. \`RewriteAnchor\` — #1714, anchor change
3. \`RewriteTask\` — #1713, title/description
4. \`KeepTask\` — no change

The model carries one op per task per batch, so a combined request rides multiple rescope iterations — the highest-precedence change lands first.

## In-progress handling
\`reorder_tasks\` now also fires \`_on_inprogress_affected\` when the active task is explicitly completed.  Unlike text/anchor changes, the task is NOT reset to pending — it's done; the worker just aborts the now-stale turn and re-picks the next task.

## Notification machinery
\`_compute_thread_changes\` already keys completion records on \`result.status == COMPLETED\`, so the explicit completion path naturally produces \`kind=completed\` change records that reply-back consumers (#1256) will eventually filter and post.

## Test plan
- [x] \`./fido ci\` (pre-commit hook) — 4267 tests, 100% coverage
- [x] explicit completion sets status to COMPLETED
- [x] precedence: completion preempts anchor + text rewrites
- [x] omitted task survives at PENDING (regression for #1357)
- [x] thread-task explicit completion fires "completed" change record
- [x] in-progress explicit completion fires _on_inprogress_affected and leaves status=COMPLETED

## Out of scope
Prompt vocabulary (#1247), reply-back materiality filtering (#1256).