### PR TITLE
Rescope L#1719: explicit operation schema parser (closes #1719)

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -372,34 +372,35 @@ class Prompts:
         prior_attempts: list[ClosedPR] | None = None,
         intents: list[RescopeIntent] | None = None,
     ) -> str:
-        """Build an Opus prompt for full task-list synthesis from old tasks + intents.
+        """Build an Opus prompt for explicit-operations rescope (#1719).
 
-        Presents the full task list and a summary of commits already made, then
-        asks Opus to synthesize a complete new task list that reflects the current
-        codebase state and all accumulated change requests.
+        Presents the full task list and a summary of commits already made,
+        then asks Opus to reply with a typed list of operations over the
+        snapshot — every snapped task id is claimed by exactly one
+        operation; new tasks are explicit ``new`` ops.  No "infer
+        mutation from omission" guessing.
 
-        Unlike a simple reorder, Opus may add entirely new tasks, merge, split,
-        rescope, delete, or wipe existing tasks — any transformation needed to
-        produce a coherent task list that describes how to reach the desired new
-        state.  Accumulated intents are listed in chronological order; newer ones
-        override older ones where they conflict.
+        Operation schema (one per item in ``operations``):
 
-        When *issue* is provided, the rendered active-context block (issue,
-        optional PR, prior attempts, task list) is prepended so Opus has full
-        context about what is being worked on.
+        * ``{"op": "keep", "id": "..."}`` — leave the task unchanged.
+        * ``{"op": "rewrite", "id": "...", "title": "...", "description": "..."}``
+          — replace title/description on an existing task id.
+        * ``{"op": "rewrite_anchor", "id": "...", "anchor_comment_id": 12345}``
+          — re-target the source-comment anchor (reply destination).
+        * ``{"op": "remove", "id": "..."}`` — close the task.
+        * ``{"op": "merge", "target_id": "...", "sources": ["..."],
+              "title": "...", "description": "..."}`` — fold each source's
+          lineage into target; sources close.
+        * ``{"op": "split", "id": "...",
+              "children": [{"title": "...", "description": "..."}]}`` —
+          close source and spawn N children inheriting its lineage.
+        * ``{"op": "new", "title": "...", "description": "...", "type": "spec"}``
+          — create a fresh task.
 
-        When *intents* is provided (comment-triggered rescope), the originating
-        comment IDs, timestamps, and change request texts are shown so Opus can
-        synthesize a coherent picture from all accumulated requests.
-
-        Rules enforced in the prompt:
-        - CI tasks (type "ci") must come first.
-        - Existing task IDs must be preserved when kept or modified.
-        - New tasks (not in the current list) must have a null or absent id.
-        - Completed tasks are excluded from the output.
-        - Tasks already covered by a commit should be omitted.
-
-        The caller is responsible for parsing the returned JSON and applying it.
+        The caller parses the returned JSON via
+        :func:`fido.tasks._parse_rescope_operations`, which collects every
+        malformation in one pass and feeds them back via
+        :meth:`rescope_parse_nudge` for retries.
         """
         pending = [t for t in task_list if t.get("status") != "completed"]
         completed = [t for t in task_list if t.get("status") == "completed"]
@@ -458,32 +459,88 @@ class Prompts:
             f"{intents_block}"
             "Pending tasks (current order):\n"
             f"{pending_json}\n\n"
-            "Synthesize a complete new task list from the pending tasks above and "
-            "the accumulated change requests.  The result replaces the entire "
-            "pending task list.\n\n"
-            "Any transformation is valid — keep tasks unchanged, modify their scope, "
-            "merge multiple tasks into one, split one into several, delete tasks no "
-            "longer needed, add entirely new tasks, or wipe and start fresh.  "
-            "Integrate all change requests into a coherent picture: newer requests "
-            "override older ones where they conflict.\n\n"
-            "The task list must break down how to get from the current codebase "
-            "state to the desired new state.\n\n"
-            "Rules:\n"
-            '1. Tasks with type "ci" must come first.\n'
-            "2. For existing tasks you keep or modify, preserve the exact task ID.\n"
-            "3. For entirely new tasks (not in the current pending list), set "
-            '"id" to null or omit it — a fresh ID will be assigned.\n'
-            "4. If a task is already covered by a recent commit, omit it from the "
-            "output — it will be marked done.\n"
-            "5. Include only pending and in_progress tasks in the output — omit "
-            "completed.\n"
-            "6. If a pending task already exists for one of the change requests "
-            "above (matched by content or by its thread metadata), KEEP that "
-            "task and use its exact ID — do NOT emit a second entry with a "
-            'null "id" for the same change request, even if you are rewriting '
-            "its description.  One change request → one task (#1337).\n\n"
-            'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
-            'Each element: {"id": "..." or null, "title": "...", "description": "..."}.\n'
+            "Reply with a typed list of OPERATIONS over this snapshot.  Every "
+            "pending task id MUST appear in exactly one operation; new tasks "
+            'use "new" ops.\n\n'
+            "Operation schema (each entry of the operations array):\n"
+            '  {"op": "keep", "id": "<existing-id>"}\n'
+            "      — leave the task unchanged\n"
+            '  {"op": "rewrite", "id": "<existing-id>", '
+            '"title": "...", "description": "..."}\n'
+            "      — replace the title and/or description\n"
+            '  {"op": "rewrite_anchor", "id": "<existing-id>", '
+            '"anchor_comment_id": <int>}\n'
+            "      — re-target the source-comment anchor (reply destination)\n"
+            '  {"op": "remove", "id": "<existing-id>"}\n'
+            "      — close the task (covered by recent commit, no longer needed)\n"
+            '  {"op": "merge", "target_id": "<existing-id>", '
+            '"sources": ["<existing-id>", ...], '
+            '"title": "...", "description": "..."}\n'
+            "      — fold each source's lineage into the target; sources close\n"
+            '  {"op": "split", "id": "<existing-id>", "children": '
+            '[{"title": "...", "description": "..."}, ...]}\n'
+            "      — close the source and spawn N children inheriting its lineage\n"
+            '  {"op": "new", "title": "...", "description": "...", '
+            '"type": "spec"}\n'
+            "      — create a brand-new task (fresh id assigned by the runtime)\n"
+            "\n"
+            "Constraints:\n"
+            '1. Tasks of type "ci" must come first in the operations array.\n'
+            "2. Each pending snapshot id may appear in at most one operation "
+            "(no rewrite + remove on the same id).\n"
+            "3. Each existing task id you reference must be in the pending "
+            "snapshot above — no inventing ids.\n"
+            "4. A source id may appear in at most one merge or split (lineage "
+            "duplication is rejected).\n"
+            "5. ASK:/DEFER:/CI FAILURE: tasks cannot be split (kind is "
+            'title-prefix driven; use "remove" + "new" if you want to '
+            "convert one into actionable work).\n"
+            "6. If a pending task already covers an intent above (by content "
+            'or thread metadata), use "keep" or "rewrite" on its id — do '
+            'NOT emit "new" for the same intent (#1337).\n\n'
+            'Reply with ONLY a JSON object in the form {"operations": [...]}.\n'
+            "No other text before or after the JSON."
+        )
+
+    def rescope_parse_nudge(self, errors: list[str], *, attempts_remaining: int) -> str:
+        """Build a follow-up nudge when the rescope response failed to parse.
+
+        Hands Opus the full error list so it can correct every defect at
+        once — fail-fast on the first error would force more round trips
+        than necessary.  The schema is reiterated so the model has the
+        full reference inline (rather than relying on memory of the
+        original rescope_prompt several turns back).
+        """
+        if attempts_remaining == 0:
+            attempt_line = (
+                "This is your final attempt — if the response still fails to "
+                "parse, the rescope batch will be dropped."
+            )
+        else:
+            attempt_line = (
+                f"You have {attempts_remaining} attempt(s) remaining after this one."
+            )
+        bulleted = "\n".join(f"- {e}" for e in errors)
+        return (
+            "Your previous rescope response had the following problems:\n\n"
+            f"{bulleted}\n\n"
+            "Resubmit the full operations array, fixing every problem above. "
+            f"{attempt_line}\n\n"
+            "Operation schema (recap):\n"
+            '  {"op": "keep", "id": "<existing-id>"}\n'
+            '  {"op": "rewrite", "id": "<existing-id>", '
+            '"title": "...", "description": "..."}\n'
+            '  {"op": "rewrite_anchor", "id": "<existing-id>", '
+            '"anchor_comment_id": <int>}\n'
+            '  {"op": "remove", "id": "<existing-id>"}\n'
+            '  {"op": "merge", "target_id": "<existing-id>", '
+            '"sources": ["<existing-id>", ...], '
+            '"title": "...", "description": "..."}\n'
+            '  {"op": "split", "id": "<existing-id>", "children": '
+            '[{"title": "...", "description": "..."}, ...]}\n'
+            '  {"op": "new", "title": "...", "description": "...", '
+            '"type": "spec"}\n\n'
+            'Reply with ONLY a JSON object in the form {"operations": [...]}.\n'
             "No other text before or after the JSON."
         )
 
@@ -514,10 +571,10 @@ class Prompts:
             f"Your previous response proposed the same title for multiple different "
             f"tasks: {quoted}.\n\n"
             "Task titles must be unique — each task needs a distinct title that "
-            "clearly describes what that specific task does. Resubmit the full task "
-            f"list with a unique title for every task. {attempt_line}\n\n"
-            'Reply with ONLY a JSON object in the form {"tasks": [...]}.\n'
-            'Each element: {"id": "...", "title": "...", "description": "..."}.\n'
+            "clearly describes what that specific task does. Resubmit the full "
+            "operations array using unique titles for every task. "
+            f"{attempt_line}\n\n"
+            'Reply with ONLY a JSON object in the form {"operations": [...]}.\n'
             "No other text before or after the JSON."
         )
 

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -9,6 +9,7 @@ import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any
 
@@ -1154,32 +1155,469 @@ def sync_tasks(
         sync_lock_fd.close()
 
 
-def _parse_reorder_response(raw: str) -> list[dict[str, Any]] | None:
-    """Parse the Opus rescope response into a list of task items.
+# ── Explicit rescope operation schema (#1719) ─────────────────────────────────
+#
+# The rescope output is a typed sum of operations over the snapped task
+# queue.  Each operation says exactly what it does — no "infer mutation
+# from omission" guessing.  The parser below decodes a strict
+# {"operations": [...]} envelope into this dataclass union and collects
+# every malformation in one pass so a follow-up nudge can hand Opus the
+# full complaint list (rather than fail-on-first).
+#
+# The translator below converts the typed operations back into the
+# existing item-dict shape that the validator/reducer/materializer
+# pipeline already consumes — so this leaf only redesigns the I/O
+# contract with Opus, not the downstream apply path.
 
-    Uses a :class:`json.JSONDecoder` consume loop — scans *raw* for ``{``,
-    attempts :meth:`~json.JSONDecoder.raw_decode` from that position, and
-    advances past the decoded span on success or skips the character on
-    failure.  Returns the first ``"tasks"`` list found in any decoded object,
-    or ``None`` if no valid response is found.
+
+@dataclass(frozen=True)
+class _RescopeOpKeep:
+    """Keep an existing task unchanged."""
+
+    id: str
+
+
+@dataclass(frozen=True)
+class _RescopeOpRewrite:
+    """Rewrite an existing task's title and/or description."""
+
+    id: str
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class _RescopeOpRewriteAnchor:
+    """Re-target an existing task's source-comment anchor (#1714)."""
+
+    id: str
+    anchor_comment_id: int
+
+
+@dataclass(frozen=True)
+class _RescopeOpRemove:
+    """Close an existing task (rocq CompleteTask)."""
+
+    id: str
+
+
+@dataclass(frozen=True)
+class _RescopeOpMerge:
+    """Fold sources' lineage into target (rocq MergeTasks).  Sources close."""
+
+    target_id: str
+    sources: list[str]
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class _RescopeOpSplitChild:
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class _RescopeOpSplit:
+    """Close source and spawn N children inheriting its lineage (rocq SplitTask)."""
+
+    id: str
+    children: list[_RescopeOpSplitChild]
+
+
+@dataclass(frozen=True)
+class _RescopeOpNew:
+    """Create a brand-new task with a fresh id."""
+
+    title: str
+    description: str
+    type: str  # noqa: A003 — schema field name
+
+
+_RescopeOp = (
+    _RescopeOpKeep
+    | _RescopeOpRewrite
+    | _RescopeOpRewriteAnchor
+    | _RescopeOpRemove
+    | _RescopeOpMerge
+    | _RescopeOpSplit
+    | _RescopeOpNew
+)
+
+
+def _parse_rescope_operations(
+    raw: str,
+) -> tuple[list[_RescopeOp], list[str]]:
+    """Parse the explicit rescope-operation envelope, collecting every error.
+
+    The strict schema is::
+
+        {"operations": [
+          {"op": "keep", "id": "..."},
+          {"op": "rewrite", "id": "...", "title": "...", "description": "..."},
+          {"op": "rewrite_anchor", "id": "...", "anchor_comment_id": 12345},
+          {"op": "remove", "id": "..."},
+          {"op": "merge", "target_id": "...", "sources": ["..."],
+                          "title": "...", "description": "..."},
+          {"op": "split", "id": "...",
+                          "children": [{"title": "...", "description": "..."}]},
+          {"op": "new", "title": "...", "description": "...", "type": "spec"}
+        ]}
+
+    Every malformation found is appended to the returned error list so
+    one parse pass produces the full complaint set the retry nudge
+    sends back to Opus (Rob: "useful retries that detail what was
+    wrong, as many things as we can find at once").  When errors are
+    non-empty the returned op list is also empty — callers must reject
+    the whole batch rather than partially apply.
+    """
+    errors: list[str] = []
+    envelope = _decode_first_json_object(raw)
+    if envelope is None:
+        return [], ["response: no JSON object found"]
+    if "operations" not in envelope:
+        return [], ['response: missing top-level "operations" array']
+    raw_ops = envelope["operations"]
+    if not isinstance(raw_ops, list):
+        return [], [
+            f"response.operations: must be a list, got {type(raw_ops).__name__}"
+        ]
+    operations: list[_RescopeOp] = []
+    for index, raw_op in enumerate(raw_ops):
+        path = f"operations[{index}]"
+        if not isinstance(raw_op, dict):
+            errors.append(f"{path}: must be a dict, got {type(raw_op).__name__}")
+            continue
+        op_name = raw_op.get("op")
+        if not isinstance(op_name, str):
+            errors.append(f"{path}.op: must be a string, got {op_name!r}")
+            continue
+        parser = _OP_PARSERS.get(op_name)
+        if parser is None:
+            errors.append(
+                f"{path}.op: unknown operation {op_name!r} (expected one of "
+                "keep, rewrite, rewrite_anchor, remove, merge, split, new)"
+            )
+            continue
+        op_or_none, op_errors = parser(raw_op, path)
+        errors.extend(op_errors)
+        if op_or_none is not None:
+            operations.append(op_or_none)
+    if errors:
+        return [], errors
+    return operations, []
+
+
+def _decode_first_json_object(raw: str) -> dict[str, Any] | None:
+    """Find and decode the first top-level JSON object in *raw*.
+
+    Same scan loop the legacy parser used; left here so the caller can
+    distinguish "no JSON at all" (parser-error nudge fires) from
+    "decoded JSON but the schema is wrong" (per-op errors fire).
     """
     decoder = json.JSONDecoder()
     pos = 0
-    while pos < len(raw):
+    while True:
         brace = raw.find("{", pos)
         if brace == -1:
-            break
+            return None
         try:
-            obj, end = decoder.raw_decode(raw, brace)
+            obj, _end = decoder.raw_decode(raw, brace)
         except json.JSONDecodeError:
             pos = brace + 1
             continue
-        if isinstance(obj, dict):
-            tasks = obj.get("tasks")
-            if isinstance(tasks, list):
-                return tasks
-        pos = end
-    return None
+        # raw_decode starting at '{' always yields a dict (JSON object);
+        # the only non-error outcome is a parsed object.
+        return obj
+
+
+def _require_string_field(
+    raw_op: dict[str, Any], field: str, path: str, errors: list[str]
+) -> str | None:
+    value = raw_op.get(field)
+    if not isinstance(value, str) or not value:
+        errors.append(f"{path}.{field}: must be a non-empty string, got {value!r}")
+        return None
+    return value
+
+
+def _require_string_field_allow_empty(
+    raw_op: dict[str, Any], field: str, path: str, errors: list[str]
+) -> str | None:
+    value = raw_op.get(field)
+    if not isinstance(value, str):
+        errors.append(f"{path}.{field}: must be a string, got {value!r}")
+        return None
+    return value
+
+
+def _parse_op_keep(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    task_id = _require_string_field(raw_op, "id", path, errors)
+    if task_id is None:
+        return None, errors
+    return _RescopeOpKeep(id=task_id), errors
+
+
+def _parse_op_rewrite(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    task_id = _require_string_field(raw_op, "id", path, errors)
+    title = _require_string_field(raw_op, "title", path, errors)
+    description = _require_string_field_allow_empty(raw_op, "description", path, errors)
+    if task_id is None or title is None or description is None:
+        return None, errors
+    return (
+        _RescopeOpRewrite(id=task_id, title=title, description=description),
+        errors,
+    )
+
+
+def _parse_op_rewrite_anchor(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    task_id = _require_string_field(raw_op, "id", path, errors)
+    anchor = raw_op.get("anchor_comment_id")
+    if not _is_valid_anchor_id(anchor):
+        errors.append(
+            f"{path}.anchor_comment_id: must be a positive int "
+            f"(GitHub comment id), got {anchor!r}"
+        )
+        anchor = None
+    if task_id is None or anchor is None:
+        return None, errors
+    return _RescopeOpRewriteAnchor(id=task_id, anchor_comment_id=anchor), errors
+
+
+def _parse_op_remove(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    task_id = _require_string_field(raw_op, "id", path, errors)
+    if task_id is None:
+        return None, errors
+    return _RescopeOpRemove(id=task_id), errors
+
+
+def _parse_op_merge(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    target = _require_string_field(raw_op, "target_id", path, errors)
+    title = _require_string_field(raw_op, "title", path, errors)
+    description = _require_string_field_allow_empty(raw_op, "description", path, errors)
+    raw_sources = raw_op.get("sources")
+    sources: list[str] = []
+    if not isinstance(raw_sources, list) or not raw_sources:
+        errors.append(
+            f"{path}.sources: must be a non-empty list of task ids, got {raw_sources!r}"
+        )
+    else:
+        for src_index, source in enumerate(raw_sources):
+            if not isinstance(source, str) or not source:
+                errors.append(
+                    f"{path}.sources[{src_index}]: must be a non-empty string, "
+                    f"got {source!r}"
+                )
+                continue
+            sources.append(source)
+        if not sources:
+            errors.append(
+                f"{path}.sources: every entry was malformed; merge needs at "
+                "least one valid source id"
+            )
+    if target is None or title is None or description is None or not sources:
+        return None, errors
+    return (
+        _RescopeOpMerge(
+            target_id=target,
+            sources=sources,
+            title=title,
+            description=description,
+        ),
+        errors,
+    )
+
+
+def _parse_op_split(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    task_id = _require_string_field(raw_op, "id", path, errors)
+    raw_children = raw_op.get("children")
+    children: list[_RescopeOpSplitChild] = []
+    if not isinstance(raw_children, list) or not raw_children:
+        errors.append(
+            f"{path}.children: must be a non-empty list of "
+            f'{{"title": ..., "description": ...}} dicts, got {raw_children!r}'
+        )
+    else:
+        for child_index, raw_child in enumerate(raw_children):
+            child_path = f"{path}.children[{child_index}]"
+            if not isinstance(raw_child, dict):
+                errors.append(
+                    f"{child_path}: must be a dict, got {type(raw_child).__name__}"
+                )
+                continue
+            child_title = _require_string_field(raw_child, "title", child_path, errors)
+            child_description = _require_string_field_allow_empty(
+                raw_child, "description", child_path, errors
+            )
+            if child_title is not None and child_description is not None:
+                children.append(
+                    _RescopeOpSplitChild(
+                        title=child_title, description=child_description
+                    )
+                )
+        if not children:
+            errors.append(
+                f"{path}.children: every child was malformed; split needs at "
+                "least one valid child"
+            )
+    if task_id is None or not children:
+        return None, errors
+    return _RescopeOpSplit(id=task_id, children=children), errors
+
+
+def _parse_op_new(
+    raw_op: dict[str, Any], path: str
+) -> tuple[_RescopeOp | None, list[str]]:
+    errors: list[str] = []
+    title = _require_string_field(raw_op, "title", path, errors)
+    description = _require_string_field_allow_empty(raw_op, "description", path, errors)
+    task_type = _require_string_field(raw_op, "type", path, errors)
+    if title is None or description is None or task_type is None:
+        return None, errors
+    return (
+        _RescopeOpNew(title=title, description=description, type=task_type),
+        errors,
+    )
+
+
+_OP_PARSERS: dict[
+    str, Callable[[dict[str, Any], str], tuple[_RescopeOp | None, list[str]]]
+] = {
+    "keep": _parse_op_keep,
+    "rewrite": _parse_op_rewrite,
+    "rewrite_anchor": _parse_op_rewrite_anchor,
+    "remove": _parse_op_remove,
+    "merge": _parse_op_merge,
+    "split": _parse_op_split,
+    "new": _parse_op_new,
+}
+
+
+def _find_cross_op_errors(
+    operations: list[_RescopeOp], snapshot_ids: frozenset[str]
+) -> list[str]:
+    """Pre-reducer cross-op invariants from #1719's acceptance criteria.
+
+    - Every existing-task op references an id in the current snapshot
+      (unknown ids would silently no-op or error in the reducer).
+    - No two ops claim the same snapshot id (per-task coverage; ambiguity
+      between e.g. rewrite + remove on the same id).
+    - No source id appears in more than one merge or split op (lineage
+      duplication; the rocq invariants reject this too at the reducer).
+    """
+    errors: list[str] = []
+    claim_count: dict[str, int] = {}
+
+    def _claim(claimed_id: str, op_index: int) -> None:
+        if claimed_id not in snapshot_ids:
+            errors.append(
+                f"operations[{op_index}]: id {claimed_id!r} is not in the "
+                "pending snapshot (unknown task id — it may have been "
+                "completed concurrently or never existed)"
+            )
+        claim_count[claimed_id] = claim_count.get(claimed_id, 0) + 1
+
+    for index, op in enumerate(operations):
+        match op:
+            case _RescopeOpKeep(id=tid) | _RescopeOpRewrite(id=tid):
+                _claim(tid, index)
+            case _RescopeOpRewriteAnchor(id=tid):
+                _claim(tid, index)
+            case _RescopeOpRemove(id=tid):
+                _claim(tid, index)
+            case _RescopeOpMerge(target_id=tid, sources=sources):
+                _claim(tid, index)
+                for src in sources:
+                    _claim(src, index)
+            case _RescopeOpSplit(id=tid):
+                _claim(tid, index)
+            case _RescopeOpNew():
+                pass
+
+    for tid, count in claim_count.items():
+        if count > 1:
+            errors.append(
+                f"id {tid!r}: claimed by {count} operations; each snapshot "
+                "task may appear in at most one operation"
+            )
+    return errors
+
+
+def _operations_to_items(operations: list[_RescopeOp]) -> list[dict[str, Any]]:
+    """Convert typed operations into the item-dict shape the apply path uses.
+
+    Lets the existing ``_validate_rescope_batch`` / ``_apply_reorder``
+    pipeline keep working unchanged: each operation lowers to one or
+    more items in the legacy schema (a merge expands into one target
+    item plus N source-completion items, since the reducer's per-task
+    coverage invariant requires every source to carry its own
+    ``CompleteTask``).
+    """
+    items: list[dict[str, Any]] = []
+    for op in operations:
+        match op:
+            case _RescopeOpKeep(id=tid):
+                items.append({"id": tid})
+            case _RescopeOpRewrite(id=tid, title=title, description=desc):
+                items.append({"id": tid, "title": title, "description": desc})
+            case _RescopeOpRewriteAnchor(id=tid, anchor_comment_id=anchor):
+                items.append({"id": tid, "anchor_comment_id": anchor})
+            case _RescopeOpRemove(id=tid):
+                items.append({"id": tid, "status": str(TaskStatus.COMPLETED)})
+            case _RescopeOpMerge(
+                target_id=target,
+                sources=sources,
+                title=title,
+                description=desc,
+            ):
+                items.append(
+                    {
+                        "id": target,
+                        "title": title,
+                        "description": desc,
+                        "merge_sources": list(sources),
+                    }
+                )
+                for src in sources:
+                    items.append({"id": src, "status": str(TaskStatus.COMPLETED)})
+            case _RescopeOpSplit(id=tid, children=children):
+                items.append(
+                    {
+                        "id": tid,
+                        "split_targets": [
+                            {"title": c.title, "description": c.description}
+                            for c in children
+                        ],
+                    }
+                )
+            case _RescopeOpNew(title=title, description=desc, type=task_type):
+                items.append(
+                    {
+                        "id": None,
+                        "title": title,
+                        "description": desc,
+                        "type": task_type,
+                    }
+                )
+    return items
 
 
 def _make_new_tasks_from_opus(
@@ -1863,10 +2301,59 @@ def reorder_tasks(
         log.warning("reorder_tasks: Opus returned empty response — skipping")
         return
 
-    ordered_items = _parse_reorder_response(raw)
-    if ordered_items is None:
-        log.warning("reorder_tasks: could not parse Opus response — skipping")
+    # Parse + cross-op-validate; on errors, nudge Opus with the FULL
+    # complaint list (not just the first defect) so it can fix
+    # everything at once (#1719).  Budget shared with the duplicate-
+    # title nudge below.
+    snapshot_ids = frozenset(
+        t["id"]
+        for t in task_list
+        if t.get("status") != TaskStatus.COMPLETED and "id" in t
+    )
+    operations: list[_RescopeOp] = []
+    parse_errors: list[str] = ["initial parse"]
+    for nudge_attempt in range(_RESCOPE_MAX_NUDGES + 1):
+        operations, parse_errors = _parse_rescope_operations(raw)
+        if not parse_errors:
+            cross_errors = _find_cross_op_errors(operations, snapshot_ids)
+            if not cross_errors:
+                break
+            parse_errors = cross_errors
+        attempts_remaining = _RESCOPE_MAX_NUDGES - nudge_attempt
+        if attempts_remaining <= 0:
+            log.warning(
+                "reorder_tasks: rescope batch dropped after %d parse-error "
+                "nudges; final errors: %s",
+                _RESCOPE_MAX_NUDGES,
+                "; ".join(parse_errors),
+            )
+            return
+        log.warning(
+            "reorder_tasks: Opus rescope response had %d problem(s) — "
+            "nudging (attempt %d/%d, %d remaining)",
+            len(parse_errors),
+            nudge_attempt + 1,
+            _RESCOPE_MAX_NUDGES,
+            attempts_remaining - 1,
+        )
+        nudge = prompts.rescope_parse_nudge(
+            parse_errors, attempts_remaining=attempts_remaining - 1
+        )
+        nudge_raw = agent.run_turn(
+            nudge,
+            model=agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        )
+        if not nudge_raw:
+            log.warning(
+                "reorder_tasks: empty response after parse-error nudge — dropping batch"
+            )
+            return
+        raw = nudge_raw
+    else:  # pragma: no cover — loop body always returns or breaks
         return
+
+    ordered_items = _operations_to_items(operations)
 
     # Snapshot existing titles for the dedup check.  The check runs on
     # *effective* titles (post-normalization, post-existing-title fallback)
@@ -1910,14 +2397,15 @@ def reorder_tasks(
                 "proceeding with fallback"
             )
             break
-        nudge_items = _parse_reorder_response(nudge_raw)
-        if nudge_items is None:
+        nudge_ops, nudge_errors = _parse_rescope_operations(nudge_raw)
+        if nudge_errors:
             log.warning(
                 "reorder_tasks: unparseable response after duplicate nudge — "
-                "proceeding with fallback"
+                "proceeding with fallback (errors: %s)",
+                "; ".join(nudge_errors),
             )
             break
-        ordered_items = nudge_items
+        ordered_items = _operations_to_items(nudge_ops)
 
     # Route the write through Tasks's public modify() — its on_mutate
     # hook (e.g. the SCADA snapshot publisher) fires automatically on

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -437,13 +437,16 @@ class TestRescopePrompt:
     def test_json_output_format_instructed(self) -> None:
         tasks = [self._task("Do something", task_id="1")]
         result = Prompts("").rescope_prompt(tasks, "")
-        assert '{"tasks": [...]}' in result
+        assert '{"operations": [...]}' in result
 
     def test_preserve_ids_rule_stated(self) -> None:
         tasks = [self._task("Task A", task_id="abc-123")]
         result = Prompts("").rescope_prompt(tasks, "")
-        assert "ID" in result or "id" in result
-        assert "preserve" in result.lower() or "never change" in result.lower()
+        # New schema requires every existing id to appear in exactly one
+        # operation — the preservation rule is "id must be in the
+        # snapshot" and "no inventing ids".
+        assert "must be in the pending snapshot" in result
+        assert "no inventing ids" in result
 
     def test_remove_covered_tasks_rule_stated(self) -> None:
         tasks = [self._task("Task A", task_id="1")]
@@ -545,28 +548,37 @@ class TestRescopePrompt:
         assert "Add logging" in result
         assert "Refactor tests" in result
 
-    def test_synthesize_framing_present(self) -> None:
+    def test_explicit_operations_framing_present(self) -> None:
         tasks = [self._task("Do thing", task_id="1")]
         result = Prompts("").rescope_prompt(tasks, "")
-        assert "synthesize" in result.lower() or "synthesis" in result.lower()
+        # New schema replaces "synthesize a task list" with "reply with
+        # a typed list of operations" — explicit, no inference from
+        # omission (#1719).
+        assert "operations" in result.lower()
+        assert "exactly one operation" in result
 
-    def test_new_task_null_id_instruction_present(self) -> None:
+    def test_every_op_kind_documented(self) -> None:
         tasks = [self._task("Do thing", task_id="1")]
         result = Prompts("").rescope_prompt(tasks, "")
-        assert "null" in result.lower()
+        # The schema reference must list every operation Opus can emit
+        # so it has the full vocabulary inline.
+        for op_name in (
+            "keep",
+            "rewrite",
+            "rewrite_anchor",
+            "remove",
+            "merge",
+            "split",
+            "new",
+        ):
+            assert f'"op": "{op_name}"' in result, f"missing op {op_name}"
 
-    def test_all_transformations_mentioned(self) -> None:
+    def test_new_op_documented_for_brand_new_tasks(self) -> None:
         tasks = [self._task("Do thing", task_id="1")]
         result = Prompts("").rescope_prompt(tasks, "")
-        # prompt should mention the full set of valid transformations
-        assert "merge" in result.lower() or "split" in result.lower()
-        assert "delete" in result.lower() or "omit" in result.lower()
-        assert "add" in result.lower() or "new tasks" in result.lower()
-
-    def test_newer_overrides_older_instruction_present(self) -> None:
-        tasks = [self._task("Do thing", task_id="1")]
-        result = Prompts("").rescope_prompt(tasks, "")
-        assert "newer" in result.lower() or "override" in result.lower()
+        # Brand-new tasks come from "new" ops, no null-id mechanism
+        # in the new schema.
+        assert '{"op": "new"' in result
 
 
 # ── Prompts.rescope_duplicate_nudge ──────────────────────────────────────────
@@ -592,7 +604,7 @@ class TestRescopeDuplicateNudge:
 
     def test_includes_json_format_instruction(self) -> None:
         result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)
-        assert '{"tasks": [...]}' in result
+        assert '{"operations": [...]}' in result
 
     def test_no_other_text_instruction_present(self) -> None:
         result = Prompts("").rescope_duplicate_nudge(["Dup"], attempts_remaining=0)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -15,10 +15,12 @@ from fido.tasks import (
     _assert_rescope_matches_oracle,
     _build_task_list_snapshot,
     _compute_thread_changes,
+    _find_cross_op_errors,
     _find_duplicate_titles,
     _format_work_queue,
     _make_new_tasks_from_opus,
-    _parse_reorder_response,
+    _operations_to_items,
+    _parse_rescope_operations,
     _rescope_releases_for_oracle,
     _rescope_snapshot_order_for_oracle,
     _rescope_state_for_oracle,
@@ -770,50 +772,293 @@ class TestBuildTaskListSnapshot:
         assert snap.task_total == 0
 
 
-# ── _parse_reorder_response ───────────────────────────────────────────────────
+# ── _parse_rescope_operations (#1719) ─────────────────────────────────────────
 
 
-class TestParseReorderResponse:
-    def test_parses_valid_json(self) -> None:
-        raw = '{"tasks": [{"id": "1", "title": "Task A", "description": ""}]}'
-        result = _parse_reorder_response(raw)
-        assert result == [{"id": "1", "title": "Task A", "description": ""}]
+class TestParseRescopeOperations:
+    def test_parses_keep(self) -> None:
+        raw = '{"operations": [{"op": "keep", "id": "abc"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [{"id": "abc"}]
+
+    def test_parses_rewrite(self) -> None:
+        raw = (
+            '{"operations": [{"op": "rewrite", "id": "abc", '
+            '"title": "New", "description": "scope"}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [
+            {"id": "abc", "title": "New", "description": "scope"}
+        ]
+
+    def test_parses_rewrite_anchor(self) -> None:
+        raw = (
+            '{"operations": [{"op": "rewrite_anchor", "id": "abc", '
+            '"anchor_comment_id": 12345}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [{"id": "abc", "anchor_comment_id": 12345}]
+
+    def test_parses_remove(self) -> None:
+        raw = '{"operations": [{"op": "remove", "id": "abc"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [{"id": "abc", "status": "completed"}]
+
+    def test_parses_merge_with_source_completion_expansion(self) -> None:
+        # A single merge op lowers to one target item (with merge_sources)
+        # plus N source-completion items so the rocq per-task coverage
+        # invariant still holds.
+        raw = (
+            '{"operations": [{"op": "merge", "target_id": "a", '
+            '"sources": ["b", "c"], "title": "Merged", '
+            '"description": "scope"}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [
+            {
+                "id": "a",
+                "title": "Merged",
+                "description": "scope",
+                "merge_sources": ["b", "c"],
+            },
+            {"id": "b", "status": "completed"},
+            {"id": "c", "status": "completed"},
+        ]
+
+    def test_parses_split(self) -> None:
+        raw = (
+            '{"operations": [{"op": "split", "id": "src", '
+            '"children": [{"title": "A", "description": "first"}, '
+            '{"title": "B", "description": "second"}]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [
+            {
+                "id": "src",
+                "split_targets": [
+                    {"title": "A", "description": "first"},
+                    {"title": "B", "description": "second"},
+                ],
+            }
+        ]
+
+    def test_parses_new(self) -> None:
+        raw = (
+            '{"operations": [{"op": "new", "title": "T", '
+            '"description": "d", "type": "spec"}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [
+            {"id": None, "title": "T", "description": "d", "type": "spec"}
+        ]
 
     def test_parses_json_with_preamble(self) -> None:
-        raw = 'Here are the reordered tasks:\n\n{"tasks": [{"id": "1", "title": "Task A", "description": ""}]}'
-        result = _parse_reorder_response(raw)
-        assert result is not None
-        assert result[0]["id"] == "1"
+        raw = 'Reordered:\n{"operations": [{"op": "keep", "id": "1"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert len(ops) == 1
 
-    def test_returns_none_for_invalid_json(self) -> None:
-        assert _parse_reorder_response("not json at all") is None
+    def test_no_json_at_all_yields_one_error(self) -> None:
+        ops, errors = _parse_rescope_operations("not json at all")
+        assert ops == []
+        assert errors == ["response: no JSON object found"]
 
-    def test_skips_invalid_brace_and_continues(self) -> None:
-        # First ``{`` cannot be parsed as JSON — exercises the
-        # JSONDecodeError-skip-and-advance branch — but a later ``{``
-        # contains the real response and is returned.
-        raw = '{ this is { junk } before {"tasks": [{"id": "1"}]}'
-        assert _parse_reorder_response(raw) == [{"id": "1"}]
+    def test_missing_operations_key(self) -> None:
+        ops, errors = _parse_rescope_operations('{"tasks": []}')
+        assert ops == []
+        assert errors == ['response: missing top-level "operations" array']
 
-    def test_returns_none_when_no_tasks_key(self) -> None:
-        assert _parse_reorder_response('{"other": []}') is None
+    def test_operations_must_be_list(self) -> None:
+        ops, errors = _parse_rescope_operations('{"operations": "nope"}')
+        assert ops == []
+        assert any("must be a list" in e for e in errors)
 
-    def test_returns_none_when_tasks_not_list(self) -> None:
-        assert _parse_reorder_response('{"tasks": "not a list"}') is None
+    def test_unknown_op_name(self) -> None:
+        raw = '{"operations": [{"op": "bogus", "id": "x"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any("unknown operation 'bogus'" in e for e in errors)
 
-    def test_returns_none_for_json_non_dict(self) -> None:
-        # raw_decode on a bare "null" finds no "{", so returns None
-        assert _parse_reorder_response("null") is None
+    def test_collects_every_error_in_one_pass(self) -> None:
+        # Rob's directive: useful retries that detail what was wrong,
+        # as many things as we can find at once.  This batch combines
+        # five distinct defects across five operations — the parser
+        # must report them all, not bail on the first.
+        raw = (
+            '{"operations": ['
+            '{"op": "keep"},'  # missing id
+            '{"op": "rewrite", "id": "x", "title": ""},'  # blank title, missing description
+            '{"op": "rewrite_anchor", "id": "y", "anchor_comment_id": -1},'  # bad anchor
+            '{"op": "merge", "target_id": "z", "sources": [], '
+            '"title": "T", "description": "d"},'  # empty sources
+            '{"op": "split", "id": "s", "children": [{"title": ""}]}'  # bad child
+            "]}"
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        # Each defect produces at least one error message; assert the
+        # full set without pinning exact wording.
+        joined = " | ".join(errors)
+        assert "operations[0].id" in joined
+        assert "operations[1].title" in joined
+        assert "operations[2].anchor_comment_id" in joined
+        assert "operations[3].sources" in joined
+        assert "operations[4].children" in joined
 
-    def test_returns_empty_list_when_tasks_is_empty(self) -> None:
-        result = _parse_reorder_response('{"tasks": []}')
-        assert result == []
+    def test_op_must_be_string(self) -> None:
+        raw = '{"operations": [{"op": 42}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any("operations[0].op" in e and "must be a string" in e for e in errors)
 
-    def test_parses_multiple_tasks(self) -> None:
-        raw = '{"tasks": [{"id": "1", "title": "A", "description": ""}, {"id": "2", "title": "B", "description": ""}]}'
-        result = _parse_reorder_response(raw)
-        assert result is not None
-        assert len(result) == 2
+    def test_op_must_be_dict(self) -> None:
+        raw = '{"operations": ["not a dict"]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any("operations[0]: must be a dict" in e for e in errors)
+
+    def test_empty_operations_list_is_valid(self) -> None:
+        ops, errors = _parse_rescope_operations('{"operations": []}')
+        assert ops == []
+        assert errors == []
+
+    def test_skips_junk_brace_and_decodes_real_envelope(self) -> None:
+        raw = '{ this is { junk } before {"operations": [{"op": "keep", "id": "1"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        assert _operations_to_items(ops) == [{"id": "1"}]
+
+    def test_remove_missing_id(self) -> None:
+        ops, errors = _parse_rescope_operations('{"operations": [{"op": "remove"}]}')
+        assert ops == []
+        assert any("operations[0].id" in e for e in errors)
+
+    def test_new_missing_title_description_type(self) -> None:
+        ops, errors = _parse_rescope_operations('{"operations": [{"op": "new"}]}')
+        assert ops == []
+        joined = " | ".join(errors)
+        assert "operations[0].title" in joined
+        assert "operations[0].description" in joined
+        assert "operations[0].type" in joined
+
+    def test_merge_with_non_string_source_entries(self) -> None:
+        # The error-collecting parser flags every bad entry in the
+        # sources list — not just the first.
+        raw = (
+            '{"operations": [{"op": "merge", "target_id": "a", '
+            '"sources": ["b", 42, ""], "title": "M", "description": ""}]}'
+        )
+        _ops, errors = _parse_rescope_operations(raw)
+        assert any("operations[0].sources[1]" in e for e in errors)
+        assert any("operations[0].sources[2]" in e for e in errors)
+
+    def test_merge_with_all_invalid_sources(self) -> None:
+        # Empty after filtering bad entries — distinct error from the
+        # "list is structurally empty" branch above.
+        raw = (
+            '{"operations": [{"op": "merge", "target_id": "a", '
+            '"sources": ["", 0], "title": "M", "description": ""}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any("every entry was malformed" in e for e in errors)
+
+    def test_split_with_empty_children_list(self) -> None:
+        raw = '{"operations": [{"op": "split", "id": "src", "children": []}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any(
+            "operations[0].children" in e and "non-empty list" in e for e in errors
+        )
+
+    def test_split_with_non_dict_child(self) -> None:
+        raw = (
+            '{"operations": [{"op": "split", "id": "src", "children": ["not a dict"]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any(
+            "operations[0].children[0]" in e and "must be a dict" in e for e in errors
+        )
+
+    def test_decode_skips_non_dict_first_value(self) -> None:
+        # First decodable JSON value at the first ``{`` could be a
+        # nested non-dict shape; the decoder advances past it and
+        # finds the real envelope.  Two sibling objects in a row
+        # exercise the ``pos = end`` continue-and-keep-scanning path.
+        raw = '{"unrelated": []} {"operations": [{"op": "keep", "id": "1"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []  # first decoded object lacks "operations" key
+        assert errors == ['response: missing top-level "operations" array']
+
+
+class TestFindCrossOpErrors:
+    def test_unknown_id_rejected(self) -> None:
+        from fido.tasks import _RescopeOpKeep
+
+        errors = _find_cross_op_errors([_RescopeOpKeep(id="ghost")], frozenset({"a"}))
+        assert any(
+            "'ghost'" in e and "not in the pending snapshot" in e for e in errors
+        )
+
+    def test_duplicate_id_across_ops_rejected(self) -> None:
+        from fido.tasks import _RescopeOpKeep, _RescopeOpRemove
+
+        ops = [_RescopeOpKeep(id="a"), _RescopeOpRemove(id="a")]
+        errors = _find_cross_op_errors(ops, frozenset({"a"}))
+        assert any("claimed by 2 operations" in e for e in errors)
+
+    def test_overlapping_merge_sources_rejected(self) -> None:
+        # Source 'b' folded into TWO different targets — lineage would
+        # land in both, contradicting "each source merges into at most
+        # one target".  cross-op layer catches it the same way the
+        # validator does (#1738 codex Medium).
+        from fido.tasks import _RescopeOpMerge
+
+        ops = [
+            _RescopeOpMerge(target_id="a", sources=["b"], title="A", description=""),
+            _RescopeOpMerge(target_id="c", sources=["b"], title="C", description=""),
+        ]
+        errors = _find_cross_op_errors(ops, frozenset({"a", "b", "c"}))
+        assert any("'b'" in e and "claimed by 2 operations" in e for e in errors)
+
+    def test_merge_source_id_validated(self) -> None:
+        from fido.tasks import _RescopeOpMerge
+
+        ops = [
+            _RescopeOpMerge(target_id="a", sources=["ghost"], title="A", description="")
+        ]
+        errors = _find_cross_op_errors(ops, frozenset({"a"}))
+        assert any(
+            "'ghost'" in e and "not in the pending snapshot" in e for e in errors
+        )
+
+    def test_new_op_does_not_claim_any_id(self) -> None:
+        # `new` ops mint fresh ids at apply time — they don't reference
+        # the snapshot, so the cross-op claim count must skip them.
+        from fido.tasks import _RescopeOpNew
+
+        ops = [_RescopeOpNew(title="A", description="", type="spec")]
+        assert _find_cross_op_errors(ops, frozenset()) == []
+
+    def test_split_op_claims_source_id(self) -> None:
+        from fido.tasks import _RescopeOpSplit, _RescopeOpSplitChild
+
+        ops = [
+            _RescopeOpSplit(
+                id="src", children=[_RescopeOpSplitChild(title="C", description="")]
+            )
+        ]
+        # Unknown source id.
+        errors = _find_cross_op_errors(ops, frozenset())
+        assert any("'src'" in e and "not in the pending snapshot" in e for e in errors)
 
 
 # ── _apply_reorder ────────────────────────────────────────────────────────────
@@ -2493,7 +2738,91 @@ class TestReorderTasks:
         return Tasks(tmp_path).add(title=title, task_type=task_type)
 
     def _response(self, items: list[dict]) -> str:
-        return json.dumps({"tasks": items})
+        """Translate legacy-shape item dicts into the new operations envelope.
+
+        Lets the existing TestReorderTasks suite keep passing the
+        familiar item dicts while the rescope I/O contract upgrades to
+        explicit ``{"operations": [...]}`` (#1719).  Mapping:
+
+        * ``{"id": x, "status": "completed"}``   → ``remove``
+        * ``{"id": x, "merge_sources": [...]}``  → ``merge``
+        * ``{"id": x, "split_targets": [...]}``  → ``split``
+        * ``{"id": x, "anchor_comment_id": n}``  → ``rewrite_anchor``
+        * ``{"id": x, "title": ..., "description": ...}`` → ``rewrite``
+        * ``{"id": x}`` (id only)                → ``keep``
+        * ``{"id": null, ...}``                  → ``new``
+
+        Per-source ``{"id": src, "status": "completed"}`` items that
+        accompany a ``merge`` are dropped here because the new ``merge``
+        op auto-expands its source closures (the rocq per-task coverage
+        invariant runs in the translator below, not in the test
+        fixture).
+        """
+        merge_source_ids: set[str] = set()
+        for item in items:
+            if isinstance(item.get("merge_sources"), list):
+                for src in item["merge_sources"]:
+                    if isinstance(src, str):
+                        merge_source_ids.add(src)
+        operations: list[dict] = []
+        for item in items:
+            if item.get("status") == "completed" and item.get("id") in merge_source_ids:
+                continue
+            item_id = item.get("id")
+            if item_id is None or item_id == "":
+                operations.append(
+                    {
+                        "op": "new",
+                        "title": item.get("title", ""),
+                        "description": item.get("description", ""),
+                        "type": item.get("type", "spec"),
+                    }
+                )
+                continue
+            if item.get("status") == "completed":
+                operations.append({"op": "remove", "id": item_id})
+                continue
+            if isinstance(item.get("merge_sources"), list) and item["merge_sources"]:
+                operations.append(
+                    {
+                        "op": "merge",
+                        "target_id": item_id,
+                        "sources": list(item["merge_sources"]),
+                        "title": item.get("title", ""),
+                        "description": item.get("description", ""),
+                    }
+                )
+                continue
+            if isinstance(item.get("split_targets"), list) and item["split_targets"]:
+                operations.append(
+                    {
+                        "op": "split",
+                        "id": item_id,
+                        "children": list(item["split_targets"]),
+                    }
+                )
+                continue
+            if "anchor_comment_id" in item:
+                operations.append(
+                    {
+                        "op": "rewrite_anchor",
+                        "id": item_id,
+                        "anchor_comment_id": item["anchor_comment_id"],
+                    }
+                )
+                continue
+            if "title" in item or "description" in item:
+                operations.append(
+                    {
+                        "op": "rewrite",
+                        "id": item_id,
+                        "title": item.get("title", ""),
+                        "description": item.get("description", ""),
+                    }
+                )
+                continue
+            operations.append({"op": "keep", "id": item_id})
+        return json.dumps({"operations": operations})
 
     def test_skips_when_no_tasks(self, tmp_path: Path) -> None:
         client = _client("")
@@ -2578,6 +2907,62 @@ class TestReorderTasks:
             _on_changes=lambda changes: received.extend(changes),
         )
         assert received == []
+
+    def test_validator_rejection_after_parse_success_drops_batch(
+        self, tmp_path: Path
+    ) -> None:
+        # Parse + cross-op succeed, but the disk-aware validator
+        # rejects (ASK source can't be split — kind is title-prefix
+        # driven, splitting would silently reclassify children).  This
+        # exercises the validator-rejection logging path and the
+        # post-rejection early-return that skips _on_done / _on_changes.
+        ask = Tasks(tmp_path).add(title="ASK: how do I X?", task_type=TaskType.SPEC)
+        before = Tasks(tmp_path).list()
+        # Build the operations envelope by hand so we can emit the
+        # split shape that the legacy-shape translator wouldn't produce.
+        raw = json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "split",
+                        "id": ask["id"],
+                        "children": [{"title": "Do X", "description": ""}],
+                    }
+                ]
+            }
+        )
+        done_calls: list[int] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_done=lambda: done_calls.append(1),
+        )
+        # Durable list unchanged; _on_done not fired.
+        assert Tasks(tmp_path).list() == before
+        assert done_calls == []
+
+    def test_parse_error_nudge_with_empty_response_drops_batch(
+        self, tmp_path: Path
+    ) -> None:
+        # Initial response has parse errors → nudge fires → empty
+        # response from Opus on the nudge → batch dropped.  Exercises
+        # the empty-after-parse-error-nudge log + early-return.
+        from unittest.mock import MagicMock
+
+        Tasks(tmp_path).add(title="Original", task_type=TaskType.SPEC)
+        before = Tasks(tmp_path).list()
+        bad_raw = json.dumps({"operations": [{"op": "bogus", "id": "x"}]})
+        client = MagicMock(spec=ClaudeClient)
+        client.voice_model = "claude-opus-4-6"
+        client.work_model = "claude-sonnet-4-6"
+        client.brief_model = "claude-haiku-4-5"
+        # First call returns the unparseable response; nudge call
+        # returns empty so the loop drops the batch.
+        client.run_turn.side_effect = [bad_raw, ""]
+        reorder_tasks(Tasks(tmp_path), "", agent=client)
+        assert Tasks(tmp_path).list() == before
+        assert client.run_turn.call_count == 2
 
     def test_preserves_snapshot_order_for_non_ci_tasks(self, tmp_path: Path) -> None:
         t1 = self._add(tmp_path, "First")


### PR DESCRIPTION
## Summary

Replaces the legacy ``{\"tasks\": [...]}`` synthesis contract — where
Opus proposed a full new task list and the adapter inferred mutations
from omission — with an explicit typed operation envelope.  Every
snapshot id is claimed by exactly one operation; no inference, no
inventing ids, no overlapping merge sources.

## New schema

\`\`\`json
{\"operations\": [
  {\"op\": \"keep\",           \"id\": \"...\"},
  {\"op\": \"rewrite\",        \"id\": \"...\", \"title\": \"...\", \"description\": \"...\"},
  {\"op\": \"rewrite_anchor\", \"id\": \"...\", \"anchor_comment_id\": 12345},
  {\"op\": \"remove\",         \"id\": \"...\"},
  {\"op\": \"merge\",          \"target_id\": \"...\", \"sources\": [\"...\"],
                                  \"title\": \"...\", \"description\": \"...\"},
  {\"op\": \"split\",          \"id\": \"...\",
                                  \"children\": [{\"title\": \"...\", \"description\": \"...\"}]},
  {\"op\": \"new\",            \"title\": \"...\", \"description\": \"...\", \"type\": \"spec\"}
]}
\`\`\`

## Useful retries

Per Rob's directive: useful retries that detail what was wrong, as
many things as we can find at once.  The parser collects EVERY
malformation in one pass (never bails on first), and the new
\`rescope_parse_nudge\` sends the complete complaint list to Opus
so one corrected response can fix every defect.

Cross-op pre-reducer checks (unknown ids, duplicate output ids,
overlapping merge/split source ids) layer on top, so the validator
only sees batches that already passed structural sanity.

## Pipeline

Operations lower into the existing item-dict shape that the
validator/reducer/materializer pipeline already consumes (a merge
op auto-expands its source closures so the rocq per-task coverage
invariant still holds).  This leaf redesigns only the I/O contract
with Opus, not the downstream apply path.

## Out of scope (deferred to later #1247 leaves)

- Timestamp-ordered intent synthesis in the prompt (#1720).
- Explicit full-plan rebuild semantics (#1721).

## Test plan

- [x] \`./fido ci\` (4338 tests, 100% coverage)
- [x] Per-op parse tests for every shape (keep/rewrite/rewrite_anchor/remove/merge/split/new)
- [x] Multi-defect-per-pass collection test (5 defects in one batch → 5 errors reported)
- [x] Cross-op invariant tests (unknown id, duplicate id claim, overlapping merge sources)
- [x] Validator-rejection-after-parse-success path (split on ASK source)
- [x] Empty response after parse-error nudge → batch dropped