### PR TITLE
Rescope L#1722: track contributing intent provenance per op (closes #1722)

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -496,6 +496,14 @@ class Prompts:
             '"type": "spec"}\n'
             "      — create a brand-new task (fresh id assigned by the runtime)\n"
             "\n"
+            "Provenance — every op above accepts an optional "
+            '"contributing_intents": [<intent comment_id>, ...] field listing '
+            "the change-request comment ids from the intents block above that "
+            "drove this op.  Attribute every op to the intent(s) that caused "
+            "it whenever you can — a downstream classifier reads these to "
+            "decide which commenter(s) to notify when the task lands.  Omit "
+            "or use [] when the op is implicit (e.g. an unattributed "
+            "rewrite from your own context analysis).\n\n"
             "Constraints:\n"
             '1. Tasks of type "ci" must come first in the operations array.\n'
             "2. Each pending snapshot id may appear in at most one operation "

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -483,12 +483,31 @@ def _split_source_ids(ordered_items: list[dict[str, Any]]) -> set[str]:
     }
 
 
+def _union_intents(*lists: list[int]) -> list[int]:
+    """Insertion-ordered union of intent comment id lists (#1722).
+
+    Used everywhere a task's ``contributing_intents`` field needs to
+    accumulate intents across rescope rounds (e.g. merge target =
+    op's intents ∪ each source's pre-existing intents) without
+    losing chronology.
+    """
+    seen: set[int] = set()
+    out: list[int] = []
+    for src in lists:
+        for value in src:
+            if value not in seen:
+                seen.add(value)
+                out.append(value)
+    return out
+
+
 def _split_child_synthetic_task(
     source_task: dict[str, Any],
     child_id: str,
     child_title: str,
     child_description: str,
     created_at: str,
+    op_contributing_intents: list[int],
 ) -> dict[str, Any]:
     """Build the synthetic original task dict for a split child.
 
@@ -506,12 +525,19 @@ def _split_child_synthetic_task(
     wall-clock read here would make the divergence verifier raise on
     any batch that straddles a second boundary (codex P1).
 
+    ``op_contributing_intents`` (#1722) is the SplitTask op's own
+    contributing-intent list — every child inherits the parent op's
+    intents in addition to whatever intents already lived on the
+    source task, so a downstream classifier can decide whether the
+    split materially affected each commenter.
+
     The thread is shallow-copied per child: every ``lineage_comment_ids``
     write in this codebase rebuilds the list and re-assigns the slot
     rather than mutating in place, so the inherited list reference is
     safe to share — but the dict itself does get re-keyed on writes, so
     each child needs its own dict.
     """
+    source_intents = source_task.get("contributing_intents") or []
     child: dict[str, Any] = {
         "id": child_id,
         "title": child_title,
@@ -519,6 +545,7 @@ def _split_child_synthetic_task(
         "description": child_description,
         "status": str(TaskStatus.PENDING),
         "created_at": created_at,
+        "contributing_intents": _union_intents(source_intents, op_contributing_intents),
     }
     source_thread = source_task.get("thread")
     if isinstance(source_thread, dict):
@@ -579,6 +606,17 @@ def _rescope_releases_for_oracle(
             )
             merge_sources = _merge_source_oracle_ids(item, ids_by_task_id)
             split_targets = _split_target_specs(item)
+            # #1722: stamp the synthetic original-task dict with the
+            # union of any pre-existing intents and the op's
+            # contributing_intents so the materializer copies them
+            # through to the persisted task.  For merges, sources'
+            # existing intents fold into the target below.
+            op_intents = item.get("contributing_intents") or []
+            if op_intents:
+                existing_intents = task.get("contributing_intents") or []
+                tasks_by_oracle_id[oracle_id]["contributing_intents"] = _union_intents(
+                    existing_intents, op_intents
+                )
             # Op precedence (most structural first):
             #   1. Explicit completion (#1716): item.status == "completed".
             #      Removes the task — strictly more structural than any
@@ -607,6 +645,25 @@ def _rescope_releases_for_oracle(
                 decision = rescope_oracle.MergeTasks(
                     oracle_id, merge_sources, new_title, new_description
                 )
+                # #1722: fold every source's pre-existing intents into
+                # the merge target's contributing_intents.  Without
+                # this, intents that drove a source task to exist
+                # would be invisible to the classifier on the merged
+                # row, and the corresponding commenters wouldn't get a
+                # reply when the merged target eventually completes.
+                merged_intents = list(
+                    tasks_by_oracle_id[oracle_id].get("contributing_intents") or []
+                )
+                for src_oracle_id in merge_sources:
+                    src_task = tasks_by_oracle_id.get(src_oracle_id)
+                    if src_task is not None:
+                        merged_intents = _union_intents(
+                            merged_intents, src_task.get("contributing_intents") or []
+                        )
+                if merged_intents:
+                    tasks_by_oracle_id[oracle_id]["contributing_intents"] = (
+                        merged_intents
+                    )
             elif split_targets:
                 # Allocator and validator both iterate the same
                 # ``split_targets`` list, so the pre-allocated child
@@ -626,6 +683,7 @@ def _rescope_releases_for_oracle(
                         child_title,
                         child_description,
                         child_created_at,
+                        op_intents,
                     )
                     children_specs.append(
                         rescope_oracle.SplitChild(
@@ -1170,11 +1228,23 @@ def sync_tasks(
 # contract with Opus, not the downstream apply path.
 
 
+# #1722 — every operation may carry a list of contributing
+# RescopeIntent comment ids: the originating intents that drove this
+# rescope decision.  The classifier in #1723 reads these to decide
+# notification behavior (material rescope vs. pure aggregation
+# per intent).  Empty list = the model didn't attribute the op to
+# any specific intent (typical for KeepTask omissions and for
+# implicit-context decisions); the field is optional in the wire
+# schema.
+_RescopeIntentIds = list[int]
+
+
 @dataclass(frozen=True)
 class _RescopeOpKeep:
     """Keep an existing task unchanged."""
 
     id: str
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1184,6 +1254,7 @@ class _RescopeOpRewrite:
     id: str
     title: str
     description: str
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1192,6 +1263,7 @@ class _RescopeOpRewriteAnchor:
 
     id: str
     anchor_comment_id: int
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1199,6 +1271,7 @@ class _RescopeOpRemove:
     """Close an existing task (rocq CompleteTask)."""
 
     id: str
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1209,6 +1282,7 @@ class _RescopeOpMerge:
     sources: list[str]
     title: str
     description: str
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1223,6 +1297,7 @@ class _RescopeOpSplit:
 
     id: str
     children: list[_RescopeOpSplitChild]
+    contributing_intents: _RescopeIntentIds
 
 
 @dataclass(frozen=True)
@@ -1232,6 +1307,7 @@ class _RescopeOpNew:
     title: str
     description: str
     type: str  # noqa: A003 — schema field name
+    contributing_intents: _RescopeIntentIds
 
 
 _RescopeOp = (
@@ -1351,14 +1427,52 @@ def _require_string_field_allow_empty(
     return value
 
 
+def _parse_contributing_intents(
+    raw_op: dict[str, Any], path: str, errors: list[str]
+) -> _RescopeIntentIds:
+    """Validate the optional ``contributing_intents`` field on every op (#1722).
+
+    Missing or empty list = the model didn't attribute this op to any
+    specific RescopeIntent (typical for KeepTask omissions and for
+    decisions Opus made from implicit context).  Present means a list
+    of positive int comment ids — duplicate entries are de-duplicated
+    in arrival order so the materializer can persist a clean
+    insertion-ordered set.
+    """
+    raw = raw_op.get("contributing_intents")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        errors.append(
+            f"{path}.contributing_intents: must be a list of positive ints "
+            f"(intent comment ids), got {type(raw).__name__}"
+        )
+        return []
+    seen: set[int] = set()
+    out: _RescopeIntentIds = []
+    for index, value in enumerate(raw):
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            errors.append(
+                f"{path}.contributing_intents[{index}]: must be a positive "
+                f"int (intent comment id), got {value!r}"
+            )
+            continue
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return out
+
+
 def _parse_op_keep(
     raw_op: dict[str, Any], path: str
 ) -> tuple[_RescopeOp | None, list[str]]:
     errors: list[str] = []
     task_id = _require_string_field(raw_op, "id", path, errors)
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if task_id is None:
         return None, errors
-    return _RescopeOpKeep(id=task_id), errors
+    return _RescopeOpKeep(id=task_id, contributing_intents=intents), errors
 
 
 def _parse_op_rewrite(
@@ -1368,10 +1482,16 @@ def _parse_op_rewrite(
     task_id = _require_string_field(raw_op, "id", path, errors)
     title = _require_string_field(raw_op, "title", path, errors)
     description = _require_string_field_allow_empty(raw_op, "description", path, errors)
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if task_id is None or title is None or description is None:
         return None, errors
     return (
-        _RescopeOpRewrite(id=task_id, title=title, description=description),
+        _RescopeOpRewrite(
+            id=task_id,
+            title=title,
+            description=description,
+            contributing_intents=intents,
+        ),
         errors,
     )
 
@@ -1388,9 +1508,17 @@ def _parse_op_rewrite_anchor(
             f"(GitHub comment id), got {anchor!r}"
         )
         anchor = None
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if task_id is None or anchor is None:
         return None, errors
-    return _RescopeOpRewriteAnchor(id=task_id, anchor_comment_id=anchor), errors
+    return (
+        _RescopeOpRewriteAnchor(
+            id=task_id,
+            anchor_comment_id=anchor,
+            contributing_intents=intents,
+        ),
+        errors,
+    )
 
 
 def _parse_op_remove(
@@ -1398,9 +1526,10 @@ def _parse_op_remove(
 ) -> tuple[_RescopeOp | None, list[str]]:
     errors: list[str] = []
     task_id = _require_string_field(raw_op, "id", path, errors)
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if task_id is None:
         return None, errors
-    return _RescopeOpRemove(id=task_id), errors
+    return _RescopeOpRemove(id=task_id, contributing_intents=intents), errors
 
 
 def _parse_op_merge(
@@ -1430,6 +1559,7 @@ def _parse_op_merge(
                 f"{path}.sources: every entry was malformed; merge needs at "
                 "least one valid source id"
             )
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if target is None or title is None or description is None or not sources:
         return None, errors
     return (
@@ -1438,6 +1568,7 @@ def _parse_op_merge(
             sources=sources,
             title=title,
             description=description,
+            contributing_intents=intents,
         ),
         errors,
     )
@@ -1478,9 +1609,13 @@ def _parse_op_split(
                 f"{path}.children: every child was malformed; split needs at "
                 "least one valid child"
             )
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if task_id is None or not children:
         return None, errors
-    return _RescopeOpSplit(id=task_id, children=children), errors
+    return (
+        _RescopeOpSplit(id=task_id, children=children, contributing_intents=intents),
+        errors,
+    )
 
 
 def _parse_op_new(
@@ -1490,10 +1625,16 @@ def _parse_op_new(
     title = _require_string_field(raw_op, "title", path, errors)
     description = _require_string_field_allow_empty(raw_op, "description", path, errors)
     task_type = _require_string_field(raw_op, "type", path, errors)
+    intents = _parse_contributing_intents(raw_op, path, errors)
     if title is None or description is None or task_type is None:
         return None, errors
     return (
-        _RescopeOpNew(title=title, description=description, type=task_type),
+        _RescopeOpNew(
+            title=title,
+            description=description,
+            type=task_type,
+            contributing_intents=intents,
+        ),
         errors,
     )
 
@@ -1570,23 +1711,59 @@ def _operations_to_items(operations: list[_RescopeOp]) -> list[dict[str, Any]]:
     item plus N source-completion items, since the reducer's per-task
     coverage invariant requires every source to carry its own
     ``CompleteTask``).
+
+    Each item carries the op's ``contributing_intents`` (a list of
+    originating ``RescopeIntent.comment_id`` values; #1722) under the
+    same key so the materializer can persist them on the resulting
+    task.  Source-completion items synthesised by a merge expansion
+    inherit the merge op's contributing_intents too — those intents
+    drove the source's closure in addition to the target's mutation.
     """
     items: list[dict[str, Any]] = []
     for op in operations:
         match op:
-            case _RescopeOpKeep(id=tid):
-                items.append({"id": tid})
-            case _RescopeOpRewrite(id=tid, title=title, description=desc):
-                items.append({"id": tid, "title": title, "description": desc})
-            case _RescopeOpRewriteAnchor(id=tid, anchor_comment_id=anchor):
-                items.append({"id": tid, "anchor_comment_id": anchor})
-            case _RescopeOpRemove(id=tid):
-                items.append({"id": tid, "status": str(TaskStatus.COMPLETED)})
+            case _RescopeOpKeep(id=tid, contributing_intents=intents):
+                items.append({"id": tid, "contributing_intents": list(intents)})
+            case _RescopeOpRewrite(
+                id=tid,
+                title=title,
+                description=desc,
+                contributing_intents=intents,
+            ):
+                items.append(
+                    {
+                        "id": tid,
+                        "title": title,
+                        "description": desc,
+                        "contributing_intents": list(intents),
+                    }
+                )
+            case _RescopeOpRewriteAnchor(
+                id=tid,
+                anchor_comment_id=anchor,
+                contributing_intents=intents,
+            ):
+                items.append(
+                    {
+                        "id": tid,
+                        "anchor_comment_id": anchor,
+                        "contributing_intents": list(intents),
+                    }
+                )
+            case _RescopeOpRemove(id=tid, contributing_intents=intents):
+                items.append(
+                    {
+                        "id": tid,
+                        "status": str(TaskStatus.COMPLETED),
+                        "contributing_intents": list(intents),
+                    }
+                )
             case _RescopeOpMerge(
                 target_id=target,
                 sources=sources,
                 title=title,
                 description=desc,
+                contributing_intents=intents,
             ):
                 items.append(
                     {
@@ -1594,11 +1771,20 @@ def _operations_to_items(operations: list[_RescopeOp]) -> list[dict[str, Any]]:
                         "title": title,
                         "description": desc,
                         "merge_sources": list(sources),
+                        "contributing_intents": list(intents),
                     }
                 )
                 for src in sources:
-                    items.append({"id": src, "status": str(TaskStatus.COMPLETED)})
-            case _RescopeOpSplit(id=tid, children=children):
+                    items.append(
+                        {
+                            "id": src,
+                            "status": str(TaskStatus.COMPLETED),
+                            "contributing_intents": list(intents),
+                        }
+                    )
+            case _RescopeOpSplit(
+                id=tid, children=children, contributing_intents=intents
+            ):
                 items.append(
                     {
                         "id": tid,
@@ -1606,15 +1792,22 @@ def _operations_to_items(operations: list[_RescopeOp]) -> list[dict[str, Any]]:
                             {"title": c.title, "description": c.description}
                             for c in children
                         ],
+                        "contributing_intents": list(intents),
                     }
                 )
-            case _RescopeOpNew(title=title, description=desc, type=task_type):
+            case _RescopeOpNew(
+                title=title,
+                description=desc,
+                type=task_type,
+                contributing_intents=intents,
+            ):
                 items.append(
                     {
                         "id": None,
                         "title": title,
                         "description": desc,
                         "type": task_type,
+                        "contributing_intents": list(intents),
                     }
                 )
     return items
@@ -1685,6 +1878,12 @@ def _make_new_tasks_from_opus(
             "status": str(TaskStatus.PENDING),
             "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
+        # #1722: a brand-new task carries the originating intents the
+        # `new` op declared so a downstream classifier can route the
+        # eventual completion notification to the right commenter(s).
+        op_intents = item.get("contributing_intents") or []
+        if op_intents:
+            task["contributing_intents"] = list(op_intents)
         new_tasks.append(task)
     return new_tasks
 
@@ -2219,8 +2418,20 @@ def _compute_thread_changes(
             continue
         tid = t["id"]
         r = result_by_id.get(tid)
+        # #1722: surface the post-rescope task's contributing_intents
+        # on every change record so the future material-vs-aggregation
+        # classifier (#1723) and per-intent notifier (#1724) can route
+        # replies to the right commenters.  Empty list = no intents
+        # attributed.
+        contributing = list((r or {}).get("contributing_intents") or [])
         if r is None or r.get("status") == TaskStatus.COMPLETED:
-            changes.append({"task": t, "kind": "completed"})
+            changes.append(
+                {
+                    "task": t,
+                    "kind": "completed",
+                    "contributing_intents": contributing,
+                }
+            )
         elif r.get("title") != t.get("title"):
             changes.append(
                 {
@@ -2228,6 +2439,7 @@ def _compute_thread_changes(
                     "kind": "modified",
                     "new_title": r.get("title", ""),
                     "new_description": r.get("description", ""),
+                    "contributing_intents": contributing,
                 }
             )
     return changes

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -780,7 +780,7 @@ class TestParseRescopeOperations:
         raw = '{"operations": [{"op": "keep", "id": "abc"}]}'
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
-        assert _operations_to_items(ops) == [{"id": "abc"}]
+        assert _operations_to_items(ops) == [{"id": "abc", "contributing_intents": []}]
 
     def test_parses_rewrite(self) -> None:
         raw = (
@@ -790,7 +790,12 @@ class TestParseRescopeOperations:
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
         assert _operations_to_items(ops) == [
-            {"id": "abc", "title": "New", "description": "scope"}
+            {
+                "id": "abc",
+                "title": "New",
+                "description": "scope",
+                "contributing_intents": [],
+            }
         ]
 
     def test_parses_rewrite_anchor(self) -> None:
@@ -800,13 +805,21 @@ class TestParseRescopeOperations:
         )
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
-        assert _operations_to_items(ops) == [{"id": "abc", "anchor_comment_id": 12345}]
+        assert _operations_to_items(ops) == [
+            {
+                "id": "abc",
+                "anchor_comment_id": 12345,
+                "contributing_intents": [],
+            }
+        ]
 
     def test_parses_remove(self) -> None:
         raw = '{"operations": [{"op": "remove", "id": "abc"}]}'
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
-        assert _operations_to_items(ops) == [{"id": "abc", "status": "completed"}]
+        assert _operations_to_items(ops) == [
+            {"id": "abc", "status": "completed", "contributing_intents": []}
+        ]
 
     def test_parses_merge_with_source_completion_expansion(self) -> None:
         # A single merge op lowers to one target item (with merge_sources)
@@ -825,9 +838,10 @@ class TestParseRescopeOperations:
                 "title": "Merged",
                 "description": "scope",
                 "merge_sources": ["b", "c"],
+                "contributing_intents": [],
             },
-            {"id": "b", "status": "completed"},
-            {"id": "c", "status": "completed"},
+            {"id": "b", "status": "completed", "contributing_intents": []},
+            {"id": "c", "status": "completed", "contributing_intents": []},
         ]
 
     def test_parses_split(self) -> None:
@@ -845,6 +859,7 @@ class TestParseRescopeOperations:
                     {"title": "A", "description": "first"},
                     {"title": "B", "description": "second"},
                 ],
+                "contributing_intents": [],
             }
         ]
 
@@ -856,7 +871,13 @@ class TestParseRescopeOperations:
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
         assert _operations_to_items(ops) == [
-            {"id": None, "title": "T", "description": "d", "type": "spec"}
+            {
+                "id": None,
+                "title": "T",
+                "description": "d",
+                "type": "spec",
+                "contributing_intents": [],
+            }
         ]
 
     def test_parses_json_with_preamble(self) -> None:
@@ -933,7 +954,7 @@ class TestParseRescopeOperations:
         raw = '{ this is { junk } before {"operations": [{"op": "keep", "id": "1"}]}'
         ops, errors = _parse_rescope_operations(raw)
         assert errors == []
-        assert _operations_to_items(ops) == [{"id": "1"}]
+        assert _operations_to_items(ops) == [{"id": "1", "contributing_intents": []}]
 
     def test_remove_missing_id(self) -> None:
         ops, errors = _parse_rescope_operations('{"operations": [{"op": "remove"}]}')
@@ -988,6 +1009,88 @@ class TestParseRescopeOperations:
             "operations[0].children[0]" in e and "must be a dict" in e for e in errors
         )
 
+    def test_keep_carries_contributing_intents(self) -> None:
+        # #1722: every op may attribute itself to one or more
+        # originating RescopeIntent comment ids.  The translator
+        # stamps the resulting item dict so the materializer can
+        # persist them on the task.
+        raw = (
+            '{"operations": [{"op": "keep", "id": "abc", '
+            '"contributing_intents": [101, 202]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        items = _operations_to_items(ops)
+        assert items == [{"id": "abc", "contributing_intents": [101, 202]}]
+
+    def test_contributing_intents_default_empty(self) -> None:
+        # Missing field = no attribution; translator emits an empty
+        # list so callers don't need to special-case ``None``.
+        raw = '{"operations": [{"op": "keep", "id": "abc"}]}'
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        items = _operations_to_items(ops)
+        assert items == [{"id": "abc", "contributing_intents": []}]
+
+    def test_contributing_intents_dedup_in_arrival_order(self) -> None:
+        # Duplicate entries in a single op's intents list are
+        # collapsed in arrival order so the persisted set is clean.
+        raw = (
+            '{"operations": [{"op": "keep", "id": "x", '
+            '"contributing_intents": [5, 5, 7, 5, 7]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        items = _operations_to_items(ops)
+        assert items[0]["contributing_intents"] == [5, 7]
+
+    def test_contributing_intents_must_be_list(self) -> None:
+        raw = (
+            '{"operations": [{"op": "keep", "id": "x", '
+            '"contributing_intents": "not a list"}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        assert any(
+            "operations[0].contributing_intents" in e and "must be a list" in e
+            for e in errors
+        )
+
+    def test_contributing_intents_entries_must_be_positive_int(self) -> None:
+        # Every malformed entry is reported in one pass — booleans,
+        # zero, negatives, and non-ints all fail.  Rob's directive:
+        # useful retries that detail every problem at once.
+        raw = (
+            '{"operations": [{"op": "keep", "id": "x", '
+            '"contributing_intents": [0, -1, "str", true, 42]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert ops == []
+        for index in (0, 1, 2, 3):
+            assert any(
+                f"operations[0].contributing_intents[{index}]" in e for e in errors
+            )
+
+    def test_merge_op_carries_contributing_intents_on_target_and_sources(
+        self,
+    ) -> None:
+        # #1722: merge target item carries the op's intents AND each
+        # synthesised source-completion item carries them too — those
+        # intents drove the source's closure as well as the target's
+        # mutation.
+        raw = (
+            '{"operations": [{"op": "merge", "target_id": "a", '
+            '"sources": ["b"], "title": "Merged", '
+            '"description": "scope", "contributing_intents": [99]}]}'
+        )
+        ops, errors = _parse_rescope_operations(raw)
+        assert errors == []
+        items = _operations_to_items(ops)
+        target = next(i for i in items if i["id"] == "a")
+        source_completion = next(i for i in items if i["id"] == "b")
+        assert target["contributing_intents"] == [99]
+        assert source_completion["contributing_intents"] == [99]
+
     def test_decode_skips_non_dict_first_value(self) -> None:
         # First decodable JSON value at the first ``{`` could be a
         # nested non-dict shape; the decoder advances past it and
@@ -1003,7 +1106,10 @@ class TestFindCrossOpErrors:
     def test_unknown_id_rejected(self) -> None:
         from fido.tasks import _RescopeOpKeep
 
-        errors = _find_cross_op_errors([_RescopeOpKeep(id="ghost")], frozenset({"a"}))
+        errors = _find_cross_op_errors(
+            [_RescopeOpKeep(id="ghost", contributing_intents=[])],
+            frozenset({"a"}),
+        )
         assert any(
             "'ghost'" in e and "not in the pending snapshot" in e for e in errors
         )
@@ -1011,7 +1117,10 @@ class TestFindCrossOpErrors:
     def test_duplicate_id_across_ops_rejected(self) -> None:
         from fido.tasks import _RescopeOpKeep, _RescopeOpRemove
 
-        ops = [_RescopeOpKeep(id="a"), _RescopeOpRemove(id="a")]
+        ops: list = [
+            _RescopeOpKeep(id="a", contributing_intents=[]),
+            _RescopeOpRemove(id="a", contributing_intents=[]),
+        ]
         errors = _find_cross_op_errors(ops, frozenset({"a"}))
         assert any("claimed by 2 operations" in e for e in errors)
 
@@ -1022,9 +1131,21 @@ class TestFindCrossOpErrors:
         # validator does (#1738 codex Medium).
         from fido.tasks import _RescopeOpMerge
 
-        ops = [
-            _RescopeOpMerge(target_id="a", sources=["b"], title="A", description=""),
-            _RescopeOpMerge(target_id="c", sources=["b"], title="C", description=""),
+        ops: list = [
+            _RescopeOpMerge(
+                target_id="a",
+                sources=["b"],
+                title="A",
+                description="",
+                contributing_intents=[],
+            ),
+            _RescopeOpMerge(
+                target_id="c",
+                sources=["b"],
+                title="C",
+                description="",
+                contributing_intents=[],
+            ),
         ]
         errors = _find_cross_op_errors(ops, frozenset({"a", "b", "c"}))
         assert any("'b'" in e and "claimed by 2 operations" in e for e in errors)
@@ -1032,8 +1153,14 @@ class TestFindCrossOpErrors:
     def test_merge_source_id_validated(self) -> None:
         from fido.tasks import _RescopeOpMerge
 
-        ops = [
-            _RescopeOpMerge(target_id="a", sources=["ghost"], title="A", description="")
+        ops: list = [
+            _RescopeOpMerge(
+                target_id="a",
+                sources=["ghost"],
+                title="A",
+                description="",
+                contributing_intents=[],
+            )
         ]
         errors = _find_cross_op_errors(ops, frozenset({"a"}))
         assert any(
@@ -1045,15 +1172,21 @@ class TestFindCrossOpErrors:
         # the snapshot, so the cross-op claim count must skip them.
         from fido.tasks import _RescopeOpNew
 
-        ops = [_RescopeOpNew(title="A", description="", type="spec")]
+        ops: list = [
+            _RescopeOpNew(
+                title="A", description="", type="spec", contributing_intents=[]
+            )
+        ]
         assert _find_cross_op_errors(ops, frozenset()) == []
 
     def test_split_op_claims_source_id(self) -> None:
         from fido.tasks import _RescopeOpSplit, _RescopeOpSplitChild
 
-        ops = [
+        ops: list = [
             _RescopeOpSplit(
-                id="src", children=[_RescopeOpSplitChild(title="C", description="")]
+                id="src",
+                children=[_RescopeOpSplitChild(title="C", description="")],
+                contributing_intents=[],
             )
         ]
         # Unknown source id.
@@ -1893,6 +2026,106 @@ class TestApplyReorder:
             "otherwise the divergence verifier would raise on a batch "
             "straddling a wall-clock second"
         )
+
+    def test_rewrite_carries_contributing_intents_to_persisted_task(self) -> None:
+        # #1722: contributing_intents on the op flows through the
+        # apply path and lands on the resulting task dict so a future
+        # classifier can read which intents drove the rewrite.
+        current = [self._t("1", "Old")]
+        items = [
+            {
+                "id": "1",
+                "title": "New",
+                "description": "scoped",
+                "contributing_intents": [42, 99],
+            }
+        ]
+        result = _apply_reorder(current, items)
+        assert result[0]["contributing_intents"] == [42, 99]
+
+    def test_multiple_intents_can_contribute_to_one_task(self) -> None:
+        # Acceptance criteria from #1722: tests cover multiple intents
+        # contributing to one task.  Two intents both attributed to a
+        # single rewrite op land on the resulting task as a list.
+        current = [self._t("1", "Original")]
+        items = [
+            {
+                "id": "1",
+                "title": "Combined ask",
+                "description": "...",
+                "contributing_intents": [101, 202, 303],
+            }
+        ]
+        result = _apply_reorder(current, items)
+        assert result[0]["contributing_intents"] == [101, 202, 303]
+
+    def test_split_propagates_contributing_intents_to_every_child(self) -> None:
+        # Acceptance criteria from #1722: split records associate the
+        # source intent ids with every split child unless explicitly
+        # narrowed (this leaf does not implement narrowing — children
+        # always inherit).  The split source's pre-existing intents
+        # also flow to every child.
+        src = self._t("src", "Original", task_type="thread")
+        src["thread"] = {"repo": "r/r", "pr": 1, "comment_id": 100}
+        src["contributing_intents"] = [50]  # pre-existing intent on source
+        items = [
+            {
+                "id": "src",
+                "split_targets": [
+                    {"title": "Child A", "description": "first"},
+                    {"title": "Child B", "description": "second"},
+                ],
+                "contributing_intents": [777],  # split-trigger intent
+            }
+        ]
+        result = _apply_reorder([src], items)
+        children = [t for t in result if t["id"] != "src"]
+        assert len(children) == 2
+        for child in children:
+            # Source's [50] + op's [777] union = [50, 777] in insertion
+            # order.
+            assert child["contributing_intents"] == [50, 777]
+
+    def test_merge_unions_source_intents_into_target(self) -> None:
+        # Sources' pre-existing contributing_intents fold into the
+        # merged target alongside the merge op's own intents.
+        a = self._t("a", "Task A")
+        a["contributing_intents"] = [10]
+        b = self._t("b", "Task B")
+        b["contributing_intents"] = [20, 30]
+        items = [
+            {
+                "id": "a",
+                "title": "Merged",
+                "description": "",
+                "merge_sources": ["b"],
+                "contributing_intents": [40],
+            },
+            {"id": "b", "status": "completed"},
+        ]
+        result = _apply_reorder([a, b], items)
+        target = next(t for t in result if t["id"] == "a")
+        # Target's prior [10] + op's [40] + source b's [20, 30] union.
+        assert target["contributing_intents"] == [10, 40, 20, 30]
+
+    def test_new_op_carries_contributing_intents_to_new_task(self) -> None:
+        # Brand-new tasks created via `new` ops keep the originating
+        # intent ids so a downstream classifier can route the eventual
+        # completion notification to the right commenter(s).
+        current: list = []
+        items = [
+            {
+                "id": None,
+                "title": "Brand new",
+                "description": "scope",
+                "type": "spec",
+                "contributing_intents": [555],
+            }
+        ]
+        result = _apply_reorder(current, items)
+        assert len(result) == 1
+        assert result[0]["title"] == "Brand new"
+        assert result[0]["contributing_intents"] == [555]
 
     def test_explicit_completion_marks_task_completed(self) -> None:
         # #1716: an item with status="completed" emits CompleteTask, which
@@ -3846,6 +4079,28 @@ class TestComputeThreadChanges:
         t = self._t("1", "Task", thread=self._thread())
         changes = _compute_thread_changes([t], [t], frozenset({"1"}))
         assert changes == []
+
+    def test_change_record_carries_post_rescope_contributing_intents(self) -> None:
+        # #1722: change records expose contributing_intents from the
+        # post-rescope task so the future classifier (#1723) and
+        # per-intent notifier (#1724) can route replies.  Both
+        # "completed" and "modified" records carry the field.
+        thread = self._thread()
+        original = [self._t("1", "Old", thread=thread)]
+        result_modified = [self._t("1", "New", thread=thread)]
+        result_modified[0]["contributing_intents"] = [42, 99]
+        modified = _compute_thread_changes(original, result_modified, frozenset({"1"}))
+        assert modified[0]["kind"] == "modified"
+        assert modified[0]["contributing_intents"] == [42, 99]
+        # Same for completion records.
+        result_completed: list = []
+        completed = _compute_thread_changes(
+            original, result_completed, frozenset({"1"})
+        )
+        assert completed[0]["kind"] == "completed"
+        # The original task had no contributing_intents and the result
+        # is missing entirely — empty list, not None.
+        assert completed[0]["contributing_intents"] == []
 
     def test_spec_task_not_reported_even_if_dropped(self) -> None:
         t = self._t("1", "Spec task")  # no thread


### PR DESCRIPTION
## Summary

First leaf of the reply-back filter epic (#1256).  Every rescope
operation now carries an optional list of originating
`RescopeIntent.comment_id` values; the parser, translator, and
materializer thread them through to the persisted task and the
change records the future classifier (#1723) and per-intent
notifier (#1724) will consume.

## Schema addition (every op type)

\`\`\`json
{\"op\": \"<...>\", ..., \"contributing_intents\": [<intent comment_id>, ...]}
\`\`\`

Optional (missing or empty = no attribution).  Per-op parser
validates list-of-positive-ints and dedupes in arrival order so the
persisted set is clean.  Cross-op invariants are unchanged.

## Apply-time semantics

- `rewrite` / `rewrite_anchor` / `remove` / `new` / `keep` →
  contributing_intents stamped on the resulting task dict.
- `merge` → target's `contributing_intents` = union of (op's
  intents, target's pre-existing, every source's pre-existing).
  Source-completion items inherit the op's intents too — those
  intents drove the source's closure.
- `split` → every child's `contributing_intents` = union of (op's
  intents, source's pre-existing).  Children inherit unless
  explicitly narrowed (this leaf doesn't implement narrowing).

Change records (`_compute_thread_changes`) expose the post-rescope
task's `contributing_intents` so downstream callers can route
notifications to the right commenter(s) without re-deriving
provenance from scratch.

## Out of scope

The classifier itself (#1723) and notification dispatch (#1724).
This leaf is data plumbing only.

## Test plan
- [x] `./fido ci` (4357 tests, 100% coverage)
- [x] Per-op parser tests for the optional field
- [x] Dedup-in-arrival-order test
- [x] Validation tests for non-list / non-positive-int / boolean / non-int entries (every defect collected in one pass)
- [x] Apply-time: rewrite, multi-intent contribution, split children inherit, merge unions sources, new task carries op intents
- [x] Change records carry post-rescope contributing_intents