### PR TITLE
Rescope L#1723: classify per-intent material vs aggregation (closes #1723)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from fido.appstate import FidoState, TaskListSnapshot
@@ -2367,6 +2367,133 @@ def _merge_source_ids(ordered_items: list[dict[str, Any]]) -> set[str]:
     return merged
 
 
+# ── #1723: classify per-intent rescope dispositions ──────────────────────────
+#
+# The reply-back filter epic (#1256) needs to decide, per originating
+# RescopeIntent, whether the rescope materially affected that
+# commenter's ask or just absorbed it into existing work.  This
+# classifier consumes the contributing_intents provenance written by
+# #1722's apply path and the original/result task lists; #1724 will
+# turn its output into per-intent notifications.
+
+_IntentDispositionKind = Literal["material", "aggregation", "unhandled"]
+
+
+@dataclass(frozen=True)
+class _IntentDisposition:
+    """How a single RescopeIntent was treated by one rescope batch.
+
+    * ``material`` — at least one task this intent contributed to had
+      a change the commenter needs to hear about (title/description
+      rewrite, status change to completed, anchor re-target, brand-new
+      task created for the intent).
+    * ``aggregation`` — intent attributed to one or more tasks but
+      none of those tasks materially changed (pure absorption into
+      an existing pending task without rewording or restructuring).
+    * ``unhandled`` — intent didn't appear in any task's
+      ``contributing_intents`` (Opus didn't act on it this batch).
+
+    ``affected_task_ids`` lists every task this intent contributed to
+    (in result-list order) so #1724 can route per-intent replies to
+    the right tasks.  ``reason`` is a short human-readable string
+    describing what the classifier saw.
+    """
+
+    kind: _IntentDispositionKind
+    reason: str
+    affected_task_ids: list[str]
+
+
+def _intent_material_reasons(
+    original_task: dict[str, Any] | None, result_task: dict[str, Any]
+) -> list[str]:
+    """Return one reason per material change between *original_task* and *result_task*.
+
+    Empty list means the resulting task didn't change in any way that
+    the commenter needs to hear about — pure aggregation.
+
+    Material changes (per #1723 acceptance criteria):
+      * brand-new task (no original counterpart)
+      * status flipped to completed
+      * title rewritten
+      * description rewritten (counts as task wording)
+      * source-comment anchor re-targeted
+    """
+    if original_task is None:
+        return [f"new task created for this intent ({result_task['id']!r})"]
+    reasons: list[str] = []
+    completed_value = str(TaskStatus.COMPLETED)
+    if (
+        result_task.get("status") == completed_value
+        and original_task.get("status") != completed_value
+    ):
+        reasons.append(f"task closed ({result_task['id']!r})")
+    if result_task.get("title") != original_task.get("title"):
+        reasons.append(f"task title rewritten ({result_task['id']!r})")
+    if result_task.get("description") != original_task.get("description"):
+        reasons.append(f"task description rewritten ({result_task['id']!r})")
+    old_anchor = (original_task.get("thread") or {}).get("comment_id")
+    new_anchor = (result_task.get("thread") or {}).get("comment_id")
+    if old_anchor != new_anchor:
+        reasons.append(f"task anchor re-targeted ({result_task['id']!r})")
+    return reasons
+
+
+def _classify_rescope_intents(
+    original: list[dict[str, Any]],
+    result: list[dict[str, Any]],
+    intents: list[RescopeIntent],
+) -> dict[int, _IntentDisposition]:
+    """Per-intent classification for the reply-back filter (#1723).
+
+    Returns a dict keyed on ``intent.comment_id`` so the caller can
+    look up each originating intent independently — the classifier
+    operates per ORIGINATING COMMENT id, not per task id.  An intent
+    that contributed to multiple tasks aggregates "material" if any
+    affected task had a material change; an intent that contributed
+    to zero tasks is ``unhandled``.
+
+    The downstream notifier (#1724) decides notification policy from
+    these dispositions; this layer just classifies and explains.
+    """
+    original_by_id = {t["id"]: t for t in original}
+    intent_to_tasks: dict[int, list[dict[str, Any]]] = {}
+    for task in result:
+        for intent_id in task.get("contributing_intents") or []:
+            intent_to_tasks.setdefault(intent_id, []).append(task)
+
+    out: dict[int, _IntentDisposition] = {}
+    for intent in intents:
+        cid = intent.comment_id
+        attributed = intent_to_tasks.get(cid, [])
+        if not attributed:
+            out[cid] = _IntentDisposition(
+                kind="unhandled",
+                reason="not attributed to any operation",
+                affected_task_ids=[],
+            )
+            continue
+        affected_ids = [t["id"] for t in attributed]
+        material_reasons: list[str] = []
+        for task in attributed:
+            material_reasons.extend(
+                _intent_material_reasons(original_by_id.get(task["id"]), task)
+            )
+        if material_reasons:
+            out[cid] = _IntentDisposition(
+                kind="material",
+                reason="; ".join(material_reasons),
+                affected_task_ids=affected_ids,
+            )
+        else:
+            out[cid] = _IntentDisposition(
+                kind="aggregation",
+                reason="absorbed into existing task(s) without material change",
+                affected_task_ids=affected_ids,
+            )
+    return out
+
+
 def _compute_thread_changes(
     original: list[dict[str, Any]],
     result: list[dict[str, Any]],
@@ -2457,6 +2584,8 @@ def reorder_tasks(
     prior_attempts: list[ClosedPR] | None = None,
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
     _on_inprogress_affected: Callable[[str], None] | None = None,
+    _on_intent_dispositions: Callable[[dict[int, _IntentDisposition]], None]
+    | None = None,
     _on_done: Callable[[], None] | None = None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
@@ -2744,6 +2873,15 @@ def reorder_tasks(
                 | _split_source_ids(ordered_items),
             )
         )
+
+    if _on_intent_dispositions is not None and intents is not None:
+        # #1723: per-intent material vs aggregation classification.
+        # The future #1724 leaf reads these dispositions and decides
+        # which originating commenter(s) to ping.  Computed always
+        # when an intents list is provided so the callback fires with
+        # the full disposition map even for batches that produced no
+        # thread-change records.
+        _on_intent_dispositions(_classify_rescope_intents(pre_rescope, result, intents))
 
     if inprogress_affected and _on_inprogress_affected is not None:
         assert inprogress is not None  # inprogress_affected is True

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3141,6 +3141,63 @@ class TestReorderTasks:
         )
         assert received == []
 
+    def test_intent_dispositions_callback_fires_with_classification(
+        self, tmp_path: Path
+    ) -> None:
+        # #1723: when intents are provided, the on_intent_dispositions
+        # callback fires with the per-intent material/aggregation/
+        # unhandled classification so #1724 can route notifications.
+        t1 = self._add(tmp_path, "Original")
+        intents = [
+            RescopeIntent(
+                change_request="rename it",
+                comment_id=101,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        # Op rewrites the task and attributes it to the intent.
+        raw = json.dumps(
+            {
+                "operations": [
+                    {
+                        "op": "rewrite",
+                        "id": t1["id"],
+                        "title": "Renamed",
+                        "description": "",
+                        "contributing_intents": [101],
+                    }
+                ]
+            }
+        )
+        captured: list[dict] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            intents=intents,
+            _on_intent_dispositions=lambda d: captured.append(d),
+        )
+        assert len(captured) == 1
+        assert 101 in captured[0]
+        assert captured[0][101].kind == "material"
+
+    def test_intent_dispositions_callback_skipped_without_intents(
+        self, tmp_path: Path
+    ) -> None:
+        # When no intents are provided (e.g. a CI-triggered rescope
+        # with no fresh comment intents), the dispositions callback
+        # doesn't fire — there's nothing to classify.
+        self._add(tmp_path, "Task")
+        raw = json.dumps({"operations": []})
+        called: list[int] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_intent_dispositions=lambda _d: called.append(1),
+        )
+        assert called == []
+
     def test_validator_rejection_after_parse_success_drops_batch(
         self, tmp_path: Path
     ) -> None:
@@ -4126,6 +4183,187 @@ class TestComputeThreadChanges:
         kinds = {c["kind"] for c in changes}
         assert "completed" in kinds
         assert "modified" in kinds
+
+
+class TestClassifyRescopeIntents:
+    """Per-intent material vs aggregation classifier (#1723)."""
+
+    def _intent(self, comment_id: int) -> RescopeIntent:
+        return RescopeIntent(
+            change_request="ask",
+            comment_id=comment_id,
+            timestamp="2024-01-15T10:00:00+00:00",
+        )
+
+    def _t(
+        self,
+        task_id: str,
+        title: str,
+        description: str = "",
+        status: str = "pending",
+        thread: dict | None = None,
+        contributing_intents: list[int] | None = None,
+    ) -> dict:
+        t: dict = {
+            "id": task_id,
+            "title": title,
+            "type": "thread" if thread else "spec",
+            "status": status,
+            "description": description,
+        }
+        if thread:
+            t["thread"] = thread
+        if contributing_intents is not None:
+            t["contributing_intents"] = contributing_intents
+        return t
+
+    def test_unattributed_intent_is_unhandled(self) -> None:
+        # Intent doesn't appear in any post-rescope task's
+        # contributing_intents → Opus didn't act on it this batch.
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "A")]
+        result = [self._t("1", "A")]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "unhandled"
+        assert out[101].affected_task_ids == []
+
+    def test_intent_absorbed_without_change_is_aggregation(self) -> None:
+        # Intent attributed to a task that didn't change in any
+        # material way — pure aggregation (don't ping the commenter).
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "A")]
+        result = [self._t("1", "A", contributing_intents=[101])]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "aggregation"
+        assert out[101].affected_task_ids == ["1"]
+
+    def test_title_rewrite_is_material(self) -> None:
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "Old")]
+        result = [self._t("1", "New", contributing_intents=[101])]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        assert "title rewritten" in out[101].reason
+
+    def test_description_rewrite_is_material(self) -> None:
+        # The acceptance criteria call out "task wording/scope changes"
+        # — description counts even though the legacy
+        # _compute_thread_changes auto-notification ignores it (#1388
+        # was about chat noise, not classification semantics).
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "Same", description="old scope")]
+        result = [
+            self._t("1", "Same", description="new scope", contributing_intents=[101])
+        ]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        assert "description rewritten" in out[101].reason
+
+    def test_completion_is_material(self) -> None:
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "A")]
+        result = [self._t("1", "A", status="completed", contributing_intents=[101])]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        assert "task closed" in out[101].reason
+
+    def test_anchor_retarget_is_material(self) -> None:
+        from fido.tasks import _classify_rescope_intents
+
+        old_thread = {"repo": "r/r", "pr": 1, "comment_id": 50}
+        new_thread = {"repo": "r/r", "pr": 1, "comment_id": 99}
+        original = [self._t("1", "A", thread=old_thread)]
+        result = [self._t("1", "A", thread=new_thread, contributing_intents=[101])]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        assert "anchor re-targeted" in out[101].reason
+
+    def test_brand_new_task_is_material(self) -> None:
+        # No original counterpart for the intent's task — by
+        # construction, the rescope created a new task to honor it.
+        from fido.tasks import _classify_rescope_intents
+
+        original: list[dict] = []
+        result = [self._t("new-1", "Brand new", contributing_intents=[101])]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        assert "new task created" in out[101].reason
+        assert out[101].affected_task_ids == ["new-1"]
+
+    def test_merge_into_differently_scoped_target_is_material(self) -> None:
+        # Source's intent contributes to a merged target whose title
+        # changed (the merge introduced a different scope to absorb
+        # multiple intents).  Material per the issue's literal spec.
+        from fido.tasks import _classify_rescope_intents
+
+        original = [
+            self._t("a", "Task A"),
+            self._t("b", "Task B"),
+        ]
+        # After merge: target 'a' now titled "Combined" with both
+        # source intents on it (b closed, intent_b folded onto a).
+        result = [
+            self._t("a", "Combined", contributing_intents=[101, 202]),
+            self._t("b", "Task B", status="completed", contributing_intents=[202]),
+        ]
+        out = _classify_rescope_intents(
+            original, result, [self._intent(101), self._intent(202)]
+        )
+        # Both intents see the target's title change → material.
+        assert out[101].kind == "material"
+        assert out[202].kind == "material"
+
+    def test_split_into_multiple_children_is_material(self) -> None:
+        # Source's intent appears on multiple split children — each
+        # child has a different title from the original.  Material.
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("src", "Big task")]
+        result = [
+            self._t("src", "Big task", status="completed", contributing_intents=[101]),
+            self._t("child-A", "Half A", contributing_intents=[101]),
+            self._t("child-B", "Half B", contributing_intents=[101]),
+        ]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "material"
+        # All three tasks list the intent.
+        assert set(out[101].affected_task_ids) == {"src", "child-A", "child-B"}
+
+    def test_classifier_keys_on_comment_id_not_task_id(self) -> None:
+        # One intent contributing to two distinct tasks aggregates a
+        # single disposition keyed on the comment_id — not two
+        # records per task.
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "A"), self._t("2", "B")]
+        result = [
+            self._t("1", "A new", contributing_intents=[55]),
+            self._t("2", "B", contributing_intents=[55]),
+        ]
+        out = _classify_rescope_intents(original, result, [self._intent(55)])
+        assert list(out.keys()) == [55]
+        assert out[55].kind == "material"
+        assert out[55].affected_task_ids == ["1", "2"]
+
+    def test_aggregation_when_only_unrelated_tasks_changed(self) -> None:
+        # Intent's task is unchanged, but other tasks in the result
+        # changed — aggregation because the classifier looks at the
+        # tasks the intent contributed to, nothing else.
+        from fido.tasks import _classify_rescope_intents
+
+        original = [self._t("1", "A"), self._t("2", "B")]
+        result = [
+            self._t("1", "A", contributing_intents=[101]),  # unchanged
+            self._t("2", "B rewritten"),  # different intent's change
+        ]
+        out = _classify_rescope_intents(original, result, [self._intent(101)])
+        assert out[101].kind == "aggregation"
+        assert out[101].affected_task_ids == ["1"]
 
 
 class TestTasks:


### PR DESCRIPTION
## Summary

Second leaf of the reply-back filter epic (#1256).  Adds the
per-originating-intent classifier — reads the
`contributing_intents` provenance written by #1722 plus the
original/result task lists and produces a disposition per intent
comment id.

## Disposition shapes

- **material** — at least one task this intent contributed to had a
  change the commenter needs to hear about: title or description
  rewritten, status closed, anchor re-targeted, or a brand-new task
  created for it.
- **aggregation** — intent attributed to one or more tasks but none
  materially changed (pure absorption — don't notify).
- **unhandled** — intent didn't appear in any task's
  `contributing_intents` (Opus didn't act on it this batch).

Each disposition carries a human-readable `reason` and the list of
`affected_task_ids` so #1724 can route per-intent replies.

## Wiring

New `_on_intent_dispositions` callback hook on `reorder_tasks`.
Fires with the full per-intent disposition map whenever intents are
provided; #1724 attaches its dispatcher here.  Out of scope per
issue: notification dispatch itself.

## Test plan
- [x] `./fido ci` (4370 tests, 100% coverage)
- [x] Each disposition shape (material via title/description/anchor/status/new-task; aggregation; unhandled)
- [x] Merge into differently-scoped target (target title changed) → material for both source intents
- [x] Split into multiple children → material
- [x] Per comment-id (not per task-id): one intent contributing to two tasks aggregates as one disposition
- [x] Aggregation isolation: unrelated tasks changing doesn't make this intent material
- [x] Callback fires with classification when intents provided
- [x] Callback skipped when no intents