### PR TITLE
Rescope L#1724: notify only materially rescoped intents (closes #1724)

### DIFF
--- a/models/BUG_MINED_INVARIANTS.md
+++ b/models/BUG_MINED_INVARIANTS.md
@@ -283,6 +283,17 @@ Python adapter and outbox; the rocq model intentionally doesn't
 track contributing_intents because it carries no coordination
 semantics — only notification routing.
 
+**Known gap (tracked):** the reply-back path only sees intents
+present in the *current* rescope batch's `intents` parameter.
+Past-batch intents — whose `comment_id` lives on
+`task.contributing_intents` from a prior batch — silently skip
+classification because the `RescopeIntent` records have aged out.
+**#1748** (per-PR comment cache) and **#1749** (collapse
+`RescopeIntent` to a comment-id reference, fetch metadata via
+the cache) close this loop by making intents first-class durable
+references that the classifier/notifier can resolve uniformly
+across batches.
+
 **Status.** Modeled in **D11 (#749) — model rescope confluence**.
 The original "title is immutable" framing has been reshaped by epic
 **#1340**: identity is the id, not the text. See #1665, #1713, #1714,

--- a/models/BUG_MINED_INVARIANTS.md
+++ b/models/BUG_MINED_INVARIANTS.md
@@ -262,10 +262,33 @@ source and spawns N children that inherit `lineage_comments` and
 `split_preserves_source_lineage` proves no child loses the inherited
 origin metadata, mirrored at runtime by `_assert_split_lineage_preserved`).
 
+The rescope I/O contract is explicit under epic **#1247**: the prompt
+and parser share a single typed-operation schema (#1719 —
+`{"operations": [{"op": ..., ...}, ...]}`); intents render in
+chronological order with an explicit conflict-resolution rule (#1720);
+empty/partial responses keep the queue (no implicit wipe — full
+rebuild is `remove` + `new` per #1721).
+
+The reply-back surface is filtered under epic **#1256**: every
+operation carries optional `contributing_intents` provenance
+(#1722); the per-originating-intent classifier (#1723) labels each
+intent material/aggregation/unhandled; the per-intent notifier
+(#1724) replies in `RescopeIntent.timestamp` order with Opus-voice
+narrative for material AND unhandled dispositions (aggregation stays
+silent), drawing on co-contributing and sibling intents in the same
+batch so the reply tells the *story* of how each commenter's ask
+landed.  The notifier explicitly never implies the work is done —
+the rescope only replanned it.  These layers live entirely in the
+Python adapter and outbox; the rocq model intentionally doesn't
+track contributing_intents because it carries no coordination
+semantics — only notification routing.
+
 **Status.** Modeled in **D11 (#749) — model rescope confluence**.
 The original "title is immutable" framing has been reshaped by epic
 **#1340**: identity is the id, not the text. See #1665, #1713, #1714,
-#1716, #1717, #1718, #1666, #1667 for the per-leaf invariants.
+#1716, #1717, #1718, #1666, #1667 (reducer); #1719, #1720, #1721,
+#1247 (prompt vocabulary); #1722, #1723, #1724, #1256 (reply-back
+filter) for the per-leaf invariants.
 
 **E1 flip point.** D11 currently runs as a runtime oracle around
 `reorder_tasks`: Python translates Opus's omission-based result into explicit

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2043,26 +2043,40 @@ def _notify_intent_outcome(
     repo_cfg: RepoConfig,
     gh: GitHub,
     *,
+    batch_intents: list[RescopeIntent],
+    batch_dispositions: dict[int, IntentDisposition],
+    result: list[dict[str, Any]],
     agent: ProviderAgent | None = None,
     prompts: Prompts | None = None,
 ) -> None:
-    """Post a per-intent reply when rescope materially changed the ask (#1724).
+    """Post a per-intent reply per the reply-back filter (#1724).
 
     The reply-back filter epic (#1256) consumes the per-intent
-    classifier output (#1723) and emits an Opus-voice note to the
-    originating commenter ONLY when the rescope materially affected
-    their request.  Aggregation (intent absorbed without change) and
-    unhandled (intent not acted on) silently produce no reply.
+    classifier output (#1723).  Material and unhandled both emit a
+    notification — material describes the outcome of the rescope on
+    this ask; unhandled explains why no operation was attributed to
+    it (typically because a later sibling intent superseded it, or
+    Opus judged the ask already covered).  Aggregation (intent
+    absorbed without material change) stays silent.
 
-    The reply text is generated per-call by Opus (per the
-    voice-text-not-templated convention) and instructed to describe
-    the OUTCOME of the rescope on this specific intent — without
-    implying the work is done when the rescope only replanned it.
+    The Opus instruction asks the model to TELL THE STORY of how the
+    rescope handled this commenter's ask, grounding the explanation
+    in:
+
+    * For material: every co-contributing intent in the batch that
+      shaped any of the same affected tasks.  Opus can then say
+      "your ask was rewritten because @rhencke's later comment...".
+    * For unhandled: every sibling intent in the batch with its
+      disposition.  Opus can then say "we acted on @bob's later
+      comment instead / your ask was already covered by..."
+
+    Reply text is generated per-call by Opus (voice-text-not-
+    templated convention) and instructed never to imply the work is
+    done — the rescope only replanned.
     """
-    # Defense-in-depth: callers (build_on_intent_dispositions) are
-    # supposed to filter to material before invoking us, but the
-    # branch is cheap and lets us be the single source of truth.
-    if disposition.kind != "material":
+    # Aggregation = pure absorption with no material effect — no
+    # narrative to tell, stay silent (acceptance criteria #1723).
+    if disposition.kind == "aggregation":
         return
 
     if agent is None:
@@ -2070,17 +2084,95 @@ def _notify_intent_outcome(
     if prompts is None:
         prompts = Prompts(_load_persona(config))
 
-    instruction = (
-        "A change request from a PR comment was rescoped — the work has "
-        "been REPLANNED, not completed.  Tell the commenter what happened "
-        "to their ask without implying the work is done.\n\n"
-        f"Their original change request: {intent.change_request}\n"
-        f"Affected task id(s): {', '.join(disposition.affected_task_ids)}\n"
-        f"What changed: {disposition.reason}\n\n"
-        "Write a very brief reply.  Be specific about which tasks were "
-        "rewritten / merged / split / closed.  Do NOT say the work is "
-        "done — the rescope only restructured the plan."
-    )
+    intents_by_cid = {i.comment_id: i for i in batch_intents}
+    tasks_by_id = {t["id"]: t for t in result}
+
+    # Co-contributing intents: other commenters whose intents shaped
+    # the same tasks this intent's ask landed on.  Insertion-ordered
+    # (first task's contributors first), de-duplicated by comment_id.
+    seen_cids: set[int] = set()
+    co_contributing: list[RescopeIntent] = []
+    for task_id in disposition.affected_task_ids:
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            continue
+        for other_cid in task.get("contributing_intents") or []:
+            if other_cid == intent.comment_id or other_cid in seen_cids:
+                continue
+            other = intents_by_cid.get(other_cid)
+            if other is None:
+                continue
+            seen_cids.add(other_cid)
+            co_contributing.append(other)
+
+    # Sibling intents: every other intent in this batch with its
+    # disposition.  Used by the unhandled branch to explain why this
+    # commenter's ask was passed over (likely a later sibling
+    # superseded it, or it was already covered).
+    siblings: list[tuple[RescopeIntent, IntentDisposition]] = []
+    for other in batch_intents:
+        if other.comment_id == intent.comment_id:
+            continue
+        other_disposition = batch_dispositions.get(other.comment_id)
+        if other_disposition is not None:
+            siblings.append((other, other_disposition))
+
+    if disposition.kind == "material":
+        framing = (
+            "A change request from a PR comment was rescoped — the work "
+            "has been REPLANNED, not completed.  Tell this commenter the "
+            "STORY of how their ask landed: which task(s) absorbed it, "
+            "what changed, and where other commenters' input shaped the "
+            "same task(s).  Be specific about which tasks were rewritten "
+            "/ merged / split / closed.  Do NOT say the work is done — "
+            "the rescope only restructured the plan."
+        )
+    else:  # unhandled
+        framing = (
+            "A change request from a PR comment was NOT acted on this "
+            "rescope batch — Opus attributed no operation to it.  Tell "
+            "this commenter the STORY of why their ask is sitting in "
+            "this round: did a later sibling intent supersede it?  Was "
+            "the ask already covered by an existing pending task?  Use "
+            "the sibling intents below to ground the explanation; don't "
+            "apologize, just narrate what happened."
+        )
+
+    instruction_parts = [
+        framing,
+        "",
+        f"This commenter's change request: {intent.change_request}",
+        f"Their comment id: {intent.comment_id} ({intent.timestamp})",
+        f"Disposition: {disposition.kind}",
+        f"What changed: {disposition.reason}",
+        f"Affected task id(s): {', '.join(disposition.affected_task_ids) or '(none)'}",
+    ]
+    if co_contributing:
+        instruction_parts.append("")
+        instruction_parts.append(
+            "Other commenters who contributed to the SAME affected task(s) "
+            "(chronological):"
+        )
+        for other in co_contributing:
+            instruction_parts.append(
+                f"- comment #{other.comment_id} ({other.timestamp}): "
+                f"{other.change_request}"
+            )
+    if siblings and disposition.kind == "unhandled":
+        instruction_parts.append("")
+        instruction_parts.append(
+            "Other intents processed in this same rescope batch "
+            "(chronological, with their dispositions):"
+        )
+        for other, other_disposition in siblings:
+            instruction_parts.append(
+                f"- comment #{other.comment_id} "
+                f"({other.timestamp}, {other_disposition.kind}): "
+                f"{other.change_request}"
+            )
+    instruction_parts.append("")
+    instruction_parts.append("Write a very brief reply.")
+    instruction = "\n".join(instruction_parts)
 
     body = safe_voice_turn(
         agent,
@@ -2092,7 +2184,11 @@ def _notify_intent_outcome(
     )
     try:
         gh.reply_to_review_comment(repo, pr, body, intent.comment_id)
-        log.info("notified intent comment %s (material rescope)", intent.comment_id)
+        log.info(
+            "notified intent comment %s (%s rescope)",
+            intent.comment_id,
+            disposition.kind,
+        )
     except Exception:
         log.exception("failed to notify intent comment %s", intent.comment_id)
 
@@ -2416,16 +2512,19 @@ def _build_on_intent_dispositions(
 
     def on_intent_dispositions(
         dispositions: dict[int, IntentDisposition],
-        _result: list[dict[str, Any]],
+        result: list[dict[str, Any]],
     ) -> None:
         if pr_ctx is None:
             return
         # Dispositions dict iteration order is intent-timestamp
-        # ascending (the classifier sorts).  Iterate in order and
-        # fire material notifications only.
+        # ascending (the classifier sorts) — we fire notifications in
+        # the same order so the chronological story reads top to
+        # bottom on the reviewer's thread.  Both material AND
+        # unhandled trigger replies (the notifier branches on kind);
+        # aggregation is silent.
         for cid, disposition in dispositions.items():
             intent = intents_by_cid.get(cid)
-            if intent is None or disposition.kind != "material":
+            if intent is None or disposition.kind == "aggregation":
                 continue
             _notify_intent_outcome(
                 intent,
@@ -2435,6 +2534,9 @@ def _build_on_intent_dispositions(
                 config=config,
                 repo_cfg=repo_cfg,
                 gh=gh,
+                batch_intents=intents,
+                batch_dispositions=dispositions,
+                result=result,
                 agent=agent,
                 prompts=prompts,
             )

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2079,6 +2079,19 @@ def _notify_intent_outcome(
     if disposition.kind == "aggregation":
         return
 
+    # Issue comments already received a triage reply from the
+    # webhook handler (same policy as _notify_thread_change).  A
+    # second top-level comment here would duplicate that reply
+    # without thread-nesting, so we skip — codex P2 on #1747 caught
+    # the original "always-review-thread" routing.
+    if intent.comment_type != "pulls":
+        log.info(
+            "skipping intent notification for issue comment %s "
+            "(webhook already replied)",
+            intent.comment_id,
+        )
+        return
+
     if agent is None:
         agent = _configured_agent(config, repo_cfg)
     if prompts is None:
@@ -2191,94 +2204,6 @@ def _notify_intent_outcome(
         )
     except Exception:
         log.exception("failed to notify intent comment %s", intent.comment_id)
-
-
-def _notify_thread_change(
-    change: dict[str, Any],
-    config: Config,
-    gh: GitHub,
-    *,
-    agent: ProviderAgent | None = None,
-    prompts: Prompts | None = None,
-) -> None:
-    """Post a brief comment notifying a commenter that their task was rescoped.
-
-    Called for each thread task that was dropped or modified during dependency
-    analysis.  Uses Opus (in Fido's voice) to generate the message.
-
-    Only fires for review comments (comment_type='pulls'), where it replies
-    in-thread via the pull review comment API.  Issue comments
-    (comment_type='issues') are skipped: the webhook handler already posted a
-    triage reply to the original comment, and a second notification here would
-    be a duplicate top-level issue comment.
-    """
-    task = change["task"]
-    thread = task.get("thread") or {}
-    comment_id = thread.get("comment_id")
-    repo = thread.get("repo", "")
-    pr = thread.get("pr")
-    url = thread.get("url", "")
-    author = thread.get("author", "")
-    comment_type = thread.get("comment_type", "issues")
-    if not (comment_id and repo and pr):
-        return
-
-    # Issue comments already received a triage reply from the webhook handler.
-    # Posting again here would produce a duplicate top-level PR comment.
-    if comment_type != "pulls":
-        log.info(
-            "skipping rescope notification for issue comment %s"
-            " (webhook already replied)",
-            comment_id,
-        )
-        return
-
-    if agent is None:
-        agent = _configured_agent(
-            config, config.repos[change["task"]["thread"]["repo"]]
-        )
-    if prompts is None:
-        prompts = Prompts(_load_persona(config))
-
-    kind = change["kind"]
-    original_title = task.get("title", "")
-
-    if kind == "completed":
-        instruction = (
-            f"A task originating from a PR comment has been marked done — it was "
-            f"covered by work already committed and is no longer in the active queue.\n\n"
-            f"Original task: {original_title}\n"
-            f"Comment author: {author or '(unknown)'}\n"
-            f"Comment: {url}\n\n"
-            "Write a very brief reply notifying the commenter that their task has been "
-            "marked done because it was covered by recent commits. Reference the comment URL."
-        )
-    else:
-        new_title = change.get("new_title", "")
-        instruction = (
-            f"The task you were planning from a PR comment has been updated to "
-            f"reflect new requirements.\n\n"
-            f"Original task: {original_title}\n"
-            f"Updated task: {new_title}\n"
-            f"Comment author: {author or '(unknown)'}\n"
-            f"Comment: {url}\n\n"
-            "Write a very brief reply notifying the commenter that their original task "
-            "has been updated. Reference the comment URL."
-        )
-
-    body = safe_voice_turn(
-        agent,
-        prompts.persona_wrap(instruction),
-        model=agent.voice_model,
-        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
-        system_prompt=prompts.reply_system_prompt(),
-        log_prefix="_notify_thread_change",
-    )
-    try:
-        gh.reply_to_review_comment(repo, pr, body, comment_id)
-        log.info("notified thread %s (%s)", comment_id, kind)
-    except Exception:
-        log.exception("failed to notify thread %s", comment_id)
 
 
 def _task_snapshot(task_list: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
@@ -2428,10 +2353,6 @@ def _make_reorder_kwargs(
 ) -> dict[str, Any]:
     """Build the kwargs dict for a :func:`~fido.tasks.reorder_tasks` call."""
 
-    def on_changes(changes: list[dict[str, Any]]) -> None:
-        for change in changes:
-            _notify_thread_change(change, config, gh, agent=None, prompts=None)
-
     def on_done() -> None:
         if sync_fn is None:
             from fido.tasks import sync_tasks
@@ -2454,8 +2375,19 @@ def _make_reorder_kwargs(
         )
         registry.abort_task(repo_cfg.name, task_id=task_id)
 
+    # Note: _on_changes (per-task-change notifications via
+    # _notify_thread_change) was removed when the per-intent
+    # classifier-driven notifier landed (#1724 codex P2).  Keeping
+    # both produced duplicate replies for the same rescope event —
+    # one per affected task and one per material intent.  The
+    # per-intent path is now the canonical reply mechanism; for
+    # rewrites driven by intents in the current batch it covers
+    # everything the old path did, with richer "tell the story"
+    # context.  Past-batch-driven rewrites (intent not in current
+    # batch) silently skip — persisting pending intents across
+    # batches is a separate follow-up the #1256 epic doesn't
+    # require.
     kwargs: dict[str, Any] = {
-        "_on_changes": on_changes,
         "_on_done": on_done,
         "_on_inprogress_affected": on_inprogress_affected,
         "agent": agent,
@@ -2519,12 +2451,22 @@ def _build_on_intent_dispositions(
         # Dispositions dict iteration order is intent-timestamp
         # ascending (the classifier sorts) — we fire notifications in
         # the same order so the chronological story reads top to
-        # bottom on the reviewer's thread.  Both material AND
-        # unhandled trigger replies (the notifier branches on kind);
-        # aggregation is silent.
+        # bottom on the reviewer's thread.  Aggregation is silent;
+        # material always notifies; unhandled only notifies when an
+        # EARLIER-timestamp sibling was attributed (Rob's #1747
+        # directive — "if later say nothing because there is nothing
+        # to tell them, their original ask still honored").
         for cid, disposition in dispositions.items():
             intent = intents_by_cid.get(cid)
             if intent is None or disposition.kind == "aggregation":
+                continue
+            if disposition.kind == "unhandled" and not _has_earlier_attributed_sibling(
+                intent, intents, dispositions
+            ):
+                # Either no other intents touched anything, or every
+                # attributed sibling is strictly newer than this one.
+                # In both cases the original "got it" reply remains
+                # accurate — silent.
                 continue
             _notify_intent_outcome(
                 intent,
@@ -2542,6 +2484,35 @@ def _build_on_intent_dispositions(
             )
 
     return on_intent_dispositions
+
+
+def _has_earlier_attributed_sibling(
+    intent: RescopeIntent,
+    batch_intents: list[RescopeIntent],
+    dispositions: dict[int, IntentDisposition],
+) -> bool:
+    """True iff some other intent in the batch is older AND was acted on.
+
+    "Acted on" = its disposition is material or aggregation (i.e.,
+    Opus attributed at least one op to it).  Used to decide whether
+    an *unhandled* disposition is worth telling the commenter about
+    (Rob on #1747): if their ask was dropped because an EARLIER
+    intent already covered it, they should hear "your ask is covered
+    by that earlier task" — but if every acted-on sibling is NEWER
+    than them, the work continues under the later cover and the
+    original triage reply still stands, so we say nothing.
+    """
+    for other in batch_intents:
+        if other.comment_id == intent.comment_id:
+            continue
+        # Classifier produces a disposition for every batch intent —
+        # missing key here would be a bug; let it AttributeError loudly.
+        other_disposition = dispositions[other.comment_id]
+        if other_disposition.kind == "unhandled":
+            continue
+        if other.timestamp < intent.timestamp:
+            return True
+    return False
 
 
 def _reorder_tasks_background(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -41,7 +41,11 @@ from fido.synthesis_call import (
     call_synthesis,
 )
 from fido.synthesis_executor import CommentTarget, SynthesisExecutor
-from fido.tasks import Tasks, thread_comment_author_for_auto_resolve_oracle
+from fido.tasks import (
+    IntentDisposition,
+    Tasks,
+    thread_comment_author_for_auto_resolve_oracle,
+)
 from fido.types import ActiveIssue, ActivePR, RescopeIntent, TaskType
 from fido.worker import ActivityReporter
 
@@ -2030,6 +2034,69 @@ def _get_commit_summary(work_dir: Path) -> str:
     return result.stdout.strip()
 
 
+def _notify_intent_outcome(
+    intent: RescopeIntent,
+    disposition: IntentDisposition,
+    repo: str,
+    pr: int,
+    config: Config,
+    repo_cfg: RepoConfig,
+    gh: GitHub,
+    *,
+    agent: ProviderAgent | None = None,
+    prompts: Prompts | None = None,
+) -> None:
+    """Post a per-intent reply when rescope materially changed the ask (#1724).
+
+    The reply-back filter epic (#1256) consumes the per-intent
+    classifier output (#1723) and emits an Opus-voice note to the
+    originating commenter ONLY when the rescope materially affected
+    their request.  Aggregation (intent absorbed without change) and
+    unhandled (intent not acted on) silently produce no reply.
+
+    The reply text is generated per-call by Opus (per the
+    voice-text-not-templated convention) and instructed to describe
+    the OUTCOME of the rescope on this specific intent — without
+    implying the work is done when the rescope only replanned it.
+    """
+    # Defense-in-depth: callers (build_on_intent_dispositions) are
+    # supposed to filter to material before invoking us, but the
+    # branch is cheap and lets us be the single source of truth.
+    if disposition.kind != "material":
+        return
+
+    if agent is None:
+        agent = _configured_agent(config, repo_cfg)
+    if prompts is None:
+        prompts = Prompts(_load_persona(config))
+
+    instruction = (
+        "A change request from a PR comment was rescoped — the work has "
+        "been REPLANNED, not completed.  Tell the commenter what happened "
+        "to their ask without implying the work is done.\n\n"
+        f"Their original change request: {intent.change_request}\n"
+        f"Affected task id(s): {', '.join(disposition.affected_task_ids)}\n"
+        f"What changed: {disposition.reason}\n\n"
+        "Write a very brief reply.  Be specific about which tasks were "
+        "rewritten / merged / split / closed.  Do NOT say the work is "
+        "done — the rescope only restructured the plan."
+    )
+
+    body = safe_voice_turn(
+        agent,
+        prompts.persona_wrap(instruction),
+        model=agent.voice_model,
+        allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+        system_prompt=prompts.reply_system_prompt(),
+        log_prefix="_notify_intent_outcome",
+    )
+    try:
+        gh.reply_to_review_comment(repo, pr, body, intent.comment_id)
+        log.info("notified intent comment %s (material rescope)", intent.comment_id)
+    except Exception:
+        log.exception("failed to notify intent comment %s", intent.comment_id)
+
+
 def _notify_thread_change(
     change: dict[str, Any],
     config: Config,
@@ -2303,7 +2370,76 @@ def _make_reorder_kwargs(
         kwargs["issue"] = issue_ctx
     if pr_ctx is not None:
         kwargs["pr"] = pr_ctx
+
+    # #1724 — per-intent reply-back when rescope materially changed the
+    # ask.  Closure captures pr_ctx so the notifier can post replies
+    # to the right PR; intents come from the per-iteration list, so
+    # the actual closure binding is built fresh in
+    # ``_reorder_tasks_background``'s run_loop (see usage there) and
+    # injected over this kwargs entry.  We wire the no-op default
+    # here so kwargs is shape-stable for callers that don't override.
+    kwargs["_on_intent_dispositions"] = _build_on_intent_dispositions(
+        intents=[],
+        repo=repo_cfg.name,
+        pr_ctx=pr_ctx,
+        config=config,
+        repo_cfg=repo_cfg,
+        gh=gh,
+        agent=agent,
+        prompts=prompts,
+    )
     return kwargs
+
+
+def _build_on_intent_dispositions(
+    intents: list[RescopeIntent],
+    repo: str,
+    pr_ctx: ActivePR | None,
+    config: Config,
+    repo_cfg: RepoConfig,
+    gh: GitHub,
+    agent: ProviderAgent | None,
+    prompts: Prompts | None,
+) -> Callable[[dict[int, IntentDisposition], list[dict[str, Any]]], None]:
+    """Build the per-iteration intent-dispositions callback (#1724).
+
+    Each rescope iteration may carry a different ``current_intents``
+    list (the coalescing loop in ``_reorder_tasks_background`` swaps
+    the pending entry each iteration); this factory closes over the
+    intents for THIS iteration so the notifier posts to the right
+    commenters in the right order.
+
+    Returns a no-op when ``pr_ctx`` is None — intent-driven rescope
+    only happens against an active PR.
+    """
+    intents_by_cid = {i.comment_id: i for i in intents}
+
+    def on_intent_dispositions(
+        dispositions: dict[int, IntentDisposition],
+        _result: list[dict[str, Any]],
+    ) -> None:
+        if pr_ctx is None:
+            return
+        # Dispositions dict iteration order is intent-timestamp
+        # ascending (the classifier sorts).  Iterate in order and
+        # fire material notifications only.
+        for cid, disposition in dispositions.items():
+            intent = intents_by_cid.get(cid)
+            if intent is None or disposition.kind != "material":
+                continue
+            _notify_intent_outcome(
+                intent,
+                disposition,
+                repo=repo,
+                pr=pr_ctx.number,
+                config=config,
+                repo_cfg=repo_cfg,
+                gh=gh,
+                agent=agent,
+                prompts=prompts,
+            )
+
+    return on_intent_dispositions
 
 
 def _reorder_tasks_background(
@@ -2417,6 +2553,21 @@ def _reorder_tasks_background(
             while True:
                 iteration += 1
                 log.info("rescope BG: iteration %d starting", iteration)
+                # #1724: rebuild the on_intent_dispositions callback
+                # each iteration so it closes over THIS iteration's
+                # current_intents (coalesced batches accumulate).
+                # pr_ctx and other context are immutable across
+                # iterations so re-extracting from kw is safe.
+                kw["_on_intent_dispositions"] = _build_on_intent_dispositions(
+                    intents=current_intents,
+                    repo=repo_cfg.name,
+                    pr_ctx=kw.get("pr"),
+                    config=config,
+                    repo_cfg=repo_cfg,
+                    gh=gh,
+                    agent=kw.get("agent"),
+                    prompts=kw.get("prompts"),
+                )
                 reorder(
                     registry.tasks_for(repo_cfg.name),
                     cs,

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -242,6 +242,7 @@ class SynthesisExecutor:
                 change_request=response.change_request,
                 comment_id=target.comment_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
+                comment_type=target.comment_type,
             )
             log.info(
                 "triggering rescope for comment %d: %s",

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2376,11 +2376,11 @@ def _merge_source_ids(ordered_items: list[dict[str, Any]]) -> set[str]:
 # #1722's apply path and the original/result task lists; #1724 will
 # turn its output into per-intent notifications.
 
-_IntentDispositionKind = Literal["material", "aggregation", "unhandled"]
+IntentDispositionKind = Literal["material", "aggregation", "unhandled"]
 
 
 @dataclass(frozen=True)
-class _IntentDisposition:
+class IntentDisposition:
     """How a single RescopeIntent was treated by one rescope batch.
 
     * ``material`` — at least one task this intent contributed to had
@@ -2399,7 +2399,7 @@ class _IntentDisposition:
     describing what the classifier saw.
     """
 
-    kind: _IntentDispositionKind
+    kind: IntentDispositionKind
     reason: str
     affected_task_ids: list[str]
 
@@ -2443,7 +2443,7 @@ def _classify_rescope_intents(
     original: list[dict[str, Any]],
     result: list[dict[str, Any]],
     intents: list[RescopeIntent],
-) -> dict[int, _IntentDisposition]:
+) -> dict[int, IntentDisposition]:
     """Per-intent classification for the reply-back filter (#1723).
 
     Returns a dict keyed on ``intent.comment_id`` so the caller can
@@ -2452,6 +2452,11 @@ def _classify_rescope_intents(
     that contributed to multiple tasks aggregates "material" if any
     affected task had a material change; an intent that contributed
     to zero tasks is ``unhandled``.
+
+    Iteration order of the returned dict is intent-timestamp ascending
+    (oldest first) — #1724's notifier reads dispositions in dict
+    insertion order to fire per-intent replies in chronological
+    sequence.
 
     The downstream notifier (#1724) decides notification policy from
     these dispositions; this layer just classifies and explains.
@@ -2462,12 +2467,13 @@ def _classify_rescope_intents(
         for intent_id in task.get("contributing_intents") or []:
             intent_to_tasks.setdefault(intent_id, []).append(task)
 
-    out: dict[int, _IntentDisposition] = {}
-    for intent in intents:
+    out: dict[int, IntentDisposition] = {}
+    # Sort by timestamp so dict iteration order matches chronology.
+    for intent in sorted(intents, key=lambda i: i.timestamp):
         cid = intent.comment_id
         attributed = intent_to_tasks.get(cid, [])
         if not attributed:
-            out[cid] = _IntentDisposition(
+            out[cid] = IntentDisposition(
                 kind="unhandled",
                 reason="not attributed to any operation",
                 affected_task_ids=[],
@@ -2480,13 +2486,13 @@ def _classify_rescope_intents(
                 _intent_material_reasons(original_by_id.get(task["id"]), task)
             )
         if material_reasons:
-            out[cid] = _IntentDisposition(
+            out[cid] = IntentDisposition(
                 kind="material",
                 reason="; ".join(material_reasons),
                 affected_task_ids=affected_ids,
             )
         else:
-            out[cid] = _IntentDisposition(
+            out[cid] = IntentDisposition(
                 kind="aggregation",
                 reason="absorbed into existing task(s) without material change",
                 affected_task_ids=affected_ids,
@@ -2584,7 +2590,9 @@ def reorder_tasks(
     prior_attempts: list[ClosedPR] | None = None,
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
     _on_inprogress_affected: Callable[[str], None] | None = None,
-    _on_intent_dispositions: Callable[[dict[int, _IntentDisposition]], None]
+    _on_intent_dispositions: Callable[
+        [dict[int, IntentDisposition], list[dict[str, Any]]], None
+    ]
     | None = None,
     _on_done: Callable[[], None] | None = None,
 ) -> None:
@@ -2881,7 +2889,9 @@ def reorder_tasks(
         # when an intents list is provided so the callback fires with
         # the full disposition map even for batches that produced no
         # thread-change records.
-        _on_intent_dispositions(_classify_rescope_intents(pre_rescope, result, intents))
+        _on_intent_dispositions(
+            _classify_rescope_intents(pre_rescope, result, intents), result
+        )
 
     if inprogress_affected and _on_inprogress_affected is not None:
         assert inprogress is not None  # inprogress_affected is True

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -138,6 +138,12 @@ class RescopeIntent:
     change_request: str
     comment_id: int
     timestamp: str
+    comment_type: str = "pulls"
+    """GitHub comment namespace: ``"pulls"`` for review-thread comments
+    (the rescope reply path posts via ``reply_to_review_comment``);
+    ``"issues"`` for top-level PR/issue comments where the webhook
+    handler already posted a triage reply (rescope notifier silently
+    skips per #1724 codex P2 — same policy as ``_notify_thread_change``)."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -2419,46 +2419,6 @@ class TestEventsThreadResolved:
         assert result is True
 
 
-class TestEventsNotifyThreadChange:
-    """Cover the ``modified`` branch of ``_notify_thread_change``
-    (events.py:2322-2333)."""
-
-    def test_modified_branch_uses_new_title_and_posts_reply(
-        self, tmp_path: Path
-    ) -> None:
-        from fido.events import _notify_thread_change
-
-        change = {
-            "task": {
-                "title": "Old title",
-                "thread": {
-                    "comment_id": 42,
-                    "repo": "test/repo",
-                    "pr": 1,
-                    "url": "https://example.com/c",
-                    "author": "alice",
-                    "comment_type": "pulls",  # required to skip early-return
-                },
-            },
-            "kind": "modified",
-            "new_title": "New title",
-        }
-        config = MagicMock()
-        gh = MagicMock()
-        agent = MagicMock()
-        agent.voice_model = "voice"
-        agent.generate_reply.return_value = "reply body"
-        prompts = MagicMock()
-        prompts.persona_wrap.return_value = "wrapped"
-        prompts.reply_system_prompt.return_value = "system"
-        _ = tmp_path  # quiet unused-arg warning
-        _notify_thread_change(change, config, gh, agent=agent, prompts=prompts)
-        gh.reply_to_review_comment.assert_called_once()
-        # The instruction should mention the new title.
-        wrap_arg = prompts.persona_wrap.call_args[0][0]
-        assert "New title" in wrap_arg
-
-
 class TestCodexJsonlIteration:
     """Cover _iter_jsonl small branches (codex.py:397-398, 401-402)."""
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5430,62 +5430,83 @@ class TestNotifyIntentOutcome:
             affected_task_ids=affected if affected is not None else ["t1"],
         )
 
+    def _kwargs(
+        self,
+        intent: RescopeIntent,
+        disposition: IntentDisposition,
+        cfg: Config,
+        gh: MagicMock,
+        agent: object,
+        *,
+        batch_intents: list[RescopeIntent] | None = None,
+        batch_dispositions: dict[int, IntentDisposition] | None = None,
+        result: list[dict] | None = None,
+    ) -> dict[str, object]:
+        return {
+            "repo": "owner/repo",
+            "pr": 42,
+            "config": cfg,
+            "repo_cfg": cfg.repos["owner/repo"],
+            "gh": gh,
+            "agent": agent,
+            "batch_intents": batch_intents if batch_intents is not None else [intent],
+            "batch_dispositions": batch_dispositions
+            if batch_dispositions is not None
+            else {intent.comment_id: disposition},
+            "result": result if result is not None else [],
+        }
+
     def test_aggregation_disposition_silently_skips(self, tmp_path: Path) -> None:
-        # Per-intent notifier filters: only material → reply.
-        # Aggregation and unhandled produce nothing.
+        # Aggregation = pure absorption with no material change.
+        # Acceptance criteria #1723: don't notify.
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
+        intent = self._intent()
+        disposition = self._disposition(kind="aggregation")
         _notify_intent_outcome(
-            self._intent(),
-            self._disposition(kind="aggregation"),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=mock_gh,
-            agent=_client("should not fire"),
+            intent,
+            disposition,
+            **self._kwargs(intent, disposition, cfg, mock_gh, _client("nope")),
         )
         mock_gh.reply_to_review_comment.assert_not_called()
         mock_gh.comment_issue.assert_not_called()
 
-    def test_unhandled_disposition_silently_skips(self, tmp_path: Path) -> None:
+    def test_unhandled_disposition_fires_with_story_framing(
+        self, tmp_path: Path
+    ) -> None:
+        # Per Q1: unhandled now notifies with Opus framing so the
+        # commenter knows their ask was considered (likely superseded).
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
+        intent = self._intent()
+        disposition = self._disposition(kind="unhandled", affected=[])
         _notify_intent_outcome(
-            self._intent(),
-            self._disposition(kind="unhandled"),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=mock_gh,
-            agent=_client("should not fire"),
+            intent,
+            disposition,
+            **self._kwargs(intent, disposition, cfg, mock_gh, _client("ack")),
         )
-        mock_gh.reply_to_review_comment.assert_not_called()
+        mock_gh.reply_to_review_comment.assert_called_once()
 
     def test_material_posts_review_thread_reply(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
+        intent = self._intent(comment_id=999)
+        disposition = self._disposition()
         _notify_intent_outcome(
-            self._intent(comment_id=999),
-            self._disposition(),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=mock_gh,
-            agent=_client("Replanned, not done."),
+            intent,
+            disposition,
+            **self._kwargs(
+                intent, disposition, cfg, mock_gh, _client("Replanned, not done.")
+            ),
         )
         mock_gh.reply_to_review_comment.assert_called_once_with(
             "owner/repo", 42, "Replanned, not done.", 999
         )
 
-    def test_opus_instruction_says_replanned_not_completed(
+    def test_material_instruction_says_replanned_not_completed(
         self, tmp_path: Path
     ) -> None:
-        # The reply text must NOT imply work is done — the rescope
-        # only replanned (acceptance criteria #1724).  Capture the
-        # Opus prompt to assert the wording reaches the model.
+        # The reply text must NOT imply work is done (acceptance #1724).
         cfg = self._cfg(tmp_path)
         captured: list[str] = []
 
@@ -5493,20 +5514,21 @@ class TestNotifyIntentOutcome:
             captured.append(prompt)
             return "ok"
 
+        intent = self._intent()
+        disposition = self._disposition()
         _notify_intent_outcome(
-            self._intent(),
-            self._disposition(),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=MagicMock(),
-            agent=_client(side_effect=fake_pp),
+            intent,
+            disposition,
+            **self._kwargs(
+                intent, disposition, cfg, MagicMock(), _client(side_effect=fake_pp)
+            ),
         )
         assert any("REPLANNED, not completed" in p for p in captured)
         assert any("Do NOT say the work is done" in p for p in captured)
 
-    def test_opus_instruction_includes_intent_and_reason(self, tmp_path: Path) -> None:
+    def test_material_instruction_includes_intent_and_reason(
+        self, tmp_path: Path
+    ) -> None:
         cfg = self._cfg(tmp_path)
         captured: list[str] = []
 
@@ -5514,51 +5536,161 @@ class TestNotifyIntentOutcome:
             captured.append(prompt)
             return "ok"
 
+        intent = self._intent(comment_id=777)
+        disposition = self._disposition(reason="task closed ('abc')", affected=["abc"])
         _notify_intent_outcome(
-            self._intent(comment_id=777),
-            self._disposition(reason="task closed ('abc')", affected=["abc"]),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=MagicMock(),
-            agent=_client(side_effect=fake_pp),
+            intent,
+            disposition,
+            **self._kwargs(
+                intent, disposition, cfg, MagicMock(), _client(side_effect=fake_pp)
+            ),
         )
-        # Both the intent's change request and the disposition reason
-        # land in the Opus prompt so it can write a specific reply.
         assert any("please rename the parser" in p for p in captured)
         assert any("task closed" in p for p in captured)
+
+    def test_material_instruction_lists_co_contributing_intents(
+        self, tmp_path: Path
+    ) -> None:
+        # "Tell the story": the prompt must enumerate other intents
+        # that contributed to the same affected task(s) so Opus can
+        # narrate "your ask landed on T2 because @bob's later
+        # comment...".
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
+            captured.append(prompt)
+            return "ok"
+
+        a = self._intent(comment_id=101)
+        b = RescopeIntent(
+            change_request="actually do Y instead",
+            comment_id=202,
+            timestamp="2024-01-15T10:01:00+00:00",
+        )
+        disp = self._disposition(affected=["t2"])
+        # Task t2 carries both intents in contributing_intents — they
+        # both shaped the same task.
+        result = [{"id": "t2", "title": "Y", "contributing_intents": [101, 202]}]
+        kwargs = self._kwargs(
+            a,
+            disp,
+            cfg,
+            MagicMock(),
+            _client(side_effect=fake_pp),
+            batch_intents=[a, b],
+            batch_dispositions={101: disp, 202: self._disposition()},
+            result=result,
+        )
+        _notify_intent_outcome(a, disp, **kwargs)
+        joined = "\n".join(captured)
+        # Other commenters who contributed to the same task surface
+        # in the prompt as a chronological list.
+        assert "Other commenters who contributed to the SAME" in joined
+        assert "comment #202" in joined
+        assert "actually do Y instead" in joined
+
+    def test_unhandled_instruction_lists_sibling_intents_with_dispositions(
+        self, tmp_path: Path
+    ) -> None:
+        # "Tell the story" for the unhandled case: include every
+        # other intent in the batch with its disposition so Opus can
+        # explain why this one was skipped (likely superseded).
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
+            captured.append(prompt)
+            return "ok"
+
+        a = self._intent(comment_id=101)
+        b = RescopeIntent(
+            change_request="superseding ask",
+            comment_id=202,
+            timestamp="2024-01-15T10:01:00+00:00",
+        )
+        a_disp = self._disposition(kind="unhandled", affected=[])
+        b_disp = self._disposition(kind="material")
+        kwargs = self._kwargs(
+            a,
+            a_disp,
+            cfg,
+            MagicMock(),
+            _client(side_effect=fake_pp),
+            batch_intents=[a, b],
+            batch_dispositions={101: a_disp, 202: b_disp},
+            result=[],
+        )
+        _notify_intent_outcome(a, a_disp, **kwargs)
+        joined = "\n".join(captured)
+        assert "Other intents processed in this same rescope batch" in joined
+        assert "comment #202" in joined
+        assert "material" in joined
+        assert "superseding ask" in joined
+        # Unhandled framing tells Opus to narrate why, not apologize.
+        assert "NOT acted on" in joined
+
+    def test_co_contributing_intent_outside_batch_silently_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        # Real production case: a task's contributing_intents may
+        # include comment ids from PRIOR rescope batches whose
+        # RescopeIntent objects aren't in this batch's intents list.
+        # The notifier silently skips them rather than crashing —
+        # we don't have the change_request text to include in the
+        # prompt anyway.  (Persisting past-batch intents is a
+        # follow-up; #1256 epic doesn't require it.)
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
+            captured.append(prompt)
+            return "ok"
+
+        intent = self._intent(comment_id=101)
+        disp = self._disposition(affected=["t1"])
+        # t1 has TWO contributing_intents: 101 (this batch) and 999
+        # (a prior batch — not in batch_intents).
+        result = [{"id": "t1", "title": "T", "contributing_intents": [101, 999]}]
+        kwargs = self._kwargs(
+            intent,
+            disp,
+            cfg,
+            MagicMock(),
+            _client(side_effect=fake_pp),
+            batch_intents=[intent],  # 999 deliberately absent
+            batch_dispositions={101: disp},
+            result=result,
+        )
+        _notify_intent_outcome(intent, disp, **kwargs)
+        # Past-batch intent silently skipped: no co-contributing
+        # block in the prompt, but the call still completes.
+        joined = "\n".join(captured)
+        assert "Other commenters who contributed" not in joined
 
     def test_post_failure_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         mock_gh.reply_to_review_comment.side_effect = RuntimeError("network")
-        # Should swallow and log — must not break the rescope loop.
+        intent = self._intent()
+        disposition = self._disposition()
         _notify_intent_outcome(
-            self._intent(),
-            self._disposition(),
-            repo="owner/repo",
-            pr=42,
-            config=cfg,
-            repo_cfg=cfg.repos["owner/repo"],
-            gh=mock_gh,
-            agent=_client("ok"),
+            intent,
+            disposition,
+            **self._kwargs(intent, disposition, cfg, mock_gh, _client("ok")),
         )
 
     def test_default_agent_constructed_when_none(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
+        intent = self._intent()
+        disposition = self._disposition()
+        kwargs = self._kwargs(intent, disposition, cfg, mock_gh, agent=None)
+        # Drop the agent kwarg so the default-construction path fires.
+        del kwargs["agent"]
         with patch("fido.events.DefaultProviderFactory") as factory_cls:
             factory_cls.return_value.create_agent.return_value = _client("Auto reply")
-            _notify_intent_outcome(
-                self._intent(),
-                self._disposition(),
-                repo="owner/repo",
-                pr=42,
-                config=cfg,
-                repo_cfg=cfg.repos["owner/repo"],
-                gh=mock_gh,
-            )
+            _notify_intent_outcome(intent, disposition, **kwargs)
         factory_cls.return_value.create_agent.assert_called_once()
         mock_gh.reply_to_review_comment.assert_called_once()
 
@@ -5612,7 +5744,12 @@ class TestBuildOnIntentDispositions:
         cb({101: self._disposition()}, [])
         mock_gh.reply_to_review_comment.assert_not_called()
 
-    def test_aggregation_and_unhandled_filtered(self, tmp_path: Path) -> None:
+    def test_aggregation_filtered_material_and_unhandled_fire(
+        self, tmp_path: Path
+    ) -> None:
+        # Per Q1 (#1724): material AND unhandled both notify; only
+        # aggregation stays silent.  Per Q3: notifications fire in
+        # dispositions iteration order (timestamp-ascending).
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         pr = ActivePR(
@@ -5632,21 +5769,23 @@ class TestBuildOnIntentDispositions:
             config=cfg,
             repo_cfg=cfg.repos["owner/repo"],
             gh=mock_gh,
-            agent=_client("Material reply"),
+            agent=_client("Reply text"),
             prompts=Prompts("p"),
         )
         cb(
             {
                 101: self._disposition(kind="aggregation"),
                 202: self._disposition(kind="material"),
-                303: self._disposition(kind="unhandled"),
+                303: self._disposition(kind="unhandled", affected=[]),
             },
             [],
         )
-        # Only the material disposition (intent 202) fires a reply.
-        assert mock_gh.reply_to_review_comment.call_count == 1
-        args = mock_gh.reply_to_review_comment.call_args.args
-        assert args[3] == 202
+        # 101 silent (aggregation); 202 + 303 both fire — in
+        # dispositions iteration order (timestamp).
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        assert comment_ids == [202, 303]
 
     def test_notifications_fire_in_dispositions_iteration_order(
         self, tmp_path: Path

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,7 +26,6 @@ from fido.events import (
     _load_active_context_for_rescope,
     _make_reorder_kwargs,
     _notify_intent_outcome,
-    _notify_thread_change,
     _posted_comment_id,
     _record_reply_artifact,
     _reorder_tasks_background,
@@ -4403,45 +4402,6 @@ class TestReorderTasksBackground:
         registry.tasks_for.assert_called_with("owner/repo")
         assert calls[0][1] == "feat: add parser"
 
-    def test_on_changes_callback_notifies_thread_changes(self, tmp_path: Path) -> None:
-        started: list = []
-        mock_gh = MagicMock()
-        calls, mock_reorder = self._capture_reorder_calls()
-        _reorder_tasks_background(
-            tmp_path,
-            "commits",
-            self._cfg(tmp_path),
-            mock_gh,
-            _start=lambda t: started.append(t),
-            _reorder_fn=mock_reorder,
-            _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
-            repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
-        )
-        self._run_thread(started)
-        on_changes = calls[0][2]["_on_changes"]
-        change = {
-            "task": {
-                "id": "t1",
-                "title": "Fix it",
-                "status": "pending",
-                "type": "thread",
-                "thread": {
-                    "repo": "owner/repo",
-                    "pr": 1,
-                    "comment_id": 42,
-                    "url": "https://github.com/owner/repo/pull/1#issuecomment-42",
-                    "author": "bob",
-                },
-            },
-            "kind": "completed",
-        }
-        with patch("fido.events._notify_thread_change") as mock_notify:
-            on_changes([change])
-        mock_notify.assert_called_once_with(
-            change, self._cfg(tmp_path), mock_gh, agent=None, prompts=None
-        )
-
     def test_on_inprogress_affected_aborts_worker_via_registry(
         self, tmp_path: Path
     ) -> None:
@@ -5208,194 +5168,6 @@ class TestReorderTasksBackground:
         assert current_thread_kind() == "worker"  # default when not set
 
 
-class TestNotifyThreadChange:
-    def _cfg(self, tmp_path: Path) -> Config:
-        return Config(
-            port=9000,
-            secret=b"test",
-            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
-            allowed_bots=frozenset(),
-            log_level="WARNING",
-            sub_dir=tmp_path / "sub",
-        )
-
-    def _task(self, **overrides: object) -> dict:
-        t = {
-            "id": "t1",
-            "title": "Fix the thing",
-            "status": "pending",
-            "type": "thread",
-            "thread": {
-                "repo": "owner/repo",
-                "pr": 42,
-                "comment_id": 999,
-                "url": "https://github.com/owner/repo/pull/42#issuecomment-999",
-                "author": "alice",
-                "comment_type": "issues",
-            },
-        }
-        t.update(overrides)
-        return t
-
-    def test_completed_issue_comment_skips(self, tmp_path: Path) -> None:
-        """Issue comments are silently skipped — webhook already replied."""
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        change = {"task": self._task(), "kind": "completed"}
-        agent = _client("Should not be called")
-        _notify_thread_change(change, cfg, mock_gh, agent=agent)
-        mock_gh.comment_issue.assert_not_called()
-        mock_gh.reply_to_review_comment.assert_not_called()
-
-    def test_modified_issue_comment_skips(self, tmp_path: Path) -> None:
-        """Issue comments are silently skipped — webhook already replied."""
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        change = {
-            "task": self._task(),
-            "kind": "modified",
-            "new_title": "Updated title",
-            "new_description": "",
-        }
-        agent = _client("Should not be called")
-        _notify_thread_change(change, cfg, mock_gh, agent=agent)
-        mock_gh.comment_issue.assert_not_called()
-        mock_gh.reply_to_review_comment.assert_not_called()
-
-    def test_missing_thread_skips_comment(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"] = {}
-        change = {"task": task, "kind": "completed"}
-        _notify_thread_change(change, cfg, mock_gh, agent=_client())
-        mock_gh.comment_issue.assert_not_called()
-
-    def test_review_comment_run_turn_uses_retry_on_preempt(
-        self, tmp_path: Path
-    ) -> None:
-        """run_turn must pass retry_on_preempt=True — #935.
-
-        A webhook handler arriving while this voice turn runs preempts it,
-        yielding result_len=0, cancelled=True.  Without retry_on_preempt,
-        that empty string was indistinguishable from a real provider
-        failure and used to raise ValueError, killing either the
-        reorder-<repo> daemon or the worker's rescope_before_pick path.
-        """
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        agent = _client("Reply text")
-        _notify_thread_change(change, cfg, mock_gh, agent=agent)
-        # _client wraps a MagicMock — capture the run_turn kwargs.
-        run_turn_kwargs = agent.run_turn.call_args.kwargs
-        assert run_turn_kwargs.get("retry_on_preempt") is True
-
-    def test_review_comment_empty_opus_raises(self, tmp_path: Path) -> None:
-        """Empty Opus reply after retries raises — session reconnect handles
-        recovery (#935)."""
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        with pytest.raises(ValueError, match="run_turn returned empty"):
-            _notify_thread_change(change, cfg, mock_gh, agent=_client(""))
-
-    def test_review_comment_uses_reply_to_review_comment(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        _notify_thread_change(
-            change,
-            cfg,
-            mock_gh,
-            agent=_client("In-thread reply"),
-        )
-        mock_gh.reply_to_review_comment.assert_called_once_with(
-            "owner/repo", 42, "In-thread reply", 999
-        )
-        mock_gh.comment_issue.assert_not_called()
-
-    def test_review_comment_exception_does_not_raise(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        mock_gh.reply_to_review_comment.side_effect = RuntimeError("network")
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        # Should not raise
-        _notify_thread_change(change, cfg, mock_gh, agent=_client("ok"))
-
-    def test_no_comment_type_defaults_to_skip(self, tmp_path: Path) -> None:
-        """Missing comment_type defaults to the 'issues' skip path."""
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        del task["thread"]["comment_type"]
-        change = {"task": task, "kind": "completed"}
-        _notify_thread_change(change, cfg, mock_gh, agent=_client("Fallback"))
-        mock_gh.comment_issue.assert_not_called()
-        mock_gh.reply_to_review_comment.assert_not_called()
-
-    def test_author_in_opus_instruction(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        captured_prompt: list[str] = []
-
-        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
-            captured_prompt.append(prompt)
-            return "ok"
-
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        _notify_thread_change(
-            change, cfg, MagicMock(), agent=_client(side_effect=fake_pp)
-        )
-        assert "alice" in captured_prompt[0]
-
-    def test_issue_comment_skips_before_opus_call(self, tmp_path: Path) -> None:
-        """Issue comments must not invoke the LLM — return before the expensive call."""
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        invoked: list[bool] = []
-
-        def should_not_be_called(prompt: str, model: object, **kwargs: object) -> str:
-            invoked.append(True)
-            return "oops"
-
-        change = {"task": self._task(), "kind": "completed"}
-        _notify_thread_change(
-            change, cfg, mock_gh, agent=_client(side_effect=should_not_be_called)
-        )
-        assert not invoked
-        mock_gh.comment_issue.assert_not_called()
-        mock_gh.reply_to_review_comment.assert_not_called()
-
-    def test_default_repo_configured_agent_used(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        mock_gh = MagicMock()
-        task = self._task()
-        task["thread"]["comment_type"] = "pulls"
-        change = {"task": task, "kind": "completed"}
-        with patch("fido.events.DefaultProviderFactory") as factory_cls:
-            factory_cls.return_value.create_agent.return_value = _client("Auto reply")
-            _notify_thread_change(change, cfg, mock_gh)
-        factory_cls.return_value.create_agent.assert_called_once_with(
-            cfg.repos["owner/repo"],
-            work_dir=tmp_path,
-            repo_name="owner/repo",
-        )
-        mock_gh.reply_to_review_comment.assert_called_once_with(
-            "owner/repo", 42, "Auto reply", 999
-        )
-        mock_gh.comment_issue.assert_not_called()
-
-
 class TestNotifyIntentOutcome:
     """Per-intent reply-back notifier (#1724)."""
 
@@ -5680,6 +5452,27 @@ class TestNotifyIntentOutcome:
             **self._kwargs(intent, disposition, cfg, mock_gh, _client("ok")),
         )
 
+    def test_issue_comment_intent_skips_with_log(self, tmp_path: Path) -> None:
+        # Issue comments already received a triage reply from the
+        # webhook handler — a second top-level comment here would
+        # duplicate that reply (codex P2 on #1747).
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        intent = RescopeIntent(
+            change_request="please rename",
+            comment_id=42,
+            timestamp="2024-01-15T10:00:00+00:00",
+            comment_type="issues",
+        )
+        disposition = self._disposition()
+        _notify_intent_outcome(
+            intent,
+            disposition,
+            **self._kwargs(intent, disposition, cfg, mock_gh, _client("nope")),
+        )
+        mock_gh.reply_to_review_comment.assert_not_called()
+        mock_gh.comment_issue.assert_not_called()
+
     def test_default_agent_constructed_when_none(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
@@ -5854,6 +5647,149 @@ class TestBuildOnIntentDispositions:
             prompts=Prompts("p"),
         )
         cb({101: self._disposition()}, [])
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_unhandled_with_only_later_attributed_silently_skips(
+        self, tmp_path: Path
+    ) -> None:
+        # Rob's #1747 directive: unhandled is silent when every
+        # attributed sibling is strictly NEWER than this intent.
+        # The original "got it" reply still stands — work continues
+        # under the later cover, no need to ping the original
+        # commenter.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        older_unhandled = self._intent(101, "2024-01-15T10:00:00+00:00")
+        newer_attributed = self._intent(202, "2024-01-15T10:01:00+00:00")
+        cb = _build_on_intent_dispositions(
+            intents=[older_unhandled, newer_attributed],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("text"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="unhandled", affected=[]),
+                202: self._disposition(kind="material"),
+            },
+            [],
+        )
+        # 101 silent (older unhandled, only later attributed); 202
+        # fires (material).
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        assert comment_ids == [202]
+
+    def test_unhandled_with_earlier_attributed_fires_notification(
+        self, tmp_path: Path
+    ) -> None:
+        # Inverse of the above: when an EARLIER attributed sibling
+        # exists, the unhandled one was likely covered by that earlier
+        # work and the commenter deserves to hear about it.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        earlier_attributed = self._intent(101, "2024-01-15T10:00:00+00:00")
+        later_unhandled = self._intent(202, "2024-01-15T10:01:00+00:00")
+        cb = _build_on_intent_dispositions(
+            intents=[earlier_attributed, later_unhandled],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("text"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="material"),
+                202: self._disposition(kind="unhandled", affected=[]),
+            },
+            [],
+        )
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        # Both fire: 101 material + 202 unhandled-with-earlier-cover.
+        assert comment_ids == [101, 202]
+
+    def test_solo_unhandled_intent_silently_skips(self, tmp_path: Path) -> None:
+        # Edge case: only one intent in the batch and it's unhandled
+        # (Opus dropped it for some reason, no siblings).  No
+        # earlier-attributed sibling exists → silent.  Letting Opus
+        # speculate about WHY would just be guessing.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        solo = self._intent(101, "2024-01-15T10:00:00+00:00")
+        cb = _build_on_intent_dispositions(
+            intents=[solo],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("text"),
+            prompts=Prompts("p"),
+        )
+        cb({101: self._disposition(kind="unhandled", affected=[])}, [])
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_unhandled_silent_when_only_unhandled_siblings(
+        self, tmp_path: Path
+    ) -> None:
+        # When this intent is unhandled AND every sibling is also
+        # unhandled, no attributed sibling exists at all → silent
+        # (no story to tell about being covered by someone else).
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        a = self._intent(101, "2024-01-15T10:00:00+00:00")
+        b = self._intent(202, "2024-01-15T10:01:00+00:00")
+        cb = _build_on_intent_dispositions(
+            intents=[a, b],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("text"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="unhandled", affected=[]),
+                202: self._disposition(kind="unhandled", affected=[]),
+            },
+            [],
+        )
         mock_gh.reply_to_review_comment.assert_not_called()
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Never
+from typing import Never, cast
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -16,6 +16,7 @@ from fido.events import (
     _apply_reply_result,
     _BackgroundRescopeTrigger,
     _build_issue_comment_action,
+    _build_on_intent_dispositions,
     _configured_agent,
     _existing_reply_artifact,
     _get_commit_summary,
@@ -24,6 +25,7 @@ from fido.events import (
     _is_allowed,
     _load_active_context_for_rescope,
     _make_reorder_kwargs,
+    _notify_intent_outcome,
     _notify_thread_change,
     _posted_comment_id,
     _record_reply_artifact,
@@ -42,6 +44,7 @@ from fido.events import (
     reply_to_review,
     thread_lineage_comment_ids,
 )
+from fido.prompts import Prompts
 from fido.provider import ProviderID, ThreadKind
 from fido.rocq import replied_comment_claims as oracle
 from fido.state import State
@@ -49,6 +52,7 @@ from fido.store import FidoStore, ReplyPromiseRecord
 from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import SynthesisExhaustedError
 from fido.synthesis_executor import CommentTarget
+from fido.tasks import IntentDisposition
 from fido.types import ActiveIssue, ActivePR, RescopeIntent
 from fido.worker import ActivityReporter
 from tests.fakes import _FakeDispatcher
@@ -5390,6 +5394,328 @@ class TestNotifyThreadChange:
             "owner/repo", 42, "Auto reply", 999
         )
         mock_gh.comment_issue.assert_not_called()
+
+
+class TestNotifyIntentOutcome:
+    """Per-intent reply-back notifier (#1724)."""
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _intent(self, comment_id: int = 999) -> RescopeIntent:
+        return RescopeIntent(
+            change_request="please rename the parser",
+            comment_id=comment_id,
+            timestamp="2024-01-15T10:00:00+00:00",
+        )
+
+    def _disposition(
+        self,
+        kind: str = "material",
+        reason: str = "task title rewritten ('t1')",
+        affected: list[str] | None = None,
+    ) -> IntentDisposition:
+        from fido.tasks import IntentDispositionKind  # type: ignore[reportPrivateUsage]
+
+        return IntentDisposition(
+            kind=cast("IntentDispositionKind", kind),
+            reason=reason,
+            affected_task_ids=affected if affected is not None else ["t1"],
+        )
+
+    def test_aggregation_disposition_silently_skips(self, tmp_path: Path) -> None:
+        # Per-intent notifier filters: only material → reply.
+        # Aggregation and unhandled produce nothing.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        _notify_intent_outcome(
+            self._intent(),
+            self._disposition(kind="aggregation"),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("should not fire"),
+        )
+        mock_gh.reply_to_review_comment.assert_not_called()
+        mock_gh.comment_issue.assert_not_called()
+
+    def test_unhandled_disposition_silently_skips(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        _notify_intent_outcome(
+            self._intent(),
+            self._disposition(kind="unhandled"),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("should not fire"),
+        )
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_material_posts_review_thread_reply(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        _notify_intent_outcome(
+            self._intent(comment_id=999),
+            self._disposition(),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("Replanned, not done."),
+        )
+        mock_gh.reply_to_review_comment.assert_called_once_with(
+            "owner/repo", 42, "Replanned, not done.", 999
+        )
+
+    def test_opus_instruction_says_replanned_not_completed(
+        self, tmp_path: Path
+    ) -> None:
+        # The reply text must NOT imply work is done — the rescope
+        # only replanned (acceptance criteria #1724).  Capture the
+        # Opus prompt to assert the wording reaches the model.
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
+            captured.append(prompt)
+            return "ok"
+
+        _notify_intent_outcome(
+            self._intent(),
+            self._disposition(),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=MagicMock(),
+            agent=_client(side_effect=fake_pp),
+        )
+        assert any("REPLANNED, not completed" in p for p in captured)
+        assert any("Do NOT say the work is done" in p for p in captured)
+
+    def test_opus_instruction_includes_intent_and_reason(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        def fake_pp(prompt: str, model: object, **kwargs: object) -> str:
+            captured.append(prompt)
+            return "ok"
+
+        _notify_intent_outcome(
+            self._intent(comment_id=777),
+            self._disposition(reason="task closed ('abc')", affected=["abc"]),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=MagicMock(),
+            agent=_client(side_effect=fake_pp),
+        )
+        # Both the intent's change request and the disposition reason
+        # land in the Opus prompt so it can write a specific reply.
+        assert any("please rename the parser" in p for p in captured)
+        assert any("task closed" in p for p in captured)
+
+    def test_post_failure_does_not_raise(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        mock_gh.reply_to_review_comment.side_effect = RuntimeError("network")
+        # Should swallow and log — must not break the rescope loop.
+        _notify_intent_outcome(
+            self._intent(),
+            self._disposition(),
+            repo="owner/repo",
+            pr=42,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("ok"),
+        )
+
+    def test_default_agent_constructed_when_none(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        with patch("fido.events.DefaultProviderFactory") as factory_cls:
+            factory_cls.return_value.create_agent.return_value = _client("Auto reply")
+            _notify_intent_outcome(
+                self._intent(),
+                self._disposition(),
+                repo="owner/repo",
+                pr=42,
+                config=cfg,
+                repo_cfg=cfg.repos["owner/repo"],
+                gh=mock_gh,
+            )
+        factory_cls.return_value.create_agent.assert_called_once()
+        mock_gh.reply_to_review_comment.assert_called_once()
+
+
+class TestBuildOnIntentDispositions:
+    """Per-iteration intent-dispositions callback factory (#1724)."""
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _intent(self, comment_id: int, ts: str) -> RescopeIntent:
+        return RescopeIntent(
+            change_request=f"req {comment_id}",
+            comment_id=comment_id,
+            timestamp=ts,
+        )
+
+    def _disposition(
+        self,
+        kind: str = "material",
+        affected: list[str] | None = None,
+    ) -> IntentDisposition:
+        from fido.tasks import IntentDispositionKind  # type: ignore[reportPrivateUsage]
+
+        return IntentDisposition(
+            kind=cast("IntentDispositionKind", kind),
+            reason="title rewritten",
+            affected_task_ids=affected if affected is not None else ["t1"],
+        )
+
+    def test_no_pr_ctx_skips_silently(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        cb = _build_on_intent_dispositions(
+            intents=[self._intent(101, "2024-01-15T10:00:00+00:00")],
+            repo="owner/repo",
+            pr_ctx=None,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        cb({101: self._disposition()}, [])
+        mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_aggregation_and_unhandled_filtered(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        cb = _build_on_intent_dispositions(
+            intents=[
+                self._intent(101, "2024-01-15T10:00:00+00:00"),
+                self._intent(202, "2024-01-15T10:01:00+00:00"),
+                self._intent(303, "2024-01-15T10:02:00+00:00"),
+            ],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("Material reply"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="aggregation"),
+                202: self._disposition(kind="material"),
+                303: self._disposition(kind="unhandled"),
+            },
+            [],
+        )
+        # Only the material disposition (intent 202) fires a reply.
+        assert mock_gh.reply_to_review_comment.call_count == 1
+        args = mock_gh.reply_to_review_comment.call_args.args
+        assert args[3] == 202
+
+    def test_notifications_fire_in_dispositions_iteration_order(
+        self, tmp_path: Path
+    ) -> None:
+        # Acceptance criteria #1724: notifications emitted in
+        # RescopeIntent.timestamp order.  The classifier returns
+        # dispositions sorted by timestamp; this test feeds an
+        # ordered map and asserts that order survives through the
+        # callback to the gh.* call sequence.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        cb = _build_on_intent_dispositions(
+            intents=[
+                self._intent(101, "2024-01-15T10:00:00+00:00"),
+                self._intent(202, "2024-01-15T10:01:00+00:00"),
+                self._intent(303, "2024-01-15T10:02:00+00:00"),
+            ],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("ok"),
+            prompts=Prompts("p"),
+        )
+        # Pass dispositions in oldest-first order (as the classifier does).
+        cb(
+            {
+                101: self._disposition(),
+                202: self._disposition(),
+                303: self._disposition(),
+            },
+            [],
+        )
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        assert comment_ids == [101, 202, 303]
+
+    def test_intent_not_in_intents_list_is_skipped(self, tmp_path: Path) -> None:
+        # If a disposition's comment_id isn't in this iteration's
+        # intents (shouldn't happen, but defensive), the callback
+        # silently skips rather than crashing.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        cb = _build_on_intent_dispositions(
+            intents=[],  # no intents this iteration
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        cb({101: self._disposition()}, [])
+        mock_gh.reply_to_review_comment.assert_not_called()
 
 
 class TestBackfillMissedPrComments:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3169,17 +3169,19 @@ class TestReorderTasks:
                 ]
             }
         )
-        captured: list[dict] = []
+        captured: list[tuple[dict, list[dict]]] = []
         reorder_tasks(
             Tasks(tmp_path),
             "",
             agent=_client(raw),
             intents=intents,
-            _on_intent_dispositions=lambda d: captured.append(d),
+            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
         )
         assert len(captured) == 1
-        assert 101 in captured[0]
-        assert captured[0][101].kind == "material"
+        dispositions, result_tasks = captured[0]
+        assert 101 in dispositions
+        assert dispositions[101].kind == "material"
+        assert any(t["id"] == t1["id"] for t in result_tasks)
 
     def test_intent_dispositions_callback_skipped_without_intents(
         self, tmp_path: Path
@@ -3194,7 +3196,7 @@ class TestReorderTasks:
             Tasks(tmp_path),
             "",
             agent=_client(raw),
-            _on_intent_dispositions=lambda _d: called.append(1),
+            _on_intent_dispositions=lambda _d, _r: called.append(1),
         )
         assert called == []
 


### PR DESCRIPTION
## Summary

Final leaf of the reply-back filter epic (#1256) — the leaf that
answers your earlier *"how does A know B contradicted them"*
question.  Wires the per-intent classifier (#1723) to a per-
iteration notifier that posts an Opus-voice reply per **material**
rescope intent in `RescopeIntent.timestamp` order, after the
durable batch commits.

Pure aggregation and unhandled dispositions stay silent.

## What's new

- **`_notify_intent_outcome(intent, disposition, ...)`** in `events.py`
  posts the per-intent reply via the review-thread API.  Filters to
  material; aggregation/unhandled fall through silently.
- **`_build_on_intent_dispositions(intents, ...)`** factory builds
  the per-iteration callback so the right intent timestamps and PR
  context are captured each rescope iteration (the coalescing loop
  in `_reorder_tasks_background` swaps intents per iteration).
- **`_classify_rescope_intents`** now sorts intents by timestamp
  before iterating, so the returned dict's iteration order is
  oldest-first → notifications fire in chronological sequence.
- **`IntentDisposition` / `IntentDispositionKind`** renamed from
  underscore-prefixed to public names since `events.py` consumes
  them now.

## Reply text

Opus is instructed to describe the OUTCOME (rewritten / merged /
split / closed) without implying the work is done — the rescope
only restructured the plan.  Per-call Opus prose, never templated
(matches the voice-text-not-templated convention).

## Out of scope

This leaf doesn't alter reducer mutation semantics or the
materiality classifier rules — both established by L#1722 and L#1723.

## Test plan
- [x] `./fido ci` (4381 tests, 100% coverage)
- [x] Aggregation / unhandled silently skip
- [x] Material posts review-thread reply with intent's comment_id
- [x] Opus instruction includes "REPLANNED, not completed" + intent text + disposition reason
- [x] Post failures don't raise (network resilience)
- [x] Default agent constructed when none passed
- [x] No PR ctx → callback no-ops
- [x] Mixed disposition map → only material entries fire
- [x] Multi-comment batch → notifications in timestamp order