### PR TITLE
INV-1 of #1748: CommentCache shape on WebhookCache (closes #1754)

### DIFF
--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -1,0 +1,278 @@
+"""Per-(repo, item) in-memory cache for comment & review data (#1748, #1754).
+
+The reply-back filter epic (#1256) and worker comment-inspection
+paths repeatedly need comment text for the same issue/PR within
+a short window.  Without a shared cache, every call hits GitHub
+and piles latency + rate-limit pressure on the worker.
+
+Cache scope: one instance per ``(repo, item)`` pair, bound at
+construction.  Each instance holds three resource kinds for that
+single issue/PR:
+
+* ``"issues"`` — top-level comments (``/issues/{n}/comments``,
+  covers both issues and PRs since PRs ARE issues at top level)
+* ``"pulls"`` — inline review-thread comments
+  (``/pulls/{n}/comments``); single-file AND multi-line range
+  comments distinguished only by ``line`` / ``start_line`` on the
+  raw object
+* ``"reviews"`` — review submissions (``/pulls/{n}/reviews``);
+  state (APPROVED / COMMENTED / CHANGES_REQUESTED) + optional body
+
+Storage: raw GitHub API objects, deep-frozen via
+:func:`fido.frozen.freeze_object`.  Consumers read whatever
+fields they need directly from the ``Mapping`` — no translation,
+no projection.
+
+Inherits :class:`~fido.webhook_cache.WebhookCache` for the shared
+scaffolding (lock + dict, pre-inventory queue, ``apply_event``
+staleness shell via per-entry ``last_applied_at``, on_change
+callback, metrics base).  The staleness check at the base means
+out-of-order webhook deliveries (stale edit after a newer one)
+drop naturally.
+
+INV-1 scope (this PR): shape + per-(repo, item) keying + webhook
+``apply_event``.  Hydration via ``load_inventory`` and list-style
+getters land in #1756 (INV-2).
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any
+
+from fido.frozen import freeze_object
+from fido.github import GitHub
+from fido.webhook_cache import WebhookCache
+
+# Three GitHub resource kinds the cache holds, each keyed by its
+# own id namespace.  ``(kind, id)`` is the storage key — review id
+# 42 and review-thread-comment id 42 are different things and must
+# not collide.
+KIND_ISSUES = "issues"  # top-level comments on issues/PRs
+KIND_PULLS = "pulls"  # inline review-thread comments
+KIND_REVIEWS = "reviews"  # review submissions (Approve/Comment/Request)
+
+
+@dataclass(frozen=True)
+class CommentNode:
+    """One cached entry: the raw GitHub object plus bookkeeping.
+
+    ``kind`` is which endpoint the data came from (``issues`` /
+    ``pulls`` / ``reviews``) — keeps the ``(kind, id)`` storage key
+    derivable from the node alone (no heuristic on the raw payload).
+    ``data`` is the deep-frozen raw API response (``frozendict`` +
+    ``tuple``), preserving every field GitHub gave us.
+    ``last_applied_at`` is the WebhookCache staleness watermark —
+    set from the entry's ``updated_at`` / ``submitted_at`` on
+    apply, advanced when a newer event arrives.
+    """
+
+    kind: str
+    data: Mapping[str, Any]
+    last_applied_at: datetime
+
+
+@dataclass(frozen=True)
+class CacheMetrics:
+    """Per-(repo, item) cache statistics surfaced by ``fido status``."""
+
+    repo_name: str
+    item: int
+    inventory_loaded_at: datetime | None
+    entries_cached: int
+    events_applied: int
+    events_dropped_stale: int
+    last_event_at: datetime | None
+    last_reconcile_at: datetime | None
+    last_reconcile_drift: int
+
+
+# Webhook event → (cache kind, payload key for the parent item, payload key
+# for the entry object).  ``pull_request_review`` events carry the entry on
+# ``payload["review"]``; the other two on ``payload["comment"]``.
+_EVENT_SPECS: dict[str, tuple[str, str, str]] = {
+    "issue_comment": (KIND_ISSUES, "issue", "comment"),
+    "pull_request_review_comment": (KIND_PULLS, "pull_request", "comment"),
+    "pull_request_review": (KIND_REVIEWS, "pull_request", "review"),
+}
+
+
+def _entry_timestamp(entry: Mapping[str, Any]) -> datetime:
+    """Pick the right ISO-8601 timestamp for staleness comparison.
+
+    GitHub bumps ``updated_at`` on every comment edit.  Reviews
+    use ``submitted_at`` instead (review bodies don't get an
+    ``updated_at`` on the base object).  ``created_at`` is the
+    fallback for the small handful of endpoints that emit neither.
+    All three are missing only on a malformed payload — let the
+    ``KeyError`` raise loud rather than masking it.
+    """
+    raw_ts = entry.get("updated_at") or entry.get("submitted_at") or entry["created_at"]
+    return datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+
+
+class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
+    """In-memory cache for one issue/PR's comments & reviews.
+
+    Each instance is bound to a single ``(repo, item)`` pair at
+    construction; one ``CommentCache`` per item, lazy-created by
+    :class:`~fido.registry.WorkerRegistry`.  The repo-and-item
+    binding means events for other items in the same repo route
+    to a different cache instance (per-item isolation by
+    construction).
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        gh: GitHub,
+        item: int,
+        *,
+        on_change: "Callable[[CacheMetrics], None] | None" = None,
+    ) -> None:
+        super().__init__(f"{repo}#{item}", on_change=on_change)
+        # _gh and _item are stashed for later use by INV-3 hydration;
+        # INV-1 only consumes _item via metrics.
+        self._gh = gh
+        self._item = item
+        # INV-1 scope: no inventory hydration yet (#1756 will add it).
+        # Mark the cache loaded with an empty snapshot so events apply
+        # directly instead of being held in the pre-inventory queue
+        # forever.  INV-3 will override construction to defer this
+        # until the real GitHub list-fetches complete (listen-first-
+        # fill-second).
+        super().load_inventory([], datetime.now(tz=timezone.utc))
+
+    # ── public lookup API ────────────────────────────────────────────────
+
+    def get(self, kind: str, entry_id: int) -> Mapping[str, Any] | None:
+        """Return the cached raw entry, or ``None`` if not present.
+
+        O(1) dict lookup — no GitHub round-trip.  INV-3 will add
+        the hydration path that populates the cache from list
+        fetches; until then, the cache fills only via webhook
+        events through :meth:`apply_event`.
+        """
+        with self._lock:
+            node = self._nodes.get((kind, entry_id))
+            return node.data if node is not None else None
+
+    # ── WebhookCache hooks ───────────────────────────────────────────────
+
+    def apply_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Enrich the payload with the cache key + timestamp, then
+        delegate to the base's staleness-checked shell.
+
+        GitHub webhook payloads don't naturally include the
+        ``timestamp`` / ``_kind`` keys the WebhookCache base wants —
+        we derive them from the event and inject them here.  Events
+        for unrecognised types or targeting a different item drop
+        silently.
+        """
+        spec = _EVENT_SPECS.get(event_type)
+        if spec is None:
+            return
+        kind, parent_key, entry_key = spec
+        parent = payload.get(parent_key)
+        if not isinstance(parent, dict):
+            return
+        item_number = parent.get("number")
+        if not isinstance(item_number, int) or item_number != self._item:
+            # Wrong item — webhook router shouldn't have sent it here.
+            return
+        entry = payload.get(entry_key)
+        if not isinstance(entry, dict):
+            return
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, int):
+            return
+        enriched = {
+            **payload,
+            "_kind": kind,
+            "_entry_id": entry_id,
+            "_action": payload.get("action"),
+            "_entry_frozen": freeze_object(entry),
+            "timestamp": _entry_timestamp(entry),
+        }
+        super().apply_event(event_type, enriched)
+
+    def _node_key(self, node: CommentNode) -> tuple[str, int]:
+        # data["id"] is always present on GitHub comment/review objects.
+        return (node.kind, int(node.data["id"]))
+
+    def _node_key_from_payload(self, payload: dict[str, Any]) -> tuple[str, int]:
+        return (payload["_kind"], payload["_entry_id"])
+
+    def _node_from_inventory(
+        self, raw: dict[str, Any], snapshot_started_at: datetime
+    ) -> CommentNode:
+        """Parse one raw inventory item into a CommentNode.
+
+        Inventory items are dicts with ``_kind`` pinned to the
+        endpoint they came from (``KIND_ISSUES`` / ``KIND_PULLS`` /
+        ``KIND_REVIEWS``), and the rest of the keys forming the raw
+        GitHub object.  INV-3 will compose these from the three
+        list-fetch endpoints.
+        """
+        kind = raw["_kind"]
+        rest = {k: v for k, v in raw.items() if k != "_kind"}
+        return CommentNode(
+            kind=kind,
+            data=freeze_object(rest),
+            last_applied_at=snapshot_started_at,
+        )
+
+    def _node_last_applied_at(self, node: CommentNode) -> datetime:
+        return node.last_applied_at
+
+    def _node_with_last_applied_at(
+        self, node: CommentNode, ts: datetime
+    ) -> CommentNode:
+        return replace(node, last_applied_at=ts)
+
+    def _nodes_equal(self, a: CommentNode, b: CommentNode) -> bool:
+        # Frozen mappings compare by value; ignore last_applied_at
+        # since that's cache-internal bookkeeping.
+        return a.data == b.data
+
+    def _dispatch_event(self, event_type: str, payload: dict[str, Any]) -> bool:
+        kind = payload["_kind"]
+        entry_id = payload["_entry_id"]
+        key = (kind, entry_id)
+        action = payload["_action"]
+        if action == "deleted":
+            self._nodes.pop(key, None)
+            return True
+        # All other actions (created/edited for comments,
+        # submitted/edited/dismissed for reviews) upsert.
+        self._nodes[key] = CommentNode(
+            kind=kind,
+            data=payload["_entry_frozen"],
+            last_applied_at=payload["timestamp"],
+        )
+        return True
+
+    def metrics(self) -> CacheMetrics:
+        with self._lock:
+            base = self._base_metric_fields()
+        return CacheMetrics(
+            repo_name=base["repo_name"],
+            item=self._item,
+            inventory_loaded_at=base["inventory_loaded_at"],
+            entries_cached=base["node_count"],
+            events_applied=base["events_applied"],
+            events_dropped_stale=base["events_dropped_stale"],
+            last_event_at=base["last_event_at"],
+            last_reconcile_at=base["last_reconcile_at"],
+            last_reconcile_drift=base["last_reconcile_drift"],
+        )
+
+
+__all__ = [
+    "KIND_ISSUES",
+    "KIND_PULLS",
+    "KIND_REVIEWS",
+    "CacheMetrics",
+    "CommentCache",
+    "CommentNode",
+]

--- a/src/fido/frozen.py
+++ b/src/fido/frozen.py
@@ -1,0 +1,83 @@
+"""Recursive deep-freeze for JSON-shaped Python objects (#1748).
+
+Caches that hold raw GitHub objects need to guarantee callers
+can't mutate the cached state under their feet — but projecting
+into a narrow typed dataclass throws away half the surface area
+GitHub gives us.  The honest middle ground is to keep the dict
+GitHub returned and make it deeply immutable.
+
+:func:`deep_freeze` walks a JSON-shaped value and rebuilds it as
+:class:`frozendict.frozendict` for mappings and ``tuple`` for
+sequences.  Strings, numbers, bools, and ``None`` are already
+immutable so they pass through untouched.
+
+``frozendict`` (already a project dependency) is a real
+immutable mapping — mutation methods raise rather than write
+back — and it works seamlessly with ``isinstance(..., Mapping)``
+checks consumers already use.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from frozendict import frozendict
+
+# JSON-shape, covering BOTH directions:
+#
+#  * incoming (what ``json.loads`` produces) — ``dict`` for objects,
+#    ``list`` for arrays
+#  * outgoing (what :func:`deep_freeze` returns) — ``frozendict``
+#    for objects, ``tuple`` for arrays
+#
+# ``Mapping[str, …]`` accepts both ``dict`` and ``frozendict``
+# uniformly; the ``list | tuple`` arms cover the array variants
+# without pulling in ``Sequence`` (which would also match ``str`` /
+# ``bytes`` and break the recursion).  PEP 695 ``type`` statement
+# makes the recursion lazy so the self-reference just works.
+type JsonLike = (
+    Mapping[str, JsonLike]
+    | list[JsonLike]
+    | tuple[JsonLike, ...]
+    | str
+    | int
+    | float
+    | bool
+    | None
+)
+
+
+def deep_freeze(obj: JsonLike) -> JsonLike:
+    """Recursively rebuild ``obj`` as a deeply-immutable JSON shape.
+
+    Mappings become ``frozendict`` over a fresh dict of frozen
+    values; ``list`` / ``tuple`` arrays become tuples of frozen
+    values; everything else (``str``, numbers, bools, ``None``) is
+    already immutable and passes through.
+
+    Idempotent — already-frozen inputs round-trip without copying
+    further down.
+
+    For top-level use against a known-object payload (a GitHub API
+    response, say) prefer :func:`freeze_object` — its return type
+    is narrowed to ``Mapping[str, Any]`` which is what callers
+    actually want to consume.
+    """
+    if isinstance(obj, Mapping):
+        return frozendict({k: deep_freeze(v) for k, v in obj.items()})
+    if isinstance(obj, (list, tuple)):
+        # Match list/tuple explicitly rather than ``Sequence`` — the
+        # latter would also catch ``str`` and turn "hi" into
+        # ('h', 'i').  GitHub JSON has no other sequence shapes.
+        return tuple(deep_freeze(x) for x in obj)
+    return obj
+
+
+def freeze_object(obj: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Deep-freeze a JSON *object* (top-level mapping).
+
+    Narrower-typed wrapper around :func:`deep_freeze` for the
+    common case where the caller knows the input is a JSON object.
+    The return type is preserved as ``Mapping[str, Any]`` so callers
+    don't need to narrow a ``JsonLike`` union before consuming it.
+    """
+    return frozendict({k: deep_freeze(v) for k, v in obj.items()})

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -25,6 +25,7 @@ from fido.appstate import (
     zero_repo_state,
 )
 from fido.atomic import AtomicUpdater
+from fido.comment_cache import CommentCache
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.issue_cache import CacheMetrics, IssueTreeCache
@@ -127,6 +128,12 @@ class WorkerRegistry:
         # that don't exercise the cache path don't pay setup cost.
         self._issue_caches: dict[str, IssueTreeCache] = {}
         self._issue_cache_lock = threading.Lock()
+        # Per-(repo, item) comment caches (closes #1754).  Lazily created
+        # on first lookup; each cache is bound to one issue/PR's
+        # comments + reviews.  INV-1 scope; lifecycle binding to "PR
+        # open by Fido" lands in #1757.
+        self._comment_caches: dict[tuple[str, int], CommentCache] = {}
+        self._comment_cache_lock = threading.Lock()
         # Per-repo FSM state from worker_registry_crash.v.  Only written by
         # start(), which is called sequentially during startup and from the
         # single watchdog daemon thread during crash recovery — no lock needed.
@@ -917,6 +924,27 @@ class WorkerRegistry:
         """
         with self._issue_cache_lock:
             return list(self._issue_caches.values())
+
+    def get_comment_cache(self, repo_name: str, item: int, gh: GitHub) -> CommentCache:
+        """Return (lazily creating) the per-(repo, item) comment cache (#1754).
+
+        One :class:`~fido.comment_cache.CommentCache` per ``(repo, item)``
+        pair.  Distinct items in the same repo get distinct caches —
+        per-item isolation by construction.  Webhook router uses this
+        to route events to the right cache.
+        """
+        key = (repo_name, item)
+        with self._comment_cache_lock:
+            cache = self._comment_caches.get(key)
+            if cache is None:
+                cache = CommentCache(repo_name, gh, item)
+                self._comment_caches[key] = cache
+            return cache
+
+    def all_comment_caches(self) -> list[CommentCache]:
+        """Snapshot list of every comment cache that has been created."""
+        with self._comment_cache_lock:
+            return list(self._comment_caches.values())
 
 
 def _make_thread(

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 from pathlib import Path
 from types import TracebackType
-from typing import IO, Any, cast
+from typing import IO, Any
 from urllib.parse import urlparse
 
 import requests
@@ -80,6 +80,16 @@ _PULL_BACKOFF_DELAYS: tuple[int, ...] = (10, 30, 60)
 _PULL_BUDGET_SECONDS: float = 600.0
 _RESTART_EXIT_CODE = 75
 _REQUEST_TIMEOUT_SECONDS = 10.0
+
+# Comment webhook event → the payload key carrying the item number that
+# scopes the cache.  ``pull_request_review`` events nest their entry
+# under ``payload["review"]`` (vs ``payload["comment"]`` for the other
+# two), but the item-number lookup uses the parent regardless.
+_COMMENT_EVENT_PARENT_KEYS: dict[str, str] = {
+    "issue_comment": "issue",
+    "pull_request_review_comment": "pull_request",
+    "pull_request_review": "pull_request",
+}
 
 
 class PreflightError(RuntimeError):
@@ -350,8 +360,21 @@ class WebhookHandler(BaseHTTPRequestHandler):
     state_reader: AtomicReader[FidoState]
     provider_factory: DefaultProviderFactory | None = None
     # Injectable collaborators — set as class attributes so HTTP-driven tests
-    # can replace them without patching module-level names.
-    gh: GitHub | None = None
+    # can replace them without patching module-level names.  ``gh`` is
+    # accessed through the property below so callers see ``GitHub`` rather
+    # than ``GitHub | None``; ``serve()`` sets ``_gh`` before any handler
+    # runs, so by the time the property fires it's guaranteed non-None.
+    _gh: GitHub | None = None
+
+    @property
+    def gh(self) -> GitHub:
+        gh = type(self)._gh
+        if gh is None:
+            raise RuntimeError(
+                "FidoHTTPHandler.gh accessed before serve() initialised it"
+            )
+        return gh
+
     dispatchers: dict[str, Dispatcher] = {}
     # Infrastructure ports — set by server.run() composition root.
     infra: Infra = real_infra()
@@ -519,6 +542,17 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 repo_name,
             )
 
+        # Patch the per-(repo, item) comment cache for comment / review
+        # events (#1754).  Same failure tolerance as the issue cache —
+        # log, continue, the eventual reconcile (#1759) will heal.
+        try:
+            self._patch_comment_cache(event, payload, repo_cfg)
+        except Exception:
+            log.exception(
+                "comment-cache patch failed for %s — next list fetch will heal",
+                repo_name,
+            )
+
         # Acknowledge only after dispatch succeeds.
         self._respond(200, "ok")
 
@@ -615,6 +649,29 @@ class WebhookHandler(BaseHTTPRequestHandler):
         )
         cache = self.registry.get_issue_cache(repo_cfg.name)
         cache.apply_event(cache_event_type, cache_payload)
+
+    def _patch_comment_cache(
+        self, event: str, payload: dict[str, Any], repo_cfg: RepoConfig
+    ) -> None:
+        """Route a comment / review webhook to the per-(repo, item) cache.
+
+        Extracts the item (issue or PR) number from the payload, looks
+        up the right :class:`~fido.comment_cache.CommentCache` via the
+        registry, and hands the event to ``apply_event``.  Unrelated
+        event types are silently ignored (every webhook hits this
+        method; only comment/review events have a cache target).
+        """
+        parent_key = _COMMENT_EVENT_PARENT_KEYS.get(event)
+        if parent_key is None:
+            return
+        parent = payload.get(parent_key)
+        if not isinstance(parent, dict):
+            return
+        item_number = parent.get("number")
+        if not isinstance(item_number, int):
+            return
+        cache = self.registry.get_comment_cache(repo_cfg.name, item_number, self.gh)
+        cache.apply_event(event, payload)
 
     def _process_action(self, action: Action, repo_cfg: RepoConfig) -> None:
         description = self._describe_action(action)
@@ -776,7 +833,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         # list (via :meth:`~fido.registry.WorkerRegistry.webhook_activity`).
         # Writing here would clobber the worker thread's own state, which is
         # what caused the old ``Doing: handling webhook action`` display bug.
-        gh = cast(GitHub, self.gh)  # always set by serve() before first request
+        gh = self.gh
         # Determine which comment (if any) will receive the eyes reaction.
         # Resolved before the try block so both the main path and the
         # recoverable-exception handler can reference _eyes_comment_info.
@@ -1012,8 +1069,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         if not repo or not comment_id:
             return
         try:
-            if self.gh is not None:
-                self.gh.add_reaction(repo, comment_type, comment_id, "confused")
+            self.gh.add_reaction(repo, comment_type, comment_id, "confused")
         except Exception:
             log.exception("failed to post error reaction on comment %s", comment_id)
 
@@ -1263,7 +1319,9 @@ def run(
     _populate_memberships(config, gh)
 
     WebhookHandler.config = config
-    WebhookHandler.gh = gh
+    # Composition root sets the class-level lazy collaborator; the proper
+    # constructor-DI redo is tracked in #1762.
+    WebhookHandler._gh = gh  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     dispatchers = {
         name: Dispatcher(config, repo_cfg, gh)
         for name, repo_cfg in config.repos.items()

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -660,6 +660,14 @@ class WebhookHandler(BaseHTTPRequestHandler):
         registry, and hands the event to ``apply_event``.  Unrelated
         event types are silently ignored (every webhook hits this
         method; only comment/review events have a cache target).
+
+        ``issue_comment`` events fire for plain-issue comments AND PR
+        top-level comments (PRs are issues for that endpoint).  Fido's
+        dispatcher (``events.py``) ignores plain-issue comments, so
+        we mirror that filter here — otherwise busy repos with lots of
+        issue traffic accumulate caches we'll never use (codex P2 on
+        #1751).  Proper lifecycle binding (cache created only when
+        Fido has work on the item) lands in #1757.
         """
         parent_key = _COMMENT_EVENT_PARENT_KEYS.get(event)
         if parent_key is None:
@@ -669,6 +677,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
             return
         item_number = parent.get("number")
         if not isinstance(item_number, int):
+            return
+        if event == "issue_comment" and not parent.get("pull_request"):
+            # Plain-issue comment — Dispatcher ignores these too.
             return
         cache = self.registry.get_comment_cache(repo_cfg.name, item_number, self.gh)
         cache.apply_event(event, payload)

--- a/tests/test_comment_cache.py
+++ b/tests/test_comment_cache.py
@@ -1,0 +1,412 @@
+"""Tests for the per-(repo, item) CommentCache (#1748, #1754).
+
+INV-1 scope: shape + per-(repo, item) keying + ``apply_event``.
+Hydration via ``load_inventory`` and list getters come in #1756
+and are tested there.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from frozendict import frozendict
+
+from fido.comment_cache import (
+    KIND_ISSUES,
+    KIND_PULLS,
+    KIND_REVIEWS,
+    CommentCache,
+)
+
+
+class _FakeGH:
+    """Hand-rolled GitHub fake — no MagicMock per testing convention.
+
+    INV-1 doesn't exercise any GH methods (the cache only fills via
+    apply_event), so this is a placeholder that records nothing.
+    Hydration tests (#1756) will give it teeth.
+    """
+
+
+def _comment_payload(
+    *,
+    item: int,
+    comment_id: int,
+    body: str = "hi",
+    author: str = "alice",
+    updated_at: str = "2024-01-15T10:00:00Z",
+    in_reply_to_id: int | None = None,
+    path: str | None = None,
+) -> dict[str, Any]:
+    """Raw GitHub comment payload (top-level or review-thread share shape).
+
+    GitHub bumps ``updated_at`` on every edit; freshness check
+    relies on this.
+    """
+    comment: dict[str, Any] = {
+        "id": comment_id,
+        "body": body,
+        "user": {"login": author},
+        "created_at": updated_at,
+        "updated_at": updated_at,
+        "html_url": "https://example/c",
+    }
+    if in_reply_to_id is not None:
+        comment["in_reply_to_id"] = in_reply_to_id
+    if path is not None:
+        comment["path"] = path
+    return comment
+
+
+def _review_payload(
+    *,
+    review_id: int,
+    state: str = "COMMENTED",
+    body: str = "lgtm",
+    submitted_at: str = "2024-01-15T10:00:00Z",
+) -> dict[str, Any]:
+    """Raw GitHub review-submission payload."""
+    return {
+        "id": review_id,
+        "state": state,
+        "body": body,
+        "user": {"login": "alice"},
+        "submitted_at": submitted_at,
+    }
+
+
+class TestConstruction:
+    def test_bound_to_one_repo_item_pair(self) -> None:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        m = cache.metrics()
+        assert m.item == 7
+        assert m.entries_cached == 0
+        # Repo name is folded into the log-friendly identifier.
+        assert m.repo_name == "owner/repo#7"
+
+    def test_two_items_in_same_repo_are_independent(self) -> None:
+        c7 = CommentCache("owner/repo", _FakeGH(), 7)
+        c8 = CommentCache("owner/repo", _FakeGH(), 8)
+        c7.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(item=7, comment_id=42),
+            },
+        )
+        # c7 has the entry, c8 is empty.
+        assert c7.get(KIND_ISSUES, 42) is not None
+        assert c8.get(KIND_ISSUES, 42) is None
+
+
+class TestApplyIssueComment:
+    def _cache(self) -> CommentCache:
+        # WebhookCache queues events pre-inventory; mark loaded so
+        # INV-1 tests exercise the steady-state path directly.
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.load_inventory([], datetime(2024, 1, 1, tzinfo=timezone.utc))
+        return cache
+
+    def test_created_upserts(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(item=7, comment_id=42, body="fresh"),
+            },
+        )
+        got = cache.get(KIND_ISSUES, 42)
+        assert got is not None
+        assert got["body"] == "fresh"
+        assert isinstance(got, frozendict)
+
+    def test_edited_overwrites(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=42,
+                    body="original",
+                    updated_at="2024-01-15T10:00:00Z",
+                ),
+            },
+        )
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "edited",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=42,
+                    body="edited",
+                    updated_at="2024-02-01T10:00:00Z",
+                ),
+            },
+        )
+        got = cache.get(KIND_ISSUES, 42)
+        assert got is not None and got["body"] == "edited"
+
+    def test_deleted_evicts(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(item=7, comment_id=42),
+            },
+        )
+        assert cache.metrics().entries_cached == 1
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "deleted",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=42,
+                    updated_at="2024-02-01T10:00:00Z",
+                ),
+            },
+        )
+        assert cache.metrics().entries_cached == 0
+        assert cache.get(KIND_ISSUES, 42) is None
+
+
+class TestApplyPullRequestReviewComment:
+    def _cache(self) -> CommentCache:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.load_inventory([], datetime(2024, 1, 1, tzinfo=timezone.utc))
+        return cache
+
+    def test_routed_to_pulls_kind(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "pull_request_review_comment",
+            {
+                "action": "created",
+                "pull_request": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=100,
+                    body="review-thread",
+                    path="src/foo.py",
+                ),
+            },
+        )
+        got = cache.get(KIND_PULLS, 100)
+        assert got is not None and got["body"] == "review-thread"
+        # Same id under KIND_ISSUES does NOT collide.
+        assert cache.get(KIND_ISSUES, 100) is None
+
+
+class TestApplyPullRequestReview:
+    def _cache(self) -> CommentCache:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.load_inventory([], datetime(2024, 1, 1, tzinfo=timezone.utc))
+        return cache
+
+    def test_routed_to_reviews_kind(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "pull_request_review",
+            {
+                "action": "submitted",
+                "pull_request": {"number": 7},
+                "review": _review_payload(
+                    review_id=1000, state="APPROVED", body="lgtm"
+                ),
+            },
+        )
+        got = cache.get(KIND_REVIEWS, 1000)
+        assert got is not None
+        assert got["state"] == "APPROVED"
+        assert got["body"] == "lgtm"
+
+    def test_review_id_and_comment_id_coexist_under_different_kinds(self) -> None:
+        cache = self._cache()
+        cache.apply_event(
+            "pull_request_review_comment",
+            {
+                "action": "created",
+                "pull_request": {"number": 7},
+                "comment": _comment_payload(item=7, comment_id=50, body="comment"),
+            },
+        )
+        cache.apply_event(
+            "pull_request_review",
+            {
+                "action": "submitted",
+                "pull_request": {"number": 7},
+                "review": _review_payload(review_id=50, body="review"),
+            },
+        )
+        assert cache.metrics().entries_cached == 2
+        c = cache.get(KIND_PULLS, 50)
+        r = cache.get(KIND_REVIEWS, 50)
+        assert c is not None and c["body"] == "comment"
+        assert r is not None and r["body"] == "review"
+
+
+class TestStalenessCheck:
+    def _cache(self) -> CommentCache:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.load_inventory([], datetime(2024, 1, 1, tzinfo=timezone.utc))
+        return cache
+
+    def test_older_event_dropped_after_newer(self) -> None:
+        # Out-of-order delivery: an older edit arrives after a newer
+        # one.  WebhookCache's last_applied_at check drops it.
+        cache = self._cache()
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "edited",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=42,
+                    body="newer",
+                    updated_at="2024-02-01T10:00:00Z",
+                ),
+            },
+        )
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "edited",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=42,
+                    body="older",
+                    updated_at="2024-01-15T10:00:00Z",
+                ),
+            },
+        )
+        got = cache.get(KIND_ISSUES, 42)
+        assert got is not None and got["body"] == "newer"
+        assert cache.metrics().events_dropped_stale == 1
+
+
+class TestLoadInventory:
+    """Inventory hydration shape (#1756 wires the bootstrap; this verifies
+    the parse contract that consumers will compose against)."""
+
+    def test_loads_three_kinds_via_explicit_kind_tag(self) -> None:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        snapshot_ts = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        inventory = [
+            {"_kind": KIND_ISSUES, **_comment_payload(item=7, comment_id=10)},
+            {
+                "_kind": KIND_PULLS,
+                **_comment_payload(
+                    item=7, comment_id=100, path="src/foo.py", body="line"
+                ),
+            },
+            {"_kind": KIND_REVIEWS, **_review_payload(review_id=1000, body="lgtm")},
+        ]
+        cache.load_inventory(inventory, snapshot_ts)
+        assert cache.metrics().entries_cached == 3
+        assert cache.get(KIND_ISSUES, 10) is not None
+        assert cache.get(KIND_PULLS, 100) is not None
+        rev = cache.get(KIND_REVIEWS, 1000)
+        assert rev is not None and rev["body"] == "lgtm"
+
+    def test_reconcile_evicts_missing_and_uses_nodes_equal(self) -> None:
+        # Reconcile diffs the cache against a fresh snapshot: ids absent
+        # are removed; ids that diverge from the snapshot are replaced.
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        snapshot_ts = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        cache.load_inventory(
+            [
+                {"_kind": KIND_ISSUES, **_comment_payload(item=7, comment_id=10)},
+                {"_kind": KIND_ISSUES, **_comment_payload(item=7, comment_id=11)},
+            ],
+            snapshot_ts,
+        )
+        # Reconcile with a fresh snapshot that drops 11 and changes 10.
+        cache.reconcile_with_inventory(
+            [
+                {
+                    "_kind": KIND_ISSUES,
+                    **_comment_payload(item=7, comment_id=10, body="edited"),
+                },
+            ],
+            datetime(2024, 7, 1, tzinfo=timezone.utc),
+        )
+        assert cache.metrics().entries_cached == 1
+        ten = cache.get(KIND_ISSUES, 10)
+        assert ten is not None and ten["body"] == "edited"
+        assert cache.get(KIND_ISSUES, 11) is None
+
+
+class TestIgnoredEvents:
+    def _cache(self) -> CommentCache:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.load_inventory([], datetime(2024, 1, 1, tzinfo=timezone.utc))
+        return cache
+
+    def test_unrelated_event_type_ignored(self) -> None:
+        cache = self._cache()
+        cache.apply_event("push", {"ref": "refs/heads/main"})
+        assert cache.metrics().entries_cached == 0
+        assert cache.metrics().events_applied == 0
+
+    def test_event_for_other_item_ignored(self) -> None:
+        cache = self._cache()
+        # Bound to item 7, event targets item 99.
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 99},
+                "comment": _comment_payload(item=99, comment_id=42),
+            },
+        )
+        assert cache.metrics().entries_cached == 0
+        assert cache.metrics().events_applied == 0
+
+    def test_malformed_payload_ignored(self) -> None:
+        cache = self._cache()
+        # No issue/pull_request key.
+        cache.apply_event("issue_comment", {"action": "created"})
+        # parent is not a dict.
+        cache.apply_event("issue_comment", {"action": "created", "issue": "not-a-dict"})
+        # No number on parent.
+        cache.apply_event("issue_comment", {"action": "created", "issue": {}})
+        # number not int.
+        cache.apply_event(
+            "issue_comment", {"action": "created", "issue": {"number": "x"}}
+        )
+        # No comment payload.
+        cache.apply_event(
+            "issue_comment", {"action": "created", "issue": {"number": 7}}
+        )
+        # comment not a dict.
+        cache.apply_event(
+            "issue_comment",
+            {"action": "created", "issue": {"number": 7}, "comment": "nope"},
+        )
+        # comment id missing.
+        cache.apply_event(
+            "issue_comment",
+            {"action": "created", "issue": {"number": 7}, "comment": {}},
+        )
+        # comment id not int.
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": {"id": "x"},
+            },
+        )
+        assert cache.metrics().events_applied == 0

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -1,0 +1,75 @@
+"""Tests for the deep-freeze JSON helper (#1748)."""
+
+import pytest
+from frozendict import frozendict
+
+from fido.frozen import deep_freeze, freeze_object
+
+
+class TestDeepFreeze:
+    def test_scalars_pass_through(self) -> None:
+        assert deep_freeze("hi") == "hi"
+        assert deep_freeze(42) == 42
+        assert deep_freeze(3.14) == 3.14
+        assert deep_freeze(True) is True
+        assert deep_freeze(None) is None
+
+    def test_dict_becomes_frozendict(self) -> None:
+        result = deep_freeze({"a": 1, "b": 2})
+        assert isinstance(result, frozendict)
+        assert dict(result) == {"a": 1, "b": 2}
+
+    def test_list_becomes_tuple(self) -> None:
+        result = deep_freeze([1, 2, 3])
+        assert result == (1, 2, 3)
+        assert isinstance(result, tuple)
+
+    def test_tuple_stays_tuple(self) -> None:
+        result = deep_freeze((1, 2, 3))
+        assert result == (1, 2, 3)
+        assert isinstance(result, tuple)
+
+    def test_nested_structures_recurse(self) -> None:
+        result = deep_freeze(
+            {"users": [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]}
+        )
+        assert isinstance(result, frozendict)
+        users = result["users"]
+        assert isinstance(users, tuple)
+        assert isinstance(users[0], frozendict)
+        assert users[0]["name"] == "alice"
+
+    def test_strings_are_not_treated_as_sequences(self) -> None:
+        # str matches Sequence in the typing hierarchy; deep_freeze
+        # must NOT iterate it character-by-character.
+        result = deep_freeze("hello")
+        assert result == "hello"
+        assert isinstance(result, str)
+
+    def test_frozen_inputs_idempotent(self) -> None:
+        original = deep_freeze({"a": [1, 2, {"b": "c"}]})
+        assert isinstance(original, frozendict)
+        again = deep_freeze(original)
+        assert again == original
+
+
+class TestFreezeObject:
+    def test_returns_mapping_subclass(self) -> None:
+        result = freeze_object({"a": 1})
+        assert isinstance(result, frozendict)
+        assert result["a"] == 1
+
+    def test_mutation_raises(self) -> None:
+        result = freeze_object({"a": 1})
+        with pytest.raises(TypeError):
+            result["a"] = 2  # type: ignore[index]
+
+    def test_severs_link_to_input_dict(self) -> None:
+        # The frozen view must not reflect later mutations to the
+        # input dict — otherwise a caller holding the original
+        # reference could mutate the cached state through the back
+        # door.
+        original = {"a": 1}
+        result = freeze_object(original)
+        original["a"] = 999
+        assert result["a"] == 1

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2240,3 +2240,47 @@ class TestRegistryFsmOracle:
             reg._registry_fsm_states.get("org/b"),
             registry_fsm.Active,  # pyright: ignore[reportPrivateUsage]
         )
+
+
+class TestCommentCacheRegistry:
+    """Per-(repo, item) CommentCache tracking (#1754)."""
+
+    def _reg(self) -> WorkerRegistry:
+        _, updater = create_atomic(
+            FidoState(
+                repos=frozendict(),
+                github_limits=_ZERO_GITHUB_LIMITS,
+                process_started_at=_EPOCH,
+            )
+        )
+        return WorkerRegistry(MagicMock(), updater)
+
+    def test_get_comment_cache_lazy_creates_per_key(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        c1 = reg.get_comment_cache("foo/bar", 7, gh)
+        c2 = reg.get_comment_cache("foo/bar", 7, gh)
+        assert c1 is c2  # same key → same instance
+
+    def test_distinct_items_in_same_repo_get_distinct_caches(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        c7 = reg.get_comment_cache("foo/bar", 7, gh)
+        c8 = reg.get_comment_cache("foo/bar", 8, gh)
+        assert c7 is not c8
+
+    def test_distinct_repos_with_same_item_get_distinct_caches(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        a = reg.get_comment_cache("org/a", 1, gh)
+        b = reg.get_comment_cache("org/b", 1, gh)
+        assert a is not b
+
+    def test_all_comment_caches_lists_created_instances(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        reg.get_comment_cache("foo/bar", 7, gh)
+        reg.get_comment_cache("foo/bar", 8, gh)
+        reg.get_comment_cache("baz/qux", 1, gh)
+        all_caches = reg.all_comment_caches()
+        assert len(all_caches) == 3

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -194,7 +194,7 @@ def _sign(body: bytes, secret: bytes) -> str:
 @pytest.fixture(autouse=True)
 def _restore_handler_fns() -> object:
     saved = {
-        "gh": WebhookHandler.gh,
+        "_gh": WebhookHandler._gh,
         "dispatchers": WebhookHandler.dispatchers,
         "_fn_reply_to_comment": WebhookHandler._fn_reply_to_comment,
         "_fn_reply_to_review": WebhookHandler._fn_reply_to_review,
@@ -233,6 +233,7 @@ def server(tmp_path: Path) -> object:
     WebhookHandler.config = cfg
     WebhookHandler.registry = MagicMock()
     WebhookHandler.state_reader = MagicMock()
+    WebhookHandler._gh = MagicMock()
     WebhookHandler.dispatchers = {"owner/repo": Dispatcher(cfg, repo_cfg, MagicMock())}
     WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
@@ -800,6 +801,127 @@ class TestPatchIssueCache:
         assert status == 200
 
 
+class TestPatchCommentCache:
+    """Webhook → per-(repo, item) CommentCache routing (#1754)."""
+
+    def test_issue_comment_routes_by_issue_number(self, server: tuple) -> None:
+        url, cfg = server
+        cache = MagicMock()
+        WebhookHandler.registry.get_comment_cache.return_value = cache
+        payload = {
+            **_payload(),
+            "action": "created",
+            "issue": {"number": 42},
+            "comment": {
+                "id": 100,
+                "body": "hi",
+                "user": {"login": "alice"},
+                "updated_at": "2024-01-15T10:00:00Z",
+            },
+        }
+        status = _post_webhook(url, cfg, "issue_comment", payload)
+        assert status == 200
+        WebhookHandler.registry.get_comment_cache.assert_called_with(
+            "owner/repo", 42, WebhookHandler._gh
+        )
+        cache.apply_event.assert_called_once()
+        assert cache.apply_event.call_args.args[0] == "issue_comment"
+
+    def test_pull_request_review_comment_routes_by_pr_number(
+        self, server: tuple
+    ) -> None:
+        url, cfg = server
+        cache = MagicMock()
+        WebhookHandler.registry.get_comment_cache.return_value = cache
+        payload = {
+            **_payload(),
+            "action": "created",
+            "pull_request": {"number": 7},
+            "comment": {
+                "id": 100,
+                "body": "review",
+                "user": {"login": "alice"},
+                "path": "foo.py",
+                "updated_at": "2024-01-15T10:00:00Z",
+            },
+        }
+        status = _post_webhook(url, cfg, "pull_request_review_comment", payload)
+        assert status == 200
+        WebhookHandler.registry.get_comment_cache.assert_called_with(
+            "owner/repo", 7, WebhookHandler._gh
+        )
+
+    def test_pull_request_review_routes_by_pr_number(self, server: tuple) -> None:
+        url, cfg = server
+        cache = MagicMock()
+        WebhookHandler.registry.get_comment_cache.return_value = cache
+        payload = {
+            **_payload(),
+            "action": "submitted",
+            "pull_request": {"number": 7},
+            "review": {
+                "id": 1000,
+                "state": "APPROVED",
+                "body": "lgtm",
+                "user": {"login": "alice"},
+                "submitted_at": "2024-01-15T10:00:00Z",
+            },
+        }
+        status = _post_webhook(url, cfg, "pull_request_review", payload)
+        assert status == 200
+        WebhookHandler.registry.get_comment_cache.assert_called_with(
+            "owner/repo", 7, WebhookHandler._gh
+        )
+
+    def test_unrelated_event_does_not_touch_cache(self, server: tuple) -> None:
+        url, cfg = server
+        WebhookHandler.registry.reset_mock()
+        payload = {**_payload(), "action": "synchronize", "pull_request": {"number": 7}}
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        WebhookHandler.registry.get_comment_cache.assert_not_called()
+
+    def test_malformed_payloads_do_not_route(self, tmp_path: Path) -> None:
+        # Unit-level: exercise the _patch_comment_cache defensive
+        # branches without going through the webhook dispatcher
+        # (which chokes on missing keys before our patch fires and
+        # would mask whether these branches drop cleanly).
+        cfg = _config(tmp_path)
+        repo_cfg = cfg.repos["owner/repo"]
+        handler = MagicMock(spec=WebhookHandler)
+        handler.registry = MagicMock()
+        handler.gh = MagicMock()
+        patch = WebhookHandler._patch_comment_cache.__get__(handler, WebhookHandler)
+        # No "issue" key.
+        patch("issue_comment", {"action": "created"}, repo_cfg)
+        # Parent not a dict.
+        patch("issue_comment", {"issue": "not-a-dict"}, repo_cfg)
+        # Parent missing "number".
+        patch("issue_comment", {"issue": {}}, repo_cfg)
+        # "number" not int.
+        patch("issue_comment", {"issue": {"number": "x"}}, repo_cfg)
+        handler.registry.get_comment_cache.assert_not_called()
+
+    def test_cache_apply_failure_does_not_500(self, server: tuple) -> None:
+        url, cfg = server
+        cache = MagicMock()
+        cache.apply_event.side_effect = RuntimeError("boom")
+        WebhookHandler.registry.get_comment_cache.return_value = cache
+        payload = {
+            **_payload(),
+            "action": "created",
+            "issue": {"number": 42},
+            "comment": {
+                "id": 100,
+                "body": "hi",
+                "user": {"login": "alice"},
+                "updated_at": "2024-01-15T10:00:00Z",
+            },
+        }
+        status = _post_webhook(url, cfg, "issue_comment", payload)
+        assert status == 200
+
+
 class TestProcessAction:
     """Tests for _process_action — the background thread that dispatches actions."""
 
@@ -996,7 +1118,7 @@ class TestProcessAction:
             "action": "closed",
             "pull_request": {"number": 99, "merged": True},
         }
-        WebhookHandler.gh = MagicMock()
+        WebhookHandler._gh = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock(
             side_effect=provider.SessionLeakError("leaked")
         )
@@ -1012,7 +1134,7 @@ class TestProcessAction:
             "action": "closed",
             "pull_request": {"number": 13, "merged": True},
         }
-        WebhookHandler.gh = MagicMock()
+        WebhookHandler._gh = MagicMock()
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=Exception("explode"))
         status = _post_webhook(url, cfg, "pull_request", payload)
         assert status == 200
@@ -1029,7 +1151,7 @@ class TestProcessAction:
             "pull_request": {"number": 22, "merged": True},
         }
         mock_gh = MagicMock()
-        WebhookHandler.gh = mock_gh
+        WebhookHandler._gh = mock_gh
         WebhookHandler._fn_launch_worker = MagicMock(side_effect=RuntimeError("boom"))
         _post_webhook(url, cfg, "pull_request", payload)
         mock_gh.add_reaction.assert_not_called()
@@ -1051,7 +1173,7 @@ class TestProcessAction:
             "pull_request": {"number": 24},
         }
         mock_gh = MagicMock()
-        WebhookHandler.gh = mock_gh
+        WebhookHandler._gh = mock_gh
         WebhookHandler._fn_reply_to_review = MagicMock(side_effect=RuntimeError("boom"))
         WebhookHandler._fn_launch_worker = MagicMock()
         _post_webhook(url, cfg, "pull_request_review", payload)
@@ -1066,7 +1188,7 @@ class TestProcessAction:
         url, cfg = server
         handler = WebhookHandler.__new__(WebhookHandler)
         mock_gh = MagicMock()
-        handler.gh = mock_gh
+        type(handler)._gh = mock_gh
         action = Action(
             prompt="test",
             thread={"repo": "owner/repo", "pr": 1},
@@ -1092,7 +1214,7 @@ class TestProcessAction:
         )
         handler.registry = WorkerRegistry(MagicMock(), updater)
         handler.registry.start(cfg.repos["owner/repo"])
-        handler.gh = MagicMock()
+        type(handler)._gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
         phases: list[str] = []
 
@@ -1226,7 +1348,7 @@ class TestProcessAction:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        WebhookHandler.gh = MagicMock()
+        WebhookHandler._gh = MagicMock()
         WebhookHandler._fn_reply_to_issue_comment = MagicMock(
             return_value=("ANSWER", [])
         )
@@ -1357,7 +1479,7 @@ class TestProcessAction:
         reg = WorkerRegistry(MagicMock(return_value=thread_mock), updater)
         reg.start(cfg.repos["owner/repo"])
         handler.registry = reg
-        handler.gh = MagicMock()
+        type(handler)._gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
 
         # Install the spy AFTER start() so start()'s own publish isn't counted.
@@ -1466,7 +1588,7 @@ class TestProcessAction:
         reg = WorkerRegistry(MagicMock(return_value=thread_mock), updater)
         reg.start(cfg.repos["owner/repo"])
         handler.registry = reg
-        handler.gh = MagicMock()
+        type(handler)._gh = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
 
         captured_snapshots: list[ProviderSnapshot | None] = []
@@ -1571,7 +1693,7 @@ class TestProcessActionInner:
     def _handler(self, cfg: Config) -> WebhookHandler:
         handler = object.__new__(WebhookHandler)
         handler.config = cfg
-        handler.gh = MagicMock()
+        type(handler)._gh = MagicMock()
         handler.registry = MagicMock()
         handler.dispatchers = {"owner/repo": _FakeDispatcher()}
         return handler

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -804,14 +804,21 @@ class TestPatchIssueCache:
 class TestPatchCommentCache:
     """Webhook → per-(repo, item) CommentCache routing (#1754)."""
 
-    def test_issue_comment_routes_by_issue_number(self, server: tuple) -> None:
+    def test_pr_top_level_issue_comment_routes_by_pr_number(
+        self, server: tuple
+    ) -> None:
+        # Top-level PR comments arrive as ``issue_comment`` events with
+        # ``issue.pull_request`` set — that's what makes the issue a PR.
         url, cfg = server
         cache = MagicMock()
         WebhookHandler.registry.get_comment_cache.return_value = cache
         payload = {
             **_payload(),
             "action": "created",
-            "issue": {"number": 42},
+            "issue": {
+                "number": 42,
+                "pull_request": {"url": "https://example/p/42"},
+            },
             "comment": {
                 "id": 100,
                 "body": "hi",
@@ -826,6 +833,29 @@ class TestPatchCommentCache:
         )
         cache.apply_event.assert_called_once()
         assert cache.apply_event.call_args.args[0] == "issue_comment"
+
+    def test_plain_issue_comment_does_not_create_cache(self, server: tuple) -> None:
+        # ``issue_comment`` events fire for plain issues too (issues
+        # without a ``pull_request`` field).  Fido's Dispatcher ignores
+        # those, and we ignore them here too so the registry doesn't
+        # accumulate caches for items Fido doesn't work on (codex P2
+        # on #1751).
+        url, cfg = server
+        WebhookHandler.registry.reset_mock()
+        payload = {
+            **_payload(),
+            "action": "created",
+            "issue": {"number": 42},  # no pull_request field
+            "comment": {
+                "id": 100,
+                "body": "hi",
+                "user": {"login": "alice"},
+                "updated_at": "2024-01-15T10:00:00Z",
+            },
+        }
+        status = _post_webhook(url, cfg, "issue_comment", payload)
+        assert status == 200
+        WebhookHandler.registry.get_comment_cache.assert_not_called()
 
     def test_pull_request_review_comment_routes_by_pr_number(
         self, server: tuple
@@ -910,7 +940,10 @@ class TestPatchCommentCache:
         payload = {
             **_payload(),
             "action": "created",
-            "issue": {"number": 42},
+            "issue": {
+                "number": 42,
+                "pull_request": {"url": "https://example/p/42"},
+            },
             "comment": {
                 "id": 100,
                 "body": "hi",


### PR DESCRIPTION
## Summary

First slice of the #1748 mini-epic.  Foundational refactor that lands
the per-(repo, item) CommentCache on the new ``WebhookCache`` base
(extracted in #1752 / merged via #1753) and drops the active-item
rotation legacy.  Subsequent slices (#1756, #1757, #1758, #1759,
#1760, #1761) layer hydration, lifecycle binding, status metrics,
periodic reconcile, and consumer migration on top.

## What this PR ships

* **``CommentCache``** inherits ``WebhookCache[(str, int),
  CommentNode, CacheMetrics]`` — bound to a single ``(repo, item)``
  at construction.  Storage is raw frozen GitHub objects keyed by
  ``(kind, id)``; the three resource kinds (``issues`` / ``pulls`` /
  ``reviews``) live alongside each other in one cache with disjoint
  id namespaces.
* **``CommentNode``** = frozen dataclass with ``kind``, ``data``
  (deep-frozen via ``fido.frozen``), and ``last_applied_at``.
* **Three event handlers**: ``issue_comment``,
  ``pull_request_review_comment``, ``pull_request_review``.  The
  third (review submissions with state + body) is new — previously
  ignored.
* **Stale-event drop** comes free from the WebhookCache base via
  per-entry ``last_applied_at``.
* **New ``fido.frozen``** module: ``deep_freeze`` + ``freeze_object``
  with PEP 695 recursive ``JsonLike`` type alias.  Backed by
  ``frozendict`` (already a project dep).
* **``WorkerRegistry``** keyed by ``(repo, item)``; lazy-creates each
  cache.  ``get_comment_cache(repo, item, gh)`` /
  ``all_comment_caches()``.
* **``server.py`` webhook routing** — ``_patch_comment_cache``
  extracts the item number from comment/review event payloads and
  dispatches to the right cache.  Failure-tolerant like the issue-
  cache patch path.
* **``WebhookHandler.gh`` property tidy-up** — replaced the
  ``GitHub | None`` class attribute + ``cast`` sites with a real
  ``@property``.  Storage is ``_gh``; consumers see plain ``GitHub``.
  Removes three casts and an unreachable defensive ``if self.gh is
  not None``.  Broader WebhookHandler constructor-DI redo is
  tracked in #1762.

## What this PR does NOT do (deferred to later slices)

* **#1756** — ``load_inventory`` hydration + list-style getters
* **#1757** — PR-lifecycle binding (cache lifecycle tied to Fido's
  open PR)
* **#1758** — Status metrics surface in ``/status.json``
* **#1759** — Periodic reconcile-with-inventory watchdog
* **#1760** — ``events.py`` consumer migration
* **#1761** — ``worker.py`` consumer migration

## Verification

* CI green (4410 tests passing, 100% coverage)
* No changes to the IssueCache surface — pure additive
* CommentCache fully covered (apply_event paths, staleness,
  per-item isolation, malformed payload handling)
* Registry per-(repo, item) keying covered
* server.py patch-comment-cache covered (event routing + failure
  tolerance)

## Test plan

- [x] ``./fido ci`` green locally
- [ ] CI green on GitHub
- [ ] Codex review