### PR TITLE
Refactor: extract WebhookCache base from IssueTreeCache (closes #1752)

### DIFF
--- a/src/fido/issue_cache.py
+++ b/src/fido/issue_cache.py
@@ -9,19 +9,18 @@ corrupt state.  Events are processed in their own ``timestamp`` order
 (not webhook receive order); each cache node tracks ``last_applied_at``
 so a stale event arriving after a newer one is dropped.
 
-Thread-safe under Python 3.14t (free-threaded, no GIL): a single
-``threading.Lock`` guards every mutation and read.  Per-repo caches are
-independent — pass each repo its own :class:`IssueTreeCache`.
+Inherits :class:`~fido.webhook_cache.WebhookCache` for the shared
+scaffolding (lock + dict, pre-inventory queue, ``apply_event``
+staleness shell, ``reconcile_with_inventory``, on_change callback,
+metrics base) and implements the issue-tree-specific hooks.
 """
 
-import logging
-import threading
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-log = logging.getLogger(__name__)
+from fido.webhook_cache import WebhookCache
 
 
 def _parse_iso(value: str | None) -> datetime:
@@ -34,10 +33,6 @@ def _parse_iso(value: str | None) -> datetime:
     if not value:
         return datetime.min.replace(tzinfo=timezone.utc)
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def _now() -> datetime:
-    return datetime.now(tz=timezone.utc)
 
 
 @dataclass
@@ -79,7 +74,7 @@ class CacheMetrics:
     last_reconcile_drift: int
 
 
-class IssueTreeCache:
+class IssueTreeCache(WebhookCache[int, IssueNode, CacheMetrics]):
     """Per-repo issue tree cache populated by inventory + webhook events.
 
     Lifecycle:
@@ -120,221 +115,117 @@ class IssueTreeCache:
         publishes an :class:`~fido.appstate.IssueCacheSnapshot` into
         the per-repo SCADA leaf (#1696 parity).
         """
-        self._repo = repo_name
-        self._lock = threading.Lock()
-        self._nodes: dict[int, IssueNode] = {}
-        self._inventory_loaded_at: datetime | None = None
-        self._events_applied = 0
-        self._events_dropped_stale = 0
-        self._last_event_at: datetime | None = None
-        self._last_reconcile_at: datetime | None = None
-        self._last_reconcile_drift = 0
-        self._pre_inventory_queue: list[tuple[datetime, str, dict[str, Any]]] = []
-        self._on_change = on_change
+        super().__init__(repo_name, on_change=on_change)
 
-    def _notify_change(self) -> None:
-        """Fire :attr:`_on_change` with fresh :class:`CacheMetrics`.
-
-        Called from every mutation path *after* the cache lock is
-        released so the callback is free to acquire other locks.
-        """
-        if self._on_change is None:
-            return
-        self._on_change(self.metrics())
-
-    # ── inventory ────────────────────────────────────────────────────────
+    # ── public API aliases that preserve the ``issues=`` kwarg surface ──
 
     def load_inventory(
         self,
-        issues: Iterable[dict[str, Any]],
+        issues: "Iterable[dict[str, Any]]",
         snapshot_started_at: datetime,
     ) -> None:
-        """Replace the cache with the contents of *issues* and apply any
-        queued pre-inventory events.
-
-        *snapshot_started_at* must be the time the inventory query was
-        issued (not when it returned).  Events with a timestamp earlier
-        than this are discarded as subsumed.
-        """
-        new_nodes = {
-            n.number: n
-            for n in (self._node_from_inventory(i, snapshot_started_at) for i in issues)
-        }
-        with self._lock:
-            self._nodes = new_nodes
-            self._inventory_loaded_at = _now()
-            queued = self._pre_inventory_queue
-            self._pre_inventory_queue = []
-        log.info(
-            "issue-cache[%s]: inventory loaded (%d open issues, %d events queued during boot)",
-            self._repo,
-            len(new_nodes),
-            len(queued),
-        )
-        self._notify_change()
-        for _ts, event_type, payload in sorted(queued, key=lambda x: x[0]):
-            self.apply_event(event_type, payload)
+        super().load_inventory(issues, snapshot_started_at)
 
     def reconcile_with_inventory(
         self,
-        issues: Iterable[dict[str, Any]],
+        issues: "Iterable[dict[str, Any]]",
         snapshot_started_at: datetime,
     ) -> int:
-        """Diff the cache against a fresh inventory snapshot and apply
-        every divergence.  Returns the count of corrections applied.
+        return super().reconcile_with_inventory(issues, snapshot_started_at)
 
-        Used by the hourly watchdog to heal drift caused by lost webhook
-        events.  Cache nodes absent from the snapshot are removed; nodes
-        in the snapshot that diverge from cache are replaced.  Resets the
-        per-node ``last_applied_at`` to *snapshot_started_at* so any
-        in-flight events older than the snapshot are subsumed.
-        """
-        snapshot = {
-            n.number: n
-            for n in (self._node_from_inventory(i, snapshot_started_at) for i in issues)
-        }
-        with self._lock:
-            drift = 0
-            for number in list(self._nodes.keys()):
-                if number not in snapshot:
-                    del self._nodes[number]
-                    drift += 1
-                    continue
-                cached = self._nodes[number]
-                fresh = snapshot[number]
-                if not _nodes_equal(cached, fresh):
-                    self._nodes[number] = fresh
-                    drift += 1
-            for number, fresh in snapshot.items():
-                if number not in self._nodes:
-                    self._nodes[number] = fresh
-                    drift += 1
-            self._last_reconcile_at = _now()
-            self._last_reconcile_drift = drift
-        log.info("issue-cache[%s]: reconcile applied %d corrections", self._repo, drift)
-        self._notify_change()
-        return drift
+    # ── WebhookCache hooks ───────────────────────────────────────────────
 
-    @staticmethod
+    def _node_key(self, node: IssueNode) -> int:
+        return node.number
+
+    def _node_key_from_payload(self, payload: dict[str, Any]) -> int:
+        return payload["issue_number"]
+
     def _node_from_inventory(
-        issue: dict[str, Any], snapshot_started_at: datetime
+        self, raw: dict[str, Any], snapshot_started_at: datetime
     ) -> IssueNode:
         return IssueNode(
-            number=issue["number"],
-            title=issue.get("title", ""),
+            number=raw["number"],
+            title=raw.get("title", ""),
             assignees={
                 a["login"]
-                for a in (issue.get("assignees") or {}).get("nodes") or []
+                for a in (raw.get("assignees") or {}).get("nodes") or []
                 if a.get("login")
             },
-            parent=(issue.get("parent") or {}).get("number")
-            if issue.get("parent")
+            parent=(raw.get("parent") or {}).get("number")
+            if raw.get("parent")
             else None,
             sub_issues=[
                 c["number"]
-                for c in (issue.get("subIssues") or {}).get("nodes") or []
+                for c in (raw.get("subIssues") or {}).get("nodes") or []
                 if c.get("number") is not None
             ],
-            milestone=(issue.get("milestone") or {}).get("title")
-            if issue.get("milestone")
+            milestone=(raw.get("milestone") or {}).get("title")
+            if raw.get("milestone")
             else None,
-            created_at=_parse_iso(issue.get("createdAt")),
+            created_at=_parse_iso(raw.get("createdAt")),
             last_applied_at=snapshot_started_at,
         )
 
-    # ── event entry point ────────────────────────────────────────────────
+    def _node_last_applied_at(self, node: IssueNode) -> datetime:
+        return node.last_applied_at
 
-    def apply_event(self, event_type: str, payload: dict[str, Any]) -> None:
-        """Apply a webhook-derived event to the cache.
+    def _node_with_last_applied_at(self, node: IssueNode, ts: datetime) -> IssueNode:
+        # IssueNode is mutable; advance in place and return the same ref.
+        node.last_applied_at = ts
+        return node
 
-        *payload* must contain at least ``issue_number`` (int) and
-        ``timestamp`` (tz-aware datetime).  Other keys are event-typed.
+    def _nodes_equal(self, a: IssueNode, b: IssueNode) -> bool:
+        """Ignore ``last_applied_at`` — that's cache-internal bookkeeping."""
+        return (
+            a.number == b.number
+            and a.title == b.title
+            and a.assignees == b.assignees
+            and a.parent == b.parent
+            and a.sub_issues == b.sub_issues
+            and a.milestone == b.milestone
+            and a.created_at == b.created_at
+        )
 
-        Behavior:
-
-        - Pre-inventory: queued with timestamp; drained later.
-        - Stale (``timestamp < node.last_applied_at`` for an existing
-          node): dropped, ``events_dropped_stale`` incremented.
-        - Otherwise: dispatched to the matching handler; node's
-          ``last_applied_at`` advanced.
-        """
-        if self._apply_event_locked(event_type, payload):
-            self._notify_change()
-
-    def _apply_event_locked(self, event_type: str, payload: dict[str, Any]) -> bool:
-        """Locked half of :meth:`apply_event`.  Returns ``True`` if the
-        cache mutated (event applied or dropped as stale) so the caller
-        can fire :meth:`_notify_change` outside the lock."""
-        timestamp = payload["timestamp"]
-        with self._lock:
-            if self._inventory_loaded_at is None:
-                self._pre_inventory_queue.append((timestamp, event_type, payload))
-                log.info(
-                    "issue-cache[%s]: queued %s for #%s pre-inventory (queue depth=%d)",
-                    self._repo,
-                    event_type,
-                    payload.get("issue_number"),
-                    len(self._pre_inventory_queue),
-                )
+    def _dispatch_event(self, event_type: str, payload: dict[str, Any]) -> bool:
+        match event_type:
+            case "opened":
+                self._handle_opened(payload)
+            case "closed":
+                self._handle_closed(payload)
+            case "reopened":
+                self._handle_reopened(payload)
+            case "assigned":
+                self._handle_assigned(payload)
+            case "unassigned":
+                self._handle_unassigned(payload)
+            case "milestoned":
+                self._handle_milestoned(payload)
+            case "edited_title":
+                self._handle_edited_title(payload)
+            case "sub_issue_added":
+                self._handle_sub_issue_added(payload)
+            case "sub_issue_removed":
+                self._handle_sub_issue_removed(payload)
+            case _:
                 return False
-            number = payload["issue_number"]
-            existing = self._nodes.get(number)
-            if existing is not None and timestamp < existing.last_applied_at:
-                self._events_dropped_stale += 1
-                log.info(
-                    "issue-cache[%s]: dropping stale %s for #%s "
-                    "(event=%s, last_applied=%s)",
-                    self._repo,
-                    event_type,
-                    number,
-                    timestamp.isoformat(),
-                    existing.last_applied_at.isoformat(),
-                )
-                return True
-            match event_type:
-                case "opened":
-                    self._handle_opened(payload)
-                case "closed":
-                    self._handle_closed(payload)
-                case "reopened":
-                    self._handle_reopened(payload)
-                case "assigned":
-                    self._handle_assigned(payload)
-                case "unassigned":
-                    self._handle_unassigned(payload)
-                case "milestoned":
-                    self._handle_milestoned(payload)
-                case "edited_title":
-                    self._handle_edited_title(payload)
-                case "sub_issue_added":
-                    self._handle_sub_issue_added(payload)
-                case "sub_issue_removed":
-                    self._handle_sub_issue_removed(payload)
-                case _:
-                    log.debug(
-                        "issue-cache[%s]: ignoring unknown event %r",
-                        self._repo,
-                        event_type,
-                    )
-                    return False
-            after = self._nodes.get(number)
-            if after is not None:
-                after.last_applied_at = max(after.last_applied_at, timestamp)
-            self._events_applied += 1
-            self._last_event_at = timestamp
-            log.info(
-                "issue-cache[%s]: applied %s for #%s (open=%d, applied=%d, "
-                "stale_dropped=%d)",
-                self._repo,
-                event_type,
-                number,
-                len(self._nodes),
-                self._events_applied,
-                self._events_dropped_stale,
-            )
-            return True
+        return True
 
-    # ── handlers (called under self._lock by apply_event) ────────────────
+    def metrics(self) -> CacheMetrics:
+        with self._lock:
+            base = self._base_metric_fields()
+        return CacheMetrics(
+            repo_name=base["repo_name"],
+            inventory_loaded_at=base["inventory_loaded_at"],
+            open_issue_count=base["node_count"],
+            events_applied=base["events_applied"],
+            events_dropped_stale=base["events_dropped_stale"],
+            last_event_at=base["last_event_at"],
+            last_reconcile_at=base["last_reconcile_at"],
+            last_reconcile_drift=base["last_reconcile_drift"],
+        )
+
+    # ── per-event handlers (called under self._lock by _dispatch_event) ──
 
     def _handle_opened(self, payload: dict[str, Any]) -> None:
         number = payload["issue_number"]
@@ -434,24 +325,6 @@ class IssueTreeCache:
         matching.sort(key=lambda n: (n.created_at, n.number))
         return matching
 
-    def metrics(self) -> CacheMetrics:
-        with self._lock:
-            return CacheMetrics(
-                repo_name=self._repo,
-                inventory_loaded_at=self._inventory_loaded_at,
-                open_issue_count=len(self._nodes),
-                events_applied=self._events_applied,
-                events_dropped_stale=self._events_dropped_stale,
-                last_event_at=self._last_event_at,
-                last_reconcile_at=self._last_reconcile_at,
-                last_reconcile_drift=self._last_reconcile_drift,
-            )
-
-    @property
-    def is_loaded(self) -> bool:
-        with self._lock:
-            return self._inventory_loaded_at is not None
-
 
 def _copy_node(node: IssueNode) -> IssueNode:
     """Return a defensive copy so callers can't mutate the cache through
@@ -465,23 +338,6 @@ def _copy_node(node: IssueNode) -> IssueNode:
         milestone=node.milestone,
         created_at=node.created_at,
         last_applied_at=node.last_applied_at,
-    )
-
-
-def _nodes_equal(a: IssueNode, b: IssueNode) -> bool:
-    """Field-equality check for reconcile drift detection.
-
-    Ignores ``last_applied_at`` — that's a cache-internal bookkeeping
-    field that only changes on event application, not in inventory data.
-    """
-    return (
-        a.number == b.number
-        and a.title == b.title
-        and a.assignees == b.assignees
-        and a.parent == b.parent
-        and a.sub_issues == b.sub_issues
-        and a.milestone == b.milestone
-        and a.created_at == b.created_at
     )
 
 

--- a/src/fido/webhook_cache.py
+++ b/src/fido/webhook_cache.py
@@ -1,0 +1,338 @@
+"""Generic webhook-patched in-memory cache base (#1752).
+
+Shared scaffolding for :class:`~fido.issue_cache.IssueCache` (and,
+soon, :class:`~fido.comment_cache.CommentCache`).  Owns:
+
+* the per-repo lock + dict of nodes (``_nodes: dict[K, V]``)
+* per-node staleness check via ``last_applied_at`` so a stale
+  webhook delivered after a newer one is dropped
+* pre-inventory queue draining in timestamp order after
+  :meth:`load_inventory`
+* periodic :meth:`reconcile_with_inventory` to heal missed-webhook
+  drift
+* ``on_change`` callback for SCADA publication, fired *outside*
+  the cache lock so the callback may acquire other locks
+* shared boilerplate for the ``apply_event`` shell
+
+Subclasses provide:
+
+* :meth:`_node_key` — extract the dict key from a node
+* :meth:`_node_key_from_payload` — extract the dict key from a
+  webhook payload
+* :meth:`_node_from_inventory` — parse a raw inventory item into
+  a node, seeded with the snapshot's start time as
+  ``last_applied_at``
+* :meth:`_node_last_applied_at` — accessor (works for both
+  mutable and frozen nodes)
+* :meth:`_node_with_last_applied_at` — return-or-mutate the node
+  with an advanced timestamp (frozen nodes return a new instance;
+  mutable nodes set in place and return the same reference)
+* :meth:`_dispatch_event` — apply an event-specific handler under
+  the lock; returns ``True`` if state mutated (so the base's
+  counters and ``last_applied_at`` advance), ``False`` to ignore
+* :meth:`_nodes_equal` — field-equality for reconcile drift
+  detection
+* :meth:`metrics` — return the subclass's specific
+  :class:`CacheMetrics` dataclass, composed with
+  :meth:`_base_metric_fields`
+
+Thread-safe under Python 3.14t (free-threaded, no GIL): a single
+``threading.Lock`` guards every mutation and read.  Per-repo
+caches are independent.
+"""
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
+from datetime import datetime, timezone
+from typing import Any, Generic, TypeVar
+
+log = logging.getLogger(__name__)
+
+_K = TypeVar("_K")
+_V = TypeVar("_V")
+_M = TypeVar("_M")
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class WebhookCache(ABC, Generic[_K, _V, _M]):
+    """Per-repo cache patched by webhook events, with inventory hydration."""
+
+    def __init__(
+        self,
+        repo_name: str,
+        *,
+        on_change: "Callable[[_M], None] | None" = None,
+    ) -> None:
+        """Create an empty cache.
+
+        *on_change*, when supplied, is called with a fresh
+        :meth:`metrics` snapshot after every mutation
+        (load_inventory, apply_event, reconcile_with_inventory) —
+        *outside* the cache lock so the callback may acquire other
+        locks (e.g. the atomic FidoState cell) without lock-order
+        inversion.
+        """
+        self._repo = repo_name
+        self._lock = threading.Lock()
+        self._nodes: dict[_K, _V] = {}
+        self._inventory_loaded_at: datetime | None = None
+        self._events_applied = 0
+        self._events_dropped_stale = 0
+        self._last_event_at: datetime | None = None
+        self._last_reconcile_at: datetime | None = None
+        self._last_reconcile_drift = 0
+        self._pre_inventory_queue: list[tuple[datetime, str, dict[str, Any]]] = []
+        self._on_change = on_change
+
+    # ── subclass hooks ────────────────────────────────────────────────────
+
+    @abstractmethod
+    def _node_key(self, node: _V) -> _K:
+        """Return the dict key for *node*.  Subclass implements."""
+
+    @abstractmethod
+    def _node_key_from_payload(self, payload: dict[str, Any]) -> _K:
+        """Extract the dict key from a webhook event payload."""
+
+    @abstractmethod
+    def _node_from_inventory(
+        self, raw: dict[str, Any], snapshot_started_at: datetime
+    ) -> _V:
+        """Parse one raw inventory item into a cache node.
+
+        The node's ``last_applied_at`` should be seeded with
+        *snapshot_started_at* so any in-flight events older than the
+        snapshot are subsumed.
+        """
+
+    @abstractmethod
+    def _node_last_applied_at(self, node: _V) -> datetime:
+        """Return the ``last_applied_at`` timestamp of *node*."""
+
+    @abstractmethod
+    def _node_with_last_applied_at(self, node: _V, ts: datetime) -> _V:
+        """Return *node* with ``last_applied_at`` advanced to *ts*.
+
+        For mutable node types (e.g. plain dataclass), this may mutate
+        in place and return the same reference.  For frozen node
+        types, it must return a new instance.  The base then stores
+        the returned reference back into ``self._nodes``.
+        """
+
+    @abstractmethod
+    def _dispatch_event(self, event_type: str, payload: dict[str, Any]) -> bool:
+        """Apply an event-specific handler under the cache lock.
+
+        Called by :meth:`_apply_event_locked` after the staleness
+        check passes.  Returns ``True`` if cache state mutated (so
+        the base bumps counters and advances ``last_applied_at``),
+        ``False`` for unknown / ignored event types.
+        """
+
+    @abstractmethod
+    def _nodes_equal(self, a: _V, b: _V) -> bool:
+        """Field-equality check for reconcile drift detection.
+
+        Should ignore ``last_applied_at`` — that's a cache-internal
+        bookkeeping field that only changes on event application,
+        not in inventory data.
+        """
+
+    @abstractmethod
+    def metrics(self) -> _M:
+        """Return the subclass's specific metrics dataclass.
+
+        Subclass implementations typically compose
+        :meth:`_base_metric_fields` with their own fields.
+        """
+
+    # ── shared scaffolding ────────────────────────────────────────────────
+
+    def _notify_change(self) -> None:
+        """Fire :attr:`_on_change` with fresh :meth:`metrics`.
+
+        Called from every mutation path *after* the cache lock is
+        released so the callback is free to acquire other locks.
+        """
+        if self._on_change is None:
+            return
+        self._on_change(self.metrics())
+
+    def _base_metric_fields(self) -> dict[str, Any]:
+        """Snapshot of the common metric fields.
+
+        Subclass :meth:`metrics` calls this under :attr:`_lock`
+        before composing its specific dataclass — keeps the locking
+        discipline obvious and lets subclasses add cache-specific
+        fields without re-implementing the common bookkeeping.
+        """
+        return {
+            "repo_name": self._repo,
+            "inventory_loaded_at": self._inventory_loaded_at,
+            "node_count": len(self._nodes),
+            "events_applied": self._events_applied,
+            "events_dropped_stale": self._events_dropped_stale,
+            "last_event_at": self._last_event_at,
+            "last_reconcile_at": self._last_reconcile_at,
+            "last_reconcile_drift": self._last_reconcile_drift,
+        }
+
+    @property
+    def is_loaded(self) -> bool:
+        """``True`` once :meth:`load_inventory` has run at least once."""
+        with self._lock:
+            return self._inventory_loaded_at is not None
+
+    # ── inventory ────────────────────────────────────────────────────────
+
+    def load_inventory(
+        self,
+        items: Iterable[dict[str, Any]],
+        snapshot_started_at: datetime,
+        /,
+    ) -> None:
+        """Replace the cache with the contents of *items* and apply any
+        queued pre-inventory events.
+
+        *snapshot_started_at* must be the time the inventory query
+        was issued (not when it returned).  Events with a timestamp
+        earlier than this are discarded as subsumed.
+        """
+        new_nodes: dict[_K, _V] = {}
+        for raw in items:
+            node = self._node_from_inventory(raw, snapshot_started_at)
+            new_nodes[self._node_key(node)] = node
+        with self._lock:
+            self._nodes = new_nodes
+            self._inventory_loaded_at = _now()
+            queued = self._pre_inventory_queue
+            self._pre_inventory_queue = []
+        log.info(
+            "%s[%s]: inventory loaded (%d nodes, %d events queued during boot)",
+            type(self).__name__,
+            self._repo,
+            len(new_nodes),
+            len(queued),
+        )
+        self._notify_change()
+        for _ts, event_type, payload in sorted(queued, key=lambda x: x[0]):
+            self.apply_event(event_type, payload)
+
+    def reconcile_with_inventory(
+        self,
+        items: Iterable[dict[str, Any]],
+        snapshot_started_at: datetime,
+        /,
+    ) -> int:
+        """Diff the cache against a fresh inventory snapshot and apply
+        every divergence.  Returns the count of corrections applied.
+
+        Used by the hourly watchdog to heal drift caused by lost
+        webhook events.  Cache nodes absent from the snapshot are
+        removed; nodes in the snapshot that diverge from cache (per
+        :meth:`_nodes_equal`) are replaced.
+        """
+        snapshot: dict[_K, _V] = {}
+        for raw in items:
+            node = self._node_from_inventory(raw, snapshot_started_at)
+            snapshot[self._node_key(node)] = node
+        with self._lock:
+            drift = 0
+            for key in list(self._nodes.keys()):
+                if key not in snapshot:
+                    del self._nodes[key]
+                    drift += 1
+                    continue
+                if not self._nodes_equal(self._nodes[key], snapshot[key]):
+                    self._nodes[key] = snapshot[key]
+                    drift += 1
+            for key, fresh in snapshot.items():
+                if key not in self._nodes:
+                    self._nodes[key] = fresh
+                    drift += 1
+            self._last_reconcile_at = _now()
+            self._last_reconcile_drift = drift
+        log.info(
+            "%s[%s]: reconcile applied %d corrections",
+            type(self).__name__,
+            self._repo,
+            drift,
+        )
+        self._notify_change()
+        return drift
+
+    # ── event entry point ────────────────────────────────────────────────
+
+    def apply_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        """Apply a webhook-derived event to the cache.
+
+        *payload* must contain at least ``timestamp`` (tz-aware
+        :class:`datetime`).  Behavior:
+
+        - Pre-inventory: queued with timestamp; drained later in
+          timestamp order.
+        - Stale (``timestamp < node.last_applied_at`` for an
+          existing node): dropped; ``events_dropped_stale``
+          incremented.
+        - Otherwise: dispatched to the subclass's
+          :meth:`_dispatch_event`; node's ``last_applied_at``
+          advanced.
+
+        The subclass-specific dispatcher is responsible for the
+        per-event handler logic.
+        """
+        if self._apply_event_locked(event_type, payload):
+            self._notify_change()
+
+    def _apply_event_locked(self, event_type: str, payload: dict[str, Any]) -> bool:
+        """Locked half of :meth:`apply_event`.
+
+        Returns ``True`` if the cache mutated (event applied or
+        dropped as stale) so the caller can fire
+        :meth:`_notify_change` outside the lock.
+        """
+        timestamp = payload["timestamp"]
+        with self._lock:
+            if self._inventory_loaded_at is None:
+                self._pre_inventory_queue.append((timestamp, event_type, payload))
+                log.info(
+                    "%s[%s]: queued %s pre-inventory (queue depth=%d)",
+                    type(self).__name__,
+                    self._repo,
+                    event_type,
+                    len(self._pre_inventory_queue),
+                )
+                return False
+            key = self._node_key_from_payload(payload)
+            existing = self._nodes.get(key)
+            if existing is not None and timestamp < self._node_last_applied_at(
+                existing
+            ):
+                self._events_dropped_stale += 1
+                log.info(
+                    "%s[%s]: dropping stale %s for %r (event=%s, last_applied=%s)",
+                    type(self).__name__,
+                    self._repo,
+                    event_type,
+                    key,
+                    timestamp.isoformat(),
+                    self._node_last_applied_at(existing).isoformat(),
+                )
+                return True
+            if not self._dispatch_event(event_type, payload):
+                return False
+            after = self._nodes.get(key)
+            if after is not None:
+                advanced_ts = max(self._node_last_applied_at(after), timestamp)
+                self._nodes[key] = self._node_with_last_applied_at(after, advanced_ts)
+            self._events_applied += 1
+            self._last_event_at = timestamp
+            return True
+
+
+__all__ = ["WebhookCache"]


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change.  All 4376 tests pass including
the full IssueTreeCache suite, no test changes needed.

Extracts the shared scaffolding (lock + dict, pre-inventory queue,
stale-event check, ``reconcile_with_inventory``, on_change callback,
metrics base) into a new ``fido.webhook_cache.WebhookCache[K, V, M]``
ABC.  IssueTreeCache inherits it and supplies the issue-specific
hooks.

## Why now

The CommentCache work on PR #1751 (epic #1748) needs an
identically-shaped per-repo in-memory cache.  Copying
IssueTreeCache's ~150 lines of scaffolding would duplicate every
coordination invariant it already solved.  Splitting the refactor
from the feature keeps each PR small and behavior-pure vs.
behavior-additive (per the CLAUDE.md "keep leaf issues reviewable"
rule).

## Subclass hooks (``@abstractmethod``)

* ``_node_key`` / ``_node_key_from_payload`` — K extraction in
  either direction
* ``_node_from_inventory`` — raw inventory → V parser
* ``_node_last_applied_at`` / ``_node_with_last_applied_at`` —
  accessor + advancer that handles both mutable nodes
  (``IssueNode``, in-place) and frozen nodes CommentCache will use
  (returns new instance)
* ``_dispatch_event`` — per-event handler dispatch
* ``_nodes_equal`` — reconcile drift detection
* ``metrics`` — compose subclass-specific dataclass with
  ``_base_metric_fields``

## Public API surface

Unchanged.  ``IssueTreeCache.load_inventory(issues=..., ...)``
keyword still works because the subclass overrides preserve the
original parameter name (base uses positional-only so the override
can rename).

## Test plan

- [x] All 4376 existing tests pass
- [x] 100% coverage
- [x] No changes to ``tests/test_issue_cache.py``
- [ ] After merge: rebase #1751 on this; CommentCache inherits
      from WebhookCache for #1748 epic