### PR TITLE
INV-2 of #1748: CommentCache hydration + list-style getters (closes #1756)

### DIFF
--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -37,8 +37,10 @@ getters land in #1756 (INV-2).
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
+
+import requests
 
 from fido.frozen import freeze_object
 from fido.github import GitHub
@@ -131,31 +133,160 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         on_change: "Callable[[CacheMetrics], None] | None" = None,
     ) -> None:
         super().__init__(f"{repo}#{item}", on_change=on_change)
-        # _gh and _item are stashed for later use by INV-3 hydration;
-        # INV-1 only consumes _item via metrics.
+        # ``_gh_repo`` is the plain ``owner/repo`` string the gh getters
+        # expect; the base's ``_repo`` keeps the ``owner/repo#item``
+        # identifier used for logging and metrics display.
+        self._gh_repo = repo
         self._gh = gh
         self._item = item
-        # INV-1 scope: no inventory hydration yet (#1756 will add it).
-        # Mark the cache loaded with an empty snapshot so events apply
-        # directly instead of being held in the pre-inventory queue
-        # forever.  INV-3 will override construction to defer this
-        # until the real GitHub list-fetches complete (listen-first-
-        # fill-second).
-        super().load_inventory([], datetime.now(tz=timezone.utc))
+        # The cache starts NOT loaded — WebhookCache's pre-inventory
+        # queue catches events that arrive before :meth:`hydrate` runs.
+        # The registry calls hydrate() immediately on creation; the gap
+        # only matters when concurrent webhooks arrive on a different
+        # thread while the creating thread is mid-fetch (the queue
+        # drains in timestamp order once hydrate completes).
+
+    # ── hydration ────────────────────────────────────────────────────────
+
+    def hydrate(self, snapshot_started_at: datetime) -> None:
+        """Fetch the three resource lists from GitHub and load them.
+
+        Performs three list calls (top-level comments, review-thread
+        comments, review submissions), tags each raw item with its
+        ``_kind``, and hands the composed inventory to
+        :meth:`WebhookCache.load_inventory`.  The base then drains the
+        pre-inventory queue in timestamp order — so any webhook events
+        that arrived between cache construction and hydration land
+        afterwards without loss.
+
+        *snapshot_started_at* must be the time the first list fetch
+        was issued (not when it returned).  Events older than the
+        snapshot are subsumed by it during the queue drain.
+
+        For-issues (not PRs) only ``"issues"`` kind applies — the
+        ``/pulls/...`` endpoints 404 there.  INV-1 already filters
+        non-PR ``issue_comment`` events at the router, so in practice
+        hydrate only runs against PR items, but the empty-list
+        fallback below keeps it correct either way.
+        """
+        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
+        try:
+            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
+            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
+        except requests.HTTPError as exc:
+            # /pulls/{n} 404s for plain issues; treat as no review data.
+            if exc.response is not None and exc.response.status_code == 404:
+                raw_review_comments = []
+                raw_reviews = []
+            else:
+                raise
+        inventory: list[dict[str, Any]] = [
+            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
+        ]
+        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
+        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
+        self.load_inventory(inventory, snapshot_started_at)
+
+    def refresh(self, snapshot_started_at: datetime) -> None:
+        """Re-fetch the three lists and reconcile against the cache.
+
+        Used by the periodic-reconcile watchdog (#1759) to heal drift
+        from missed webhook deliveries.  Calls
+        :meth:`WebhookCache.reconcile_with_inventory` so ids absent
+        from the fresh snapshot are evicted (closing the codex P2
+        about evict-missing on list fetches).
+        """
+        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
+        try:
+            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
+            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                raw_review_comments = []
+                raw_reviews = []
+            else:
+                raise
+        inventory: list[dict[str, Any]] = [
+            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
+        ]
+        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
+        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
+        self.reconcile_with_inventory(inventory, snapshot_started_at)
 
     # ── public lookup API ────────────────────────────────────────────────
 
     def get(self, kind: str, entry_id: int) -> Mapping[str, Any] | None:
         """Return the cached raw entry, or ``None`` if not present.
 
-        O(1) dict lookup — no GitHub round-trip.  INV-3 will add
-        the hydration path that populates the cache from list
-        fetches; until then, the cache fills only via webhook
-        events through :meth:`apply_event`.
+        O(1) dict lookup — no GitHub round-trip.
         """
         with self._lock:
             node = self._nodes.get((kind, entry_id))
             return node.data if node is not None else None
+
+    def list_top_level(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every top-level comment cached for this item.
+
+        Returns a list of the raw frozen objects, in id order.
+        Caller-side mutation is impossible (data is frozen).  Order
+        is deterministic but not guaranteed to match GitHub's
+        post-time order — callers that care should sort by
+        ``created_at``.
+        """
+        return self._snapshot_kind(KIND_ISSUES)
+
+    def list_review_comments(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every inline review-thread comment cached.
+
+        Includes single-file AND multi-line range comments — they
+        share the ``/pulls/{n}/comments`` endpoint and are
+        distinguished by ``line`` / ``start_line`` on the raw object.
+        """
+        return self._snapshot_kind(KIND_PULLS)
+
+    def list_reviews(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every review submission cached.
+
+        Each entry carries ``state`` (APPROVED / COMMENTED /
+        CHANGES_REQUESTED) and an optional ``body``.
+        """
+        return self._snapshot_kind(KIND_REVIEWS)
+
+    def thread(self, comment_id: int) -> list[Mapping[str, Any]]:
+        """Return the review thread containing *comment_id*.
+
+        A thread is the root review comment plus every reply to it.
+        Walks the cached review-thread comments, picks the root by
+        following ``in_reply_to_id``, then returns the comments
+        anchored to that root in id order.  Returns ``[]`` when
+        ``comment_id`` is not in any thread on the cache.
+        """
+        with self._lock:
+            pulls = {
+                int(node.data["id"]): node.data
+                for (kind, _), node in self._nodes.items()
+                if kind == KIND_PULLS
+            }
+        anchor = pulls.get(comment_id)
+        if anchor is None:
+            return []
+        root_id = anchor.get("in_reply_to_id") or comment_id
+        return sorted(
+            (
+                data
+                for data in pulls.values()
+                if (data.get("in_reply_to_id") or int(data["id"])) == root_id
+            ),
+            key=lambda d: int(d["id"]),
+        )
+
+    def _snapshot_kind(self, kind: str) -> list[Mapping[str, Any]]:
+        with self._lock:
+            return [
+                node.data
+                for (entry_kind, _), node in self._nodes.items()
+                if entry_kind == kind
+            ]
 
     # ── WebhookCache hooks ───────────────────────────────────────────────
 

--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -169,23 +169,7 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         hydrate only runs against PR items, but the empty-list
         fallback below keeps it correct either way.
         """
-        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
-        try:
-            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
-            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
-        except requests.HTTPError as exc:
-            # /pulls/{n} 404s for plain issues; treat as no review data.
-            if exc.response is not None and exc.response.status_code == 404:
-                raw_review_comments = []
-                raw_reviews = []
-            else:
-                raise
-        inventory: list[dict[str, Any]] = [
-            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
-        ]
-        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
-        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
-        self.load_inventory(inventory, snapshot_started_at)
+        self.load_inventory(self._fetch_full_inventory(), snapshot_started_at)
 
     def refresh(self, snapshot_started_at: datetime) -> None:
         """Re-fetch the three lists and reconcile against the cache.
@@ -196,22 +180,40 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         from the fresh snapshot are evicted (closing the codex P2
         about evict-missing on list fetches).
         """
+        self.reconcile_with_inventory(self._fetch_full_inventory(), snapshot_started_at)
+
+    def _fetch_full_inventory(self) -> list[dict[str, Any]]:
+        """Fetch all three resource lists, tagging each item with its kind.
+
+        Each endpoint is 404-tolerant independently (codex P2 on
+        #1756): the ``/pulls/...`` endpoints 404 for plain issues,
+        but a 404 on one of them must not throw away successful
+        data from the other two.  Non-404 errors propagate.
+        """
         raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
-        try:
-            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
-            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
-        except requests.HTTPError as exc:
-            if exc.response is not None and exc.response.status_code == 404:
-                raw_review_comments = []
-                raw_reviews = []
-            else:
-                raise
+        raw_review_comments = self._fetch_or_empty_on_404(
+            lambda: self._gh.get_pull_comments(self._gh_repo, self._item)
+        )
+        raw_reviews = self._fetch_or_empty_on_404(
+            lambda: self._gh.get_pull_reviews(self._gh_repo, self._item)
+        )
         inventory: list[dict[str, Any]] = [
             {"_kind": KIND_ISSUES, **r} for r in raw_top_level
         ]
         inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
         inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
-        self.reconcile_with_inventory(inventory, snapshot_started_at)
+        return inventory
+
+    @staticmethod
+    def _fetch_or_empty_on_404(
+        fetch: Callable[[], list[dict[str, Any]]],
+    ) -> list[dict[str, Any]]:
+        try:
+            return fetch()
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return []
+            raise
 
     # ── public lookup API ────────────────────────────────────────────────
 
@@ -281,12 +283,17 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         )
 
     def _snapshot_kind(self, kind: str) -> list[Mapping[str, Any]]:
+        # Documented contract: callers see entries in id order.  Dict
+        # iteration order tracks insertion history, which can diverge
+        # from id ordering after reconciles or mixed webhook/inventory
+        # updates — so sort explicitly (codex P2 on #1756).
         with self._lock:
-            return [
+            entries = [
                 node.data
                 for (entry_kind, _), node in self._nodes.items()
                 if entry_kind == kind
             ]
+        return sorted(entries, key=lambda d: int(d["id"]))
 
     # ── WebhookCache hooks ───────────────────────────────────────────────
 

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -363,6 +363,16 @@ class GitHub:
                 return None
             raise
 
+    def get_pull_reviews(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
+        """Return every review submission on a PR as raw API objects.
+
+        Distinct from :meth:`get_reviews` which projects into a narrow
+        ``{state, author, submittedAt, ...}`` summary — callers that
+        need the full review object (body, html_url, ...) for the
+        CommentCache hydration path (#1756) want the raw shape.
+        """
+        return list(self._paginate(f"{self.BASE}/repos/{repo}/pulls/{pr}/reviews"))
+
     def fetch_sibling_threads(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return all review-comment threads for a PR as a structured list.
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -952,7 +952,21 @@ class WorkerRegistry:
                 self._comment_caches[key] = cache
                 snapshot_started_at = datetime.now(tz=timezone.utc)
         if snapshot_started_at is not None:
-            cache.hydrate(snapshot_started_at)
+            try:
+                cache.hydrate(snapshot_started_at)
+            except Exception:
+                # Hydration failed — roll back the registration so the
+                # next call retries from scratch (codex P1 on #1756:
+                # otherwise the half-built cache lingers, never gets
+                # ``inventory_loaded_at`` set, and queues webhook
+                # events into a buffer that never drains).
+                with self._comment_cache_lock:
+                    # Only remove the instance we put in, in case a
+                    # concurrent caller already installed a different
+                    # one (unlikely but cheap to guard).
+                    if self._comment_caches.get(key) is cache:
+                        del self._comment_caches[key]
+                raise
         return cache
 
     def all_comment_caches(self) -> list[CommentCache]:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -932,14 +932,28 @@ class WorkerRegistry:
         pair.  Distinct items in the same repo get distinct caches —
         per-item isolation by construction.  Webhook router uses this
         to route events to the right cache.
+
+        New caches are hydrated synchronously (#1756) — three list
+        fetches from GitHub before this method returns.  That's
+        intentional for INV-2: the first webhook for an unseen item
+        pays the hydration cost so subsequent reads are warm.  INV-3
+        (#1757) moves hydration to startup / PR-open so the hot path
+        is never blocked.  Concurrent webhooks on other threads see
+        the cache registered in ``_comment_caches`` before hydrate
+        completes and queue their events in the pre-inventory buffer,
+        which drains in timestamp order at the tail of ``hydrate``.
         """
         key = (repo_name, item)
+        snapshot_started_at: datetime | None = None
         with self._comment_cache_lock:
             cache = self._comment_caches.get(key)
             if cache is None:
                 cache = CommentCache(repo_name, gh, item)
                 self._comment_caches[key] = cache
-            return cache
+                snapshot_started_at = datetime.now(tz=timezone.utc)
+        if snapshot_started_at is not None:
+            cache.hydrate(snapshot_started_at)
+        return cache
 
     def all_comment_caches(self) -> list[CommentCache]:
         """Snapshot list of every comment cache that has been created."""

--- a/tests/test_comment_cache.py
+++ b/tests/test_comment_cache.py
@@ -483,6 +483,30 @@ class TestHydrate:
         assert cache.metrics().entries_cached == 1
         assert cache.get(KIND_ISSUES, 10) is not None
 
+    def test_404_on_reviews_only_keeps_pull_comments(self) -> None:
+        # Codex P2 on #1756: a 404 on one /pulls endpoint must not
+        # discard successful data from the other.
+        import requests
+
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="a.py", body="inline"),
+        ]
+
+        def reviews_404(repo: str, pr: int) -> list[dict[str, Any]]:
+            response = requests.Response()
+            response.status_code = 404
+            raise requests.HTTPError(response=response)
+
+        gh.get_pull_reviews = reviews_404  # type: ignore[method-assign]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Top-level + pull comments survived; only reviews are empty.
+        assert cache.get(KIND_ISSUES, 10) is not None
+        assert cache.get(KIND_PULLS, 100) is not None
+        assert cache.list_reviews() == []
+
     def test_non_404_pull_error_propagates(self) -> None:
         import requests
 
@@ -662,3 +686,40 @@ class TestListGetters:
         cache = CommentCache("owner/repo", _FakeGH(), 7)
         cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
         assert cache.thread(999) == []
+
+    def test_list_getters_return_in_id_order_after_mixed_updates(self) -> None:
+        # Codex P2 on #1756: documented contract is "in id order".
+        # Insertion-history order can diverge after mixed webhook /
+        # hydrate / refresh sequences — make sure the snapshot
+        # getters actually sort.
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=30)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Apply newer webhook for a SMALLER id — would land later in
+        # insertion order but should sort first.
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=10,
+                    updated_at="2024-07-01T00:00:00Z",
+                ),
+            },
+        )
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=20,
+                    updated_at="2024-07-01T00:00:00Z",
+                ),
+            },
+        )
+        assert [int(c["id"]) for c in cache.list_top_level()] == [10, 20, 30]

--- a/tests/test_comment_cache.py
+++ b/tests/test_comment_cache.py
@@ -21,10 +21,42 @@ from fido.comment_cache import (
 class _FakeGH:
     """Hand-rolled GitHub fake — no MagicMock per testing convention.
 
-    INV-1 doesn't exercise any GH methods (the cache only fills via
-    apply_event), so this is a placeholder that records nothing.
-    Hydration tests (#1756) will give it teeth.
+    Records ``get_*`` calls and serves canned responses for the three
+    hydration endpoints.  ``raise_pull_404`` flips the
+    ``get_pull_*`` methods into raising a 404 to simulate the
+    plain-issue case where ``/pulls/{n}/...`` doesn't exist.
     """
+
+    def __init__(self) -> None:
+        self.issue_comments: list[dict[str, Any]] = []
+        self.pull_comments: list[dict[str, Any]] = []
+        self.pull_reviews: list[dict[str, Any]] = []
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.raise_pull_404: bool = False
+
+    def get_issue_comments(self, repo: str, number: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_issue_comments", (repo, number)))
+        return list(self.issue_comments)
+
+    def get_pull_comments(self, repo: str, pr: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_pull_comments", (repo, pr)))
+        if self.raise_pull_404:
+            self._raise_404()
+        return list(self.pull_comments)
+
+    def get_pull_reviews(self, repo: str, pr: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_pull_reviews", (repo, pr)))
+        if self.raise_pull_404:
+            self._raise_404()
+        return list(self.pull_reviews)
+
+    @staticmethod
+    def _raise_404() -> None:
+        import requests
+
+        response = requests.Response()
+        response.status_code = 404
+        raise requests.HTTPError(response=response)
 
 
 def _comment_payload(
@@ -86,6 +118,9 @@ class TestConstruction:
     def test_two_items_in_same_repo_are_independent(self) -> None:
         c7 = CommentCache("owner/repo", _FakeGH(), 7)
         c8 = CommentCache("owner/repo", _FakeGH(), 8)
+        snapshot_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        c7.load_inventory([], snapshot_ts)
+        c8.load_inventory([], snapshot_ts)
         c7.apply_event(
             "issue_comment",
             {
@@ -410,3 +445,220 @@ class TestIgnoredEvents:
             },
         )
         assert cache.metrics().events_applied == 0
+
+
+class TestHydrate:
+    """Hydration — fetch the three lists from GitHub and load them (#1756)."""
+
+    def test_fetches_all_three_endpoints_and_tags_kinds(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10, body="top")]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="src/foo.py", body="inline")
+        ]
+        gh.pull_reviews = [_review_payload(review_id=1000, body="approval")]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        top = cache.get(KIND_ISSUES, 10)
+        inline = cache.get(KIND_PULLS, 100)
+        review = cache.get(KIND_REVIEWS, 1000)
+        assert top is not None and top["body"] == "top"
+        assert inline is not None and inline["body"] == "inline"
+        assert review is not None and review["body"] == "approval"
+        called = {name for name, _ in gh.calls}
+        assert called == {
+            "get_issue_comments",
+            "get_pull_comments",
+            "get_pull_reviews",
+        }
+
+    def test_plain_issue_404_on_pulls_endpoints_treated_as_empty(self) -> None:
+        # /pulls/{n} 404s for plain issues — hydrate tolerates this
+        # and treats review/review-comment lists as empty.
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.raise_pull_404 = True
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 1
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_non_404_pull_error_propagates(self) -> None:
+        import requests
+
+        class _SocketErrGH(_FakeGH):
+            def get_pull_comments(self, repo: str, pr: int) -> list[dict[str, Any]]:
+                response = requests.Response()
+                response.status_code = 503
+                raise requests.HTTPError(response=response)
+
+        gh = _SocketErrGH()
+        cache = CommentCache("owner/repo", gh, 7)
+        try:
+            cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        except requests.HTTPError:
+            pass
+        else:
+            raise AssertionError("expected HTTPError to propagate")
+
+    def test_events_arriving_during_hydration_are_drained_in_order(self) -> None:
+        # WebhookCache's pre-inventory queue catches events that
+        # arrive before hydrate completes.  An event applies before
+        # hydrate runs; load_inventory drains it.
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(
+                item=7,
+                comment_id=10,
+                body="from-list",
+                updated_at="2024-06-01T00:00:00Z",
+            )
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=20,
+                    body="from-webhook",
+                    updated_at="2024-06-15T00:00:00Z",
+                ),
+            },
+        )
+        # Queued, not yet applied.
+        assert cache.get(KIND_ISSUES, 20) is None
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Both present after drain.
+        assert cache.get(KIND_ISSUES, 10) is not None
+        assert cache.get(KIND_ISSUES, 20) is not None
+
+
+class TestRefresh:
+    """Periodic refresh — re-fetch and reconcile (#1759 wires this)."""
+
+    def test_refresh_evicts_ids_missing_from_fresh_snapshot(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(item=7, comment_id=10),
+            _comment_payload(item=7, comment_id=11),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 2
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 1
+        assert cache.get(KIND_ISSUES, 11) is None
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_refresh_tolerates_pulls_404(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        gh.raise_pull_404 = True
+        cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_refresh_non_404_pull_error_propagates(self) -> None:
+        import requests
+
+        gh = _FakeGH()
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+
+        def boom(repo: str, pr: int) -> list[dict[str, Any]]:
+            response = requests.Response()
+            response.status_code = 502
+            raise requests.HTTPError(response=response)
+
+        gh.get_pull_comments = boom  # type: ignore[method-assign]
+        try:
+            cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        except requests.HTTPError:
+            pass
+        else:
+            raise AssertionError("expected HTTPError to propagate")
+
+
+class TestListGetters:
+    """``list_top_level`` / ``list_review_comments`` / ``list_reviews`` /
+    ``thread`` snapshot getters (#1756)."""
+
+    def test_list_top_level_returns_issues_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(item=7, comment_id=10),
+            _comment_payload(item=7, comment_id=11),
+        ]
+        gh.pull_comments = [_comment_payload(item=7, comment_id=100)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        top = cache.list_top_level()
+        assert {int(c["id"]) for c in top} == {10, 11}
+
+    def test_list_review_comments_returns_pulls_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="a.py"),
+            _comment_payload(item=7, comment_id=101, path="b.py"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        review = cache.list_review_comments()
+        assert {int(c["id"]) for c in review} == {100, 101}
+
+    def test_list_reviews_returns_reviews_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.pull_reviews = [
+            _review_payload(review_id=1000),
+            _review_payload(review_id=1001, state="APPROVED"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        reviews = cache.list_reviews()
+        assert {int(r["id"]) for r in reviews} == {1000, 1001}
+
+    def test_thread_returns_root_plus_replies(self) -> None:
+        gh = _FakeGH()
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, body="root", path="a.py"),
+            _comment_payload(
+                item=7,
+                comment_id=200,
+                body="reply",
+                path="a.py",
+                in_reply_to_id=100,
+            ),
+            _comment_payload(item=7, comment_id=300, body="elsewhere", path="b.py"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Look up via the reply id — walks to the root.
+        thread = cache.thread(200)
+        assert [int(c["id"]) for c in thread] == [100, 200]
+
+    def test_thread_called_on_root_returns_same_thread(self) -> None:
+        gh = _FakeGH()
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, body="root", path="a.py"),
+            _comment_payload(
+                item=7,
+                comment_id=200,
+                body="reply",
+                path="a.py",
+                in_reply_to_id=100,
+            ),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert [int(c["id"]) for c in cache.thread(100)] == [100, 200]
+
+    def test_thread_empty_when_id_not_in_cache(self) -> None:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.thread(999) == []

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -436,6 +436,21 @@ class TestGitHubClass:
         url = mock_s.get.call_args.args[0]
         assert "repos/o/r/pulls/7/comments" in url
 
+    def test_get_pull_reviews(self) -> None:
+        gh, mock_s = self._gh()
+        reviews = [
+            {"id": 1000, "state": "APPROVED", "body": ""},
+            {"id": 1001, "state": "COMMENTED", "body": "nit"},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = reviews
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.get_pull_reviews("o/r", 7)
+        assert result == reviews
+        url = mock_s.get.call_args.args[0]
+        assert "repos/o/r/pulls/7/reviews" in url
+
     def test_get_pull_comment(self) -> None:
         gh, mock_s = self._gh()
         comment = {"id": 10, "body": "hi"}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2284,3 +2284,25 @@ class TestCommentCacheRegistry:
         reg.get_comment_cache("baz/qux", 1, gh)
         all_caches = reg.all_comment_caches()
         assert len(all_caches) == 3
+
+    def test_get_comment_cache_rolls_back_on_hydrate_failure(self) -> None:
+        # Codex P1 on #1756: if the initial hydrate raises, the
+        # half-built cache must NOT linger — otherwise it accumulates
+        # queued webhook events that never drain.  Next call retries.
+        import requests
+
+        reg = self._reg()
+        gh = MagicMock()
+        gh.get_issue_comments.side_effect = requests.RequestException("boom")
+        with pytest.raises(requests.RequestException):
+            reg.get_comment_cache("foo/bar", 7, gh)
+        # Cache was rolled back — no entry in registry.
+        assert reg.all_comment_caches() == []
+        # Next call retries from scratch.
+        gh.get_issue_comments.side_effect = None
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        cache = reg.get_comment_cache("foo/bar", 7, gh)
+        assert cache is not None
+        assert cache.is_loaded is True


### PR DESCRIPTION
## Summary

Second slice of the #1748 mini-epic.  Adds hydration via the three
GitHub list endpoints, reconcile-backed refresh for drift healing,
and the public list-style getters that future consumer migrations
(#1760 / #1761) will call.

## What this PR ships

* **``hydrate(snapshot_started_at)``** — fetches top-level + review-
  thread comments + review submissions, tags each raw item with its
  ``_kind``, and hands the composed inventory to
  ``WebhookCache.load_inventory``.  Pre-inventory queue catches
  webhook events that arrive before/during the fetch and drains in
  timestamp order at the tail (listen-first-fill-second).
* **``refresh(snapshot_started_at)``** — re-fetches and reconciles.
  Evicts ids absent from the fresh snapshot (closes the codex P2
  about evict-missing on list fetches).  Wired by the #1759
  watchdog later.
* **``list_top_level()`` / ``list_review_comments()`` /
  ``list_reviews()``** — snapshot getters for each kind.  Frozen
  mappings; safe to walk without holding the cache lock.
* **``thread(comment_id)``** — root review comment + every reply,
  in id order.
* **``gh.get_pull_reviews``** — new raw-list endpoint (distinct
  from the existing ``gh.get_reviews`` which projects into a narrow
  summary).
* **Registry hydrates on creation** — first webhook arrival for an
  unseen item pays the three-list-fetch cost; subsequent reads are
  warm.  INV-3 (#1757) will move hydration to startup so the hot
  path is never blocked.

## Plain-issue 404 tolerance

``/pulls/{n}/comments`` and ``/pulls/{n}/reviews`` 404 for plain
issues.  Both ``hydrate`` and ``refresh`` catch the 404 and treat
those lists as empty.  Non-404 HTTP errors propagate.

## Construction change

Removed the auto-``load_inventory([], _now())`` from
``CommentCache.__init__`` that INV-1 used as a stop-gap.  The cache
now starts NOT loaded; the registry calls ``hydrate`` immediately
on creation, and the WebhookCache pre-inventory queue catches any
events that race in.

## What this PR does NOT do (deferred)

* #1757 — PR-lifecycle binding (cache lifecycle tied to Fido's
  open PR; startup bootstrap moves hydration off the webhook hot
  path)
* #1758 — Status metrics surface
* #1759 — Periodic reconcile watchdog (calls ``refresh``)
* #1760 / #1761 — Consumer migrations
* #1763 — Within-batch reply aggregation (orthogonal — reducer-op
  scope, not cache scope)

## Verification

* CI green (4425 tests passing, 100% coverage)
* New tests cover: hydration tagging, plain-issue 404 fallback,
  non-404 propagation, listen-first-fill-second drain, refresh
  eviction, list getters, thread walk

## Test plan

- [x] ``./fido ci`` green locally
- [ ] CI green on GitHub
- [ ] Codex review