### PR TITLE
INV-3 of #1748: CommentCache lifecycle bound to Fido's open PR (closes #1757)

### DIFF
--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -37,8 +37,10 @@ getters land in #1756 (INV-2).
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
+
+import requests
 
 from fido.frozen import freeze_object
 from fido.github import GitHub
@@ -131,31 +133,160 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         on_change: "Callable[[CacheMetrics], None] | None" = None,
     ) -> None:
         super().__init__(f"{repo}#{item}", on_change=on_change)
-        # _gh and _item are stashed for later use by INV-3 hydration;
-        # INV-1 only consumes _item via metrics.
+        # ``_gh_repo`` is the plain ``owner/repo`` string the gh getters
+        # expect; the base's ``_repo`` keeps the ``owner/repo#item``
+        # identifier used for logging and metrics display.
+        self._gh_repo = repo
         self._gh = gh
         self._item = item
-        # INV-1 scope: no inventory hydration yet (#1756 will add it).
-        # Mark the cache loaded with an empty snapshot so events apply
-        # directly instead of being held in the pre-inventory queue
-        # forever.  INV-3 will override construction to defer this
-        # until the real GitHub list-fetches complete (listen-first-
-        # fill-second).
-        super().load_inventory([], datetime.now(tz=timezone.utc))
+        # The cache starts NOT loaded — WebhookCache's pre-inventory
+        # queue catches events that arrive before :meth:`hydrate` runs.
+        # The registry calls hydrate() immediately on creation; the gap
+        # only matters when concurrent webhooks arrive on a different
+        # thread while the creating thread is mid-fetch (the queue
+        # drains in timestamp order once hydrate completes).
+
+    # ── hydration ────────────────────────────────────────────────────────
+
+    def hydrate(self, snapshot_started_at: datetime) -> None:
+        """Fetch the three resource lists from GitHub and load them.
+
+        Performs three list calls (top-level comments, review-thread
+        comments, review submissions), tags each raw item with its
+        ``_kind``, and hands the composed inventory to
+        :meth:`WebhookCache.load_inventory`.  The base then drains the
+        pre-inventory queue in timestamp order — so any webhook events
+        that arrived between cache construction and hydration land
+        afterwards without loss.
+
+        *snapshot_started_at* must be the time the first list fetch
+        was issued (not when it returned).  Events older than the
+        snapshot are subsumed by it during the queue drain.
+
+        For-issues (not PRs) only ``"issues"`` kind applies — the
+        ``/pulls/...`` endpoints 404 there.  INV-1 already filters
+        non-PR ``issue_comment`` events at the router, so in practice
+        hydrate only runs against PR items, but the empty-list
+        fallback below keeps it correct either way.
+        """
+        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
+        try:
+            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
+            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
+        except requests.HTTPError as exc:
+            # /pulls/{n} 404s for plain issues; treat as no review data.
+            if exc.response is not None and exc.response.status_code == 404:
+                raw_review_comments = []
+                raw_reviews = []
+            else:
+                raise
+        inventory: list[dict[str, Any]] = [
+            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
+        ]
+        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
+        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
+        self.load_inventory(inventory, snapshot_started_at)
+
+    def refresh(self, snapshot_started_at: datetime) -> None:
+        """Re-fetch the three lists and reconcile against the cache.
+
+        Used by the periodic-reconcile watchdog (#1759) to heal drift
+        from missed webhook deliveries.  Calls
+        :meth:`WebhookCache.reconcile_with_inventory` so ids absent
+        from the fresh snapshot are evicted (closing the codex P2
+        about evict-missing on list fetches).
+        """
+        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
+        try:
+            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
+            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                raw_review_comments = []
+                raw_reviews = []
+            else:
+                raise
+        inventory: list[dict[str, Any]] = [
+            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
+        ]
+        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
+        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
+        self.reconcile_with_inventory(inventory, snapshot_started_at)
 
     # ── public lookup API ────────────────────────────────────────────────
 
     def get(self, kind: str, entry_id: int) -> Mapping[str, Any] | None:
         """Return the cached raw entry, or ``None`` if not present.
 
-        O(1) dict lookup — no GitHub round-trip.  INV-3 will add
-        the hydration path that populates the cache from list
-        fetches; until then, the cache fills only via webhook
-        events through :meth:`apply_event`.
+        O(1) dict lookup — no GitHub round-trip.
         """
         with self._lock:
             node = self._nodes.get((kind, entry_id))
             return node.data if node is not None else None
+
+    def list_top_level(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every top-level comment cached for this item.
+
+        Returns a list of the raw frozen objects, in id order.
+        Caller-side mutation is impossible (data is frozen).  Order
+        is deterministic but not guaranteed to match GitHub's
+        post-time order — callers that care should sort by
+        ``created_at``.
+        """
+        return self._snapshot_kind(KIND_ISSUES)
+
+    def list_review_comments(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every inline review-thread comment cached.
+
+        Includes single-file AND multi-line range comments — they
+        share the ``/pulls/{n}/comments`` endpoint and are
+        distinguished by ``line`` / ``start_line`` on the raw object.
+        """
+        return self._snapshot_kind(KIND_PULLS)
+
+    def list_reviews(self) -> list[Mapping[str, Any]]:
+        """Snapshot of every review submission cached.
+
+        Each entry carries ``state`` (APPROVED / COMMENTED /
+        CHANGES_REQUESTED) and an optional ``body``.
+        """
+        return self._snapshot_kind(KIND_REVIEWS)
+
+    def thread(self, comment_id: int) -> list[Mapping[str, Any]]:
+        """Return the review thread containing *comment_id*.
+
+        A thread is the root review comment plus every reply to it.
+        Walks the cached review-thread comments, picks the root by
+        following ``in_reply_to_id``, then returns the comments
+        anchored to that root in id order.  Returns ``[]`` when
+        ``comment_id`` is not in any thread on the cache.
+        """
+        with self._lock:
+            pulls = {
+                int(node.data["id"]): node.data
+                for (kind, _), node in self._nodes.items()
+                if kind == KIND_PULLS
+            }
+        anchor = pulls.get(comment_id)
+        if anchor is None:
+            return []
+        root_id = anchor.get("in_reply_to_id") or comment_id
+        return sorted(
+            (
+                data
+                for data in pulls.values()
+                if (data.get("in_reply_to_id") or int(data["id"])) == root_id
+            ),
+            key=lambda d: int(d["id"]),
+        )
+
+    def _snapshot_kind(self, kind: str) -> list[Mapping[str, Any]]:
+        with self._lock:
+            return [
+                node.data
+                for (entry_kind, _), node in self._nodes.items()
+                if entry_kind == kind
+            ]
 
     # ── WebhookCache hooks ───────────────────────────────────────────────
 

--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -169,23 +169,7 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         hydrate only runs against PR items, but the empty-list
         fallback below keeps it correct either way.
         """
-        raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
-        try:
-            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
-            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
-        except requests.HTTPError as exc:
-            # /pulls/{n} 404s for plain issues; treat as no review data.
-            if exc.response is not None and exc.response.status_code == 404:
-                raw_review_comments = []
-                raw_reviews = []
-            else:
-                raise
-        inventory: list[dict[str, Any]] = [
-            {"_kind": KIND_ISSUES, **r} for r in raw_top_level
-        ]
-        inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
-        inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
-        self.load_inventory(inventory, snapshot_started_at)
+        self.load_inventory(self._fetch_full_inventory(), snapshot_started_at)
 
     def refresh(self, snapshot_started_at: datetime) -> None:
         """Re-fetch the three lists and reconcile against the cache.
@@ -196,22 +180,40 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         from the fresh snapshot are evicted (closing the codex P2
         about evict-missing on list fetches).
         """
+        self.reconcile_with_inventory(self._fetch_full_inventory(), snapshot_started_at)
+
+    def _fetch_full_inventory(self) -> list[dict[str, Any]]:
+        """Fetch all three resource lists, tagging each item with its kind.
+
+        Each endpoint is 404-tolerant independently (codex P2 on
+        #1756): the ``/pulls/...`` endpoints 404 for plain issues,
+        but a 404 on one of them must not throw away successful
+        data from the other two.  Non-404 errors propagate.
+        """
         raw_top_level = self._gh.get_issue_comments(self._gh_repo, self._item)
-        try:
-            raw_review_comments = self._gh.get_pull_comments(self._gh_repo, self._item)
-            raw_reviews = self._gh.get_pull_reviews(self._gh_repo, self._item)
-        except requests.HTTPError as exc:
-            if exc.response is not None and exc.response.status_code == 404:
-                raw_review_comments = []
-                raw_reviews = []
-            else:
-                raise
+        raw_review_comments = self._fetch_or_empty_on_404(
+            lambda: self._gh.get_pull_comments(self._gh_repo, self._item)
+        )
+        raw_reviews = self._fetch_or_empty_on_404(
+            lambda: self._gh.get_pull_reviews(self._gh_repo, self._item)
+        )
         inventory: list[dict[str, Any]] = [
             {"_kind": KIND_ISSUES, **r} for r in raw_top_level
         ]
         inventory += [{"_kind": KIND_PULLS, **r} for r in raw_review_comments]
         inventory += [{"_kind": KIND_REVIEWS, **r} for r in raw_reviews]
-        self.reconcile_with_inventory(inventory, snapshot_started_at)
+        return inventory
+
+    @staticmethod
+    def _fetch_or_empty_on_404(
+        fetch: Callable[[], list[dict[str, Any]]],
+    ) -> list[dict[str, Any]]:
+        try:
+            return fetch()
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                return []
+            raise
 
     # ── public lookup API ────────────────────────────────────────────────
 
@@ -281,12 +283,17 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         )
 
     def _snapshot_kind(self, kind: str) -> list[Mapping[str, Any]]:
+        # Documented contract: callers see entries in id order.  Dict
+        # iteration order tracks insertion history, which can diverge
+        # from id ordering after reconciles or mixed webhook/inventory
+        # updates — so sort explicitly (codex P2 on #1756).
         with self._lock:
-            return [
+            entries = [
                 node.data
                 for (entry_kind, _), node in self._nodes.items()
                 if entry_kind == kind
             ]
+        return sorted(entries, key=lambda d: int(d["id"]))
 
     # ── WebhookCache hooks ───────────────────────────────────────────────
 

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -363,6 +363,16 @@ class GitHub:
                 return None
             raise
 
+    def get_pull_reviews(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
+        """Return every review submission on a PR as raw API objects.
+
+        Distinct from :meth:`get_reviews` which projects into a narrow
+        ``{state, author, submittedAt, ...}`` summary — callers that
+        need the full review object (body, html_url, ...) for the
+        CommentCache hydration path (#1756) want the raw shape.
+        """
+        return list(self._paginate(f"{self.BASE}/repos/{repo}/pulls/{pr}/reviews"))
+
     def fetch_sibling_threads(self, repo: str, pr: int | str) -> list[dict[str, Any]]:
         """Return all review-comment threads for a PR as a structured list.
 

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -952,7 +952,21 @@ class WorkerRegistry:
                 self._comment_caches[key] = cache
                 snapshot_started_at = datetime.now(tz=timezone.utc)
         if snapshot_started_at is not None:
-            cache.hydrate(snapshot_started_at)
+            try:
+                cache.hydrate(snapshot_started_at)
+            except Exception:
+                # Hydration failed — roll back the registration so the
+                # next call retries from scratch (codex P1 on #1756:
+                # otherwise the half-built cache lingers, never gets
+                # ``inventory_loaded_at`` set, and queues webhook
+                # events into a buffer that never drains).
+                with self._comment_cache_lock:
+                    # Only remove the instance we put in, in case a
+                    # concurrent caller already installed a different
+                    # one (unlikely but cheap to guard).
+                    if self._comment_caches.get(key) is cache:
+                        del self._comment_caches[key]
+                raise
         return cache
 
     def all_comment_caches(self) -> list[CommentCache]:

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -932,14 +932,28 @@ class WorkerRegistry:
         pair.  Distinct items in the same repo get distinct caches —
         per-item isolation by construction.  Webhook router uses this
         to route events to the right cache.
+
+        New caches are hydrated synchronously (#1756) — three list
+        fetches from GitHub before this method returns.  That's
+        intentional for INV-2: the first webhook for an unseen item
+        pays the hydration cost so subsequent reads are warm.  INV-3
+        (#1757) moves hydration to startup / PR-open so the hot path
+        is never blocked.  Concurrent webhooks on other threads see
+        the cache registered in ``_comment_caches`` before hydrate
+        completes and queue their events in the pre-inventory buffer,
+        which drains in timestamp order at the tail of ``hydrate``.
         """
         key = (repo_name, item)
+        snapshot_started_at: datetime | None = None
         with self._comment_cache_lock:
             cache = self._comment_caches.get(key)
             if cache is None:
                 cache = CommentCache(repo_name, gh, item)
                 self._comment_caches[key] = cache
-            return cache
+                snapshot_started_at = datetime.now(tz=timezone.utc)
+        if snapshot_started_at is not None:
+            cache.hydrate(snapshot_started_at)
+        return cache
 
     def all_comment_caches(self) -> list[CommentCache]:
         """Snapshot list of every comment cache that has been created."""

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -974,6 +974,17 @@ class WorkerRegistry:
         with self._comment_cache_lock:
             return list(self._comment_caches.values())
 
+    def destroy_comment_cache(self, repo_name: str, item: int) -> bool:
+        """Remove the cache for ``(repo_name, item)``; return whether it existed.
+
+        Called when the PR closes/merges (#1757) — the cache is no
+        longer useful and would otherwise leak per the codex P2 about
+        unbounded growth.  Idempotent: calling twice is a no-op.
+        """
+        key = (repo_name, item)
+        with self._comment_cache_lock:
+            return self._comment_caches.pop(key, None) is not None
+
 
 def _make_thread(
     repo_cfg: RepoConfig,

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -61,6 +61,7 @@ from fido.registry import (
 )
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
+from fido.state import State
 from fido.static_files import StaticFiles
 from fido.store import FidoStore, ReplyPromiseRecord
 from fido.synthesis_executor import CommentTarget, SynthesisExecutor
@@ -551,6 +552,19 @@ class WebhookHandler(BaseHTTPRequestHandler):
             log.exception(
                 "comment-cache patch failed for %s — next list fetch will heal",
                 repo_name,
+            )
+
+        # Destroy the comment cache when the PR closes (merged or not).
+        # Bounds growth per the codex P2 about unbounded ``_comment_caches``
+        # (#1757).  Merged closes also trigger self-restart below which
+        # would drop the cache anyway, but tidying it here keeps the
+        # invariant (cache exists iff Fido has work on the item) holding
+        # in the pre-restart window too.  ``pull_request.number`` is
+        # validated by the dispatcher above, so a missing/non-int here
+        # would have already 500'd.
+        if event == "pull_request" and payload.get("action") == "closed":
+            self.registry.destroy_comment_cache(
+                repo_cfg.name, payload["pull_request"]["number"]
             )
 
         # Acknowledge only after dispatch succeeds.
@@ -1212,6 +1226,57 @@ def populate_memberships(config: Config, gh: GitHub) -> None:
         )
 
 
+def bootstrap_comment_caches(
+    repos: dict[str, RepoConfig],
+    gh: GitHub,
+    registry: WorkerRegistry,
+    *,
+    _State: type[State] = State,
+) -> None:
+    """Bootstrap per-(repo, PR) :class:`~fido.comment_cache.CommentCache`
+    instances for repos whose worker is mid-PR at startup (#1757).
+
+    Called once in :func:`run` after the registry is created.  For
+    each managed repo, reads ``state.json`` for the active PR number
+    (if any) and creates + hydrates a CommentCache for that ``(repo,
+    pr)`` pair.  Restart-safety mirror of
+    :func:`bootstrap_issue_caches`: avoids paying the three-list-
+    fetch cost on the first webhook arrival after restart.
+
+    Per-repo failures are swallowed (logged, not raised): a single
+    GitHub API hiccup must not block fido from starting.  The next
+    webhook arrival for the PR will lazy-create the cache as a
+    safety net.
+    """
+    for name, repo_cfg in repos.items():
+        state = _State(repo_cfg.work_dir / ".git" / "fido")
+        # State.load() returns {} when state.json is absent — no need
+        # to catch FileNotFoundError.  Missing pr_number then falls
+        # out of the isinstance check below.
+        pr_number = state.load().get("pr_number")
+        if not isinstance(pr_number, int) or pr_number <= 0:
+            continue
+        try:
+            log.info(
+                "startup: bootstrapping comment cache for %s PR #%d",
+                name,
+                pr_number,
+            )
+            registry.get_comment_cache(name, pr_number, gh)
+        except (
+            requests.RequestException,
+            GraphQLError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ):
+            log.exception(
+                "startup: failed to bootstrap comment cache for %s PR #%d — "
+                "next webhook arrival will lazy-create",
+                name,
+                pr_number,
+            )
+
+
 def bootstrap_issue_caches(
     repos: dict[str, RepoConfig],
     gh: GitHub,
@@ -1280,6 +1345,7 @@ def run(
     _preflight_gh_auth: Callable[..., None] = preflight_gh_auth,
     _GitHub: type[GitHub] = GitHub,
     _bootstrap_issue_caches: Callable[..., None] = bootstrap_issue_caches,
+    _bootstrap_comment_caches: Callable[..., None] = bootstrap_comment_caches,
 ) -> None:
     config = _from_args()
 
@@ -1366,6 +1432,10 @@ def run(
     # even for repos whose worker resumes on an existing issue and never calls
     # find_next_issue during this run (closes #837).
     _bootstrap_issue_caches(config.repos, gh, registry)
+    # Bootstrap comment caches for repos that have an active PR in
+    # state.json (#1757) — restart safety so the first webhook
+    # arrival doesn't pay the three-list-fetch cost on the hot path.
+    _bootstrap_comment_caches(config.repos, gh, registry)
     # Route webhook-handler prompt calls through the per-repo persistent
     # ClaudeSession (closes #479 — "one claude per repo" invariant).
     provider.set_session_resolver(registry.get_session)

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -61,7 +61,6 @@ from fido.registry import (
 )
 from fido.rocq import self_restart as restart_fsm
 from fido.session_lock_watchdog import SessionLockWatchdog
-from fido.state import State
 from fido.static_files import StaticFiles
 from fido.store import FidoStore, ReplyPromiseRecord
 from fido.synthesis_executor import CommentTarget, SynthesisExecutor
@@ -1230,30 +1229,34 @@ def bootstrap_comment_caches(
     repos: dict[str, RepoConfig],
     gh: GitHub,
     registry: WorkerRegistry,
-    *,
-    _State: type[State] = State,
 ) -> None:
     """Bootstrap per-(repo, PR) :class:`~fido.comment_cache.CommentCache`
     instances for repos whose worker is mid-PR at startup (#1757).
 
-    Called once in :func:`run` after the registry is created.  For
-    each managed repo, reads ``state.json`` for the active PR number
-    (if any) and creates + hydrates a CommentCache for that ``(repo,
-    pr)`` pair.  Restart-safety mirror of
+    Called once in :func:`run` after the registry is created (so
+    :meth:`WorkerRegistry.state_for` is wired with the canonical git
+    dir — matters for linked worktrees and submodules where
+    ``work_dir/.git`` is a file pointer rather than the real
+    directory).  For each managed repo, reads ``state.json`` for the
+    active PR number (if any) and creates + hydrates a CommentCache
+    for that ``(repo, pr)`` pair.  Restart-safety mirror of
     :func:`bootstrap_issue_caches`: avoids paying the three-list-
     fetch cost on the first webhook arrival after restart.
 
     Per-repo failures are swallowed (logged, not raised): a single
-    GitHub API hiccup must not block fido from starting.  The next
-    webhook arrival for the PR will lazy-create the cache as a
-    safety net.
+    GitHub API hiccup must not block fido from starting.  The
+    registry rolls back the half-built cache on hydrate failure
+    (codex P1 on #1756), and the next webhook arrival for the PR
+    will lazy-create the cache as a safety net.
     """
-    for name, repo_cfg in repos.items():
-        state = _State(repo_cfg.work_dir / ".git" / "fido")
-        # State.load() returns {} when state.json is absent — no need
-        # to catch FileNotFoundError.  Missing pr_number then falls
-        # out of the isinstance check below.
-        pr_number = state.load().get("pr_number")
+    for name in repos:
+        # Reuse the registry's State — it was constructed against the
+        # canonical git dir (``git rev-parse --absolute-git-dir``), so
+        # worktrees and submodules where ``work_dir/.git`` is a file
+        # pointer resolve to the real fido dir.  Codex P2 on #1757:
+        # hardcoding ``work_dir/.git/fido`` silently misses pr_number
+        # in those configurations.
+        pr_number = registry.state_for(name).load().get("pr_number")
         if not isinstance(pr_number, int) or pr_number <= 0:
             continue
         try:

--- a/tests/test_comment_cache.py
+++ b/tests/test_comment_cache.py
@@ -483,6 +483,30 @@ class TestHydrate:
         assert cache.metrics().entries_cached == 1
         assert cache.get(KIND_ISSUES, 10) is not None
 
+    def test_404_on_reviews_only_keeps_pull_comments(self) -> None:
+        # Codex P2 on #1756: a 404 on one /pulls endpoint must not
+        # discard successful data from the other.
+        import requests
+
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="a.py", body="inline"),
+        ]
+
+        def reviews_404(repo: str, pr: int) -> list[dict[str, Any]]:
+            response = requests.Response()
+            response.status_code = 404
+            raise requests.HTTPError(response=response)
+
+        gh.get_pull_reviews = reviews_404  # type: ignore[method-assign]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Top-level + pull comments survived; only reviews are empty.
+        assert cache.get(KIND_ISSUES, 10) is not None
+        assert cache.get(KIND_PULLS, 100) is not None
+        assert cache.list_reviews() == []
+
     def test_non_404_pull_error_propagates(self) -> None:
         import requests
 
@@ -662,3 +686,40 @@ class TestListGetters:
         cache = CommentCache("owner/repo", _FakeGH(), 7)
         cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
         assert cache.thread(999) == []
+
+    def test_list_getters_return_in_id_order_after_mixed_updates(self) -> None:
+        # Codex P2 on #1756: documented contract is "in id order".
+        # Insertion-history order can diverge after mixed webhook /
+        # hydrate / refresh sequences — make sure the snapshot
+        # getters actually sort.
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=30)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Apply newer webhook for a SMALLER id — would land later in
+        # insertion order but should sort first.
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=10,
+                    updated_at="2024-07-01T00:00:00Z",
+                ),
+            },
+        )
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=20,
+                    updated_at="2024-07-01T00:00:00Z",
+                ),
+            },
+        )
+        assert [int(c["id"]) for c in cache.list_top_level()] == [10, 20, 30]

--- a/tests/test_comment_cache.py
+++ b/tests/test_comment_cache.py
@@ -21,10 +21,42 @@ from fido.comment_cache import (
 class _FakeGH:
     """Hand-rolled GitHub fake — no MagicMock per testing convention.
 
-    INV-1 doesn't exercise any GH methods (the cache only fills via
-    apply_event), so this is a placeholder that records nothing.
-    Hydration tests (#1756) will give it teeth.
+    Records ``get_*`` calls and serves canned responses for the three
+    hydration endpoints.  ``raise_pull_404`` flips the
+    ``get_pull_*`` methods into raising a 404 to simulate the
+    plain-issue case where ``/pulls/{n}/...`` doesn't exist.
     """
+
+    def __init__(self) -> None:
+        self.issue_comments: list[dict[str, Any]] = []
+        self.pull_comments: list[dict[str, Any]] = []
+        self.pull_reviews: list[dict[str, Any]] = []
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.raise_pull_404: bool = False
+
+    def get_issue_comments(self, repo: str, number: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_issue_comments", (repo, number)))
+        return list(self.issue_comments)
+
+    def get_pull_comments(self, repo: str, pr: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_pull_comments", (repo, pr)))
+        if self.raise_pull_404:
+            self._raise_404()
+        return list(self.pull_comments)
+
+    def get_pull_reviews(self, repo: str, pr: int) -> list[dict[str, Any]]:
+        self.calls.append(("get_pull_reviews", (repo, pr)))
+        if self.raise_pull_404:
+            self._raise_404()
+        return list(self.pull_reviews)
+
+    @staticmethod
+    def _raise_404() -> None:
+        import requests
+
+        response = requests.Response()
+        response.status_code = 404
+        raise requests.HTTPError(response=response)
 
 
 def _comment_payload(
@@ -86,6 +118,9 @@ class TestConstruction:
     def test_two_items_in_same_repo_are_independent(self) -> None:
         c7 = CommentCache("owner/repo", _FakeGH(), 7)
         c8 = CommentCache("owner/repo", _FakeGH(), 8)
+        snapshot_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        c7.load_inventory([], snapshot_ts)
+        c8.load_inventory([], snapshot_ts)
         c7.apply_event(
             "issue_comment",
             {
@@ -410,3 +445,220 @@ class TestIgnoredEvents:
             },
         )
         assert cache.metrics().events_applied == 0
+
+
+class TestHydrate:
+    """Hydration — fetch the three lists from GitHub and load them (#1756)."""
+
+    def test_fetches_all_three_endpoints_and_tags_kinds(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10, body="top")]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="src/foo.py", body="inline")
+        ]
+        gh.pull_reviews = [_review_payload(review_id=1000, body="approval")]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        top = cache.get(KIND_ISSUES, 10)
+        inline = cache.get(KIND_PULLS, 100)
+        review = cache.get(KIND_REVIEWS, 1000)
+        assert top is not None and top["body"] == "top"
+        assert inline is not None and inline["body"] == "inline"
+        assert review is not None and review["body"] == "approval"
+        called = {name for name, _ in gh.calls}
+        assert called == {
+            "get_issue_comments",
+            "get_pull_comments",
+            "get_pull_reviews",
+        }
+
+    def test_plain_issue_404_on_pulls_endpoints_treated_as_empty(self) -> None:
+        # /pulls/{n} 404s for plain issues — hydrate tolerates this
+        # and treats review/review-comment lists as empty.
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.raise_pull_404 = True
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 1
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_non_404_pull_error_propagates(self) -> None:
+        import requests
+
+        class _SocketErrGH(_FakeGH):
+            def get_pull_comments(self, repo: str, pr: int) -> list[dict[str, Any]]:
+                response = requests.Response()
+                response.status_code = 503
+                raise requests.HTTPError(response=response)
+
+        gh = _SocketErrGH()
+        cache = CommentCache("owner/repo", gh, 7)
+        try:
+            cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        except requests.HTTPError:
+            pass
+        else:
+            raise AssertionError("expected HTTPError to propagate")
+
+    def test_events_arriving_during_hydration_are_drained_in_order(self) -> None:
+        # WebhookCache's pre-inventory queue catches events that
+        # arrive before hydrate completes.  An event applies before
+        # hydrate runs; load_inventory drains it.
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(
+                item=7,
+                comment_id=10,
+                body="from-list",
+                updated_at="2024-06-01T00:00:00Z",
+            )
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": _comment_payload(
+                    item=7,
+                    comment_id=20,
+                    body="from-webhook",
+                    updated_at="2024-06-15T00:00:00Z",
+                ),
+            },
+        )
+        # Queued, not yet applied.
+        assert cache.get(KIND_ISSUES, 20) is None
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Both present after drain.
+        assert cache.get(KIND_ISSUES, 10) is not None
+        assert cache.get(KIND_ISSUES, 20) is not None
+
+
+class TestRefresh:
+    """Periodic refresh — re-fetch and reconcile (#1759 wires this)."""
+
+    def test_refresh_evicts_ids_missing_from_fresh_snapshot(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(item=7, comment_id=10),
+            _comment_payload(item=7, comment_id=11),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 2
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        assert cache.metrics().entries_cached == 1
+        assert cache.get(KIND_ISSUES, 11) is None
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_refresh_tolerates_pulls_404(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        gh.raise_pull_404 = True
+        cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        assert cache.get(KIND_ISSUES, 10) is not None
+
+    def test_refresh_non_404_pull_error_propagates(self) -> None:
+        import requests
+
+        gh = _FakeGH()
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+
+        def boom(repo: str, pr: int) -> list[dict[str, Any]]:
+            response = requests.Response()
+            response.status_code = 502
+            raise requests.HTTPError(response=response)
+
+        gh.get_pull_comments = boom  # type: ignore[method-assign]
+        try:
+            cache.refresh(datetime(2024, 7, 1, tzinfo=timezone.utc))
+        except requests.HTTPError:
+            pass
+        else:
+            raise AssertionError("expected HTTPError to propagate")
+
+
+class TestListGetters:
+    """``list_top_level`` / ``list_review_comments`` / ``list_reviews`` /
+    ``thread`` snapshot getters (#1756)."""
+
+    def test_list_top_level_returns_issues_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [
+            _comment_payload(item=7, comment_id=10),
+            _comment_payload(item=7, comment_id=11),
+        ]
+        gh.pull_comments = [_comment_payload(item=7, comment_id=100)]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        top = cache.list_top_level()
+        assert {int(c["id"]) for c in top} == {10, 11}
+
+    def test_list_review_comments_returns_pulls_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.issue_comments = [_comment_payload(item=7, comment_id=10)]
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, path="a.py"),
+            _comment_payload(item=7, comment_id=101, path="b.py"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        review = cache.list_review_comments()
+        assert {int(c["id"]) for c in review} == {100, 101}
+
+    def test_list_reviews_returns_reviews_kind_only(self) -> None:
+        gh = _FakeGH()
+        gh.pull_reviews = [
+            _review_payload(review_id=1000),
+            _review_payload(review_id=1001, state="APPROVED"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        reviews = cache.list_reviews()
+        assert {int(r["id"]) for r in reviews} == {1000, 1001}
+
+    def test_thread_returns_root_plus_replies(self) -> None:
+        gh = _FakeGH()
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, body="root", path="a.py"),
+            _comment_payload(
+                item=7,
+                comment_id=200,
+                body="reply",
+                path="a.py",
+                in_reply_to_id=100,
+            ),
+            _comment_payload(item=7, comment_id=300, body="elsewhere", path="b.py"),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        # Look up via the reply id — walks to the root.
+        thread = cache.thread(200)
+        assert [int(c["id"]) for c in thread] == [100, 200]
+
+    def test_thread_called_on_root_returns_same_thread(self) -> None:
+        gh = _FakeGH()
+        gh.pull_comments = [
+            _comment_payload(item=7, comment_id=100, body="root", path="a.py"),
+            _comment_payload(
+                item=7,
+                comment_id=200,
+                body="reply",
+                path="a.py",
+                in_reply_to_id=100,
+            ),
+        ]
+        cache = CommentCache("owner/repo", gh, 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert [int(c["id"]) for c in cache.thread(100)] == [100, 200]
+
+    def test_thread_empty_when_id_not_in_cache(self) -> None:
+        cache = CommentCache("owner/repo", _FakeGH(), 7)
+        cache.hydrate(datetime(2024, 6, 1, tzinfo=timezone.utc))
+        assert cache.thread(999) == []

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -436,6 +436,21 @@ class TestGitHubClass:
         url = mock_s.get.call_args.args[0]
         assert "repos/o/r/pulls/7/comments" in url
 
+    def test_get_pull_reviews(self) -> None:
+        gh, mock_s = self._gh()
+        reviews = [
+            {"id": 1000, "state": "APPROVED", "body": ""},
+            {"id": 1001, "state": "COMMENTED", "body": "nit"},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = reviews
+        mock_resp.headers = {}
+        mock_s.get.return_value = mock_resp
+        result = gh.get_pull_reviews("o/r", 7)
+        assert result == reviews
+        url = mock_s.get.call_args.args[0]
+        assert "repos/o/r/pulls/7/reviews" in url
+
     def test_get_pull_comment(self) -> None:
         gh, mock_s = self._gh()
         comment = {"id": 10, "body": "hi"}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2284,3 +2284,25 @@ class TestCommentCacheRegistry:
         reg.get_comment_cache("baz/qux", 1, gh)
         all_caches = reg.all_comment_caches()
         assert len(all_caches) == 3
+
+    def test_get_comment_cache_rolls_back_on_hydrate_failure(self) -> None:
+        # Codex P1 on #1756: if the initial hydrate raises, the
+        # half-built cache must NOT linger — otherwise it accumulates
+        # queued webhook events that never drain.  Next call retries.
+        import requests
+
+        reg = self._reg()
+        gh = MagicMock()
+        gh.get_issue_comments.side_effect = requests.RequestException("boom")
+        with pytest.raises(requests.RequestException):
+            reg.get_comment_cache("foo/bar", 7, gh)
+        # Cache was rolled back — no entry in registry.
+        assert reg.all_comment_caches() == []
+        # Next call retries from scratch.
+        gh.get_issue_comments.side_effect = None
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        cache = reg.get_comment_cache("foo/bar", 7, gh)
+        assert cache is not None
+        assert cache.is_loaded is True

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2306,3 +2306,21 @@ class TestCommentCacheRegistry:
         cache = reg.get_comment_cache("foo/bar", 7, gh)
         assert cache is not None
         assert cache.is_loaded is True
+
+    def test_destroy_comment_cache_removes_existing(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        reg.get_comment_cache("foo/bar", 7, gh)
+        assert reg.destroy_comment_cache("foo/bar", 7) is True
+        assert len(reg.all_comment_caches()) == 0
+
+    def test_destroy_comment_cache_returns_false_when_missing(self) -> None:
+        reg = self._reg()
+        assert reg.destroy_comment_cache("foo/bar", 7) is False
+
+    def test_destroy_comment_cache_idempotent(self) -> None:
+        reg = self._reg()
+        gh = MagicMock()
+        reg.get_comment_cache("foo/bar", 7, gh)
+        assert reg.destroy_comment_cache("foo/bar", 7) is True
+        assert reg.destroy_comment_cache("foo/bar", 7) is False  # idempotent

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2989,6 +2989,138 @@ class TestBootstrapIssueCaches:
         mock_registry.wake.assert_called_once_with("b/r2")
 
 
+class TestBootstrapCommentCaches:
+    """Tests for bootstrap_comment_caches() (#1757)."""
+
+    def _state_json(self, work_dir: Path, *, pr_number: int | None) -> None:
+        fido_dir = work_dir / ".git" / "fido"
+        fido_dir.mkdir(parents=True, exist_ok=True)
+        state_path = fido_dir / "state.json"
+        data = {"issue": 100, "pr_number": pr_number} if pr_number else {"issue": 100}
+        state_path.write_text(json.dumps(data))
+
+    def test_creates_cache_when_state_has_pr_number(self, tmp_path: Path) -> None:
+        from fido.server import bootstrap_comment_caches
+
+        self._state_json(tmp_path, pr_number=42)
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_registry = MagicMock()
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        mock_registry.get_comment_cache.assert_called_once_with(
+            "owner/repo", 42, mock_gh
+        )
+
+    def test_skips_when_state_lacks_pr_number(self, tmp_path: Path) -> None:
+        from fido.server import bootstrap_comment_caches
+
+        self._state_json(tmp_path, pr_number=None)
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_registry = MagicMock()
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        mock_registry.get_comment_cache.assert_not_called()
+
+    def test_skips_when_pr_number_is_zero(self, tmp_path: Path) -> None:
+        from fido.server import bootstrap_comment_caches
+
+        self._state_json(tmp_path, pr_number=0)
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_registry = MagicMock()
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        mock_registry.get_comment_cache.assert_not_called()
+
+    def test_skips_when_state_json_missing(self, tmp_path: Path) -> None:
+        from fido.server import bootstrap_comment_caches
+
+        # No state.json written.
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_registry = MagicMock()
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        mock_registry.get_comment_cache.assert_not_called()
+
+    def test_per_repo_failure_is_swallowed(self, tmp_path: Path) -> None:
+        """A transient GH error on one repo must not stop other repos
+        from being bootstrapped — same shape as bootstrap_issue_caches."""
+        import requests
+
+        from fido.server import bootstrap_comment_caches
+
+        a_dir = tmp_path / "a"
+        b_dir = tmp_path / "b"
+        a_dir.mkdir()
+        b_dir.mkdir()
+        self._state_json(a_dir, pr_number=42)
+        self._state_json(b_dir, pr_number=99)
+        repos = {
+            "a/r1": RepoConfig(name="a/r1", work_dir=a_dir),
+            "b/r2": RepoConfig(name="b/r2", work_dir=b_dir),
+        }
+        mock_gh = MagicMock()
+        call_log: list[tuple[str, int]] = []
+
+        def get_or_fail(repo: str, item: int, _gh: object) -> MagicMock:
+            call_log.append((repo, item))
+            if repo == "a/r1":
+                raise requests.RequestException("API down")
+            return MagicMock()
+
+        mock_registry = MagicMock()
+        mock_registry.get_comment_cache.side_effect = get_or_fail
+        # Must not raise even though the first repo errored.
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        # Second repo still bootstrapped.
+        assert ("b/r2", 99) in call_log
+
+
+class TestDestroyCommentCacheOnPRClose:
+    """Webhook PR-close events destroy the per-(repo, pr) cache (#1757)."""
+
+    def test_pr_closed_destroys_cache(self, server: tuple) -> None:
+        url, cfg = server
+        WebhookHandler.registry.reset_mock()
+        payload = {
+            **_payload(),
+            "action": "closed",
+            "pull_request": {"number": 7, "merged": False},
+        }
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        WebhookHandler.registry.destroy_comment_cache.assert_called_with(
+            "owner/repo", 7
+        )
+
+    def test_pr_merged_destroys_cache_too(self, server: tuple) -> None:
+        # Merged closes self-restart, but we still tidy the cache
+        # before the restart fires.
+        url, cfg = server
+        WebhookHandler.registry.reset_mock()
+        payload = {
+            **_payload(),
+            "action": "closed",
+            "pull_request": {"number": 7, "merged": True},
+        }
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        WebhookHandler.registry.destroy_comment_cache.assert_called_with(
+            "owner/repo", 7
+        )
+
+    def test_pr_opened_does_not_destroy(self, server: tuple) -> None:
+        url, cfg = server
+        WebhookHandler.registry.reset_mock()
+        payload = {
+            **_payload(),
+            "action": "opened",
+            "pull_request": {"number": 7},
+        }
+        status = _post_webhook(url, cfg, "pull_request", payload)
+        assert status == 200
+        WebhookHandler.registry.destroy_comment_cache.assert_not_called()
+
+
 class TestRun:
     """Tests for the run() entry point."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2992,20 +2992,31 @@ class TestBootstrapIssueCaches:
 class TestBootstrapCommentCaches:
     """Tests for bootstrap_comment_caches() (#1757)."""
 
-    def _state_json(self, work_dir: Path, *, pr_number: int | None) -> None:
-        fido_dir = work_dir / ".git" / "fido"
-        fido_dir.mkdir(parents=True, exist_ok=True)
-        state_path = fido_dir / "state.json"
-        data = {"issue": 100, "pr_number": pr_number} if pr_number else {"issue": 100}
-        state_path.write_text(json.dumps(data))
+    def _registry_with_state(self, repo_states: dict[str, dict[str, Any]]) -> MagicMock:
+        """Build a mock registry whose ``state_for(name).load()``
+        returns the canned state.json contents for that repo.  This
+        mirrors the real registry: ``state_for`` returns a ``State``
+        scoped to the canonical git dir, so the bootstrap path
+        works for linked worktrees / submodules where
+        ``work_dir/.git`` is a file pointer (codex P2 on #1757)."""
+        registry = MagicMock()
+
+        def state_for(name: str) -> MagicMock:
+            state = MagicMock()
+            state.load.return_value = repo_states.get(name, {})
+            return state
+
+        registry.state_for.side_effect = state_for
+        return registry
 
     def test_creates_cache_when_state_has_pr_number(self, tmp_path: Path) -> None:
         from fido.server import bootstrap_comment_caches
 
-        self._state_json(tmp_path, pr_number=42)
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_gh = MagicMock()
-        mock_registry = MagicMock()
+        mock_registry = self._registry_with_state(
+            {"owner/repo": {"issue": 100, "pr_number": 42}}
+        )
         bootstrap_comment_caches(repos, mock_gh, mock_registry)
         mock_registry.get_comment_cache.assert_called_once_with(
             "owner/repo", 42, mock_gh
@@ -3014,32 +3025,45 @@ class TestBootstrapCommentCaches:
     def test_skips_when_state_lacks_pr_number(self, tmp_path: Path) -> None:
         from fido.server import bootstrap_comment_caches
 
-        self._state_json(tmp_path, pr_number=None)
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_gh = MagicMock()
-        mock_registry = MagicMock()
+        mock_registry = self._registry_with_state({"owner/repo": {"issue": 100}})
         bootstrap_comment_caches(repos, mock_gh, mock_registry)
         mock_registry.get_comment_cache.assert_not_called()
 
     def test_skips_when_pr_number_is_zero(self, tmp_path: Path) -> None:
         from fido.server import bootstrap_comment_caches
 
-        self._state_json(tmp_path, pr_number=0)
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_gh = MagicMock()
-        mock_registry = MagicMock()
+        mock_registry = self._registry_with_state(
+            {"owner/repo": {"issue": 100, "pr_number": 0}}
+        )
         bootstrap_comment_caches(repos, mock_gh, mock_registry)
         mock_registry.get_comment_cache.assert_not_called()
 
-    def test_skips_when_state_json_missing(self, tmp_path: Path) -> None:
+    def test_skips_when_state_is_empty(self, tmp_path: Path) -> None:
         from fido.server import bootstrap_comment_caches
 
-        # No state.json written.
+        # State.load() returns {} when state.json is absent.
         repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
         mock_gh = MagicMock()
-        mock_registry = MagicMock()
+        mock_registry = self._registry_with_state({})
         bootstrap_comment_caches(repos, mock_gh, mock_registry)
         mock_registry.get_comment_cache.assert_not_called()
+
+    def test_uses_registry_state_for_for_worktree_safety(self, tmp_path: Path) -> None:
+        """Bootstrap reads state via ``registry.state_for(name)`` —
+        not by hardcoding ``work_dir/.git/fido`` — so linked
+        worktrees and submodules (where ``work_dir/.git`` is a file
+        pointer) resolve to the real fido dir (codex P2 on #1757)."""
+        from fido.server import bootstrap_comment_caches
+
+        repos = {"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)}
+        mock_gh = MagicMock()
+        mock_registry = self._registry_with_state({"owner/repo": {"pr_number": 42}})
+        bootstrap_comment_caches(repos, mock_gh, mock_registry)
+        mock_registry.state_for.assert_called_with("owner/repo")
 
     def test_per_repo_failure_is_swallowed(self, tmp_path: Path) -> None:
         """A transient GH error on one repo must not stop other repos
@@ -3048,18 +3072,18 @@ class TestBootstrapCommentCaches:
 
         from fido.server import bootstrap_comment_caches
 
-        a_dir = tmp_path / "a"
-        b_dir = tmp_path / "b"
-        a_dir.mkdir()
-        b_dir.mkdir()
-        self._state_json(a_dir, pr_number=42)
-        self._state_json(b_dir, pr_number=99)
         repos = {
-            "a/r1": RepoConfig(name="a/r1", work_dir=a_dir),
-            "b/r2": RepoConfig(name="b/r2", work_dir=b_dir),
+            "a/r1": RepoConfig(name="a/r1", work_dir=tmp_path),
+            "b/r2": RepoConfig(name="b/r2", work_dir=tmp_path),
         }
         mock_gh = MagicMock()
         call_log: list[tuple[str, int]] = []
+        mock_registry = self._registry_with_state(
+            {
+                "a/r1": {"pr_number": 42},
+                "b/r2": {"pr_number": 99},
+            }
+        )
 
         def get_or_fail(repo: str, item: int, _gh: object) -> MagicMock:
             call_log.append((repo, item))
@@ -3067,9 +3091,7 @@ class TestBootstrapCommentCaches:
                 raise requests.RequestException("API down")
             return MagicMock()
 
-        mock_registry = MagicMock()
         mock_registry.get_comment_cache.side_effect = get_or_fail
-        # Must not raise even though the first repo errored.
         bootstrap_comment_caches(repos, mock_gh, mock_registry)
         # Second repo still bootstrapped.
         assert ("b/r2", 99) in call_log


### PR DESCRIPTION
## Summary

Third slice of the #1748 mini-epic.  Bounds CommentCache growth
and warms the cache for restarts so the first webhook arrival
doesn't pay the hydration cost.

**Stacked on #1764** (INV-2 hydration) — rebase to ``main`` once
that lands.

## What this PR ships

* **``bootstrap_comment_caches``** in ``server.py`` — mirror of
  ``bootstrap_issue_caches``.  Reads each repo's ``state.json``
  for the active ``pr_number`` and hydrates the per-(repo, PR)
  cache at startup, before the webhook server takes traffic.
  Per-repo failures swallowed (logged, not raised) like the
  issue-cache bootstrap.  Lazy-create on first webhook is still
  the fallback safety net.

* **PR-close destroy hook** — webhook handler calls
  ``registry.destroy_comment_cache(repo, pr_number)`` on every
  ``pull_request.closed`` event (merged or not).  Bounded cache
  lifetime ⇒ no monotonic growth (closes the codex P2 from #1751).
  Merged closes still self-restart (drops the cache anyway), but
  tidying here keeps the invariant holding in the pre-restart
  window too.

* **``WorkerRegistry.destroy_comment_cache(repo, item) -> bool``**
  — idempotent removal; returns whether the cache existed.

## What this PR does NOT do (deferred)

* **#1758** — Status metrics surface (cache only appears in
  ``/status.json`` when present)
* **#1759** — Periodic reconcile watchdog calling
  ``cache.refresh``
* **#1760 / #1761** — Consumer migrations
* **Worker-driven PR-create hook** — when worker creates a PR,
  immediately register a hydrated cache instead of waiting for
  the first webhook.  Tracked under #1757 follow-up; not blocking.

## Verification

* CI green (4436 tests passing, 100% coverage)
* Bootstrap tests cover: pr_number present, pr_number missing,
  pr_number=0, state.json missing, per-repo failure swallow
* PR-close tests cover: closed-not-merged destroys, merged
  destroys, opened doesn't destroy
* Registry destroy tests: existing, missing, idempotency

## Test plan

- [x] ``./fido ci`` green locally
- [ ] CI green on GitHub
- [ ] Codex review