### PR TITLE
INV-4 of #1748: CommentCache metrics in FidoState/status.json (closes #1758)

### DIFF
--- a/src/fido/appstate.py
+++ b/src/fido/appstate.py
@@ -287,6 +287,35 @@ _ZERO_ISSUE_CACHE = IssueCacheSnapshot(
 
 
 @dataclass(frozen=True, slots=True)
+class CommentCacheSnapshot:
+    """Immutable snapshot of one repo's :class:`~fido.comment_cache.CommentCache`
+    health for the SCADA display path (#1758).
+
+    Mirrors the public fields of
+    :class:`~fido.comment_cache.CacheMetrics` as JSON-friendly
+    primitives.  Published by the cache's ``on_change`` callback
+    (wired in :class:`~fido.registry.WorkerRegistry`) after every
+    mutation.  ``None`` on :attr:`RepoState.comment_cache` means
+    no cache exists for the repo (Fido has no open PR there per
+    INV-3); when present, ``item`` is the PR number the cache is
+    bound to.
+
+    Sentinel: ``loaded=False`` means inventory has not been
+    hydrated yet; timestamp fields default to :data:`_EPOCH`.
+    """
+
+    item: int
+    loaded: bool
+    entries_cached: int
+    events_applied: int
+    events_dropped_stale: int
+    events_dropped_queue_overflow: int
+    last_event_at: datetime
+    last_reconcile_at: datetime
+    last_reconcile_drift: int
+
+
+@dataclass(frozen=True, slots=True)
 class TalkerSnapshot:
     """Immutable snapshot of one repo's currently-driving
     :class:`~fido.provider.SessionTalker` for the SCADA display path.
@@ -379,6 +408,7 @@ class RepoState:
     issue: IssueSnapshot
     task_list: TaskListSnapshot
     issue_cache: IssueCacheSnapshot
+    comment_cache: CommentCacheSnapshot | None
     talker: TalkerSnapshot
     provider_pressure: ProviderPressureSnapshot
     rescoping: bool
@@ -402,6 +432,7 @@ def zero_repo_state(repo_name: str, started_at: datetime = _EPOCH) -> RepoState:
         issue=_ZERO_ISSUE,
         task_list=_ZERO_TASK_LIST,
         issue_cache=_ZERO_ISSUE_CACHE,
+        comment_cache=None,
         talker=_ZERO_TALKER,
         provider_pressure=_ZERO_PROVIDER_PRESSURE,
         rescoping=False,

--- a/src/fido/appstate.py
+++ b/src/fido/appstate.py
@@ -288,17 +288,18 @@ _ZERO_ISSUE_CACHE = IssueCacheSnapshot(
 
 @dataclass(frozen=True, slots=True)
 class CommentCacheSnapshot:
-    """Immutable snapshot of one repo's :class:`~fido.comment_cache.CommentCache`
-    health for the SCADA display path (#1758).
+    """Immutable snapshot of one per-(repo, item) ``CommentCache``
+    instance for the SCADA display path (#1758).
 
     Mirrors the public fields of
     :class:`~fido.comment_cache.CacheMetrics` as JSON-friendly
     primitives.  Published by the cache's ``on_change`` callback
     (wired in :class:`~fido.registry.WorkerRegistry`) after every
-    mutation.  ``None`` on :attr:`RepoState.comment_cache` means
-    no cache exists for the repo (Fido has no open PR there per
-    INV-3); when present, ``item`` is the PR number the cache is
-    bound to.
+    mutation.  Stored on :attr:`RepoState.comment_caches` keyed by
+    item number — multiple PRs can have live caches simultaneously
+    (created by webhook routing for each PR comment Fido sees), so
+    a singleton per repo would clobber sibling snapshots (codex P2
+    on #1758).
 
     Sentinel: ``loaded=False`` means inventory has not been
     hydrated yet; timestamp fields default to :data:`_EPOCH`.
@@ -408,7 +409,7 @@ class RepoState:
     issue: IssueSnapshot
     task_list: TaskListSnapshot
     issue_cache: IssueCacheSnapshot
-    comment_cache: CommentCacheSnapshot | None
+    comment_caches: "frozendict[int, CommentCacheSnapshot]"
     talker: TalkerSnapshot
     provider_pressure: ProviderPressureSnapshot
     rescoping: bool
@@ -432,7 +433,7 @@ def zero_repo_state(repo_name: str, started_at: datetime = _EPOCH) -> RepoState:
         issue=_ZERO_ISSUE,
         task_list=_ZERO_TASK_LIST,
         issue_cache=_ZERO_ISSUE_CACHE,
-        comment_cache=None,
+        comment_caches=frozendict(),
         talker=_ZERO_TALKER,
         provider_pressure=_ZERO_PROVIDER_PRESSURE,
         rescoping=False,

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -14,6 +14,7 @@ from fido.appstate import (
     _EPOCH,  # noqa: PLC2701  # pyright: ignore[reportPrivateUsage]
     _ZERO_CRASH,  # noqa: PLC2701  # pyright: ignore[reportPrivateUsage]
     _ZERO_TALKER,  # noqa: PLC2701  # pyright: ignore[reportPrivateUsage]
+    CommentCacheSnapshot,
     FidoState,
     IssueCacheSnapshot,
     ProviderSnapshot,
@@ -25,6 +26,7 @@ from fido.appstate import (
     zero_repo_state,
 )
 from fido.atomic import AtomicUpdater
+from fido.comment_cache import CacheMetrics as CommentCacheMetrics
 from fido.comment_cache import CommentCache
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
@@ -965,7 +967,12 @@ class WorkerRegistry:
         with self._comment_cache_lock:
             cache = self._comment_caches.get(key)
             if cache is None:
-                cache = CommentCache(repo_name, gh, item)
+                cache = CommentCache(
+                    repo_name,
+                    gh,
+                    item,
+                    on_change=self._make_comment_cache_publisher(repo_name),
+                )
                 self._comment_caches[key] = cache
         if not cache.is_loaded:
             try:
@@ -991,10 +998,50 @@ class WorkerRegistry:
         Called when the PR closes/merges (#1757) — the cache is no
         longer useful and would otherwise leak per the codex P2 about
         unbounded growth.  Idempotent: calling twice is a no-op.
+
+        Also clears the per-repo SCADA snapshot (#1758) so
+        ``/status.json`` stops showing the dead PR's cache.  The
+        clear runs only when we actually removed something — a
+        no-op destroy doesn't touch FidoState.
         """
         key = (repo_name, item)
         with self._comment_cache_lock:
-            return self._comment_caches.pop(key, None) is not None
+            removed = self._comment_caches.pop(key, None) is not None
+        if removed:
+            self._state_updater.update(
+                lambda root: root.repos[repo_name].comment_cache, None
+            )
+        return removed
+
+    def _make_comment_cache_publisher(
+        self, repo_name: str
+    ) -> "Callable[[CommentCacheMetrics], None]":
+        """Return a per-repo on_change callback that publishes a fresh
+        :class:`CommentCacheSnapshot` into FidoState every time the
+        cache mutates (#1758).
+
+        Mirrors :meth:`_make_issue_cache_publisher`.  Closure binds
+        *repo_name* (not the loop variable) so each repo's caches
+        publish to their own SCADA leaf.
+        """
+
+        def publish(metrics: "CommentCacheMetrics") -> None:
+            snap = CommentCacheSnapshot(
+                item=metrics.item,
+                loaded=metrics.inventory_loaded_at is not None,
+                entries_cached=metrics.entries_cached,
+                events_applied=metrics.events_applied,
+                events_dropped_stale=metrics.events_dropped_stale,
+                events_dropped_queue_overflow=metrics.events_dropped_queue_overflow,
+                last_event_at=metrics.last_event_at or _EPOCH,
+                last_reconcile_at=metrics.last_reconcile_at or _EPOCH,
+                last_reconcile_drift=metrics.last_reconcile_drift,
+            )
+            self._state_updater.update(
+                lambda root: root.repos[repo_name].comment_cache, snap
+            )
+
+        return publish
 
 
 def _make_thread(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -344,6 +344,13 @@ class WorkerRegistry:
             existing_cache = self._issue_caches.get(repo_cfg.name)
         if existing_cache is not None:
             existing_cache._notify_change()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        # Same crash-recovery republish for comment caches (codex P2
+        # follow-up on #1758): ``zero_repo_state`` above reset
+        # ``comment_caches`` to ``frozendict()``, but the live
+        # CommentCache instances in ``_comment_caches`` survive
+        # the restart.  Republish so /status.json reflects them
+        # without waiting for the next cache mutation.
+        self._publish_comment_caches(repo_cfg.name)
         thread.start()
         self._publish_thread_snapshot(repo_cfg.name)
         self._publish_provider_snapshot(repo_cfg.name)
@@ -1008,6 +1015,14 @@ class WorkerRegistry:
                     repo_name,
                     item,
                 )
+                # Surface the un-loaded cache in SCADA (codex P2
+                # follow-up on #1758): otherwise the stuck cache
+                # with its queue-overflow / staleness counters is
+                # invisible during the very outage that makes it
+                # worth watching.  Successful hydrate fires
+                # on_change via load_inventory; the failure path
+                # has to publish manually.
+                self._publish_comment_caches(repo_name)
         return cache
 
     def all_comment_caches(self) -> list[CommentCache]:
@@ -1061,22 +1076,32 @@ class WorkerRegistry:
 
         Mirror of :meth:`_publish_webhook_activities`: the
         authoritative state is the registry's ``_comment_caches``
-        map; this method serialises a snapshot under
-        ``_comment_cache_lock``, then releases the lock before the
-        state-updater CAS.
+        map; this method serialises a snapshot and the state-updater
+        CAS together so concurrent membership changes can't have
+        their compute interleaved with someone else's publish
+        (codex P1 follow-up on #1758: a publisher that snapshotted
+        before a peer's ``destroy_comment_cache`` could otherwise
+        write a stale dict — including the destroyed item — after
+        the destroy's publish committed, resurrecting the dead
+        cache in /status.json).
+
+        Holds ``_comment_cache_lock`` through the
+        ``state_updater.update`` call.  The CAS is microseconds;
+        the lock-ordering rule "_comment_cache_lock before any
+        cache._lock (acquired by metrics()) before the atomic
+        cell's internal lock" is preserved throughout the registry.
         """
         with self._comment_cache_lock:
-            caches_for_repo = {
-                item: cache
-                for (name, item), cache in self._comment_caches.items()
-                if name == repo_name
-            }
-        snaps = frozendict(
-            {item: _comment_cache_snapshot(c) for item, c in caches_for_repo.items()}
-        )
-        self._state_updater.update(
-            lambda root: root.repos[repo_name].comment_caches, snaps
-        )
+            snaps = frozendict(
+                {
+                    item: _comment_cache_snapshot(cache)
+                    for (name, item), cache in self._comment_caches.items()
+                    if name == repo_name
+                }
+            )
+            self._state_updater.update(
+                lambda root: root.repos[repo_name].comment_caches, snaps
+            )
 
 
 def _make_thread(

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -9,6 +9,8 @@ from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from frozendict import frozendict
+
 from fido import provider as provider_module
 from fido.appstate import (
     _EPOCH,  # noqa: PLC2701  # pyright: ignore[reportPrivateUsage]
@@ -51,6 +53,27 @@ log = logging.getLogger(__name__)
 def _utcnow() -> datetime:
     """Return the current UTC time as a timezone-aware datetime."""
     return datetime.now(tz=timezone.utc)
+
+
+def _comment_cache_snapshot(cache: CommentCache) -> CommentCacheSnapshot:
+    """Build a :class:`CommentCacheSnapshot` from a live cache's metrics.
+
+    Module-level helper (not a method) because it's a pure
+    projection — no collaborators, no behavior beyond the
+    field-by-field copy.
+    """
+    metrics = cache.metrics()
+    return CommentCacheSnapshot(
+        item=metrics.item,
+        loaded=metrics.inventory_loaded_at is not None,
+        entries_cached=metrics.entries_cached,
+        events_applied=metrics.events_applied,
+        events_dropped_stale=metrics.events_dropped_stale,
+        events_dropped_queue_overflow=metrics.events_dropped_queue_overflow,
+        last_event_at=metrics.last_event_at or _EPOCH,
+        last_reconcile_at=metrics.last_reconcile_at or _EPOCH,
+        last_reconcile_drift=metrics.last_reconcile_drift,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -999,49 +1022,61 @@ class WorkerRegistry:
         longer useful and would otherwise leak per the codex P2 about
         unbounded growth.  Idempotent: calling twice is a no-op.
 
-        Also clears the per-repo SCADA snapshot (#1758) so
-        ``/status.json`` stops showing the dead PR's cache.  The
-        clear runs only when we actually removed something — a
-        no-op destroy doesn't touch FidoState.
+        On successful removal, republishes the per-repo SCADA dict
+        from the surviving caches (#1758).  Sibling caches in the
+        same repo retain their snapshots; the destroyed item is
+        dropped from the dict.
         """
         key = (repo_name, item)
         with self._comment_cache_lock:
             removed = self._comment_caches.pop(key, None) is not None
         if removed:
-            self._state_updater.update(
-                lambda root: root.repos[repo_name].comment_cache, None
-            )
+            self._publish_comment_caches(repo_name)
         return removed
 
     def _make_comment_cache_publisher(
         self, repo_name: str
     ) -> "Callable[[CommentCacheMetrics], None]":
-        """Return a per-repo on_change callback that publishes a fresh
-        :class:`CommentCacheSnapshot` into FidoState every time the
-        cache mutates (#1758).
+        """Return a per-repo on_change callback that republishes the
+        repo's full ``comment_caches`` dict on every cache mutation.
 
-        Mirrors :meth:`_make_issue_cache_publisher`.  Closure binds
-        *repo_name* (not the loop variable) so each repo's caches
-        publish to their own SCADA leaf.
+        Closure binds *repo_name* so each repo's caches all route
+        through the same per-repo recompute path.  Per-item dict
+        means sibling caches survive any one cache's mutation
+        (codex P2 on #1758: the singleton field would have
+        clobbered them).  And the recompute reads from current
+        registry membership, so a destroyed cache's late firing
+        callback can't republish a snapshot for an unregistered
+        item (codex P2 on #1758: stale-handle republish race).
         """
 
-        def publish(metrics: "CommentCacheMetrics") -> None:
-            snap = CommentCacheSnapshot(
-                item=metrics.item,
-                loaded=metrics.inventory_loaded_at is not None,
-                entries_cached=metrics.entries_cached,
-                events_applied=metrics.events_applied,
-                events_dropped_stale=metrics.events_dropped_stale,
-                events_dropped_queue_overflow=metrics.events_dropped_queue_overflow,
-                last_event_at=metrics.last_event_at or _EPOCH,
-                last_reconcile_at=metrics.last_reconcile_at or _EPOCH,
-                last_reconcile_drift=metrics.last_reconcile_drift,
-            )
-            self._state_updater.update(
-                lambda root: root.repos[repo_name].comment_cache, snap
-            )
+        def publish(_metrics: "CommentCacheMetrics") -> None:
+            self._publish_comment_caches(repo_name)
 
         return publish
+
+    def _publish_comment_caches(self, repo_name: str) -> None:
+        """Compute the per-item snapshot dict from currently-registered
+        caches for *repo_name* and publish it to FidoState.
+
+        Mirror of :meth:`_publish_webhook_activities`: the
+        authoritative state is the registry's ``_comment_caches``
+        map; this method serialises a snapshot under
+        ``_comment_cache_lock``, then releases the lock before the
+        state-updater CAS.
+        """
+        with self._comment_cache_lock:
+            caches_for_repo = {
+                item: cache
+                for (name, item), cache in self._comment_caches.items()
+                if name == repo_name
+            }
+        snaps = frozendict(
+            {item: _comment_cache_snapshot(c) for item, c in caches_for_repo.items()}
+        )
+        self._state_updater.update(
+            lambda root: root.repos[repo_name].comment_caches, snaps
+        )
 
 
 def _make_thread(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,7 +18,7 @@ from fido.appstate import (
     ThreadSnapshot,
     WorkerCrash,
 )
-from fido.atomic import create_atomic
+from fido.atomic import AtomicReader, create_atomic
 from fido.config import RepoConfig as _RepoConfig
 from fido.provider import ProviderID
 from fido.registry import (
@@ -2245,39 +2245,47 @@ class TestRegistryFsmOracle:
 class TestCommentCacheRegistry:
     """Per-(repo, item) CommentCache tracking (#1754)."""
 
-    def _reg(self) -> WorkerRegistry:
-        _, updater = create_atomic(
+    def _reg(
+        self, *repo_names: str
+    ) -> tuple[WorkerRegistry, "AtomicReader[FidoState]"]:
+        # CommentCache publisher writes to repos[name].comment_cache,
+        # so the FidoState must be pre-populated with zero entries
+        # for any repos the test uses.  Returns both faces so tests
+        # can verify the published snapshot.
+        from fido.appstate import zero_repo_state
+
+        reader, updater = create_atomic(
             FidoState(
-                repos=frozendict(),
+                repos=frozendict({name: zero_repo_state(name) for name in repo_names}),
                 github_limits=_ZERO_GITHUB_LIMITS,
                 process_started_at=_EPOCH,
             )
         )
-        return WorkerRegistry(MagicMock(), updater)
+        return WorkerRegistry(MagicMock(), updater), reader
 
     def test_get_comment_cache_lazy_creates_per_key(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         c1 = reg.get_comment_cache("foo/bar", 7, gh)
         c2 = reg.get_comment_cache("foo/bar", 7, gh)
         assert c1 is c2  # same key → same instance
 
     def test_distinct_items_in_same_repo_get_distinct_caches(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         c7 = reg.get_comment_cache("foo/bar", 7, gh)
         c8 = reg.get_comment_cache("foo/bar", 8, gh)
         assert c7 is not c8
 
     def test_distinct_repos_with_same_item_get_distinct_caches(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("org/a", "org/b")
         gh = MagicMock()
         a = reg.get_comment_cache("org/a", 1, gh)
         b = reg.get_comment_cache("org/b", 1, gh)
         assert a is not b
 
     def test_all_comment_caches_lists_created_instances(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar", "baz/qux")
         gh = MagicMock()
         reg.get_comment_cache("foo/bar", 7, gh)
         reg.get_comment_cache("foo/bar", 8, gh)
@@ -2300,7 +2308,7 @@ class TestCommentCacheRegistry:
         # retries hydration; queued events drain on success.
         import requests
 
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         gh.get_issue_comments.side_effect = requests.RequestException("boom")
         cache = reg.get_comment_cache("foo/bar", 7, gh)
@@ -2324,7 +2332,7 @@ class TestCommentCacheRegistry:
         # successful hydration drains the queued event.
         import requests
 
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         gh.get_issue_comments.side_effect = requests.RequestException("boom")
         cache = reg.get_comment_cache("foo/bar", 7, gh)
@@ -2351,19 +2359,69 @@ class TestCommentCacheRegistry:
         assert cache.get("issues", 42) is not None
 
     def test_destroy_comment_cache_removes_existing(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         reg.get_comment_cache("foo/bar", 7, gh)
         assert reg.destroy_comment_cache("foo/bar", 7) is True
         assert len(reg.all_comment_caches()) == 0
 
     def test_destroy_comment_cache_returns_false_when_missing(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         assert reg.destroy_comment_cache("foo/bar", 7) is False
 
     def test_destroy_comment_cache_idempotent(self) -> None:
-        reg = self._reg()
+        reg, _ = self._reg("foo/bar")
         gh = MagicMock()
         reg.get_comment_cache("foo/bar", 7, gh)
         assert reg.destroy_comment_cache("foo/bar", 7) is True
         assert reg.destroy_comment_cache("foo/bar", 7) is False  # idempotent
+
+    def test_publisher_publishes_snapshot_on_cache_mutation(self) -> None:
+        """Comment cache mutations publish a CommentCacheSnapshot to
+        the per-repo SCADA leaf (#1758)."""
+        from fido.appstate import CommentCacheSnapshot
+
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        reg.get_comment_cache("foo/bar", 7, gh)
+        snap = reader.get().repos["foo/bar"].comment_cache
+        assert isinstance(snap, CommentCacheSnapshot)
+        assert snap.item == 7
+        assert snap.loaded is True
+        assert snap.entries_cached == 0
+
+    def test_destroy_clears_snapshot(self) -> None:
+        """``destroy_comment_cache`` clears the per-repo SCADA leaf
+        back to ``None`` so ``/status.json`` stops showing the dead
+        PR's cache (#1758)."""
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        reg.get_comment_cache("foo/bar", 7, gh)
+        assert reader.get().repos["foo/bar"].comment_cache is not None
+        reg.destroy_comment_cache("foo/bar", 7)
+        assert reader.get().repos["foo/bar"].comment_cache is None
+
+    def test_destroy_no_op_does_not_touch_snapshot(self) -> None:
+        """A destroy for a never-created cache must not touch
+        FidoState — otherwise it would falsely clear a sibling
+        cache's snapshot that the active cache had populated."""
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        # Populate the snapshot via a real cache.
+        reg.get_comment_cache("foo/bar", 99, gh)
+        before = reader.get().repos["foo/bar"].comment_cache
+        assert before is not None
+        # Destroy a DIFFERENT (never-created) item.  No-op.
+        assert reg.destroy_comment_cache("foo/bar", 12345) is False
+        # Snapshot for the surviving cache is unchanged.
+        after = reader.get().repos["foo/bar"].comment_cache
+        assert after is before

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2376,9 +2376,9 @@ class TestCommentCacheRegistry:
         assert reg.destroy_comment_cache("foo/bar", 7) is True
         assert reg.destroy_comment_cache("foo/bar", 7) is False  # idempotent
 
-    def test_publisher_publishes_snapshot_on_cache_mutation(self) -> None:
-        """Comment cache mutations publish a CommentCacheSnapshot to
-        the per-repo SCADA leaf (#1758)."""
+    def test_publisher_publishes_per_item_snapshot(self) -> None:
+        """Cache mutations publish a snapshot keyed by item under the
+        per-repo ``comment_caches`` dict (#1758)."""
         from fido.appstate import CommentCacheSnapshot
 
         reg, reader = self._reg("foo/bar")
@@ -2387,41 +2387,78 @@ class TestCommentCacheRegistry:
         gh.get_pull_comments.return_value = []
         gh.get_pull_reviews.return_value = []
         reg.get_comment_cache("foo/bar", 7, gh)
-        snap = reader.get().repos["foo/bar"].comment_cache
+        caches = reader.get().repos["foo/bar"].comment_caches
+        assert 7 in caches
+        snap = caches[7]
         assert isinstance(snap, CommentCacheSnapshot)
         assert snap.item == 7
         assert snap.loaded is True
         assert snap.entries_cached == 0
 
-    def test_destroy_clears_snapshot(self) -> None:
-        """``destroy_comment_cache`` clears the per-repo SCADA leaf
-        back to ``None`` so ``/status.json`` stops showing the dead
-        PR's cache (#1758)."""
+    def test_destroy_removes_only_destroyed_item(self) -> None:
+        """``destroy_comment_cache`` drops the destroyed item from the
+        per-repo ``comment_caches`` dict; sibling caches keep their
+        snapshots (codex P2 on #1758: singleton field clobbered
+        siblings)."""
         reg, reader = self._reg("foo/bar")
         gh = MagicMock()
         gh.get_issue_comments.return_value = []
         gh.get_pull_comments.return_value = []
         gh.get_pull_reviews.return_value = []
         reg.get_comment_cache("foo/bar", 7, gh)
-        assert reader.get().repos["foo/bar"].comment_cache is not None
+        reg.get_comment_cache("foo/bar", 8, gh)
+        before = reader.get().repos["foo/bar"].comment_caches
+        assert set(before) == {7, 8}
         reg.destroy_comment_cache("foo/bar", 7)
-        assert reader.get().repos["foo/bar"].comment_cache is None
+        after = reader.get().repos["foo/bar"].comment_caches
+        assert set(after) == {8}
+        assert after[8].item == 8
 
     def test_destroy_no_op_does_not_touch_snapshot(self) -> None:
         """A destroy for a never-created cache must not touch
-        FidoState — otherwise it would falsely clear a sibling
-        cache's snapshot that the active cache had populated."""
+        FidoState — sibling snapshots stay exactly as they were."""
         reg, reader = self._reg("foo/bar")
         gh = MagicMock()
         gh.get_issue_comments.return_value = []
         gh.get_pull_comments.return_value = []
         gh.get_pull_reviews.return_value = []
-        # Populate the snapshot via a real cache.
         reg.get_comment_cache("foo/bar", 99, gh)
-        before = reader.get().repos["foo/bar"].comment_cache
-        assert before is not None
-        # Destroy a DIFFERENT (never-created) item.  No-op.
+        before = reader.get().repos["foo/bar"].comment_caches
         assert reg.destroy_comment_cache("foo/bar", 12345) is False
-        # Snapshot for the surviving cache is unchanged.
-        after = reader.get().repos["foo/bar"].comment_cache
-        assert after is before
+        after = reader.get().repos["foo/bar"].comment_caches
+        assert after is before  # no FidoState mutation
+
+    def test_late_publisher_from_destroyed_cache_does_not_resurrect(self) -> None:
+        """A destroyed cache instance held by a concurrent webhook
+        handler can still mutate (its on_change fires), but the
+        republish recomputes from registry membership — so the
+        destroyed item stays out of the snapshot dict (codex P2 on
+        #1758: stale-handle republish race)."""
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        c7 = reg.get_comment_cache("foo/bar", 7, gh)
+        reg.get_comment_cache("foo/bar", 8, gh)
+        # Destroy item 7; a concurrent handler still holds c7.
+        reg.destroy_comment_cache("foo/bar", 7)
+        # Late mutation fires c7's on_change — but the republish
+        # recomputes from the REGISTRY, where c7 is gone.
+        c7.apply_event(
+            "issue_comment",
+            {
+                "action": "created",
+                "issue": {"number": 7},
+                "comment": {
+                    "id": 42,
+                    "body": "late",
+                    "user": {"login": "alice"},
+                    "created_at": "2024-06-01T00:00:00Z",
+                    "updated_at": "2024-06-01T00:00:00Z",
+                },
+            },
+        )
+        after = reader.get().repos["foo/bar"].comment_caches
+        assert 7 not in after
+        assert 8 in after

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2428,6 +2428,44 @@ class TestCommentCacheRegistry:
         after = reader.get().repos["foo/bar"].comment_caches
         assert after is before  # no FidoState mutation
 
+    def test_hydrate_failure_publishes_unloaded_cache(self) -> None:
+        """Codex P2 follow-up on #1758: hydrate failure must publish
+        the un-loaded cache so SCADA shows the stuck instance and
+        its queue-overflow / staleness counters during the outage."""
+        import requests
+
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.side_effect = requests.RequestException("boom")
+        reg.get_comment_cache("foo/bar", 7, gh)
+        caches = reader.get().repos["foo/bar"].comment_caches
+        assert 7 in caches
+        assert caches[7].loaded is False
+
+    def test_start_republishes_existing_comment_caches(self, tmp_path: Path) -> None:
+        """Codex P2 follow-up on #1758: ``WorkerRegistry.start()``
+        resets the per-repo SCADA leaf to zero, but live
+        CommentCache instances in ``_comment_caches`` survive crash
+        recovery (registry-lifetime).  ``start()`` must republish so
+        ``/status.json`` doesn't go blank until the next mutation —
+        mirror of the existing IssueCache restart republish."""
+        reg, reader = self._reg("foo/bar")
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = []
+        gh.get_pull_comments.return_value = []
+        gh.get_pull_reviews.return_value = []
+        reg.get_comment_cache("foo/bar", 7, gh)
+        assert 7 in reader.get().repos["foo/bar"].comment_caches
+        # Simulate a worker start (e.g. crash recovery): zero_repo_state
+        # wipes the leaf back to ``frozendict()``.
+        reg._state_updater.update(  # noqa: SLF001
+            lambda root: root.repos["foo/bar"].comment_caches, frozendict()
+        )
+        assert reader.get().repos["foo/bar"].comment_caches == frozendict()
+        # Re-run start against a real (git-initialised) work_dir.
+        reg.start(_repo("foo/bar", tmp_path))
+        assert 7 in reader.get().repos["foo/bar"].comment_caches
+
     def test_late_publisher_from_destroyed_cache_does_not_resurrect(self) -> None:
         """A destroyed cache instance held by a concurrent webhook
         handler can still mutate (its on_change fires), but the


### PR DESCRIPTION
## Summary

Fourth slice of the #1748 mini-epic.  Surfaces per-(repo, PR)
CommentCache health through the SCADA path so ``/status.json``
and ``./fido status`` show what's cached and how it's doing.

## What this PR ships

* **``CommentCacheSnapshot``** in ``fido.appstate`` (parity with
  ``IssueCacheSnapshot``).  Frozen dataclass mirroring
  ``CommentCache.CacheMetrics``; ``item`` carries the PR number
  so the SCADA display can identify the bound PR.

* **``RepoState.comment_cache: CommentCacheSnapshot | None``** —
  ``None`` when no cache exists (Fido has no open PR there per
  INV-3); the active cache's latest snapshot otherwise.

* **``WorkerRegistry._make_comment_cache_publisher``** — mirror of
  ``_make_issue_cache_publisher``; wired in ``get_comment_cache``
  at construction.

* **``destroy_comment_cache``** clears the per-repo
  ``comment_cache`` field back to ``None`` after a successful
  removal.  No-op destroys don't touch FidoState.

* No renderer change needed: ``server.py``'s ``_jsonable`` already
  walks frozen dataclasses and emits ``None`` correctly.

## Test coverage

* ``test_publisher_publishes_snapshot_on_cache_mutation``
* ``test_destroy_clears_snapshot``
* ``test_destroy_no_op_does_not_touch_snapshot``
* Existing INV-1/2/3 tests updated to pre-populate ``RepoState``
  entries (lens path now requires them).

## Test plan

- [x] ``./fido ci`` green locally (4444 tests, 100% coverage)
- [ ] CI green on GitHub
- [ ] Codex review