### PR TITLE
INV-5 of #1748: CommentReconcileWatchdog + parity renames (closes #1759)

### DIFF
--- a/src/fido/appstate.py
+++ b/src/fido/appstate.py
@@ -253,12 +253,12 @@ _ZERO_TASK_LIST = TaskListSnapshot(
 
 @dataclass(frozen=True, slots=True)
 class IssueCacheSnapshot:
-    """Immutable snapshot of one repo's :class:`~fido.issue_cache.IssueTreeCache`
+    """Immutable snapshot of one repo's :class:`~fido.issue_cache.IssueCache`
     health for the SCADA display path.
 
     Mirrors the public fields of :class:`~fido.issue_cache.CacheMetrics`
     as JSON-friendly primitives.  Published by
-    :class:`~fido.issue_cache.IssueTreeCache` after every mutation
+    :class:`~fido.issue_cache.IssueCache` after every mutation
     (load_inventory / apply_event / reconcile_with_inventory) via the
     ``on_change`` callback supplied at construction (#1696 parity).
 

--- a/src/fido/cache_webhooks.py
+++ b/src/fido/cache_webhooks.py
@@ -1,4 +1,4 @@
-"""Translate raw GitHub webhook payloads into :class:`IssueTreeCache`
+"""Translate raw GitHub webhook payloads into :class:`IssueCache`
 event tuples (closes #812, sub-issue half closes #817).
 
 Pure value-only helper — no I/O, no cache mutation.  Caller passes the
@@ -47,7 +47,7 @@ def translate(
     event_type: str, payload: dict[str, Any]
 ) -> tuple[str, dict[str, Any]] | None:
     """Translate a webhook event to ``(cache_event_type, payload)`` for
-    :meth:`IssueTreeCache.apply_event`, or ``None`` if the event isn't
+    :meth:`IssueCache.apply_event`, or ``None`` if the event isn't
     relevant to the cache.
 
     Webhook source-of-truth shape per GitHub docs:
@@ -145,7 +145,7 @@ def _translate_sub_issues(
     Both shapes carry the same ``parent_issue`` + ``sub_issue`` snapshots,
     so we map all four actions to the existing
     ``sub_issue_added`` / ``sub_issue_removed`` cache events keyed by the
-    parent's number.  ``IssueTreeCache._handle_sub_issue_added`` already
+    parent's number.  ``IssueCache._handle_sub_issue_added`` already
     updates *both* nodes (parent.sub_issues and child.parent), so handling
     either side once is enough — and idempotent if both sides arrive.
     """

--- a/src/fido/issue_cache.py
+++ b/src/fido/issue_cache.py
@@ -44,7 +44,7 @@ class IssueNode:
 
     ``sub_issues`` is the ordered list of *all* sub-issue numbers
     (including ones that have since closed); openness is determined at
-    query time by membership in :attr:`IssueTreeCache._nodes`.  Storing
+    query time by membership in :attr:`IssueCache._nodes`.  Storing
     closed children's numbers preserves the original GitHub ordering for
     strict first-priority descent — GitHub doesn't reorder when a child
     closes, and neither do we.
@@ -74,7 +74,7 @@ class CacheMetrics:
     last_reconcile_drift: int
 
 
-class IssueTreeCache(WebhookCache[int, IssueNode, CacheMetrics]):
+class IssueCache(WebhookCache[int, IssueNode, CacheMetrics]):
     """Per-repo issue tree cache populated by inventory + webhook events.
 
     Lifecycle:
@@ -344,5 +344,5 @@ def _copy_node(node: IssueNode) -> IssueNode:
 __all__ = [
     "CacheMetrics",
     "IssueNode",
-    "IssueTreeCache",
+    "IssueCache",
 ]

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -32,7 +32,7 @@ from fido.comment_cache import CacheMetrics as CommentCacheMetrics
 from fido.comment_cache import CommentCache
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
-from fido.issue_cache import CacheMetrics, IssueTreeCache
+from fido.issue_cache import CacheMetrics, IssueCache
 from fido.provider import PromptSession, Provider
 from fido.repo import Repo
 from fido.rocq import handler_preemption as preemption_fsm
@@ -151,7 +151,7 @@ class WorkerRegistry:
         # Per-repo issue tree caches shared between worker + webhook
         # threads (closes #812).  Lazily created on first lookup so tests
         # that don't exercise the cache path don't pay setup cost.
-        self._issue_caches: dict[str, IssueTreeCache] = {}
+        self._issue_caches: dict[str, IssueCache] = {}
         self._issue_cache_lock = threading.Lock()
         # Per-(repo, item) comment caches (closes #1754).  Lazily created
         # on first lookup; each cache is bound to one issue/PR's
@@ -334,7 +334,7 @@ class WorkerRegistry:
         provider_module.set_talker_change_callback(
             repo_cfg.name, self._make_talker_publisher(repo_cfg.name)
         )
-        # On crash recovery the existing IssueTreeCache instance is
+        # On crash recovery the existing IssueCache instance is
         # preserved in ``_issue_caches`` but ``zero_repo_state(...)``
         # above reset its snapshot to ``loaded=false``.  Republish the
         # cache's current metrics so /status.json doesn't regress to
@@ -899,7 +899,7 @@ class WorkerRegistry:
         provider = thread.current_provider()
         return provider.agent.session if provider is not None else None
 
-    def get_issue_cache(self, repo_name: str) -> IssueTreeCache:
+    def get_issue_cache(self, repo_name: str) -> IssueCache:
         """Return (lazily creating) the per-repo issue tree cache (#812).
 
         Cache is shared between the worker thread (picker reads) and the
@@ -915,7 +915,7 @@ class WorkerRegistry:
         with self._issue_cache_lock:
             cache = self._issue_caches.get(repo_name)
             if cache is None:
-                cache = IssueTreeCache(
+                cache = IssueCache(
                     repo_name,
                     on_change=self._make_issue_cache_publisher(repo_name),
                 )
@@ -949,7 +949,7 @@ class WorkerRegistry:
 
         return publish
 
-    def all_issue_caches(self) -> list[IssueTreeCache]:
+    def all_issue_caches(self) -> list[IssueCache]:
         """Snapshot list of every issue cache that has been created.
 
         Used by ``fido status`` to surface per-repo cache metrics.
@@ -1118,7 +1118,7 @@ def _make_thread(
 ) -> WorkerThread:
     """Default factory: create a WorkerThread with the provided GitHub client.
 
-    Hands the per-repo :class:`IssueTreeCache` (created lazily by the
+    Hands the per-repo :class:`IssueCache` (created lazily by the
     registry) into the worker so the picker reads from the cache and the
     webhook handler can patch it (closes #812).
     """

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -66,7 +66,8 @@ from fido.store import FidoStore, ReplyPromiseRecord
 from fido.synthesis_executor import CommentTarget, SynthesisExecutor
 from fido.tasks import Tasks
 from fido.watchdog import (
-    ReconcileWatchdog,
+    CommentReconcileWatchdog,
+    IssueReconcileWatchdog,
     Watchdog,
 )
 from fido.worker import RepoContextFilter
@@ -632,7 +633,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
         self, event: str, payload: dict[str, Any], repo_cfg: RepoConfig
     ) -> None:
         """Translate the webhook to a cache event and apply it to the
-        per-repo :class:`~fido.issue_cache.IssueTreeCache` (#812).
+        per-repo :class:`~fido.issue_cache.IssueCache` (#812).
 
         No-op when the event isn't picker-relevant (translator returns
         ``None``).  No-op also when the cache hasn't been initialized —
@@ -1285,7 +1286,7 @@ def bootstrap_issue_caches(
     gh: GitHub,
     registry: WorkerRegistry,
 ) -> None:
-    """Bootstrap every per-repo :class:`~fido.issue_cache.IssueTreeCache` at startup (#837).
+    """Bootstrap every per-repo :class:`~fido.issue_cache.IssueCache` at startup (#837).
 
     Called once in :func:`run` after the registry is created but before the
     watchdog threads start.  Each repo gets a fresh ``find_all_open_issues``
@@ -1298,7 +1299,7 @@ def bootstrap_issue_caches(
 
     Per-repo failures are swallowed (logged, not raised): a single GitHub
     API hiccup must not prevent fido from starting.  The hourly
-    :class:`~fido.watchdog.ReconcileWatchdog` will heal any cold repo
+    :class:`~fido.watchdog.IssueReconcileWatchdog` will heal any cold repo
     within the hour.
     """
     for name in repos:
@@ -1316,12 +1317,12 @@ def bootstrap_issue_caches(
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
         ):
-            # Transient GitHub/network failure — ReconcileWatchdog heals within
+            # Transient GitHub/network failure — IssueReconcileWatchdog heals within
             # the hour.  Auth errors (RuntimeError) and logic bugs are NOT
             # caught; they crash startup loud so misconfiguration is visible.
             log.exception(
                 "startup: failed to bootstrap issue cache for %s — "
-                "ReconcileWatchdog will heal within the hour",
+                "IssueReconcileWatchdog will heal within the hour",
                 name,
             )
 
@@ -1338,7 +1339,10 @@ def run(
     _signal: Callable[..., Any] = signal.signal,
     _kill_active_children: Callable[..., None] = kill_active_children,
     _Watchdog: type[Watchdog] = Watchdog,
-    _ReconcileWatchdog: type[ReconcileWatchdog] = ReconcileWatchdog,
+    _IssueReconcileWatchdog: type[IssueReconcileWatchdog] = IssueReconcileWatchdog,
+    _CommentReconcileWatchdog: type[
+        CommentReconcileWatchdog
+    ] = CommentReconcileWatchdog,
     _SessionLockWatchdog: type[SessionLockWatchdog] = SessionLockWatchdog,
     _RateLimitMonitor: type[RateLimitMonitor] = RateLimitMonitor,
     _ProviderPressureMonitor: type[ProviderPressureMonitor] = ProviderPressureMonitor,
@@ -1443,7 +1447,11 @@ def run(
     # ClaudeSession (closes #479 — "one claude per repo" invariant).
     provider.set_session_resolver(registry.get_session)
     _Watchdog(registry, config.repos).start_thread()
-    _ReconcileWatchdog(registry, config.repos, gh).start_thread()
+    _IssueReconcileWatchdog(registry, config.repos, gh).start_thread()
+    # Per-(repo, item) CommentCache reconcile (#1759) — analog to the
+    # IssueReconcileWatchdog.  Iterates every live CommentCache and
+    # calls ``refresh`` to heal drift from missed webhook deliveries.
+    _CommentReconcileWatchdog(registry).start_thread()
     # Session-lock watchdog evicts FSM lock holders that have parked past
     # the deadline — without it, a holder wedged inside
     # ``consume_until_result`` on a streaming-forever subprocess holds

--- a/src/fido/watchdog.py
+++ b/src/fido/watchdog.py
@@ -150,11 +150,11 @@ def run(registry: WorkerRegistry, repos: dict[str, RepoConfig]) -> int:
     return Watchdog(registry, repos).run()
 
 
-class ReconcileWatchdog:
+class IssueReconcileWatchdog:
     """Hourly cache reconcile to heal drift from missed webhooks (#812).
 
     For each repo, fetches a fresh ``find_all_open_issues`` snapshot and
-    calls :meth:`~fido.issue_cache.IssueTreeCache.reconcile_with_inventory`
+    calls :meth:`~fido.issue_cache.IssueCache.reconcile_with_inventory`
     to apply any divergence.  Skips repos whose cache hasn't been
     bootstrapped yet — the worker thread does that on its first
     ``find_next_issue`` iteration.
@@ -184,7 +184,7 @@ class ReconcileWatchdog:
             cache = self.registry.get_issue_cache(repo_name)
             if not cache.is_loaded:
                 log.info(
-                    "reconcile-watchdog[%s]: cache not yet loaded — skipping",
+                    "issue-reconcile-watchdog[%s]: cache not yet loaded — skipping",
                     repo_name,
                 )
                 continue
@@ -202,7 +202,7 @@ class ReconcileWatchdog:
                 # Logic bugs (KeyError, TypeError, AttributeError, …) are NOT
                 # caught; they propagate and crash this thread loudly.
                 log.exception(
-                    "reconcile-watchdog[%s]: find_all_open_issues failed — "
+                    "issue-reconcile-watchdog[%s]: find_all_open_issues failed — "
                     "next hourly tick will retry",
                     repo_name,
                 )
@@ -210,7 +210,9 @@ class ReconcileWatchdog:
             drift = cache.reconcile_with_inventory(
                 inventory, snapshot_started_at=snapshot_started_at
             )
-            log.info("reconcile-watchdog[%s]: applied %d corrections", repo_name, drift)
+            log.info(
+                "issue-reconcile-watchdog[%s]: applied %d corrections", repo_name, drift
+            )
         return 0
 
     def start_thread(
@@ -223,6 +225,86 @@ class ReconcileWatchdog:
                 time.sleep(_interval)
                 self.run()
 
-        t = threading.Thread(target=_loop, daemon=True, name="reconcile-watchdog")
+        t = threading.Thread(target=_loop, daemon=True, name="issue-reconcile-watchdog")
+        t.start()
+        return t
+
+
+class CommentReconcileWatchdog:
+    """Hourly comment-cache reconcile to heal drift from missed
+    webhooks (#1759).
+
+    For each live :class:`~fido.comment_cache.CommentCache` in the
+    registry, calls :meth:`~fido.comment_cache.CommentCache.refresh`
+    which re-fetches the three list endpoints
+    (top-level + review-thread comments + review submissions) and
+    reconciles against the cache.  Ids absent from the fresh
+    snapshot are evicted (closes the codex P2 about evict-missing
+    on list fetches via the periodic sweep that healing relies on).
+
+    Skips caches whose initial hydration hasn't completed yet —
+    nothing to reconcile against.  Per-cache failures (transient
+    GitHub/network errors, including HTTP errors propagated from
+    the post-INV-3 refresh path) log the exception and continue;
+    the next hourly tick retries.  Logic bugs propagate and crash
+    the thread loudly.
+    """
+
+    def __init__(self, registry: WorkerRegistry) -> None:
+        self.registry = registry
+
+    def run(self) -> int:
+        """Run one reconcile pass across every live comment cache.
+
+        Returns 0 (parallels :class:`IssueReconcileWatchdog.run`).
+        """
+        for cache in self.registry.all_comment_caches():
+            metrics = cache.metrics()
+            if not cache.is_loaded:
+                log.info(
+                    "comment-reconcile-watchdog[%s#%d]: cache not yet "
+                    "loaded — skipping",
+                    metrics.repo_name,
+                    metrics.item,
+                )
+                continue
+            snapshot_started_at = datetime.now(tz=timezone.utc)
+            try:
+                cache.refresh(snapshot_started_at)
+            except (
+                requests.RequestException,
+                GraphQLError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ):
+                # Transient GitHub/network failure — next tick retries.
+                # Logic bugs are NOT caught; they propagate.
+                log.exception(
+                    "comment-reconcile-watchdog[%s#%d]: refresh failed — "
+                    "next hourly tick will retry",
+                    metrics.repo_name,
+                    metrics.item,
+                )
+                continue
+            log.info(
+                "comment-reconcile-watchdog[%s#%d]: refreshed",
+                metrics.repo_name,
+                metrics.item,
+            )
+        return 0
+
+    def start_thread(
+        self, *, _interval: float = _RECONCILE_INTERVAL
+    ) -> threading.Thread:
+        """Start a daemon thread that reconciles every *_interval* seconds."""
+
+        def _loop() -> None:
+            while True:
+                time.sleep(_interval)
+                self.run()
+
+        t = threading.Thread(
+            target=_loop, daemon=True, name="comment-reconcile-watchdog"
+        )
         t.start()
         return t

--- a/src/fido/webhook_cache.py
+++ b/src/fido/webhook_cache.py
@@ -84,7 +84,7 @@ class WebhookCache(ABC, Generic[_K, _V, _M]):
         event is dropped and ``events_dropped_queue_overflow`` is
         bumped.  ``None`` (default) means unbounded — appropriate
         for caches whose hydration is guaranteed to run at startup
-        (e.g. :class:`~fido.issue_cache.IssueTreeCache`).  Caches
+        (e.g. :class:`~fido.issue_cache.IssueCache`).  Caches
         that can stay un-loaded across persistent failures (e.g.
         :class:`~fido.comment_cache.CommentCache` on a permission
         outage) supply a finite cap so memory growth is bounded.

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -32,7 +32,7 @@ from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.harness_commit import HarnessCommitter
 from fido.infra import RealProcessRunner
-from fido.issue_cache import IssueNode, IssueTreeCache
+from fido.issue_cache import IssueCache, IssueNode
 from fido.nudges import Nudges
 from fido.prompts import Prompts, render_active_context
 from fido.provider import (
@@ -1240,7 +1240,7 @@ class Worker:
         state_updater: AtomicUpdater[FidoState] | None = None,
         *,
         dispatcher: "Dispatcher",
-        issue_cache: IssueTreeCache,
+        issue_cache: IssueCache,
     ) -> None:
         self.work_dir = work_dir
         self.gh = gh
@@ -1443,7 +1443,7 @@ class Worker:
         Called each outer iteration so fido abandons an issue that was a
         leaf at pickup but has since acquired children (e.g. fido itself
         groomed it into sub-issues, or a human added children).  Reads
-        from the per-repo :class:`IssueTreeCache` (closes #812 follow-up):
+        from the per-repo :class:`IssueCache` (closes #812 follow-up):
         a child is open iff its number is still in the cache index.
         """
         del repo  # repo is the cache's scope already
@@ -1541,7 +1541,7 @@ class Worker:
         """Find the next eligible open issue assigned to gh_user.
 
         Reads candidates + the issue tree from the per-repo
-        :class:`~fido.issue_cache.IssueTreeCache` (closes #812) — zero
+        :class:`~fido.issue_cache.IssueCache` (closes #812) — zero
         GraphQL on the steady-state pick — and verifies the chosen issue
         is still open via a single REST call before committing the
         assignment.
@@ -1609,7 +1609,7 @@ class Worker:
         """Cache-driven picker (closes #812).
 
         Reads candidates + the full issue tree from the per-repo
-        :class:`~fido.issue_cache.IssueTreeCache` — zero GraphQL on the
+        :class:`~fido.issue_cache.IssueCache` — zero GraphQL on the
         steady-state pick — and runs the same priority-rank +
         strict-first-priority descent as the old GraphQL path.
 
@@ -4596,7 +4596,7 @@ class WorkerThread(threading.Thread):
         state_updater: AtomicUpdater[FidoState] | None = None,
         *,
         dispatcher: "Dispatcher",
-        issue_cache: IssueTreeCache,
+        issue_cache: IssueCache,
     ) -> None:
         super().__init__(name=f"worker-{work_dir.name}", daemon=True)
         self.work_dir = work_dir

--- a/tests/test_issue_cache.py
+++ b/tests/test_issue_cache.py
@@ -1,11 +1,11 @@
-"""Tests for fido.issue_cache.IssueTreeCache (closes #812)."""
+"""Tests for fido.issue_cache.IssueCache (closes #812)."""
 
 import threading
 from datetime import datetime, timedelta, timezone
 
 from fido.issue_cache import (
     CacheMetrics,
-    IssueTreeCache,
+    IssueCache,
 )
 
 _T0 = datetime(2026, 4, 18, 22, 0, 0, tzinfo=timezone.utc)
@@ -58,7 +58,7 @@ def _evt(
 
 class TestLoadInventory:
     def test_seeds_nodes(self) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 _inv(1, title="root", sub_issues=[2, 3]),
@@ -80,13 +80,13 @@ class TestLoadInventory:
         assert n3.milestone == "v1"
 
     def test_marks_loaded(self) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         assert cache.is_loaded is False
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
         assert cache.is_loaded is True
 
     def test_drains_pre_inventory_queue_in_timestamp_order(self) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         # Queue events while not loaded — their 'login' adds should run in
         # timestamp order, not arrival order.
         cache.apply_event("assigned", _evt(1, timestamp=_ts(20), login="alice"))
@@ -104,7 +104,7 @@ class TestLoadInventory:
         assert node.last_applied_at == _ts(20)
 
     def test_pre_inventory_event_predating_snapshot_is_dropped(self) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.apply_event(
             "assigned", _evt(1, timestamp=_T0 - timedelta(hours=1), login="ghost")
         )
@@ -120,8 +120,8 @@ class TestLoadInventory:
 
 
 class TestEventIdempotency:
-    def _loaded(self) -> IssueTreeCache:
-        cache = IssueTreeCache("o/r")
+    def _loaded(self) -> IssueCache:
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 _inv(1, title="parent", sub_issues=[2]),
@@ -189,8 +189,8 @@ class TestEventIdempotency:
 
 
 class TestEventMutations:
-    def _loaded(self) -> IssueTreeCache:
-        cache = IssueTreeCache("o/r")
+    def _loaded(self) -> IssueCache:
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 _inv(1, title="parent", sub_issues=[2, 3]),
@@ -265,7 +265,7 @@ class TestEventMutations:
         assert node.milestone == "v2"
 
     def test_milestoned_to_none_clears_milestone(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1, milestone="v1")], snapshot_started_at=_T0)
         cache.apply_event("milestoned", _evt(1, timestamp=_ts(10)))
         node = cache.get(1)
@@ -321,8 +321,8 @@ class TestHandlersAgainstMissingNode:
     """Every node-mutation handler must no-op cleanly when the target
     node is absent from the cache (idempotent on missing)."""
 
-    def _loaded(self) -> IssueTreeCache:
-        cache = IssueTreeCache("o/r")
+    def _loaded(self) -> IssueCache:
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
         return cache
 
@@ -349,7 +349,7 @@ class TestHandlersAgainstMissingNode:
 
 class TestStalenessRejection:
     def test_event_older_than_last_applied_at_dropped(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [_inv(1, assignees=["fido"])], snapshot_started_at=_ts(100)
         )
@@ -361,7 +361,7 @@ class TestStalenessRejection:
         assert cache.metrics().events_dropped_stale == 1
 
     def test_event_after_advances_last_applied_at(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
         cache.apply_event("assigned", _evt(1, timestamp=_ts(60), login="x"))
         cache.apply_event("assigned", _evt(1, timestamp=_ts(30), login="y"))
@@ -372,7 +372,7 @@ class TestStalenessRejection:
         assert cache.metrics().events_dropped_stale == 1
 
     def test_unknown_event_type_is_ignored(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
         cache.apply_event(
             "transferred",
@@ -389,7 +389,7 @@ class TestStalenessRejection:
 
 class TestReconcile:
     def test_reports_zero_drift_when_in_sync(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         snap = [_inv(1, title="x", sub_issues=[]), _inv(2, parent=1)]
         cache.load_inventory(snap, snapshot_started_at=_T0)
         drift = cache.reconcile_with_inventory(snap, snapshot_started_at=_ts(60))
@@ -399,14 +399,14 @@ class TestReconcile:
         assert m.last_reconcile_at is not None
 
     def test_removes_nodes_absent_from_snapshot(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1), _inv(2)], snapshot_started_at=_T0)
         drift = cache.reconcile_with_inventory([_inv(1)], snapshot_started_at=_ts(60))
         assert drift == 1
         assert cache.get(2) is None
 
     def test_adds_nodes_present_only_in_snapshot(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
         drift = cache.reconcile_with_inventory(
             [_inv(1), _inv(2, title="new")], snapshot_started_at=_ts(60)
@@ -417,7 +417,7 @@ class TestReconcile:
         assert n2.title == "new"
 
     def test_replaces_diverged_node(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1, assignees=["fido"])], snapshot_started_at=_T0)
         drift = cache.reconcile_with_inventory(
             [_inv(1, assignees=["alice"])], snapshot_started_at=_ts(60)
@@ -433,7 +433,7 @@ class TestReconcile:
 
 class TestThreadSafety:
     def test_concurrent_assigned_unassigned_does_not_corrupt(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1)], snapshot_started_at=_T0)
 
         def writer(login: str, n_iters: int) -> None:
@@ -460,8 +460,8 @@ class TestThreadSafety:
 
 
 class TestQueryAPI:
-    def _loaded(self) -> IssueTreeCache:
-        cache = IssueTreeCache("o/r")
+    def _loaded(self) -> IssueCache:
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 _inv(
@@ -533,7 +533,7 @@ class TestQueryAPI:
 
 class TestMetrics:
     def test_metrics_before_inventory(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         m = cache.metrics()
         assert isinstance(m, CacheMetrics)
         assert m.repo_name == "o/r"
@@ -545,7 +545,7 @@ class TestMetrics:
         assert m.last_reconcile_at is None
 
     def test_metrics_after_load_and_event(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory([_inv(1), _inv(2)], snapshot_started_at=_T0)
         cache.apply_event("assigned", _evt(1, timestamp=_ts(10), login="x"))
         m = cache.metrics()
@@ -557,7 +557,7 @@ class TestMetrics:
 
 class TestNodeShape:
     def test_inventory_with_missing_created_at_falls_back_to_min(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 {
@@ -577,7 +577,7 @@ class TestNodeShape:
         assert node.created_at == datetime.min.replace(tzinfo=timezone.utc)
 
     def test_inventory_with_no_assignees(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 {
@@ -600,7 +600,7 @@ class TestNodeShape:
         assert node.milestone is None
 
     def test_inventory_with_login_blank_skipped(self) -> None:
-        cache = IssueTreeCache("o/r")
+        cache = IssueCache("o/r")
         cache.load_inventory(
             [
                 {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -442,11 +442,11 @@ class TestWorkerRegistry:
     # ── issue tree cache (fix #812) ──────────────────────────────────────
 
     def test_get_issue_cache_creates_lazily(self) -> None:
-        from fido.issue_cache import IssueTreeCache
+        from fido.issue_cache import IssueCache
 
         reg, _, reader = self._make_registry()
         cache = reg.get_issue_cache("foo/bar")
-        assert isinstance(cache, IssueTreeCache)
+        assert isinstance(cache, IssueCache)
 
     def test_get_issue_cache_returns_same_instance(self) -> None:
         reg, _, reader = self._make_registry()
@@ -1516,7 +1516,7 @@ class TestParityPublishers:
     def test_restart_republishes_existing_issue_cache(self, tmp_path: Path) -> None:
         """Codex parity: ``zero_repo_state`` resets ``issue_cache`` to
         ``loaded=false`` on every ``start()``, but on crash recovery the
-        existing :class:`IssueTreeCache` instance is preserved.  ``start()``
+        existing :class:`IssueCache` instance is preserved.  ``start()``
         must republish the cache's current metrics so /status.json
         doesn't regress to an empty snapshot until the next mutation."""
         from datetime import datetime, timezone

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3510,7 +3510,7 @@ class TestRun:
             _preflight_gh_auth=MagicMock(),
             _GitHub=MagicMock,
             _Watchdog=mock_watchdog_cls,
-            _ReconcileWatchdog=MagicMock(),
+            _IssueReconcileWatchdog=MagicMock(),
             _ProviderPressureMonitor=MagicMock(),
             _RateLimitMonitor=MagicMock(),
         )
@@ -3541,7 +3541,7 @@ class TestRun:
             _preflight_gh_auth=MagicMock(),
             _GitHub=lambda: mock_gh_instance,
             _Watchdog=MagicMock(),
-            _ReconcileWatchdog=MagicMock(),
+            _IssueReconcileWatchdog=MagicMock(),
             _RateLimitMonitor=mock_rl_cls,
             _ProviderPressureMonitor=MagicMock(),
         )
@@ -3583,7 +3583,7 @@ class TestRun:
             _preflight_gh_auth=MagicMock(),
             _GitHub=lambda: mock_gh_instance,
             _Watchdog=MagicMock(),
-            _ReconcileWatchdog=mock_reconcile_cls,
+            _IssueReconcileWatchdog=mock_reconcile_cls,
             _ProviderPressureMonitor=MagicMock(),
             _RateLimitMonitor=MagicMock(),
         )
@@ -3685,7 +3685,7 @@ class TestRun:
             _preflight_gh_auth=MagicMock(),
             _GitHub=lambda: mock_gh_instance,
             _Watchdog=MagicMock(),
-            _ReconcileWatchdog=MagicMock(),
+            _IssueReconcileWatchdog=MagicMock(),
             _bootstrap_issue_caches=mock_bootstrap,
             _ProviderPressureMonitor=MagicMock(),
             _RateLimitMonitor=MagicMock(),

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -12,7 +12,8 @@ from fido.provider import ProviderID
 from fido.watchdog import (
     _RECONCILE_INTERVAL,  # noqa: PLC2701
     _STALE_THRESHOLD,  # noqa: PLC2701
-    ReconcileWatchdog,
+    CommentReconcileWatchdog,
+    IssueReconcileWatchdog,
     Watchdog,
     run,
 )
@@ -215,14 +216,14 @@ class TestModuleLevelRun:
         assert run(_registry(), {"owner/repo": _repo()}) == 0
 
 
-# ── ReconcileWatchdog (closes #812) ───────────────────────────────────────────
+# ── IssueReconcileWatchdog (closes #812) ───────────────────────────────────────────
 
 
 def _reconcile(
     repos: dict[str, RepoConfig] | None = None,
     *,
     cache_loaded: bool = True,
-) -> tuple[ReconcileWatchdog, MagicMock, MagicMock, MagicMock]:
+) -> tuple[IssueReconcileWatchdog, MagicMock, MagicMock, MagicMock]:
     if repos is None:
         repos = {"owner/repo": _repo()}
     registry = MagicMock()
@@ -230,10 +231,10 @@ def _reconcile(
     cache.is_loaded = cache_loaded
     registry.get_issue_cache.return_value = cache
     gh = MagicMock()
-    return ReconcileWatchdog(registry, repos, gh), registry, cache, gh
+    return IssueReconcileWatchdog(registry, repos, gh), registry, cache, gh
 
 
-class TestReconcileWatchdogRun:
+class TestIssueReconcileWatchdogRun:
     def test_returns_zero(self) -> None:
         rw, _registry, _cache, gh = _reconcile(cache_loaded=False)
         assert rw.run() == 0
@@ -291,16 +292,16 @@ class TestReconcileWatchdogRun:
         assert gh.find_all_open_issues.call_count == 2
 
 
-class TestReconcileWatchdogStartThread:
+class TestIssueReconcileWatchdogStartThread:
     def test_returns_daemon_thread(self) -> None:
         rw, _registry, _cache, _gh = _reconcile(cache_loaded=False)
         t = rw.start_thread(_interval=60.0)
         assert t.daemon
 
-    def test_thread_name_is_reconcile_watchdog(self) -> None:
+    def test_thread_name_is_issue_reconcile_watchdog(self) -> None:
         rw, _registry, _cache, _gh = _reconcile(cache_loaded=False)
         t = rw.start_thread(_interval=60.0)
-        assert t.name == "reconcile-watchdog"
+        assert t.name == "issue-reconcile-watchdog"
 
     def test_thread_is_alive(self) -> None:
         rw, _registry, _cache, _gh = _reconcile(cache_loaded=False)
@@ -317,3 +318,92 @@ class TestReconcileWatchdogStartThread:
 class TestReconcileInterval:
     def test_default_interval_is_one_hour(self) -> None:
         assert _RECONCILE_INTERVAL == 3600.0
+
+
+# ── CommentReconcileWatchdog (closes #1759) ───────────────────────────────
+
+
+def _comment_watchdog(
+    *, caches: list[MagicMock] | None = None
+) -> tuple[CommentReconcileWatchdog, MagicMock]:
+    registry = MagicMock()
+    registry.all_comment_caches.return_value = caches or []
+    return CommentReconcileWatchdog(registry), registry
+
+
+def _live_comment_cache(
+    *,
+    item: int = 7,
+    repo_name: str = "owner/repo#7",
+    loaded: bool = True,
+) -> MagicMock:
+    """A mock CommentCache shaped like the production one."""
+    cache = MagicMock()
+    cache.is_loaded = loaded
+    metrics = MagicMock()
+    metrics.item = item
+    metrics.repo_name = repo_name
+    cache.metrics.return_value = metrics
+    return cache
+
+
+class TestCommentReconcileWatchdogRun:
+    def test_returns_zero_with_no_caches(self) -> None:
+        rw, _registry = _comment_watchdog()
+        assert rw.run() == 0
+
+    def test_skips_unloaded_cache(self) -> None:
+        cache = _live_comment_cache(loaded=False)
+        rw, _registry = _comment_watchdog(caches=[cache])
+        rw.run()
+        cache.refresh.assert_not_called()
+
+    def test_refreshes_loaded_cache(self) -> None:
+        cache = _live_comment_cache()
+        rw, _registry = _comment_watchdog(caches=[cache])
+        rw.run()
+        cache.refresh.assert_called_once()
+        # snapshot_started_at is a positional datetime arg.
+        ts = cache.refresh.call_args.args[0]
+        assert ts.tzinfo is not None
+
+    def test_continues_to_next_cache_when_refresh_raises(self) -> None:
+        """Transient errors swallowed; next cache still refreshes."""
+        a = _live_comment_cache(item=7)
+        b = _live_comment_cache(item=8)
+        a.refresh.side_effect = requests.RequestException("rate limited")
+        rw, _registry = _comment_watchdog(caches=[a, b])
+        rw.run()
+        b.refresh.assert_called_once()
+
+    def test_logic_bug_propagates(self) -> None:
+        """Logic bugs (e.g. KeyError) propagate so the thread crashes
+        loudly rather than silently corrupting."""
+        cache = _live_comment_cache()
+        cache.refresh.side_effect = KeyError("unexpected")
+        rw, _registry = _comment_watchdog(caches=[cache])
+        with pytest.raises(KeyError):
+            rw.run()
+
+
+class TestCommentReconcileWatchdogStartThread:
+    def test_returns_daemon_thread(self) -> None:
+        rw, _registry = _comment_watchdog()
+        t = rw.start_thread(_interval=60.0)
+        assert t.daemon
+
+    def test_thread_name_is_comment_reconcile_watchdog(self) -> None:
+        rw, _registry = _comment_watchdog()
+        t = rw.start_thread(_interval=60.0)
+        assert t.name == "comment-reconcile-watchdog"
+
+    def test_thread_is_alive(self) -> None:
+        rw, _registry = _comment_watchdog()
+        t = rw.start_thread(_interval=60.0)
+        assert t.is_alive()
+
+    def test_calls_run_periodically(self) -> None:
+        rw, registry = _comment_watchdog()
+        rw.start_thread(_interval=0.01)
+        time.sleep(0.1)
+        registry.all_comment_caches.assert_called()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -20,7 +20,7 @@ from fido.appstate import (
 )
 from fido.claude import ClaudeClient
 from fido.config import Config, RepoConfig, RepoMembership
-from fido.issue_cache import IssueNode, IssueTreeCache
+from fido.issue_cache import IssueCache, IssueNode
 from fido.prompts import Prompts
 from fido.provider import (
     READ_ONLY_ALLOWED_TOOLS,
@@ -135,7 +135,7 @@ class Worker(_WorkerBase):
                 membership=kwargs.get("membership"),
             )
         if "issue_cache" not in kwargs:
-            kwargs["issue_cache"] = IssueTreeCache(kwargs.get("repo_name", "test/repo"))
+            kwargs["issue_cache"] = IssueCache(kwargs.get("repo_name", "test/repo"))
         if "dispatcher" not in kwargs:
             kwargs["dispatcher"] = _FakeDispatcher()
         super().__init__(work_dir, gh, *args, **kwargs)
@@ -165,7 +165,7 @@ class WorkerThread(_WorkerThreadBase):
                 membership=kwargs.get("membership"),
             )
         if "issue_cache" not in kwargs:
-            kwargs["issue_cache"] = IssueTreeCache(repo_name)
+            kwargs["issue_cache"] = IssueCache(repo_name)
         if "dispatcher" not in kwargs:
             kwargs["dispatcher"] = _FakeDispatcher()
         super().__init__(work_dir, repo_name, gh, *args, **kwargs)
@@ -2520,7 +2520,7 @@ class TestIssueHasOpenSubIssues:
 
     def _worker(self, tmp_path: Path, inventory: list[dict] | None = None) -> Worker:
         gh = MagicMock()
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         if inventory is not None:
             cache.load_inventory(
                 inventory,
@@ -2601,7 +2601,7 @@ class TestAssertGitIdentity:
                 tmp_path,
                 gh,
                 dispatcher=_FakeDispatcher(),
-                issue_cache=IssueTreeCache("test/repo"),
+                issue_cache=IssueCache("test/repo"),
             ),
             gh,
         )
@@ -3056,7 +3056,7 @@ class TestWorkerPickFromCache:
     """``Worker._pick_from_cache`` is the cache-driven picker entry point."""
 
     def _worker_with_cache(
-        self, tmp_path: Path, cache: IssueTreeCache
+        self, tmp_path: Path, cache: IssueCache
     ) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         provider = MagicMock()
@@ -3082,7 +3082,7 @@ class TestWorkerPickFromCache:
         )
 
     def test_picks_from_preloaded_cache_without_api_call(self, tmp_path: Path) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 {
@@ -3104,7 +3104,7 @@ class TestWorkerPickFromCache:
     def test_does_not_reload_inventory_when_cache_already_loaded(
         self, tmp_path: Path
     ) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 {
@@ -3124,7 +3124,7 @@ class TestWorkerPickFromCache:
         gh.find_all_open_issues.assert_not_called()
 
     def test_returns_none_when_no_candidates_for_login(self, tmp_path: Path) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 {
@@ -3143,7 +3143,7 @@ class TestWorkerPickFromCache:
         gh.view_issue.assert_not_called()
 
     def test_returns_none_when_verify_says_closed(self, tmp_path: Path) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 {
@@ -3165,10 +3165,10 @@ class TestWorkerPickFromCache:
 
 class TestWorkerFindNextIssueCacheBranch:
     """``Worker.find_next_issue`` selects the cache branch when an
-    :class:`IssueTreeCache` is injected (closes #812)."""
+    :class:`IssueCache` is injected (closes #812)."""
 
     def test_cache_branch_picks_via_cache_not_graphql(self, tmp_path: Path) -> None:
-        cache = IssueTreeCache("owner/repo")
+        cache = IssueCache("owner/repo")
         cache.load_inventory(
             [
                 {

--- a/tests/test_worker_persist_session_id.py
+++ b/tests/test_worker_persist_session_id.py
@@ -9,14 +9,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from fido.github import GitHub
-from fido.issue_cache import IssueTreeCache
+from fido.issue_cache import IssueCache
 from fido.worker import WorkerThread
 from tests.fakes import _FakeDispatcher
 
 
 def _make_thread(tmp_path: Path, **kwargs: object) -> WorkerThread:
     gh = MagicMock(spec=GitHub)
-    kwargs.setdefault("issue_cache", IssueTreeCache("owner/repo"))
+    kwargs.setdefault("issue_cache", IssueCache("owner/repo"))
     kwargs.setdefault("dispatcher", _FakeDispatcher())
     return WorkerThread(
         tmp_path,


### PR DESCRIPTION
## Summary

Fifth slice of the #1748 mini-epic.  Periodic-reconcile watchdog
for CommentCache (analog to the IssueCache one), plus naming
cleanup so the two parallel caches and their watchdogs have
matching names.

## What this PR ships

* **``CommentReconcileWatchdog``** — hourly daemon thread, same
  cadence as ``IssueReconcileWatchdog``.  Iterates
  ``registry.all_comment_caches()`` and calls ``cache.refresh()``
  on each loaded one.  Ids absent from the fresh snapshot are
  evicted — closes the long-standing codex P2 about
  evict-missing on list fetches via the periodic sweep.
* Wired in ``server.run()`` next to ``IssueReconcileWatchdog``.

## Renames for parity

* ``ReconcileWatchdog`` → ``IssueReconcileWatchdog``
* ``IssueTreeCache`` → ``IssueCache``
* Log prefix and thread name updated to match
* Docstring + import-path references swept across appstate,
  registry, cache_webhooks, watchdog

All renames done via grep+sed; no functional change beyond the
names.

## Per-tick safety

GH HTTP calls already have a 30s per-request timeout via
``_TimeoutSession`` (``fido.github``).  A single refresh = 3 calls
= max ~90s.  The loop is sequential (``while True: sleep(); run()``)
so ticks can't overlap within a process.  Across self-restart,
daemon threads die with process exit.  No "stuck old watchdog"
risk.

## Verification

* CI green (4456 tests, 100% coverage)
* New tests cover: empty case, unloaded skip, refresh on loaded,
  per-cache failure isolation, logic-bug propagation, daemon
  thread shape

## Test plan

- [x] ``./fido ci`` green locally
- [ ] CI green on GitHub
- [ ] Codex review