### PR TITLE
INV-6 of #1748: events.py routes comment reads through CommentCache (closes #1760)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from fido.comment_cache import KIND_ISSUES, KIND_PULLS
+from fido.comment_cache import KIND_ISSUES, KIND_PULLS, CommentCache
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
@@ -331,6 +331,64 @@ def _pr_number_from_api_url(url: str, kind: str) -> int:
     if match is None:
         raise ValueError(f"invalid GitHub API URL for {kind}: {url!r}")
     return int(match.group(1))
+
+
+def _comment_via_cache_or_gh(
+    cache: CommentCache,
+    kind: str,
+    *,
+    gh: GitHub,
+    repo: str,
+    comment_id: int,
+) -> Mapping[str, Any] | None:
+    """Cache-first lookup with authoritative fallback to GitHub.
+
+    The per-(repo, item) :class:`CommentCache` only carries comments
+    that belong to its scoped item, so :meth:`CommentCache.get`
+    legitimately returns ``None`` in two non-failure cases:
+
+    * the requested comment belongs to a *different* PR — common when
+      :func:`recover_reply_promises` iterates the repo-wide promise
+      table; the caller skips foreign-PR matches downstream;
+    * the cache failed to hydrate and silently stayed empty
+      (``WorkerRegistry.get_comment_cache`` swallows hydration errors
+      so the webhook handler can still queue the triggering event).
+
+    In both cases the previous direct-GitHub call was authoritative,
+    and treating cache misses as "comment deleted" would mark valid
+    promises failed.  Fall back to ``gh`` so the caller sees the same
+    behaviour as before the cache migration (INV-6 of #1748).
+    """
+    cached = cache.get(kind, comment_id)
+    if cached is not None:
+        return cached
+    if kind == KIND_PULLS:
+        return gh.get_pull_comment(repo, comment_id)
+    return gh.get_issue_comment(repo, comment_id)
+
+
+def _top_level_comments_via_cache_or_gh(
+    cache: CommentCache,
+    *,
+    gh: GitHub,
+    repo: str,
+    pr_number: int,
+) -> list[Mapping[str, Any]]:
+    """Cache-first list of top-level PR comments with authoritative fallback.
+
+    :meth:`CommentCache.list_top_level` returns ``[]`` both when the
+    PR genuinely has no top-level comments and when hydration failed
+    silently (``is_loaded == False``).  The latter would cause
+    :meth:`Dispatcher.backfill_missed_pr_comments` — a one-shot
+    startup replay — to drop every missed ``issue_comment`` event
+    until the next process restart.  Falling back to the
+    ``gh.get_issue_comments`` call that backfill used pre-INV-6
+    preserves the original loud-failure semantics for the only path
+    where the cache might still be unhydrated.
+    """
+    if cache.is_loaded:
+        return list(cache.list_top_level())
+    return [dict(c) for c in gh.get_issue_comments(repo, pr_number)]
 
 
 def build_review_comment_action(
@@ -936,13 +994,15 @@ def recover_reply_promises(
     pr_body = pr_issue["body"] or ""
     processed_any = False
     pull_entries: dict[str, tuple[Mapping[str, Any], int, int]] = {}
-    # INV-6: comment lookups route through the per-(repo, pr) cache.
-    # The cache is already hydrated at PR-open / startup; reads here
-    # are O(1) dict lookups instead of GH round-trips.
+    # INV-6: comment lookups route through the per-(repo, pr) cache,
+    # falling back to direct GitHub calls on cache miss or unhydrated
+    # cache (see ``_comment_via_cache_or_gh`` / ``_top_level_comments_via_cache_or_gh``).
     comment_cache = registry.get_comment_cache(repo_cfg.name, pr_number, gh)
     issue_comments: list[Mapping[str, Any]] = []
     if any(p.comment_type == "issues" for p in promises):
-        issue_comments = comment_cache.list_top_level()
+        issue_comments = _top_level_comments_via_cache_or_gh(
+            comment_cache, gh=gh, repo=repo_cfg.name, pr_number=pr_number
+        )
         if store.recover_from_bodies(c.get("body", "") for c in issue_comments):
             processed_any = True
         issue_comments_by_id = {int(c["id"]): c for c in issue_comments if c.get("id")}
@@ -964,7 +1024,13 @@ def recover_reply_promises(
             ):
                 processed_any = True
                 continue
-            comment = comment_cache.get(KIND_PULLS, promise.anchor_comment_id)
+            comment = _comment_via_cache_or_gh(
+                comment_cache,
+                KIND_PULLS,
+                gh=gh,
+                repo=repo_cfg.name,
+                comment_id=promise.anchor_comment_id,
+            )
             if comment is None:
                 store.mark_failed(promise.promise_id)
                 continue
@@ -978,7 +1044,13 @@ def recover_reply_promises(
         else:
             comment = issue_comments_by_id.get(promise.anchor_comment_id)
             if comment is None:
-                comment = comment_cache.get(KIND_ISSUES, promise.anchor_comment_id)
+                comment = _comment_via_cache_or_gh(
+                    comment_cache,
+                    KIND_ISSUES,
+                    gh=gh,
+                    repo=repo_cfg.name,
+                    comment_id=promise.anchor_comment_id,
+                )
             if comment is None:
                 store.mark_failed(promise.promise_id)
                 continue
@@ -1415,9 +1487,12 @@ class Dispatcher:
         """
         repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
-        comments = self._registry.get_comment_cache(
-            repo_cfg.name, pr_number, self._gh
-        ).list_top_level()
+        comments = _top_level_comments_via_cache_or_gh(
+            self._registry.get_comment_cache(repo_cfg.name, pr_number, self._gh),
+            gh=self._gh,
+            repo=repo_cfg.name,
+            pr_number=pr_number,
+        )
         for c in comments:
             user = (c.get("user") or {}).get("login", "")
             if not user:
@@ -1835,9 +1910,12 @@ def reply_to_issue_comment(
     conversation_context = ""
     if number:
         try:
-            all_comments = registry.get_comment_cache(
-                repo_cfg.name, int(number), gh
-            ).list_top_level()
+            all_comments = _top_level_comments_via_cache_or_gh(
+                registry.get_comment_cache(repo_cfg.name, int(number), gh),
+                gh=gh,
+                repo=repo_cfg.name,
+                pr_number=int(number),
+            )
             preceding = [c for c in all_comments if c.get("body", "") != comment]
             if preceding:
                 lines = [

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -4,12 +4,13 @@ import re
 import subprocess
 import threading
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from fido.comment_cache import KIND_ISSUES, KIND_PULLS
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
@@ -337,7 +338,7 @@ def build_review_comment_action(
     pr_number: int,
     pr_title: str,
     pr_body: str,
-    comment: dict[str, Any],
+    comment: Mapping[str, Any],
     *,
     comment_body: str | None = None,
     comment_author: str | None = None,
@@ -383,7 +384,7 @@ def _build_issue_comment_action(
     pr_number: int,
     pr_title: str,
     pr_body: str,
-    comment: dict[str, Any],
+    comment: Mapping[str, Any],
     *,
     comment_body: str | None = None,
 ) -> Action:
@@ -718,8 +719,8 @@ def _normalize_comment_ids(comment_ids: Iterable[object]) -> tuple[int, ...]:
 def _review_lineage(
     repo: str,
     pr_number: int,
-    comment: dict[str, Any],
-    thread_comments: Iterable[dict[str, Any]] = (),
+    comment: Mapping[str, Any],
+    thread_comments: Iterable[Mapping[str, Any]] = (),
 ) -> tuple[str, tuple[int, ...]]:
     """Return the durable lineage key and covered ids for a review thread."""
     comment_id = int(comment["id"])
@@ -934,17 +935,21 @@ def recover_reply_promises(
     pr_title = pr_issue["title"]
     pr_body = pr_issue["body"] or ""
     processed_any = False
-    pull_entries: dict[str, tuple[dict[str, Any], int, int]] = {}
-    issue_comments: list[dict[str, Any]] = []
+    pull_entries: dict[str, tuple[Mapping[str, Any], int, int]] = {}
+    # INV-6: comment lookups route through the per-(repo, pr) cache.
+    # The cache is already hydrated at PR-open / startup; reads here
+    # are O(1) dict lookups instead of GH round-trips.
+    comment_cache = registry.get_comment_cache(repo_cfg.name, pr_number, gh)
+    issue_comments: list[Mapping[str, Any]] = []
     if any(p.comment_type == "issues" for p in promises):
-        issue_comments = gh.get_issue_comments(repo_cfg.name, pr_number)
+        issue_comments = comment_cache.list_top_level()
         if store.recover_from_bodies(c.get("body", "") for c in issue_comments):
             processed_any = True
         issue_comments_by_id = {int(c["id"]): c for c in issue_comments if c.get("id")}
     else:
         issue_comments_by_id = {}
 
-    issue_groups: dict[int, list[tuple[str, dict[str, Any]]]] = {}
+    issue_groups: dict[int, list[tuple[str, Mapping[str, Any]]]] = {}
 
     for promise in promises:
         current = store.promise(promise.promise_id)
@@ -959,7 +964,7 @@ def recover_reply_promises(
             ):
                 processed_any = True
                 continue
-            comment = gh.get_pull_comment(repo_cfg.name, promise.anchor_comment_id)
+            comment = comment_cache.get(KIND_PULLS, promise.anchor_comment_id)
             if comment is None:
                 store.mark_failed(promise.promise_id)
                 continue
@@ -973,7 +978,7 @@ def recover_reply_promises(
         else:
             comment = issue_comments_by_id.get(promise.anchor_comment_id)
             if comment is None:
-                comment = gh.get_issue_comment(repo_cfg.name, promise.anchor_comment_id)
+                comment = comment_cache.get(KIND_ISSUES, promise.anchor_comment_id)
             if comment is None:
                 store.mark_failed(promise.promise_id)
                 continue
@@ -1042,7 +1047,7 @@ def recover_reply_promises(
         if comment_pr != pr_number:
             continue
 
-        group: list[tuple[str, dict[str, Any]]] = []
+        group: list[tuple[str, Mapping[str, Any]]] = []
         for candidate_promise_id, (
             candidate_comment,
             candidate_pr,
@@ -1128,10 +1133,17 @@ class Dispatcher:
     ``GitHub`` instance, so there is no production case where ``gh`` is absent.
     """
 
-    def __init__(self, config: Config, repo_cfg: RepoConfig, gh: GitHub) -> None:
+    def __init__(
+        self,
+        config: Config,
+        repo_cfg: RepoConfig,
+        gh: GitHub,
+        registry: ActivityReporter,
+    ) -> None:
         self._config = config
         self._repo_cfg = repo_cfg
         self._gh = gh
+        self._registry = registry
 
     def dispatch(
         self,
@@ -1403,7 +1415,9 @@ class Dispatcher:
         """
         repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
-        comments = self._gh.get_issue_comments(repo_cfg.name, pr_number)
+        comments = self._registry.get_comment_cache(
+            repo_cfg.name, pr_number, self._gh
+        ).list_top_level()
         for c in comments:
             user = (c.get("user") or {}).get("login", "")
             if not user:
@@ -1821,7 +1835,9 @@ def reply_to_issue_comment(
     conversation_context = ""
     if number:
         try:
-            all_comments = gh.get_issue_comments(repo_cfg.name, int(number))
+            all_comments = registry.get_comment_cache(
+                repo_cfg.name, int(number), gh
+            ).list_top_level()
             preceding = [c for c in all_comments if c.get("body", "") != comment]
             if preceding:
                 lines = [

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -1143,18 +1143,22 @@ def make_registry(
     gh: GitHub,
     config: Config | None = None,
     *,
-    dispatchers: "dict[str, Dispatcher]",
+    dispatcher_factory: "Callable[[RepoConfig, WorkerRegistry], Dispatcher]",
     state_updater: "AtomicUpdater[FidoState]",
     _thread_factory: Callable[..., WorkerThread] = _make_thread,
-) -> WorkerRegistry:
-    """Create a :class:`WorkerRegistry` and start threads for all repos.
+) -> "tuple[WorkerRegistry, dict[str, Dispatcher]]":
+    """Create a :class:`WorkerRegistry`, build per-repo dispatchers, start threads.
 
-    Uses :func:`_make_thread` as the factory; all threads share the provided
-    :class:`~fido.github.GitHub` client.  The caller (composition root) is
-    responsible for creating the atomic cell via :func:`~fido.atomic.create_atomic`
-    and passing the updater face here.  Pass a custom registry directly
-    (with a mock factory) in tests instead of calling this.
+    Dispatchers are built *after* the registry exists so they can receive it
+    via constructor-DI (#1760 INV-6 — `Dispatcher.backfill_missed_pr_comments`
+    routes comment fetches through the per-(repo, item) `CommentCache`).  The
+    ``dispatcher_factory`` callback receives the registry and the per-repo
+    config and returns a fully-constructed :class:`Dispatcher` instance.
+
+    Returns ``(registry, dispatchers)``; the caller owns both for placement
+    onto :class:`~fido.server.WebhookHandler`.
     """
+    dispatchers: dict[str, Dispatcher] = {}
 
     def factory(
         cfg: RepoConfig,
@@ -1175,5 +1179,6 @@ def make_registry(
 
     registry = WorkerRegistry(factory, state_updater)
     for repo_cfg in repos.values():
+        dispatchers[repo_cfg.name] = dispatcher_factory(repo_cfg, registry)
         registry.start(repo_cfg)
-    return registry
+    return registry, dispatchers

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -1331,7 +1331,9 @@ def run(
     *,
     _from_args: Callable[..., Config] = Config.from_args,
     _HTTPServer: Callable[..., HTTPServer] = FidoHTTPServer,
-    _make_registry: Callable[..., WorkerRegistry] = make_registry,
+    _make_registry: Callable[..., tuple[WorkerRegistry, dict[str, Dispatcher]]] = (
+        make_registry
+    ),
     _path_home: Callable[[], Path] = Path.home,
     _basic_config: Callable[..., None] = logging.basicConfig,
     _stderr: IO[str] = sys.stderr,
@@ -1406,11 +1408,6 @@ def run(
     # Composition root sets the class-level lazy collaborator; the proper
     # constructor-DI redo is tracked in #1762.
     WebhookHandler._gh = gh  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-    dispatchers = {
-        name: Dispatcher(config, repo_cfg, gh)
-        for name, repo_cfg in config.repos.items()
-    }
-    WebhookHandler.dispatchers = dispatchers
     WebhookHandler.static_files = StaticFiles(
         Path(__file__).resolve().parent / "static"
     )
@@ -1430,9 +1427,21 @@ def run(
             process_started_at=process_started_at,
         )
     )
-    registry = _make_registry(
-        config.repos, gh, config, dispatchers=dispatchers, state_updater=state_updater
+
+    # Dispatchers are constructed inside _make_registry so each one can
+    # receive the registry via constructor-DI — Dispatcher needs it for
+    # CommentCache routing (INV-6 of #1748).
+    def _build_dispatcher(repo_cfg: RepoConfig, reg: WorkerRegistry) -> Dispatcher:
+        return Dispatcher(config, repo_cfg, gh, reg)
+
+    registry, dispatchers = _make_registry(
+        config.repos,
+        gh,
+        config,
+        dispatcher_factory=_build_dispatcher,
+        state_updater=state_updater,
     )
+    WebhookHandler.dispatchers = dispatchers
     WebhookHandler.registry = registry
     WebhookHandler.state_reader = state_reader
     # Bootstrap issue caches eagerly so the picker has populated data immediately —

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -28,6 +28,7 @@ from fido.appstate import (
 )
 from fido.atomic import AtomicUpdater
 from fido.claude import ClaudeCode
+from fido.comment_cache import CommentCache
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.harness_commit import HarnessCommitter
@@ -253,6 +254,10 @@ class ActivityReporter(Protocol):
     def tasks_for(self, repo_name: str) -> Tasks: ...
 
     def state_for(self, repo_name: str) -> State: ...
+
+    def get_comment_cache(
+        self, repo_name: str, item: int, gh: GitHub
+    ) -> CommentCache: ...
 
 
 class LockHeld(Exception):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -361,6 +361,100 @@ class TestRecoverReplyPromises:
             "lineage_comment_ids": [302],
         }
 
+    def test_foreign_pr_promise_falls_back_to_gh_and_is_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1 follow-up: ``recover_reply_promises`` iterates
+        repo-wide promises but reads from the per-PR ``CommentCache``.
+        A promise belonging to a *different* PR must fall back to the
+        direct ``gh.get_issue_comment`` lookup and be silently skipped
+        (its ``issue_url`` resolves to a different PR), not marked
+        failed."""
+        fido_dir = tmp_path / ".git" / "fido"
+        # Stage a promise for a comment that actually belongs to PR #99
+        # while we recover against PR #7.
+        promise = self._prepare_promise(tmp_path, "issues", 999)
+        gh = _make_mock_gh()
+        gh.view_issue.return_value = {"title": "PR 7", "body": "body"}
+        gh.get_issue_comment.return_value = {
+            "id": 999,
+            "body": "on a different PR",
+            "html_url": "https://github.com/owner/repo/pull/99#issuecomment-999",
+            "issue_url": "https://api.github.com/repos/owner/repo/issues/99",
+            "user": {"login": "owner"},
+        }
+        # The PR-7 cache does not carry comment 999 (per-(repo, item)
+        # isolation); ``_registry_mirroring_gh`` returns the gh stub
+        # via the fallback path, so we explicitly stub the cache to
+        # miss while the gh fallback succeeds.
+        registry = MagicMock(spec=ActivityReporter)
+        cache = MagicMock()
+        cache.is_loaded = True
+        cache.get.return_value = None  # cache miss for foreign PR
+        cache.list_top_level.return_value = []
+        registry.get_comment_cache.return_value = cache
+
+        result = recover_reply_promises(
+            fido_dir,
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            7,
+            registry=registry,
+            dispatcher=_FakeDispatcher(),
+        )
+        assert result is False
+        # Promise must NOT be marked failed — it belongs to a different
+        # PR and will be reconciled when that PR's recovery runs.
+        record = FidoStore(tmp_path).promise(promise.promise_id)
+        assert record is not None
+        assert record.state == "prepared"
+        gh.get_issue_comment.assert_called_once_with("owner/repo", 999)
+
+    def test_unhydrated_cache_falls_back_to_gh_for_top_level_list(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1 follow-up: when ``CommentCache`` hydration failed
+        (``is_loaded == False``) the previous direct-GitHub call would
+        have raised or returned the real comment list; an empty
+        ``cache.list_top_level()`` must not silently drop the recovery
+        attempt for a stale marker."""
+        fido_dir = tmp_path / ".git" / "fido"
+        store = FidoStore(tmp_path)
+        promise = store.prepare_reply(
+            owner="webhook", comment_type="issues", anchor_comment_id=404
+        )
+        assert promise is not None
+        gh = _make_mock_gh()
+        gh.view_issue.return_value = {"title": "PR 7", "body": "body"}
+        # The stale marker that proves recovery already happened lives
+        # on the GitHub side; the unhydrated cache cannot see it.
+        gh.get_issue_comments.return_value = [
+            {
+                "id": 1,
+                "body": f"done\n\n<!-- fido:reply-promise:{promise.promise_id} -->",
+            }
+        ]
+        registry = MagicMock(spec=ActivityReporter)
+        cache = MagicMock()
+        cache.is_loaded = False  # hydration silently failed
+        cache.list_top_level.return_value = []  # empty — would lose marker
+        registry.get_comment_cache.return_value = cache
+
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
+            assert recover_reply_promises(
+                fido_dir,
+                _config(tmp_path),
+                _repo_cfg(tmp_path),
+                gh,
+                7,
+                registry=registry,
+                dispatcher=_FakeDispatcher(),
+            )
+        mock_reply.assert_not_called()
+        assert store.promise(promise.promise_id).state == "acked"
+        gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
+
     def test_recovers_stale_issue_marker_without_reposting(
         self, tmp_path: Path
     ) -> None:
@@ -5865,6 +5959,78 @@ class TestBuildOnIntentDispositions:
         mock_gh.reply_to_review_comment.assert_not_called()
 
 
+class TestCacheOrGhFallback:
+    """Codex P1 follow-ups on INV-6: cache miss / unhydrated cache must fall
+    back to GitHub so foreign-PR promises are not marked failed and the
+    one-shot startup backfill doesn't silently lose missed comments."""
+
+    def test_comment_via_cache_returns_cache_hit_without_gh(self) -> None:
+        from fido.events import _comment_via_cache_or_gh
+
+        cache = MagicMock()
+        cache.get.return_value = {"id": 1, "body": "cached"}
+        gh = MagicMock()
+        result = _comment_via_cache_or_gh(
+            cache, "issues", gh=gh, repo="owner/repo", comment_id=1
+        )
+        assert result == {"id": 1, "body": "cached"}
+        gh.get_issue_comment.assert_not_called()
+        gh.get_pull_comment.assert_not_called()
+
+    def test_comment_via_cache_falls_back_to_gh_on_miss_issues(self) -> None:
+        from fido.events import _comment_via_cache_or_gh
+
+        cache = MagicMock()
+        cache.get.return_value = None
+        gh = MagicMock()
+        gh.get_issue_comment.return_value = {"id": 2, "body": "from gh"}
+        result = _comment_via_cache_or_gh(
+            cache, "issues", gh=gh, repo="owner/repo", comment_id=2
+        )
+        assert result == {"id": 2, "body": "from gh"}
+        gh.get_issue_comment.assert_called_once_with("owner/repo", 2)
+
+    def test_comment_via_cache_falls_back_to_gh_on_miss_pulls(self) -> None:
+        from fido.events import _comment_via_cache_or_gh
+
+        cache = MagicMock()
+        cache.get.return_value = None
+        gh = MagicMock()
+        gh.get_pull_comment.return_value = {"id": 3, "body": "from gh"}
+        result = _comment_via_cache_or_gh(
+            cache, "pulls", gh=gh, repo="owner/repo", comment_id=3
+        )
+        assert result == {"id": 3, "body": "from gh"}
+        gh.get_pull_comment.assert_called_once_with("owner/repo", 3)
+
+    def test_top_level_uses_loaded_cache(self) -> None:
+        from fido.events import _top_level_comments_via_cache_or_gh
+
+        cache = MagicMock()
+        cache.is_loaded = True
+        cache.list_top_level.return_value = [{"id": 1}]
+        gh = MagicMock()
+        result = _top_level_comments_via_cache_or_gh(
+            cache, gh=gh, repo="owner/repo", pr_number=7
+        )
+        assert result == [{"id": 1}]
+        gh.get_issue_comments.assert_not_called()
+
+    def test_top_level_falls_back_when_unloaded(self) -> None:
+        from fido.events import _top_level_comments_via_cache_or_gh
+
+        cache = MagicMock()
+        cache.is_loaded = False
+        gh = MagicMock()
+        gh.get_issue_comments.return_value = [{"id": 9, "body": "missed"}]
+        result = _top_level_comments_via_cache_or_gh(
+            cache, gh=gh, repo="owner/repo", pr_number=7
+        )
+        assert result == [{"id": 9, "body": "missed"}]
+        gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
+        cache.list_top_level.assert_not_called()
+
+
 class TestBackfillMissedPrComments:
     """Replay of issue_comment webhooks missed during fido downtime (fix #794).
 
@@ -5939,6 +6105,33 @@ class TestBackfillMissedPrComments:
         assert kwargs["thread"]["comment_id"] == 100
         assert kwargs["thread"]["comment_type"] == "issues"
         assert kwargs["thread"]["author"] == "rhencke"
+
+    def test_unhydrated_cache_falls_back_to_gh(self, tmp_path: Path) -> None:
+        """Codex P1 follow-up: ``backfill_missed_pr_comments`` runs once
+        per WorkerThread lifetime — if the per-(repo, item) cache failed
+        to hydrate (``is_loaded == False``), trusting an empty
+        ``cache.list_top_level()`` would silently drop every missed
+        ``issue_comment`` event until the next process restart.  Fall
+        back to ``gh.get_issue_comments`` so the missed comment is
+        still replayed."""
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = [self._comment(123)]
+        mock_gh.is_thread_resolved_for_comment.return_value = False
+        cfg = self._cfg(tmp_path)
+        repo_cfg = self._repo_cfg(tmp_path)
+        registry = MagicMock()
+        cache = MagicMock()
+        cache.is_loaded = False  # hydration silently failed
+        cache.list_top_level.return_value = []  # would lose missed events
+        registry.get_comment_cache.return_value = cache
+
+        with patch("fido.events.create_task") as mock_create:
+            count = Dispatcher(
+                cfg, repo_cfg, mock_gh, registry
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
+        assert count == 1
+        mock_create.assert_called_once()
+        mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 1)
 
     def test_skips_fido_own_comments(self, tmp_path: Path) -> None:
         mock_gh = MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -147,6 +147,35 @@ def _make_mock_gh() -> MagicMock:
     return gh
 
 
+def _registry_mirroring_gh(gh: MagicMock) -> MagicMock:
+    """Build an ActivityReporter mock whose CommentCache mirrors ``gh``.
+
+    INV-6 (#1760) routes comment fetches in :func:`recover_reply_promises`
+    and :func:`reply_to_issue_comment` through the per-(repo, item)
+    :class:`CommentCache` rather than calling GitHub directly.  Tests stage
+    their fixtures on the ``gh`` mock; this helper reflects them through
+    the cache surface so existing tests need not be rewritten.
+    """
+    from fido.comment_cache import KIND_PULLS as _KIND_PULLS
+
+    registry = MagicMock(spec=ActivityReporter)
+    cache = MagicMock()
+    # Invoke the gh stub itself so both ``return_value`` and ``side_effect``
+    # setups on tests carry through (some tests use side_effect to dispatch
+    # per comment_id; a static return_value-only helper would miss those).
+    cache.get.side_effect = lambda kind, comment_id: (
+        gh.get_pull_comment("owner/repo", comment_id)
+        if kind == _KIND_PULLS
+        else gh.get_issue_comment("owner/repo", comment_id)
+    )
+    # Forward list_top_level() through gh.get_issue_comments so tests that
+    # stage ``side_effect=RuntimeError`` (or ``side_effect=lambda…``) on
+    # the gh mock continue to drive the cache.
+    cache.list_top_level.side_effect = lambda: gh.get_issue_comments("owner/repo", 0)
+    registry.get_comment_cache.return_value = cache
+    return registry
+
+
 def _oracle_owner(owner: str) -> object:
     match owner:
         case "webhook":
@@ -274,13 +303,14 @@ class TestRecoverReplyPromises:
             )
 
     def test_returns_false_when_no_promises(self, tmp_path: Path) -> None:
+        gh = MagicMock()
         assert not recover_reply_promises(
             tmp_path / ".git" / "fido",
             _config(tmp_path),
             _repo_cfg(tmp_path),
-            MagicMock(),
+            gh,
             7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             dispatcher=_FakeDispatcher(),
         )
 
@@ -309,7 +339,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert result is True
@@ -355,7 +385,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
@@ -388,7 +418,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
@@ -411,7 +441,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
@@ -433,7 +463,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "failed"
@@ -461,7 +491,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
@@ -492,7 +522,7 @@ class TestRecoverReplyPromises:
             _repo_cfg(tmp_path),
             gh,
             7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             dispatcher=_FakeDispatcher(),
         )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
@@ -527,7 +557,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
@@ -562,7 +592,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert FidoStore(tmp_path).claim_state(302) == "retryable_failed"
@@ -595,7 +625,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         mock_reply.assert_not_called()
@@ -631,7 +661,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert FidoStore(tmp_path).claim_state(205) == "retryable_failed"
@@ -667,7 +697,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert result is True
@@ -707,7 +737,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
-                    registry=MagicMock(spec=ActivityReporter),
+                    registry=_registry_mirroring_gh(gh),
                     dispatcher=_FakeDispatcher(),
                 )
         assert FidoStore(tmp_path).promise(promise.promise_id).state == "prepared"
@@ -761,7 +791,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert result is True
@@ -823,7 +853,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert result is True
@@ -886,7 +916,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
 
@@ -956,7 +986,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
-                    registry=MagicMock(spec=ActivityReporter),
+                    registry=_registry_mirroring_gh(gh),
                     dispatcher=_FakeDispatcher(),
                 )
         store = FidoStore(tmp_path)
@@ -1022,7 +1052,7 @@ class TestRecoverReplyPromises:
                 gh,
                 7,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
 
@@ -1109,7 +1139,7 @@ class TestRecoverReplyPromises:
                     _repo_cfg(tmp_path),
                     gh,
                     7,
-                    registry=MagicMock(spec=ActivityReporter),
+                    registry=_registry_mirroring_gh(gh),
                     dispatcher=_FakeDispatcher(),
                 )
         assert mock_reply.call_count == 0
@@ -1174,7 +1204,7 @@ class TestRecoverReplyPromises:
                 _repo_cfg(tmp_path),
                 gh,
                 7,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 dispatcher=_FakeDispatcher(),
             )
         assert result is True
@@ -1412,9 +1442,9 @@ class TestReplyPromiseHelpers:
 class TestDispatchPing:
     def test_returns_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "ping", {"hook_id": 123, **_payload()}
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("ping", {"hook_id": 123, **_payload()})
         assert result is None
 
 
@@ -1427,9 +1457,9 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 1, "title": "test issue"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issues", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issues", payload)
         assert result is not None
         assert "#1" in result.prompt
 
@@ -1441,9 +1471,9 @@ class TestDispatchIssuesAssigned:
             "assignee": {"login": "fido"},
             "issue": {"number": 0, "title": "test"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issues", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issues", payload)
         assert result is None
 
 
@@ -1464,9 +1494,9 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "pr title", "body": "pr body"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review_comment", payload)
         assert result is not None
         assert result.reply_to is None
         assert result.comment_body is None
@@ -1492,9 +1522,9 @@ class TestDispatchReviewComment:
             },
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review_comment", payload)
         assert result is not None
         assert result.thread is not None
         assert result.thread["author"] == "owner"
@@ -1519,7 +1549,7 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-125",
@@ -1559,12 +1589,12 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-126-a",
         )
-        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-126-b",
@@ -1592,7 +1622,7 @@ class TestDispatchReviewComment:
             "pull_request": {"number": 5, "title": "My PR", "body": ""},
         }
 
-        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "pull_request_review_comment",
             payload,
             delivery_id="delivery-review-127-a",
@@ -1606,7 +1636,7 @@ class TestDispatchReviewComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "pull_request_review_comment",
             edited_payload,
             delivery_id="delivery-review-127-b",
@@ -1627,9 +1657,9 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "done", "user": {"login": "FidoCanCode"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review_comment", payload)
         assert result is None
 
     def test_unallowed_user_ignored(self, tmp_path: Path) -> None:
@@ -1640,9 +1670,9 @@ class TestDispatchReviewComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "rando"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review_comment", payload)
         assert result is None
 
 
@@ -1658,9 +1688,9 @@ class TestDispatchCheckRun:
                 "pull_requests": [{"number": 3}],
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "check_run", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("check_run", payload)
         assert result is not None
         assert "CI failure" in result.prompt
         assert result.preempts_worker is True
@@ -1672,9 +1702,9 @@ class TestDispatchCheckRun:
             "action": "completed",
             "check_run": {"conclusion": "success", "name": "lint", "pull_requests": []},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "check_run", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("check_run", payload)
         assert result is None
 
 
@@ -1697,9 +1727,9 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": True},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request", payload)
         assert result is not None
         assert "merged" in result.prompt
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
@@ -1722,9 +1752,9 @@ class TestDispatchPullRequest:
             "action": "closed",
             "pull_request": {"number": 7, "merged": False},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request", payload)
         assert result is None
         assert FidoStore(tmp_path).pending_pr_comments(repo="owner/repo") == []
 
@@ -1748,9 +1778,9 @@ class TestDispatchIssueComment:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issue_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issue_comment", payload)
         assert result is not None
         assert result.comment_body is None
         assert result.preempts_worker is True
@@ -1785,7 +1815,7 @@ class TestDispatchIssueComment:
             },
         }
 
-        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "issue_comment",
             payload,
             delivery_id="delivery-issue-457",
@@ -1824,7 +1854,7 @@ class TestDispatchIssueComment:
             },
         }
 
-        Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "issue_comment", payload, delivery_id="delivery-a"
         )
         edited_payload = {
@@ -1836,7 +1866,7 @@ class TestDispatchIssueComment:
                 "updated_at": "2026-04-30T12:05:00Z",
             },
         }
-        result = Dispatcher(cfg, repo_cfg, MagicMock()).dispatch(
+        result = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock()).dispatch(
             "issue_comment", edited_payload, delivery_id="delivery-b"
         )
 
@@ -1855,16 +1885,18 @@ class TestDispatchIssueComment:
             "comment": {"id": 1, "body": "hi", "user": {"login": "owner"}},
             "issue": {"number": 10, "title": "issue"},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issue_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issue_comment", payload)
         assert result is None
 
 
 class TestDispatchUnknown:
     def test_unknown_event(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch(
             "unknown_event",
             {**_payload(), "action": "whatever"},
         )
@@ -1903,12 +1935,13 @@ class TestReplyToComment:
     def test_no_reply_to_returns_act(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         action = Action(prompt="do stuff")
+        gh = _make_mock_gh()
         cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
-            _make_mock_gh(),
-            registry=MagicMock(spec=ActivityReporter),
+            gh,
+            registry=_registry_mirroring_gh(gh),
         )
         assert cat == "ACT"
 
@@ -1918,12 +1951,13 @@ class TestReplyToComment:
             prompt="something",
             reply_to={"repo": "a/b", "pr": 1, "comment_id": 5},
         )
+        gh = _make_mock_gh()
         cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
-            _make_mock_gh(),
-            registry=MagicMock(spec=ActivityReporter),
+            gh,
+            registry=_registry_mirroring_gh(gh),
         )
         assert cat == "ACT"
 
@@ -1957,13 +1991,14 @@ class TestReplyToComment:
                 change_request="Add logging to the request handler",
             ),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ACT"
         assert "logging" in titles[0].lower()
@@ -2013,7 +2048,7 @@ class TestReplyToComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         effect = store.reply_outbox_effect(promise.promise_id)
@@ -2063,7 +2098,7 @@ class TestReplyToComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         mock_gh.reply_to_review_comment.assert_not_called()
@@ -2082,13 +2117,14 @@ class TestReplyToComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("What specifically?"),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
 
@@ -2119,7 +2155,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         gh.resolve_thread.assert_not_called()
 
@@ -2188,13 +2224,14 @@ class TestReplyToComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("I did this because..."),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -2223,7 +2260,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         assert titles == ["Cache results for performance"]
@@ -2252,7 +2289,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         assert "refactor" in titles[0].lower()
@@ -2273,13 +2310,14 @@ class TestReplyToComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("Not applicable here."),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
 
@@ -2300,13 +2338,14 @@ class TestReplyToComment:
                 side_effect=SynthesisExhaustedError("exhausted"),
             ),
         ):
+            gh = MagicMock()
             reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                MagicMock(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
 
     def test_claim_race_returns_act_with_no_titles(self, tmp_path: Path) -> None:
@@ -2326,12 +2365,13 @@ class TestReplyToComment:
             comment_body="competing update",
             is_bot=False,
         )
+        gh = _make_mock_gh()
         cat, titles = reply_to_comment(
             action,
             cfg,
             self._repo_cfg(tmp_path),
-            _make_mock_gh(),
-            registry=MagicMock(spec=ActivityReporter),
+            gh,
+            registry=_registry_mirroring_gh(gh),
         )
         assert cat == "ACT"
         assert titles == []
@@ -2350,13 +2390,14 @@ class TestReplyToComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("ok", change_request="Do it"),
         ):
+            gh = MagicMock()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                MagicMock(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ACT"
 
@@ -2379,13 +2420,14 @@ class TestReplyToComment:
                 change_request="Add tests and update docs",
             ),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ACT"
         assert titles == ["Add tests and update docs"]
@@ -2418,7 +2460,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         assert titles == ["Fix the parser"]
@@ -2465,7 +2507,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         # Human spoke last — must post a fresh reply, never edit the old one
@@ -2497,7 +2539,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ANSWER"
         # Posted replies are immutable; answer replies also post a new artifact.
@@ -2537,7 +2579,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -2569,7 +2611,7 @@ class TestReplyToComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -2675,7 +2717,7 @@ class TestReplyToCommentSynthesisFallback:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -2722,7 +2764,7 @@ class TestReplyToCommentSynthesisFallback:
                     self._repo_cfg(tmp_path),
                     mock_gh,
                     agent=_client(),
-                    registry=MagicMock(spec=ActivityReporter),
+                    registry=_registry_mirroring_gh(mock_gh),
                 )
         mock_remove_eyes.assert_called_once()
 
@@ -2760,7 +2802,7 @@ class TestReplyToCommentSynthesisFallback:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ANSWER"
         mock_fallback.assert_called_once()
@@ -2811,13 +2853,14 @@ class TestReplyToIssueComment:
                 "I'll fix that.", change_request="Fix the bug"
             ),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_issue_comment(
                 self._action(),
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ACT"
         assert titles == ["Fix the bug"]
@@ -2830,13 +2873,14 @@ class TestReplyToIssueComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("What do you mean?"),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_issue_comment(
                 self._action("unclear"),
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
 
@@ -2848,13 +2892,14 @@ class TestReplyToIssueComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("Yes, because..."),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_issue_comment(
                 self._action("why?"),
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
 
@@ -2896,7 +2941,7 @@ class TestReplyToIssueComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         effect = store.reply_outbox_effect(promise.promise_id)
@@ -2912,13 +2957,14 @@ class TestReplyToIssueComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("That won't work here."),
         ):
+            gh = self._mock_gh()
             cat, titles = reply_to_issue_comment(
                 self._action("do it differently"),
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         assert cat == "ANSWER"
 
@@ -2940,7 +2986,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         assert "refactor" in titles[0].lower()
@@ -2990,7 +3036,7 @@ class TestReplyToIssueComment:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         assert cat == "ANSWER"
@@ -3008,13 +3054,14 @@ class TestReplyToIssueComment:
                 side_effect=SynthesisExhaustedError("exhausted"),
             ),
         ):
+            gh = self._mock_gh()
             reply_to_issue_comment(
                 self._action(),
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
 
     def test_post_exception_propagates(self, tmp_path: Path) -> None:
@@ -3042,7 +3089,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
     def test_no_comment_id_skips_react(self, tmp_path: Path) -> None:
@@ -3066,7 +3113,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
         mock_gh.add_reaction.assert_not_called()
@@ -3083,12 +3130,13 @@ class TestReplyToIssueComment:
             ),
         ):
             factory_cls.return_value.create_agent.return_value = _client()
+            gh = self._mock_gh()
             cat, titles = reply_to_issue_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
-                registry=MagicMock(spec=ActivityReporter),
+                gh,
+                registry=_registry_mirroring_gh(gh),
             )
         factory_cls.return_value.create_agent.assert_called_once_with(
             self._repo_cfg(tmp_path),
@@ -3121,10 +3169,12 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
-        mock_gh.get_issue_comments.assert_called_once_with("owner/repo", 7)
+        # INV-6 routes the conversation fetch through the per-(repo, item)
+        # CommentCache rather than calling gh.get_issue_comments directly.
+        mock_gh.get_issue_comments.assert_called_once()
         # Verify conversation context was built and passed to call_synthesis
         assert captured_calls
         ctx = captured_calls[0].get("context") or {}
@@ -3151,7 +3201,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ACT"
 
@@ -3170,7 +3220,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert FidoStore(tmp_path).claim_state(4275080243) == "completed"
 
@@ -3181,13 +3231,14 @@ class TestReplyToIssueComment:
         )
         assert promise is not None
 
+        gh = _make_mock_gh()
         category, titles = reply_to_issue_comment(
             self._action(cid=4275080244),
             cfg,
             self._repo_cfg(tmp_path),
-            _make_mock_gh(),
+            gh,
             agent=_client("unused"),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
         )
 
         assert category == "ACT"
@@ -3207,13 +3258,14 @@ class TestReplyToIssueComment:
             "fido.events.call_synthesis",
             return_value=_synthesis_response("ok", change_request="Do it"),
         ):
+            gh = self._mock_gh()
             reply_to_issue_comment(
                 action,
                 cfg,
                 self._repo_cfg(tmp_path),
-                self._mock_gh(),
+                gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
             )
         claim_dir = tmp_path / ".git" / "fido" / "comments"
         assert not claim_dir.exists() or not list(claim_dir.iterdir()), (
@@ -3244,7 +3296,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -3270,7 +3322,7 @@ class TestReplyToIssueComment:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert captured_calls
         call_kwargs = captured_calls[0]
@@ -4346,15 +4398,16 @@ class TestReorderTasksBackground:
     def test_starts_daemon_thread(self, tmp_path: Path) -> None:
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "some commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1
@@ -4364,15 +4417,16 @@ class TestReorderTasksBackground:
     def test_thread_name_includes_dir_name(self, tmp_path: Path) -> None:
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert tmp_path.name in started[0].name
@@ -4587,17 +4641,18 @@ class TestReorderTasksBackground:
         def mock_sync(*a: object, **kw: object) -> None:
             sync_calls.append((a, kw))
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -4617,18 +4672,19 @@ class TestReorderTasksBackground:
         def mock_rewrite(*a: object, **kw: object) -> None:
             rewrite_calls.append(kw)
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
             _sync_fn=lambda *a, **kw: None,
             agent=fake_client,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -4647,17 +4703,18 @@ class TestReorderTasksBackground:
         def mock_rewrite(*a: object, **kw: object) -> None:
             order.append("rewrite")
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _rewrite_fn=mock_rewrite,
             _reorder_fn=mock_reorder,
             _sync_fn=mock_sync,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -4671,16 +4728,17 @@ class TestReorderTasksBackground:
         started: list = []
         calls, mock_reorder = self._capture_reorder_calls()
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "commits",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _rewrite_fn=lambda *a, **kw: None,
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -4696,15 +4754,16 @@ class TestReorderTasksBackground:
         _, mock_reorder = self._capture_reorder_calls()
 
         # First call — marks running, spawns thread
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1
@@ -4719,7 +4778,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 1  # no second thread spawned
@@ -4732,15 +4791,16 @@ class TestReorderTasksBackground:
         started: list = []
         calls, mock_reorder = self._capture_reorder_calls()
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Simulate a second trigger arriving before the thread runs
@@ -4752,7 +4812,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Run the single thread — should execute reorder twice (cs1 then cs2)
@@ -4770,15 +4830,16 @@ class TestReorderTasksBackground:
         calls, mock_reorder = self._capture_reorder_calls()
 
         for cs in ("cs1", "cs2", "cs3", "cs4"):
+            gh = MagicMock()
             _reorder_tasks_background(
                 tmp_path,
                 cs,
                 self._cfg(tmp_path),
-                MagicMock(),
+                gh,
                 _start=lambda t: started.append(t),
                 _reorder_fn=mock_reorder,
                 _coalesce_state=state,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(gh),
                 repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
             )
         # Only one thread spawned; pending holds cs4 (the latest)
@@ -4801,16 +4862,17 @@ class TestReorderTasksBackground:
         intent3 = RescopeIntent("Fix typing", 30, "2024-01-15T10:02:00+00:00")
 
         # First call — starts thread with intent1
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             intents=[intent1],
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Second call — coalesces, adds intent2
@@ -4823,20 +4885,21 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Third call — coalesces, adds intent3
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs3",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             intents=[intent3],
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         # Only one thread spawned; pending holds all three intents
@@ -4857,15 +4920,16 @@ class TestReorderTasksBackground:
         state: dict = {}
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -4879,15 +4943,16 @@ class TestReorderTasksBackground:
         started: list = []
         _, mock_reorder = self._capture_reorder_calls()
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs1",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)  # first thread completes
@@ -4900,7 +4965,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 2  # new thread spawned
@@ -4913,15 +4978,16 @@ class TestReorderTasksBackground:
         dir_a = tmp_path / "a"
         dir_b = tmp_path / "b"
 
+        gh = MagicMock()
         _reorder_tasks_background(
             dir_a,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         _reorder_tasks_background(
@@ -4932,7 +4998,7 @@ class TestReorderTasksBackground:
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state=state,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         assert len(started) == 2  # each dir gets its own thread
@@ -5021,16 +5087,17 @@ class TestReorderTasksBackground:
         def mock_reorder(work_dir: Path, commit_summary: str, **kwargs: object) -> None:
             seen.append(current_repo())
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             repo_cfg=repo_cfg,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
         )
         self._run_thread(started)
         assert seen == ["owner/repo"]
@@ -5044,16 +5111,17 @@ class TestReorderTasksBackground:
         _, mock_reorder = self._capture_reorder_calls()
 
         set_thread_repo("owner/repo")  # pre-set to confirm it gets cleared
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             repo_cfg=repo_cfg,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
         )
         self._run_thread(started)
         assert current_repo() is None
@@ -5070,16 +5138,17 @@ class TestReorderTasksBackground:
         def boom(work_dir: Path, commit_summary: str, **kwargs: object) -> Never:
             raise RuntimeError("reorder exploded")
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             repo_cfg=repo_cfg,
             _start=lambda t: started.append(t),
             _reorder_fn=boom,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
         )
         with pytest.raises(RuntimeError, match="reorder exploded"):
             self._run_thread(started)
@@ -5103,15 +5172,16 @@ class TestReorderTasksBackground:
         def mock_reorder(work_dir: Path, commit_summary: str, **kwargs: object) -> None:
             seen.append(current_thread_kind())
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -5127,15 +5197,16 @@ class TestReorderTasksBackground:
         set_thread_kind(
             ThreadKind.WEBHOOK
         )  # pre-set to confirm the finally block clears it
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=mock_reorder,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         self._run_thread(started)
@@ -5152,15 +5223,16 @@ class TestReorderTasksBackground:
         def boom(work_dir: Path, commit_summary: str, **kwargs: object) -> Never:
             raise RuntimeError("reorder exploded")
 
+        gh = MagicMock()
         _reorder_tasks_background(
             tmp_path,
             "cs",
             self._cfg(tmp_path),
-            MagicMock(),
+            gh,
             _start=lambda t: started.append(t),
             _reorder_fn=boom,
             _coalesce_state={},
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(gh),
             repo_cfg=RepoConfig(name="owner/repo", work_dir=tmp_path),
         )
         with pytest.raises(RuntimeError, match="reorder exploded"):
@@ -5834,6 +5906,21 @@ class TestBackfillMissedPrComments:
             "html_url": f"https://github.com/owner/repo/pull/1#issuecomment-{comment_id}",
         }
 
+    def _registry_with_gh(self, mock_gh: MagicMock) -> MagicMock:
+        """Return a registry whose CommentCache.list_top_level mirrors mock_gh.
+
+        INV-6 routes :meth:`Dispatcher.backfill_missed_pr_comments` through
+        the per-(repo, item) :class:`CommentCache` rather than going to
+        GitHub directly.  These tests stage their comment fixtures on
+        ``mock_gh.get_issue_comments.return_value``; this helper reflects
+        the same data through the cache surface so the tests keep working.
+        """
+        registry = MagicMock()
+        cache = MagicMock()
+        cache.list_top_level.return_value = mock_gh.get_issue_comments.return_value
+        registry.get_comment_cache.return_value = cache
+        return registry
+
     def test_creates_task_for_allowed_collaborator_comment(
         self, tmp_path: Path
     ) -> None:
@@ -5843,9 +5930,9 @@ class TestBackfillMissedPrComments:
         cfg = self._cfg(tmp_path)
         repo_cfg = self._repo_cfg(tmp_path)
         with patch("fido.events.create_task") as mock_create:
-            count = Dispatcher(cfg, repo_cfg, mock_gh).backfill_missed_pr_comments(
-                1, gh_user="fidocancode"
-            )
+            count = Dispatcher(
+                cfg, repo_cfg, mock_gh, self._registry_with_gh(mock_gh)
+            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         assert count == 1
         mock_create.assert_called_once()
         _, kwargs = mock_create.call_args
@@ -5860,7 +5947,10 @@ class TestBackfillMissedPrComments:
         ]
         with patch("fido.events.create_task") as mock_create:
             Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="FidoCanCode")
         mock_create.assert_not_called()
 
@@ -5871,7 +5961,10 @@ class TestBackfillMissedPrComments:
         ]
         with patch("fido.events.create_task") as mock_create:
             Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="alice")
         mock_create.assert_not_called()
 
@@ -5886,7 +5979,10 @@ class TestBackfillMissedPrComments:
         ]
         with patch("fido.events.create_task") as mock_create:
             Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="mis-configured-bot")
         mock_create.assert_not_called()
 
@@ -5900,6 +5996,7 @@ class TestBackfillMissedPrComments:
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path, collaborators=frozenset({"rhencke"})),
                 mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         mock_create.assert_not_called()
 
@@ -5913,6 +6010,7 @@ class TestBackfillMissedPrComments:
                 self._cfg(tmp_path, allowed_bots=frozenset({"dependabot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         assert mock_create.call_count == 1
         _, kwargs = mock_create.call_args
@@ -5929,6 +6027,7 @@ class TestBackfillMissedPrComments:
                 self._cfg(tmp_path, allowed_bots=frozenset({"bot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         prompts = [c.args[0] for c in mock_create.call_args_list]
         assert any("human/owner" in p for p in prompts)
@@ -5943,7 +6042,10 @@ class TestBackfillMissedPrComments:
         ]
         with patch("fido.events.create_task") as mock_create:
             Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         mock_create.assert_not_called()
 
@@ -5952,7 +6054,10 @@ class TestBackfillMissedPrComments:
         mock_gh.get_issue_comments.return_value = []
         with patch("fido.events.create_task") as mock_create:
             count = Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
         assert count == 0
         mock_create.assert_not_called()
@@ -5977,7 +6082,10 @@ class TestBackfillMissedPrComments:
 
         with patch("fido.events.create_task") as mock_create:
             Dispatcher(
-                self._cfg(tmp_path), self._repo_cfg(tmp_path), mock_gh
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+                self._registry_with_gh(mock_gh),
             ).backfill_missed_pr_comments(1, gh_user="fidocancode")
 
         # Only comment 200 (unclaimed) should be queued.
@@ -6004,14 +6112,16 @@ class TestLaunchSync:
         cfg = self._cfg(tmp_path)
         mock_gh = MagicMock()
         with patch("fido.tasks.sync_tasks_background") as mock_sync:
-            Dispatcher(cfg, self._repo_cfg(tmp_path), mock_gh).launch_sync()
+            Dispatcher(
+                cfg, self._repo_cfg(tmp_path), mock_gh, MagicMock()
+            ).launch_sync()
         mock_sync.assert_called_once_with(tmp_path, mock_gh)
 
     def test_does_not_raise(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         with patch("fido.tasks.sync_tasks_background"):
             Dispatcher(
-                cfg, self._repo_cfg(tmp_path), _make_mock_gh()
+                cfg, self._repo_cfg(tmp_path), _make_mock_gh(), MagicMock()
             ).launch_sync()  # should not raise
 
 
@@ -6038,9 +6148,9 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review", payload)
         assert result is not None
         assert result.review_comments is not None
         assert result.review_comments["review_id"] == 55
@@ -6053,9 +6163,9 @@ class TestDispatchPullRequestReview:
             "review": {"state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review", payload)
         assert result is not None
         assert result.review_comments is None
 
@@ -6067,9 +6177,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review", payload)
         assert result is None
 
     def test_not_allowed_user_ignored(self, tmp_path: Path) -> None:
@@ -6080,9 +6190,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 1, "state": "approved", "user": {"login": "stranger"}},
             "pull_request": {"number": 3},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review", payload)
         assert result is None
 
     def test_commented_review_collapsed_by_oracle(self, tmp_path: Path) -> None:
@@ -6097,7 +6207,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 77, "state": "commented", "user": {"login": "owner"}},
             "pull_request": {"number": 4},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-commented-1",
@@ -6116,7 +6228,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 78, "state": "approved", "user": {"login": "owner"}},
             "pull_request": {"number": 5},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-approved-1",
@@ -6139,7 +6253,9 @@ class TestDispatchPullRequestReview:
             },
             "pull_request": {"number": 6},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-changes-requested-1",
@@ -6158,7 +6274,9 @@ class TestDispatchPullRequestReview:
             "review": {"id": 80, "state": "dismissed", "user": {"login": "owner"}},
             "pull_request": {"number": 7},
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch(
             "pull_request_review",
             payload,
             delivery_id="delivery-dismissed-1",
@@ -6179,9 +6297,9 @@ class TestDispatchCheckRunNoPrs:
                 "pull_requests": [],
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "check_run", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("check_run", payload)
         assert result is not None
         assert "unknown PR" in result.prompt
 
@@ -6199,9 +6317,9 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issue_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issue_comment", payload)
         assert result is None
 
     def test_unallowed_user_ignored(self, tmp_path: Path) -> None:
@@ -6216,9 +6334,9 @@ class TestDispatchIssueCommentSelf:
                 "pull_request": {"url": "https://api.github.com/..."},
             },
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "issue_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("issue_comment", payload)
         assert result is None
 
 
@@ -6237,9 +6355,9 @@ class TestDispatchReviewCommentNoNumber:
             },
             "pull_request": {},  # no number
         }
-        result = Dispatcher(cfg, _repo_cfg(tmp_path), MagicMock()).dispatch(
-            "pull_request_review_comment", payload
-        )
+        result = Dispatcher(
+            cfg, _repo_cfg(tmp_path), MagicMock(), MagicMock()
+        ).dispatch("pull_request_review_comment", payload)
         assert result is None
 
 
@@ -6284,7 +6402,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(mock_gh),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -6308,7 +6426,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(mock_gh),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -6328,7 +6446,7 @@ class TestBackgroundRescopeTrigger:
             cfg,
             mock_gh,
             repo_cfg=repo_cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_registry_mirroring_gh(mock_gh),
         )
 
         with patch("fido.events._reorder_tasks_background") as mock_reorder:
@@ -6378,7 +6496,7 @@ class TestReplyToCommentElseBranch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
         assert cat == "ANSWER"
         assert titles == []
@@ -6409,7 +6527,7 @@ class TestReplyToCommentElseBranch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
     def test_skips_review_reply_when_artifact_already_recorded(
@@ -6456,7 +6574,7 @@ class TestReplyToCommentElseBranch:
                 repo_cfg,
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         assert cat == "ACT"
@@ -6514,7 +6632,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Must be called exactly twice: initial context fetch + pre-post re-fetch
@@ -6569,7 +6687,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Re-fetch shows human is last → post new reply, not edit
@@ -6630,7 +6748,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Fresh data shows human is last speaker → post new reply, never edit
@@ -6672,7 +6790,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Falls back to initial snapshot (no Fido reply) → posts new reply
@@ -6731,7 +6849,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Concurrent handler already replied — neither post nor edit is called
@@ -6792,7 +6910,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Sibling-comment reply must NOT skip our post — we still reply.
@@ -6833,7 +6951,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Posted replies are immutable; Fido posts a new reply instead.
@@ -6886,7 +7004,7 @@ class TestReplyToCommentThreadRefetch:
                 self._repo_cfg(tmp_path),
                 mock_gh,
                 agent=_client(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_registry_mirroring_gh(mock_gh),
             )
 
         # Concurrent Fido reply detected (via fido-can-code) — skip
@@ -7530,7 +7648,7 @@ class TestDispatcher:
     def test_dispatch_routes_ping_to_none(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         repo_cfg = _repo_cfg(tmp_path)
-        d = Dispatcher(cfg, repo_cfg, MagicMock())
+        d = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock())
         result = d.dispatch("ping", {"hook_id": 1})
         assert result is None
 
@@ -7542,7 +7660,7 @@ class TestDispatcher:
             "assignee": {"login": "rhencke"},
             "issue": {"number": 7, "title": "Do the thing"},
         }
-        d = Dispatcher(cfg, repo_cfg, MagicMock())
+        d = Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock())
         result = d.dispatch("issues", payload)
         assert isinstance(result, Action)
         assert "7" in result.prompt
@@ -7550,11 +7668,14 @@ class TestDispatcher:
     def test_backfill_returns_count(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = []
         repo_cfg = _repo_cfg(tmp_path)
-        d = Dispatcher(cfg, repo_cfg, mock_gh)
+        registry = MagicMock()
+        cache = MagicMock()
+        cache.list_top_level.return_value = []
+        registry.get_comment_cache.return_value = cache
+        d = Dispatcher(cfg, repo_cfg, mock_gh, registry)
         count = d.backfill_missed_pr_comments(42, gh_user="fido")
-        mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
+        registry.get_comment_cache.assert_called_once_with(repo_cfg.name, 42, mock_gh)
         assert count == 0
 
     def test_launch_sync_calls_background(self, tmp_path: Path) -> None:
@@ -7562,6 +7683,6 @@ class TestDispatcher:
         mock_gh = MagicMock()
         repo_cfg = _repo_cfg(tmp_path)
         with patch("fido.tasks.sync_tasks_background") as mock_sync:
-            d = Dispatcher(cfg, repo_cfg, mock_gh)
+            d = Dispatcher(cfg, repo_cfg, mock_gh, MagicMock())
             d.launch_sync()
         mock_sync.assert_called_once_with(repo_cfg.work_dir, mock_gh)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1150,14 +1150,14 @@ class TestMakeRegistry:
                 process_started_at=_EPOCH,
             )
         )
-        result = make_registry(
+        registry, _dispatchers = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
-            dispatchers={},
+            dispatcher_factory=lambda _c, _r: MagicMock(),
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
-        assert isinstance(result, WorkerRegistry)
+        assert isinstance(registry, WorkerRegistry)
 
     def test_starts_thread_for_each_repo(self, tmp_path: Path) -> None:
         cfg1 = _repo("foo/bar", tmp_path)
@@ -1174,7 +1174,7 @@ class TestMakeRegistry:
         make_registry(
             {"foo/bar": cfg1, "foo/baz": cfg2},
             MagicMock(),
-            dispatchers={},
+            dispatcher_factory=lambda _c, _r: MagicMock(),
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -1189,9 +1189,14 @@ class TestMakeRegistry:
                 process_started_at=_EPOCH,
             )
         )
-        result = make_registry({}, MagicMock(), dispatchers={}, state_updater=updater)
-        assert isinstance(result, WorkerRegistry)
-        assert result.is_alive("anything") is False
+        registry, _dispatchers = make_registry(
+            {},
+            MagicMock(),
+            dispatcher_factory=lambda _c, _r: MagicMock(),
+            state_updater=updater,
+        )
+        assert isinstance(registry, WorkerRegistry)
+        assert registry.is_alive("anything") is False
 
     def test_wakes_registered_repos(self, tmp_path: Path) -> None:
         cfg = _repo("foo/bar", tmp_path)
@@ -1204,10 +1209,10 @@ class TestMakeRegistry:
                 process_started_at=_EPOCH,
             )
         )
-        reg = make_registry(
+        reg, _dispatchers = make_registry(
             {"foo/bar": cfg},
             MagicMock(),
-            dispatchers={},
+            dispatcher_factory=lambda _c, _r: MagicMock(),
             state_updater=updater,
             _thread_factory=MagicMock(return_value=mock_thread),
         )
@@ -1237,7 +1242,7 @@ class TestMakeRegistry:
             {"foo/bar": cfg},
             MagicMock(),
             config,
-            dispatchers={},
+            dispatcher_factory=lambda _c, _r: MagicMock(),
             state_updater=updater,
             _thread_factory=mock_factory,
         )
@@ -1257,7 +1262,7 @@ class TestMakeRegistry:
         make_registry(
             {"foo/bar": cfg},
             MagicMock(),
-            dispatchers={},
+            dispatcher_factory=lambda _c, _r: MagicMock(),
             state_updater=updater,
             _thread_factory=mock_factory,
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,7 +234,9 @@ def server(tmp_path: Path) -> object:
     WebhookHandler.registry = MagicMock()
     WebhookHandler.state_reader = MagicMock()
     WebhookHandler._gh = MagicMock()
-    WebhookHandler.dispatchers = {"owner/repo": Dispatcher(cfg, repo_cfg, MagicMock())}
+    WebhookHandler.dispatchers = {
+        "owner/repo": Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock())
+    }
     WebhookHandler._fn_spawn_bg = staticmethod(_capturing_spawn_bg)  # type: ignore[assignment]
     srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
     port = srv.server_address[1]
@@ -3166,7 +3168,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3213,7 +3215,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3245,7 +3247,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3277,7 +3279,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3319,7 +3321,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
@@ -3351,7 +3353,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
@@ -3380,7 +3382,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _stderr=mock_stderr,
@@ -3424,7 +3426,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
@@ -3470,7 +3472,7 @@ class TestRun:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=fake_basic_config,
             _populate_memberships=MagicMock(),
@@ -3494,7 +3496,7 @@ class TestRun:
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         mock_registry = MagicMock()
-        mock_make_registry = MagicMock(return_value=mock_registry)
+        mock_make_registry = MagicMock(return_value=(mock_registry, {}))
         mock_watchdog_cls = MagicMock()
 
         run(
@@ -3524,7 +3526,7 @@ class TestRun:
         fake_cfg = self._fake_cfg(tmp_path)
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
-        mock_make_registry = MagicMock(return_value=MagicMock())
+        mock_make_registry = MagicMock(return_value=(MagicMock(), {}))
         mock_rl_cls = MagicMock()
         mock_gh_instance = MagicMock()
 
@@ -3557,6 +3559,42 @@ class TestRun:
         assert rl_args[1] is mock_make_registry.call_args.kwargs["state_updater"]
         mock_rl_cls.return_value.start_thread.assert_called_once()
 
+    def test_run_dispatcher_factory_builds_dispatcher_with_registry(
+        self, tmp_path: Path
+    ) -> None:
+        """INV-6: ``run`` passes a ``dispatcher_factory`` to ``make_registry``;
+        invoking it must produce a :class:`Dispatcher` wired with the registry
+        so :meth:`Dispatcher.backfill_missed_pr_comments` can reach the
+        per-(repo, item) :class:`CommentCache`."""
+        from fido.events import Dispatcher
+        from fido.server import run
+
+        fake_cfg = self._fake_cfg(tmp_path)
+        mock_server = MagicMock()
+        mock_server.serve_forever.side_effect = KeyboardInterrupt
+        mock_make_registry = MagicMock(return_value=(MagicMock(), {}))
+
+        run(
+            _from_args=lambda: fake_cfg,
+            _HTTPServer=lambda *a, **kw: mock_server,
+            _make_registry=mock_make_registry,
+            _path_home=lambda: tmp_path,
+            _basic_config=MagicMock(),
+            _populate_memberships=MagicMock(),
+            _preflight_repo_identity=MagicMock(),
+            _preflight_tools=MagicMock(),
+            _preflight_sub_dir=MagicMock(),
+            _preflight_gh_auth=MagicMock(),
+            _GitHub=MagicMock,
+            _ProviderPressureMonitor=MagicMock(),
+            _RateLimitMonitor=MagicMock(),
+        )
+
+        factory = mock_make_registry.call_args.kwargs["dispatcher_factory"]
+        repo_cfg = next(iter(fake_cfg.repos.values()))
+        produced = factory(repo_cfg, MagicMock())
+        assert isinstance(produced, Dispatcher)
+
     def test_run_starts_reconcile_watchdog_with_registry_repos_and_gh(
         self, tmp_path: Path
     ) -> None:
@@ -3566,7 +3604,7 @@ class TestRun:
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         mock_registry = MagicMock()
-        mock_make_registry = MagicMock(return_value=mock_registry)
+        mock_make_registry = MagicMock(return_value=(mock_registry, {}))
         mock_reconcile_cls = MagicMock()
         mock_gh_instance = MagicMock()
 
@@ -3611,7 +3649,7 @@ class TestRun:
             run(
                 _from_args=lambda: fake_cfg,
                 _HTTPServer=lambda *a, **kw: mock_server,
-                _make_registry=MagicMock(),
+                _make_registry=MagicMock(return_value=(MagicMock(), {})),
                 _path_home=lambda: tmp_path,
                 _basic_config=MagicMock(),
                 _populate_memberships=MagicMock(),
@@ -3668,7 +3706,7 @@ class TestRun:
         mock_server = MagicMock()
         mock_server.serve_forever.side_effect = KeyboardInterrupt
         mock_registry = MagicMock()
-        mock_make_registry = MagicMock(return_value=mock_registry)
+        mock_make_registry = MagicMock(return_value=(mock_registry, {}))
         mock_bootstrap = MagicMock()
         mock_gh_instance = MagicMock()
 
@@ -3913,7 +3951,7 @@ class TestPreflightRepoIdentity:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3946,7 +3984,7 @@ class TestPreflightRepoIdentity:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -3979,7 +4017,7 @@ class TestPreflightRepoIdentity:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -4012,7 +4050,7 @@ class TestPreflightRepoIdentity:
         run(
             _from_args=lambda: fake_cfg,
             _HTTPServer=lambda *a, **kw: mock_server,
-            _make_registry=MagicMock(),
+            _make_registry=MagicMock(return_value=(MagicMock(), {})),
             _path_home=lambda: tmp_path,
             _basic_config=MagicMock(),
             _populate_memberships=MagicMock(),
@@ -4044,7 +4082,7 @@ class TestPreflightRepoIdentity:
             run(
                 _from_args=lambda: fake_cfg,
                 _HTTPServer=lambda *a, **kw: mock_server,
-                _make_registry=MagicMock(),
+                _make_registry=MagicMock(return_value=(MagicMock(), {})),
                 _path_home=lambda: tmp_path,
                 _basic_config=MagicMock(),
                 _populate_memberships=MagicMock(),
@@ -4334,7 +4372,7 @@ class TestSelfRestart:
         WebhookHandler.config = cfg
         WebhookHandler.registry = mock_registry
         WebhookHandler.dispatchers = {
-            "owner/fido": Dispatcher(cfg, repo_cfg, MagicMock())
+            "owner/fido": Dispatcher(cfg, repo_cfg, MagicMock(), MagicMock())
         }
         srv = HTTPServer(("127.0.0.1", 0), WebhookHandler)
         port = srv.server_address[1]


### PR DESCRIPTION
## Summary

INV-6 of the #1748 epic: every comment-fetch site in `events.py` now goes
through the per-(repo, item) `CommentCache` set up in INV-1..3. The five
call sites that previously hit `gh.get_issue_comments` /
`gh.get_pull_comment` / `gh.get_issue_comment` directly are gone from the
event-handling path.

* `recover_reply_promises`: resolves the cache once at entry, uses
  `cache.list_top_level()` + `cache.get(KIND_ISSUES|KIND_PULLS, id)`.
* `Dispatcher.backfill_missed_pr_comments`: reads from the cache;
  `Dispatcher.__init__` accepts `registry: ActivityReporter` via
  constructor-DI.
* `reply_to_issue_comment`: reads the conversation history through the
  cache via the existing `registry` parameter.

`ActivityReporter` (Protocol on `worker.py`) grows
`get_comment_cache(repo_name, item, gh) -> CommentCache`, so `events.py`
can reach the cache without importing the concrete `WorkerRegistry`.

Because `Dispatcher` now needs the registry, `make_registry` switches
its pre-built `dispatchers` dict to a `dispatcher_factory` callback and
returns `(registry, dispatchers)` — the registry is constructed first,
then each dispatcher is built with it before the matching
`registry.start` runs. Server composition root updated accordingly.

Action builders (`build_review_comment_action`,
`_build_issue_comment_action`, `_review_lineage`) take
`Mapping[str, Any]` so frozen cache entries pass through without copies.

## Test plan
- [x] `./fido ci` green (4457 passed, 100% coverage)
- [x] `TestBackfillMissedPrComments`, `TestRecoverReplyPromises`,
      `TestReplyToIssueComment`, `TestDispatcher`, `TestRun` updated to
      assert on cache surface
- [x] New `test_run_dispatcher_factory_builds_dispatcher_with_registry`
      covers the dispatcher_factory wiring

Refs #1748.