### PR TITLE
INV-7 (#1761) + per-repo ETag-cached GitHub session

### DIFF
--- a/src/fido/comment_cache.py
+++ b/src/fido/comment_cache.py
@@ -430,6 +430,62 @@ class CommentCache(WebhookCache[tuple[str, int], CommentNode, CacheMetrics]):
         )
 
 
+def comment_via_cache_or_gh(
+    cache: "CommentCache",
+    kind: str,
+    *,
+    gh: GitHub,
+    repo: str,
+    comment_id: int,
+) -> Mapping[str, Any] | None:
+    """Cache-first single-comment lookup with authoritative ``gh`` fallback.
+
+    Shared between the events.py recovery path (INV-6) and the
+    worker.py consumer paths (INV-7).  The per-(repo, item) cache
+    legitimately returns ``None`` in two non-failure cases:
+
+    * the requested comment belongs to a *different* item — common
+      when the caller iterates a repo-wide promise table but reads
+      from a single-item cache;
+    * the cache failed to hydrate and silently stayed empty
+      (``WorkerRegistry.get_comment_cache`` swallows hydration
+      errors so the webhook handler can still queue the triggering
+      event).
+
+    In both cases the previous direct-GitHub call was authoritative,
+    so falling back to ``gh`` preserves correctness.
+    """
+    cached = cache.get(kind, comment_id)
+    if cached is not None:
+        return cached
+    if kind == KIND_PULLS:
+        return gh.get_pull_comment(repo, comment_id)
+    return gh.get_issue_comment(repo, comment_id)
+
+
+def top_level_comments_via_cache_or_gh(
+    cache: "CommentCache",
+    *,
+    gh: GitHub,
+    repo: str,
+    pr_number: int,
+) -> list[Mapping[str, Any]]:
+    """Cache-first list of top-level PR comments with ``gh`` fallback.
+
+    :meth:`CommentCache.list_top_level` returns ``[]`` both when the
+    item genuinely has no top-level comments and when hydration
+    failed silently (``is_loaded == False``).  In the latter case
+    callers that act on the empty list — e.g. one-shot startup
+    backfill or scan-once reconciliation — would silently drop
+    missed events until the next process restart.  Falling back to
+    ``gh.get_issue_comments`` for unloaded caches preserves the
+    loud-failure semantics callers had before the cache migration.
+    """
+    if cache.is_loaded:
+        return list(cache.list_top_level())
+    return [dict(c) for c in gh.get_issue_comments(repo, pr_number)]
+
+
 __all__ = [
     "KIND_ISSUES",
     "KIND_PULLS",
@@ -437,4 +493,6 @@ __all__ = [
     "CacheMetrics",
     "CommentCache",
     "CommentNode",
+    "comment_via_cache_or_gh",
+    "top_level_comments_via_cache_or_gh",
 ]

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -10,7 +10,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from fido.comment_cache import KIND_ISSUES, KIND_PULLS, CommentCache
+from fido.comment_cache import (
+    KIND_ISSUES,
+    KIND_PULLS,
+    comment_via_cache_or_gh,
+    top_level_comments_via_cache_or_gh,
+)
 from fido.config import Config, RepoConfig
 from fido.github import GitHub
 from fido.prompts import NO_TOOLS_CLAUSE, Prompts
@@ -331,64 +336,6 @@ def _pr_number_from_api_url(url: str, kind: str) -> int:
     if match is None:
         raise ValueError(f"invalid GitHub API URL for {kind}: {url!r}")
     return int(match.group(1))
-
-
-def _comment_via_cache_or_gh(
-    cache: CommentCache,
-    kind: str,
-    *,
-    gh: GitHub,
-    repo: str,
-    comment_id: int,
-) -> Mapping[str, Any] | None:
-    """Cache-first lookup with authoritative fallback to GitHub.
-
-    The per-(repo, item) :class:`CommentCache` only carries comments
-    that belong to its scoped item, so :meth:`CommentCache.get`
-    legitimately returns ``None`` in two non-failure cases:
-
-    * the requested comment belongs to a *different* PR — common when
-      :func:`recover_reply_promises` iterates the repo-wide promise
-      table; the caller skips foreign-PR matches downstream;
-    * the cache failed to hydrate and silently stayed empty
-      (``WorkerRegistry.get_comment_cache`` swallows hydration errors
-      so the webhook handler can still queue the triggering event).
-
-    In both cases the previous direct-GitHub call was authoritative,
-    and treating cache misses as "comment deleted" would mark valid
-    promises failed.  Fall back to ``gh`` so the caller sees the same
-    behaviour as before the cache migration (INV-6 of #1748).
-    """
-    cached = cache.get(kind, comment_id)
-    if cached is not None:
-        return cached
-    if kind == KIND_PULLS:
-        return gh.get_pull_comment(repo, comment_id)
-    return gh.get_issue_comment(repo, comment_id)
-
-
-def _top_level_comments_via_cache_or_gh(
-    cache: CommentCache,
-    *,
-    gh: GitHub,
-    repo: str,
-    pr_number: int,
-) -> list[Mapping[str, Any]]:
-    """Cache-first list of top-level PR comments with authoritative fallback.
-
-    :meth:`CommentCache.list_top_level` returns ``[]`` both when the
-    PR genuinely has no top-level comments and when hydration failed
-    silently (``is_loaded == False``).  The latter would cause
-    :meth:`Dispatcher.backfill_missed_pr_comments` — a one-shot
-    startup replay — to drop every missed ``issue_comment`` event
-    until the next process restart.  Falling back to the
-    ``gh.get_issue_comments`` call that backfill used pre-INV-6
-    preserves the original loud-failure semantics for the only path
-    where the cache might still be unhydrated.
-    """
-    if cache.is_loaded:
-        return list(cache.list_top_level())
-    return [dict(c) for c in gh.get_issue_comments(repo, pr_number)]
 
 
 def build_review_comment_action(
@@ -996,11 +943,11 @@ def recover_reply_promises(
     pull_entries: dict[str, tuple[Mapping[str, Any], int, int]] = {}
     # INV-6: comment lookups route through the per-(repo, pr) cache,
     # falling back to direct GitHub calls on cache miss or unhydrated
-    # cache (see ``_comment_via_cache_or_gh`` / ``_top_level_comments_via_cache_or_gh``).
+    # cache (see ``comment_via_cache_or_gh`` / ``top_level_comments_via_cache_or_gh``).
     comment_cache = registry.get_comment_cache(repo_cfg.name, pr_number, gh)
     issue_comments: list[Mapping[str, Any]] = []
     if any(p.comment_type == "issues" for p in promises):
-        issue_comments = _top_level_comments_via_cache_or_gh(
+        issue_comments = top_level_comments_via_cache_or_gh(
             comment_cache, gh=gh, repo=repo_cfg.name, pr_number=pr_number
         )
         if store.recover_from_bodies(c.get("body", "") for c in issue_comments):
@@ -1024,7 +971,7 @@ def recover_reply_promises(
             ):
                 processed_any = True
                 continue
-            comment = _comment_via_cache_or_gh(
+            comment = comment_via_cache_or_gh(
                 comment_cache,
                 KIND_PULLS,
                 gh=gh,
@@ -1044,7 +991,7 @@ def recover_reply_promises(
         else:
             comment = issue_comments_by_id.get(promise.anchor_comment_id)
             if comment is None:
-                comment = _comment_via_cache_or_gh(
+                comment = comment_via_cache_or_gh(
                     comment_cache,
                     KIND_ISSUES,
                     gh=gh,
@@ -1487,7 +1434,7 @@ class Dispatcher:
         """
         repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
-        comments = _top_level_comments_via_cache_or_gh(
+        comments = top_level_comments_via_cache_or_gh(
             self._registry.get_comment_cache(repo_cfg.name, pr_number, self._gh),
             gh=self._gh,
             repo=repo_cfg.name,
@@ -1910,7 +1857,7 @@ def reply_to_issue_comment(
     conversation_context = ""
     if number:
         try:
-            all_comments = _top_level_comments_via_cache_or_gh(
+            all_comments = top_level_comments_via_cache_or_gh(
                 registry.get_comment_cache(repo_cfg.name, int(number), gh),
                 gh=gh,
                 repo=repo_cfg.name,

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -4,8 +4,10 @@ import logging
 import os
 import re
 import subprocess
+import threading
 import time
 import urllib.parse
+from collections import OrderedDict
 from collections.abc import Callable, Iterator, Mapping
 from pathlib import Path
 from typing import Any
@@ -82,16 +84,147 @@ _RETRYABLE_STATUS: frozenset[int] = frozenset({500, 502, 503, 504})
 
 
 class _TimeoutSession(_requests.Session):
-    """requests.Session that applies _HTTP_TIMEOUT to every request by default."""
+    """``requests.Session`` with a uniform 30s timeout AND a per-repo
+    ETag-validating GET cache.
 
-    def request(  # pyright: ignore[reportIncompatibleMethodOverride]
+    Cache semantics
+    ===============
+
+    Every ``GET`` against ``api.github.com/repos/{owner}/{name}/...``
+    stores its body keyed by the request URL, alongside the response's
+    ``ETag`` and ``Last-Modified`` headers (if present).  The next GET
+    of the same URL replays those headers as ``If-None-Match`` /
+    ``If-Modified-Since``; GitHub returns ``304 Not Modified`` when
+    nothing changed, and we return the cached body.  ``304`` responses
+    do not count against the primary rate limit, so the cache is a
+    free correctness win on every read hot path — the server stays
+    authoritative (no webhook-staleness reasoning) and the client pays
+    one round-trip rather than a full body fetch.
+
+    Per-repo scope + lifecycle
+    --------------------------
+
+    Entries are partitioned by the ``owner/name`` segment of the URL.
+    :meth:`clear_repo_cache` drops all entries for one repo, called by
+    the worker on PR transitions (open / close / handoff) and by the
+    webhook handler on ``pull_request.closed`` — so within a PR's
+    lifetime the cache size is bounded by "URLs touched while working
+    on this PR", which is small and self-limiting.  No LRU eviction
+    needed because the PR-transition wipe is the natural bound.
+
+    Thread safety
+    -------------
+
+    All cache mutations go through ``_lock`` because the worker thread,
+    the webhook handler thread, and any background reconcile thread
+    can hit the same session concurrently (Python 3.14t free-threaded
+    — no GIL).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def request(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         method: str | bytes,
         url: str | bytes,
-        **kwargs: Any,  # noqa: ANN401  # forwarded verbatim to requests.Session.request
-    ) -> _requests.Response:  # type: ignore[override]
+        *args: Any,  # noqa: ANN401  # forwarded verbatim to base.request
+        **kwargs: Any,  # noqa: ANN401  # forwarded verbatim to base.request
+    ) -> _requests.Response:
         kwargs.setdefault("timeout", _HTTP_TIMEOUT)
-        return super().request(method, url, **kwargs)
+        method_s = method.decode() if isinstance(method, bytes) else method
+        url_s = url.decode() if isinstance(url, bytes) else url
+        if method_s.upper() != "GET":
+            return super().request(method, url, *args, **kwargs)
+        return self._cached_get(url_s, args, kwargs)
+
+    def _cached_get(
+        self,
+        url: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> _requests.Response:
+        with self._lock:
+            cached = self._cache.get(url)
+        headers = dict(kwargs.get("headers") or {})
+        if cached is not None:
+            if cached.etag:
+                headers["If-None-Match"] = cached.etag
+            if cached.last_modified:
+                headers["If-Modified-Since"] = cached.last_modified
+            kwargs["headers"] = headers
+        resp = super().request("GET", url, *args, **kwargs)
+        if resp.status_code == 304 and cached is not None:
+            return cached.replay(resp)
+        if resp.status_code == 200 and (
+            resp.headers.get("ETag") or resp.headers.get("Last-Modified")
+        ):
+            with self._lock:
+                self._cache[url] = _CacheEntry.from_response(resp)
+                self._cache.move_to_end(url)
+        return resp
+
+    def clear_repo_cache(self, repo: str) -> int:
+        """Drop every cached entry whose URL belongs to ``repo``.
+
+        ``repo`` is ``owner/name``.  Returns the number of entries
+        dropped, for logging / metrics.  Called on PR transitions
+        (worker switching to a different issue / PR, or webhook
+        observing ``pull_request.closed``) to keep the cache bounded
+        without LRU machinery.
+        """
+        prefix = f"/repos/{repo}/"
+        with self._lock:
+            doomed = [u for u in self._cache if prefix in u]
+            for u in doomed:
+                del self._cache[u]
+        return len(doomed)
+
+
+class _CacheEntry:
+    """One cached ``GET`` response — body + revalidation headers."""
+
+    __slots__ = ("etag", "last_modified", "content", "headers")
+
+    def __init__(
+        self,
+        etag: str,
+        last_modified: str,
+        content: bytes,
+        headers: Mapping[str, str],
+    ) -> None:
+        self.etag = etag
+        self.last_modified = last_modified
+        self.content = content
+        self.headers = dict(headers)
+
+    @classmethod
+    def from_response(cls, resp: _requests.Response) -> "_CacheEntry":
+        return cls(
+            etag=resp.headers.get("ETag", ""),
+            last_modified=resp.headers.get("Last-Modified", ""),
+            content=resp.content,
+            headers=dict(resp.headers),
+        )
+
+    def replay(self, not_modified: _requests.Response) -> _requests.Response:
+        """Materialize a fresh 200 ``Response`` carrying the cached body.
+
+        ``requests`` returns the live 304 response to the caller by
+        default, which has no body — every GitHub helper would have to
+        learn about 304.  Instead we synthesize a 200 with the cached
+        body so the rest of the codebase reads ``resp.json()`` /
+        ``resp.content`` uniformly.
+        """
+        replayed = _requests.Response()
+        replayed.status_code = 200
+        replayed._content = self.content  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        replayed.headers.update(self.headers)
+        replayed.url = not_modified.url
+        replayed.request = not_modified.request
+        return replayed
 
 
 class GraphQLError(Exception):
@@ -171,6 +304,22 @@ class GitHub:
             }
         )
         self._sleep = sleeper
+
+    def clear_repo_cache(self, repo: str) -> int:
+        """Drop all cached GET responses for ``repo`` from the session.
+
+        Called by the worker on PR transitions (open / close / handoff)
+        and by the webhook handler on ``pull_request.closed`` to bound
+        the in-process ETag cache without LRU machinery — within a
+        PR's lifetime the cache holds only URLs touched while working
+        on that PR.
+
+        Returns the number of entries dropped, or ``0`` if the session
+        does not expose a cache (e.g. an injected test session).
+        """
+        if isinstance(self._s, _TimeoutSession):
+            return self._s.clear_repo_cache(repo)
+        return 0
 
     def refresh_token(self) -> bool:
         """Re-resolve the gh-CLI token; update session headers if changed.

--- a/src/fido/github.py
+++ b/src/fido/github.py
@@ -82,6 +82,17 @@ def _pr_state_str(pr: dict[str, object]) -> str:
 _GET_RETRY_DELAYS: tuple[float, ...] = (1.0, 3.0, 10.0)
 _RETRYABLE_STATUS: frozenset[int] = frozenset({500, 502, 503, 504})
 
+# Only requests under ``/repos/{owner}/{repo}/...`` may enter the
+# transport-level GET cache.  The per-repo wipe (called on PR
+# transitions) is the cache's only lifecycle hook, so caching
+# endpoints that aren't owned by a repo — ``/user``, ``/users/{login}``,
+# ``/search/issues``, ``/rate_limit``, etc. — would grow unbounded
+# without a parallel LRU mechanism.  Scoping the cache to the URLs
+# the wipe knows about keeps "no LRU needed" honest.
+_CACHEABLE_URL_RE: re.Pattern[str] = re.compile(
+    r"^https://api\.github\.com/repos/(?P<repo>[^/]+/[^/]+)/"
+)
+
 
 class _TimeoutSession(_requests.Session):
     """``requests.Session`` with a uniform 30s timeout AND a per-repo
@@ -146,6 +157,9 @@ class _TimeoutSession(_requests.Session):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> _requests.Response:
+        cacheable = _CACHEABLE_URL_RE.match(url) is not None
+        if not cacheable:
+            return super().request("GET", url, *args, **kwargs)
         with self._lock:
             cached = self._cache.get(url)
         headers = dict(kwargs.get("headers") or {})
@@ -174,6 +188,11 @@ class _TimeoutSession(_requests.Session):
         (worker switching to a different issue / PR, or webhook
         observing ``pull_request.closed``) to keep the cache bounded
         without LRU machinery.
+
+        Cache-eligible URLs are restricted to ``/repos/{owner}/{repo}/...``
+        (see ``_CACHEABLE_URL_RE``), so this wipe is complete — there
+        are no orphan entries from ``/user`` / ``/search/issues`` /
+        ``/rate_limit`` etc. that this method couldn't reach.
         """
         prefix = f"/repos/{repo}/"
         with self._lock:
@@ -181,6 +200,22 @@ class _TimeoutSession(_requests.Session):
             for u in doomed:
                 del self._cache[u]
         return len(doomed)
+
+    def clear_all(self) -> int:
+        """Drop every cached entry across all repos.
+
+        Called by :meth:`GitHub.refresh_token` when the gh-CLI token
+        actually rotates — without this, the next GET would revalidate
+        with an ``If-None-Match`` validated under the *old* token and
+        a server-side 304 would replay the old body, weakening the
+        ``#1207`` identity guard that ``Worker.assert_git_identity``
+        relies on (it calls ``refresh_token`` then immediately reads
+        the authenticated identity).
+        """
+        with self._lock:
+            n = len(self._cache)
+            self._cache.clear()
+        return n
 
 
 class _CacheEntry:
@@ -341,6 +376,14 @@ class GitHub:
             return False
         self._token = new_token
         self._s.headers["Authorization"] = f"Bearer {new_token}"
+        # Wipe every cached response so the next GET re-authenticates
+        # with the new token from scratch.  Without this the URL-keyed
+        # ETag cache would replay bodies validated under the *old*
+        # token on a 304 — bypassing the #1207 identity guard that
+        # ``Worker.assert_git_identity`` relies on (it calls
+        # ``refresh_token`` then ``get_authenticated_identity``).
+        if isinstance(self._s, _TimeoutSession):
+            self._s.clear_all()
         return True
 
     def _retryable_get(self, url: str) -> _requests.Response:

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -566,6 +566,11 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.registry.destroy_comment_cache(
                 repo_cfg.name, payload["pull_request"]["number"]
             )
+            # The per-repo HTTP cache (see :meth:`GitHub.clear_repo_cache`)
+            # is wiped on the worker's next PR-transition hook rather than
+            # here — webhook-side wipe would need its own access to gh and
+            # the worker already covers it within a few seconds of the
+            # close on its next loop iteration.
 
         # Acknowledge only after dispatch succeeds.
         self._respond(200, "ok")

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1957,6 +1957,10 @@ class Worker:
             with self._state.modify() as state:
                 state["pr_number"] = pr_number
                 state["pr_title"] = pr_title
+            # PR transition (resuming an existing PR after worker
+            # restart / handoff) — drop any cached GET bodies for the
+            # previous session.  See :meth:`GitHub.clear_repo_cache`.
+            self.gh.clear_repo_cache(repo_ctx.repo)
             # Open PR — resume
             log.info("resuming PR #%s on branch %s", pr_number, slug)
             self._git(["fetch", remote])
@@ -2134,6 +2138,11 @@ class Worker:
         with self._state.modify() as state:
             state["pr_number"] = pr_number
             state["pr_title"] = request
+        # PR transition (new PR opened) — drop any cached GET bodies for
+        # the previous PR so the per-repo HTTP cache stays bounded by
+        # "URLs touched on the currently-active PR".  See
+        # :meth:`GitHub.clear_repo_cache` (INV-7 follow-up).
+        self.gh.clear_repo_cache(repo_ctx.repo)
 
         if not self._tasks.list():
             # Setup legitimately produced zero tasks — the model decided no

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -33,7 +33,6 @@ from fido.comment_cache import (
     KIND_PULLS,
     CommentCache,
     comment_via_cache_or_gh,
-    top_level_comments_via_cache_or_gh,
 )
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
@@ -1834,27 +1833,6 @@ class Worker:
             default,
         )
 
-    def _resolved_top_level_comments(
-        self, repo: str, item: int
-    ) -> list[Mapping[str, Any]]:
-        """Cache-first list of top-level comments for ``(repo, item)``.
-
-        INV-7 of #1748: every comment-fetch site in this module reads
-        from the per-(repo, item) :class:`CommentCache` instead of
-        going to GitHub directly.  Falls back to ``gh.get_issue_comments``
-        on unhydrated cache (handled inside
-        :func:`top_level_comments_via_cache_or_gh`) or when the worker
-        was constructed without a registry (test paths).
-        """
-        if self._registry is None:
-            return [dict(c) for c in self.gh.get_issue_comments(repo, item)]
-        return top_level_comments_via_cache_or_gh(
-            self._registry.get_comment_cache(repo, item, self.gh),
-            gh=self.gh,
-            repo=repo,
-            pr_number=item,
-        )
-
     def _resolved_comment(
         self, repo: str, item: int, kind: str, comment_id: int
     ) -> Mapping[str, Any] | None:
@@ -1903,7 +1881,11 @@ class Worker:
             if e.get("event") == "reopened":
                 last_opened = e.get("created_at", last_opened)
 
-        comments = self._resolved_top_level_comments(repo, issue)
+        # Authoritative read (codex P2 follow-up on INV-7): this is a
+        # non-PR issue, and ``CommentCache`` only covers PR items —
+        # going through the cache here would 404 on the ``/pulls``
+        # hydration endpoints every call.
+        comments = self.gh.get_issue_comments(repo, issue)
         has_retry_ack = any(
             c.get("user", {}).get("login") == gh_user
             and c.get("created_at", "") >= last_opened
@@ -2937,8 +2919,13 @@ class Worker:
         cleanup.  Best-effort: on upstream error returns an empty set, which
         conservatively means every later fido comment is treated as new.
         """
+        # Authoritative read (codex P2 follow-up on INV-7): leak-cleanup
+        # diffs the live comment set against a before-image, so reading
+        # from the eventually-consistent ``CommentCache`` would let a
+        # delayed/dropped webhook leave newly-leaked comments invisible
+        # to the snapshot and silently skip the cleanup.
         try:
-            comments = self._resolved_top_level_comments(repo, pr_number)
+            comments = self.gh.get_issue_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "leak-check: failed to snapshot issue comments on %s#%d",
@@ -2966,8 +2953,12 @@ class Worker:
         after the task completion path; HTTP errors here are logged and
         swallowed so a transient GitHub hiccup doesn't abort the caller.
         """
+        # Authoritative read (codex P2 follow-up on INV-7): see
+        # :meth:`_snapshot_fido_issue_comment_ids` — the cleanup diff
+        # must observe the current GitHub state, not a webhook-lagged
+        # cache snapshot, or new leaked comments slip through.
         try:
-            comments = self._resolved_top_level_comments(repo, pr_number)
+            comments = self.gh.get_issue_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "leak-check: failed to fetch issue comments on %s#%d",
@@ -3221,9 +3212,13 @@ class Worker:
         # a crash between the comment post and the close calls doesn't leave
         # the issue/PR permanently open on retry.
         if closed_sub_issues and not has_real_diff and explicit_no_tasks:
-            existing_issue_comments = self._resolved_top_level_comments(
-                repo_ctx.repo, issue
-            )
+            # Authoritative read (codex P2 follow-up on INV-7):
+            # ``issue`` here is a non-PR issue number — ``CommentCache``
+            # only covers PR items.  Also a post-then-read dedupe gate
+            # for the sub-issue coverage comment, which requires
+            # read-your-writes that the eventually-consistent cache
+            # cannot guarantee.
+            existing_issue_comments = self.gh.get_issue_comments(repo_ctx.repo, issue)
             already_posted = any(
                 _NO_TASKS_PR_COMMENT_MARKER in (c.get("body") or "")
                 for c in existing_issue_comments
@@ -3292,7 +3287,12 @@ class Worker:
         # pr_ready / add_pr_reviewers still run unconditionally (they are
         # API-idempotent) so a crash between the comment and the ready call
         # is retried correctly.
-        existing = self._resolved_top_level_comments(repo_ctx.repo, pr_number)
+        # Authoritative read (codex P2 follow-up on INV-7): the marker
+        # check is a post-then-read dedupe gate to keep the worker loop
+        # from re-posting on every iteration.  An eventually-consistent
+        # cache read could miss a just-posted marker and break the
+        # idempotency invariant.
+        existing = self.gh.get_issue_comments(repo_ctx.repo, pr_number)
         already_posted = any(
             _NO_TASKS_PR_COMMENT_MARKER in (c.get("body") or "") for c in existing
         )
@@ -3402,8 +3402,14 @@ class Worker:
         which prevents the worker loop from re-posting the same comment
         on every iteration.
         """
+        # Authoritative read (codex P1 follow-up on INV-7): this whole
+        # method is documented as idempotent on
+        # :data:`_EMPTY_PR_COMMENT_MARKER` so the worker loop won't
+        # re-post each iteration.  Reading through the eventually-
+        # consistent ``CommentCache`` would miss a just-posted marker
+        # if its webhook is delayed/dropped and break that invariant.
         try:
-            existing = self._resolved_top_level_comments(repo, pr_number)
+            existing = self.gh.get_issue_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "_post_empty_pr_comment_once: failed to fetch comments on %s#%d",
@@ -4005,7 +4011,13 @@ class Worker:
             if e.get("event") == "reopened":
                 last_opened = e.get("created_at", last_opened)
 
-        comments = self._resolved_top_level_comments(repo, issue)
+        # Authoritative read (codex P2 follow-up on INV-7): ``issue``
+        # may be a non-PR issue (``CommentCache`` only covers PRs), and
+        # this is the dedupe gate for the pickup-marker comment that
+        # ``_ensure_pickup_comment`` calls *before* writing the
+        # ``pickup_comment_ensured`` durable bit — a stale cache could
+        # re-post the marker on crash/restart.
+        comments = self.gh.get_issue_comments(repo, issue)
         has_pickup_comment = any(
             c.get("user", {}).get("login") == gh_user
             and c.get("created_at", "") >= last_opened

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -28,7 +28,13 @@ from fido.appstate import (
 )
 from fido.atomic import AtomicUpdater
 from fido.claude import ClaudeCode
-from fido.comment_cache import CommentCache
+from fido.comment_cache import (
+    KIND_ISSUES,
+    KIND_PULLS,
+    CommentCache,
+    comment_via_cache_or_gh,
+    top_level_comments_via_cache_or_gh,
+)
 from fido.config import Config, RepoConfig, RepoMembership, default_sub_dir
 from fido.github import GitHub
 from fido.harness_commit import HarnessCommitter
@@ -1828,6 +1834,51 @@ class Worker:
             default,
         )
 
+    def _resolved_top_level_comments(
+        self, repo: str, item: int
+    ) -> list[Mapping[str, Any]]:
+        """Cache-first list of top-level comments for ``(repo, item)``.
+
+        INV-7 of #1748: every comment-fetch site in this module reads
+        from the per-(repo, item) :class:`CommentCache` instead of
+        going to GitHub directly.  Falls back to ``gh.get_issue_comments``
+        on unhydrated cache (handled inside
+        :func:`top_level_comments_via_cache_or_gh`) or when the worker
+        was constructed without a registry (test paths).
+        """
+        if self._registry is None:
+            return [dict(c) for c in self.gh.get_issue_comments(repo, item)]
+        return top_level_comments_via_cache_or_gh(
+            self._registry.get_comment_cache(repo, item, self.gh),
+            gh=self.gh,
+            repo=repo,
+            pr_number=item,
+        )
+
+    def _resolved_comment(
+        self, repo: str, item: int, kind: str, comment_id: int
+    ) -> Mapping[str, Any] | None:
+        """Cache-first single-comment lookup for ``(repo, item)``.
+
+        INV-7 of #1748: see :meth:`_resolved_top_level_comments`.
+        Falls back to ``gh.get_*_comment`` on cache miss / unhydrated
+        cache (handled inside :func:`comment_via_cache_or_gh`) or
+        when the worker was constructed without a registry.
+        """
+        if self._registry is None:
+            return (
+                self.gh.get_pull_comment(repo, comment_id)
+                if kind == KIND_PULLS
+                else self.gh.get_issue_comment(repo, comment_id)
+            )
+        return comment_via_cache_or_gh(
+            self._registry.get_comment_cache(repo, item, self.gh),
+            kind,
+            gh=self.gh,
+            repo=repo,
+            comment_id=comment_id,
+        )
+
     def _post_retry_acknowledgement(
         self,
         repo: str,
@@ -1852,7 +1903,7 @@ class Worker:
             if e.get("event") == "reopened":
                 last_opened = e.get("created_at", last_opened)
 
-        comments = self.gh.get_issue_comments(repo, issue)
+        comments = self._resolved_top_level_comments(repo, issue)
         has_retry_ack = any(
             c.get("user", {}).get("login") == gh_user
             and c.get("created_at", "") >= last_opened
@@ -2525,7 +2576,9 @@ class Worker:
             promise = promise_by_anchor.get(first_db_id)
             if promise is None:
                 continue
-            comment = self.gh.get_pull_comment(repo_ctx.repo, first_db_id)
+            comment = self._resolved_comment(
+                repo_ctx.repo, pr_number, KIND_PULLS, first_db_id
+            )
             if comment is None:
                 log.info("skipping thread %s — root comment missing", first_db_id)
                 store.mark_failed(promise.promise_id)
@@ -2764,7 +2817,9 @@ class Worker:
     ) -> "Action | None":
         from fido import events
 
-        comment = self.gh.get_pull_comment(repo, queued.comment_id)
+        comment = self._resolved_comment(
+            repo, queued.pr_number, KIND_PULLS, queued.comment_id
+        )
         if comment is None:
             log.info("queued review comment %s is gone — completing", queued.comment_id)
             return None
@@ -2787,7 +2842,9 @@ class Worker:
     ) -> "Action | None":
         from fido import events
 
-        comment = self.gh.get_issue_comment(repo, queued.comment_id)
+        comment = self._resolved_comment(
+            repo, queued.pr_number, KIND_ISSUES, queued.comment_id
+        )
         if comment is None:
             log.info("queued issue comment %s is gone — completing", queued.comment_id)
             return None
@@ -2881,7 +2938,7 @@ class Worker:
         conservatively means every later fido comment is treated as new.
         """
         try:
-            comments = self.gh.get_issue_comments(repo, pr_number)
+            comments = self._resolved_top_level_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "leak-check: failed to snapshot issue comments on %s#%d",
@@ -2910,7 +2967,7 @@ class Worker:
         swallowed so a transient GitHub hiccup doesn't abort the caller.
         """
         try:
-            comments = self.gh.get_issue_comments(repo, pr_number)
+            comments = self._resolved_top_level_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "leak-check: failed to fetch issue comments on %s#%d",
@@ -3164,7 +3221,9 @@ class Worker:
         # a crash between the comment post and the close calls doesn't leave
         # the issue/PR permanently open on retry.
         if closed_sub_issues and not has_real_diff and explicit_no_tasks:
-            existing_issue_comments = self.gh.get_issue_comments(repo_ctx.repo, issue)
+            existing_issue_comments = self._resolved_top_level_comments(
+                repo_ctx.repo, issue
+            )
             already_posted = any(
                 _NO_TASKS_PR_COMMENT_MARKER in (c.get("body") or "")
                 for c in existing_issue_comments
@@ -3233,7 +3292,7 @@ class Worker:
         # pr_ready / add_pr_reviewers still run unconditionally (they are
         # API-idempotent) so a crash between the comment and the ready call
         # is retried correctly.
-        existing = self.gh.get_issue_comments(repo_ctx.repo, pr_number)
+        existing = self._resolved_top_level_comments(repo_ctx.repo, pr_number)
         already_posted = any(
             _NO_TASKS_PR_COMMENT_MARKER in (c.get("body") or "") for c in existing
         )
@@ -3344,7 +3403,7 @@ class Worker:
         on every iteration.
         """
         try:
-            existing = self.gh.get_issue_comments(repo, pr_number)
+            existing = self._resolved_top_level_comments(repo, pr_number)
         except _requests.RequestException:
             log.exception(
                 "_post_empty_pr_comment_once: failed to fetch comments on %s#%d",
@@ -3946,7 +4005,7 @@ class Worker:
             if e.get("event") == "reopened":
                 last_opened = e.get("created_at", last_opened)
 
-        comments = self.gh.get_issue_comments(repo, issue)
+        comments = self._resolved_top_level_comments(repo, issue)
         has_pickup_comment = any(
             c.get("user", {}).get("login") == gh_user
             and c.get("created_at", "") >= last_opened

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -1822,7 +1822,15 @@ class TestWorkerHandleQueuedCommentsDrain:
         worker._config = MagicMock()  # type: ignore[attr-defined]
         worker._repo_cfg = MagicMock()  # type: ignore[attr-defined]
         worker._repo_cfg.work_dir = tmp_path
-        worker._registry = MagicMock()  # type: ignore[attr-defined]
+        # INV-7: ``_queued_issue_comment_action`` routes through
+        # ``Worker._resolved_comment`` which consults the per-(repo, item)
+        # ``CommentCache`` first.  Wire the registry's cache to miss so the
+        # fallback path consumes the staged ``gh.get_issue_comment`` return.
+        registry = MagicMock()
+        comment_cache = MagicMock()
+        comment_cache.get.return_value = None
+        registry.get_comment_cache.return_value = comment_cache
+        worker._registry = registry  # type: ignore[attr-defined]
         worker._repo_name = "test/repo"  # type: ignore[attr-defined]
 
         queued = PRCommentQueueRecord(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5965,12 +5965,12 @@ class TestCacheOrGhFallback:
     one-shot startup backfill doesn't silently lose missed comments."""
 
     def test_comment_via_cache_returns_cache_hit_without_gh(self) -> None:
-        from fido.events import _comment_via_cache_or_gh
+        from fido.events import comment_via_cache_or_gh
 
         cache = MagicMock()
         cache.get.return_value = {"id": 1, "body": "cached"}
         gh = MagicMock()
-        result = _comment_via_cache_or_gh(
+        result = comment_via_cache_or_gh(
             cache, "issues", gh=gh, repo="owner/repo", comment_id=1
         )
         assert result == {"id": 1, "body": "cached"}
@@ -5978,52 +5978,52 @@ class TestCacheOrGhFallback:
         gh.get_pull_comment.assert_not_called()
 
     def test_comment_via_cache_falls_back_to_gh_on_miss_issues(self) -> None:
-        from fido.events import _comment_via_cache_or_gh
+        from fido.events import comment_via_cache_or_gh
 
         cache = MagicMock()
         cache.get.return_value = None
         gh = MagicMock()
         gh.get_issue_comment.return_value = {"id": 2, "body": "from gh"}
-        result = _comment_via_cache_or_gh(
+        result = comment_via_cache_or_gh(
             cache, "issues", gh=gh, repo="owner/repo", comment_id=2
         )
         assert result == {"id": 2, "body": "from gh"}
         gh.get_issue_comment.assert_called_once_with("owner/repo", 2)
 
     def test_comment_via_cache_falls_back_to_gh_on_miss_pulls(self) -> None:
-        from fido.events import _comment_via_cache_or_gh
+        from fido.events import comment_via_cache_or_gh
 
         cache = MagicMock()
         cache.get.return_value = None
         gh = MagicMock()
         gh.get_pull_comment.return_value = {"id": 3, "body": "from gh"}
-        result = _comment_via_cache_or_gh(
+        result = comment_via_cache_or_gh(
             cache, "pulls", gh=gh, repo="owner/repo", comment_id=3
         )
         assert result == {"id": 3, "body": "from gh"}
         gh.get_pull_comment.assert_called_once_with("owner/repo", 3)
 
     def test_top_level_uses_loaded_cache(self) -> None:
-        from fido.events import _top_level_comments_via_cache_or_gh
+        from fido.events import top_level_comments_via_cache_or_gh
 
         cache = MagicMock()
         cache.is_loaded = True
         cache.list_top_level.return_value = [{"id": 1}]
         gh = MagicMock()
-        result = _top_level_comments_via_cache_or_gh(
+        result = top_level_comments_via_cache_or_gh(
             cache, gh=gh, repo="owner/repo", pr_number=7
         )
         assert result == [{"id": 1}]
         gh.get_issue_comments.assert_not_called()
 
     def test_top_level_falls_back_when_unloaded(self) -> None:
-        from fido.events import _top_level_comments_via_cache_or_gh
+        from fido.events import top_level_comments_via_cache_or_gh
 
         cache = MagicMock()
         cache.is_loaded = False
         gh = MagicMock()
         gh.get_issue_comments.return_value = [{"id": 9, "body": "missed"}]
-        result = _top_level_comments_via_cache_or_gh(
+        result = top_level_comments_via_cache_or_gh(
             cache, gh=gh, repo="owner/repo", pr_number=7
         )
         assert result == [{"id": 9, "body": "missed"}]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -169,6 +169,148 @@ class TestTimeoutSession:
         gh = GitHub("tok")
         assert isinstance(gh._s, _TimeoutSession)
 
+    def test_get_caches_response_then_replays_on_304(self) -> None:
+        """GET response with ETag is cached; second GET that gets a 304
+        returns a synthesized 200 carrying the original body."""
+        from unittest.mock import patch
+
+        first = MagicMock()
+        first.status_code = 200
+        first.headers = {"ETag": 'W/"abc"', "Content-Type": "application/json"}
+        first.content = b'{"hello": "world"}'
+
+        second = MagicMock()
+        second.status_code = 304
+        second.headers = {}
+        second.url = "https://api.github.com/repos/o/r/issues/1/comments"
+        second.request = None
+
+        with patch("requests.Session.request") as mock_req:
+            mock_req.side_effect = [first, second]
+            s = _TimeoutSession()
+            r1 = s.request("GET", "https://api.github.com/repos/o/r/issues/1/comments")
+            assert r1.status_code == 200
+            r2 = s.request("GET", "https://api.github.com/repos/o/r/issues/1/comments")
+        assert r2.status_code == 200
+        assert r2.content == b'{"hello": "world"}'
+        # If-None-Match must have been sent on the second call.
+        second_call_kwargs = mock_req.call_args_list[1].kwargs
+        assert second_call_kwargs["headers"]["If-None-Match"] == 'W/"abc"'
+
+    def test_get_caches_last_modified_when_no_etag(self) -> None:
+        """Responses with only Last-Modified still get cached and the
+        next GET sends If-Modified-Since."""
+        from unittest.mock import patch
+
+        first = MagicMock()
+        first.status_code = 200
+        first.headers = {"Last-Modified": "Wed, 21 Oct 2026 07:28:00 GMT"}
+        first.content = b"body"
+        second = MagicMock()
+        second.status_code = 304
+        second.headers = {}
+        second.url = "https://api.github.com/repos/o/r/issues/2"
+        second.request = None
+        with patch("requests.Session.request") as mock_req:
+            mock_req.side_effect = [first, second]
+            s = _TimeoutSession()
+            s.request("GET", "https://api.github.com/repos/o/r/issues/2")
+            s.request("GET", "https://api.github.com/repos/o/r/issues/2")
+        assert (
+            mock_req.call_args_list[1].kwargs["headers"]["If-Modified-Since"]
+            == "Wed, 21 Oct 2026 07:28:00 GMT"
+        )
+
+    def test_get_without_etag_or_last_modified_is_not_cached(self) -> None:
+        from unittest.mock import patch
+
+        first = MagicMock()
+        first.status_code = 200
+        first.headers = {"Content-Type": "text/plain"}
+        first.content = b"hi"
+        second = MagicMock()
+        second.status_code = 200
+        second.headers = {}
+        second.content = b"hi2"
+        with patch("requests.Session.request") as mock_req:
+            mock_req.side_effect = [first, second]
+            s = _TimeoutSession()
+            s.request("GET", "https://api.github.com/repos/o/r/x")
+            r2 = s.request("GET", "https://api.github.com/repos/o/r/x")
+        # No cache hit — second body returned as-is, no If-None-Match sent.
+        assert r2.content == b"hi2"
+        second_headers = mock_req.call_args_list[1].kwargs.get("headers") or {}
+        assert "If-None-Match" not in second_headers
+
+    def test_non_get_methods_bypass_cache(self) -> None:
+        from unittest.mock import patch
+
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.headers = {}
+        with patch("requests.Session.request") as mock_req:
+            mock_req.return_value = resp
+            s = _TimeoutSession()
+            s.request("POST", "https://api.github.com/repos/o/r/issues")
+            s.request("POST", "https://api.github.com/repos/o/r/issues")
+        # POSTs always reach the underlying session; never cached.
+        assert mock_req.call_count == 2
+        for call in mock_req.call_args_list:
+            assert "If-None-Match" not in (call.kwargs.get("headers") or {})
+
+    def test_bytes_method_and_url_are_accepted(self) -> None:
+        from unittest.mock import patch
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        with patch("requests.Session.request") as mock_req:
+            mock_req.return_value = resp
+            s = _TimeoutSession()
+            s.request(b"GET", b"https://api.github.com/repos/o/r/x")
+        assert mock_req.call_count == 1
+
+    def test_clear_repo_cache_drops_only_that_repos_entries(self) -> None:
+        from unittest.mock import patch
+
+        def mk(etag: str, body: bytes) -> MagicMock:
+            r = MagicMock()
+            r.status_code = 200
+            r.headers = {"ETag": etag}
+            r.content = body
+            return r
+
+        with patch("requests.Session.request") as mock_req:
+            mock_req.side_effect = [
+                mk('W/"a"', b"A"),
+                mk('W/"b"', b"B"),
+            ]
+            s = _TimeoutSession()
+            s.request("GET", "https://api.github.com/repos/owner/foo/issues/1")
+            s.request("GET", "https://api.github.com/repos/owner/bar/issues/1")
+            dropped = s.clear_repo_cache("owner/foo")
+        assert dropped == 1
+        # The bar entry survives — verify by sending a 304 and getting B back.
+        not_modified = MagicMock()
+        not_modified.status_code = 304
+        not_modified.headers = {}
+        not_modified.url = "https://api.github.com/repos/owner/bar/issues/1"
+        not_modified.request = None
+        with patch("requests.Session.request", return_value=not_modified):
+            r = s.request("GET", "https://api.github.com/repos/owner/bar/issues/1")
+        assert r.content == b"B"
+
+    def test_github_clear_repo_cache_delegates_to_session(self) -> None:
+        gh = GitHub("tok")
+        # Empty cache → 0 dropped, no error.
+        assert gh.clear_repo_cache("owner/repo") == 0
+
+    def test_github_clear_repo_cache_returns_zero_for_non_caching_session(
+        self,
+    ) -> None:
+        gh = GitHub("tok", session=MagicMock())
+        assert gh.clear_repo_cache("owner/repo") == 0
+
 
 class TestGitHubClass:
     def _gh(self) -> tuple[GitHub, MagicMock]:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -311,6 +311,87 @@ class TestTimeoutSession:
         gh = GitHub("tok", session=MagicMock())
         assert gh.clear_repo_cache("owner/repo") == 0
 
+    def test_non_repo_urls_are_not_cached(self) -> None:
+        """``/user``, ``/search/issues``, ``/rate_limit`` etc. live
+        outside any per-repo lifecycle hook — caching them would grow
+        unbounded.  These URLs must bypass the cache entirely; even
+        on a fresh ``200`` with ``ETag``, the entry is not stored."""
+        from unittest.mock import patch
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"ETag": 'W/"u"'}
+        resp.content = b'{"login": "fido"}'
+        with patch("requests.Session.request", return_value=resp):
+            s = _TimeoutSession()
+            for url in (
+                "https://api.github.com/user",
+                "https://api.github.com/users/rhencke",
+                "https://api.github.com/search/issues?q=foo",
+                "https://api.github.com/rate_limit",
+            ):
+                s.request("GET", url)
+        # Nothing should have landed in the cache.
+        assert len(s._cache) == 0  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+    def test_non_repo_get_does_not_send_revalidation_headers(self) -> None:
+        """Even if a non-repo URL were sneakily cached, the request
+        path must never inject ``If-None-Match`` for non-cacheable
+        URLs — guards against bypassing the bypass."""
+        from unittest.mock import patch
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        with patch("requests.Session.request", return_value=resp) as mock_req:
+            s = _TimeoutSession()
+            s.request("GET", "https://api.github.com/user")
+        headers = mock_req.call_args.kwargs.get("headers") or {}
+        assert "If-None-Match" not in headers
+        assert "If-Modified-Since" not in headers
+
+    def test_refresh_token_clears_cache_when_token_changes(self) -> None:
+        """Without this, an attacker (or stale gh-auth state) could
+        replay a body validated under the previous token via a 304 on
+        the next ``/user`` read and bypass the #1207 identity guard."""
+        from unittest.mock import patch
+
+        first = MagicMock()
+        first.status_code = 200
+        first.headers = {"ETag": 'W/"a"'}
+        first.content = b"under old token"
+        with patch("requests.Session.request", return_value=first):
+            gh = GitHub("tok-old", token_fetcher=lambda: "tok-old")
+            gh._s.request(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+                "GET", "https://api.github.com/repos/o/r/issues/1"
+            )
+        assert (
+            "https://api.github.com/repos/o/r/issues/1" in gh._s._cache  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        )
+        gh._token_fetcher = lambda: "tok-new"  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        changed = gh.refresh_token()
+        assert changed is True
+        assert len(gh._s._cache) == 0  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+    def test_refresh_token_keeps_cache_when_token_unchanged(self) -> None:
+        """No-op token refresh must not invalidate the cache —
+        ``refresh_token`` runs at every assertion boundary, so wiping
+        on every call would destroy the ETag win."""
+        from unittest.mock import patch
+
+        first = MagicMock()
+        first.status_code = 200
+        first.headers = {"ETag": 'W/"a"'}
+        first.content = b"stable"
+        with patch("requests.Session.request", return_value=first):
+            gh = GitHub("tok", token_fetcher=lambda: "tok")
+            gh._s.request(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+                "GET", "https://api.github.com/repos/o/r/issues/1"
+            )
+        assert len(gh._s._cache) == 1  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        assert gh.refresh_token() is False
+        assert len(gh._s._cache) == 1  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
 
 class TestGitHubClass:
     def _gh(self) -> tuple[GitHub, MagicMock]:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -90,6 +90,25 @@ from tests.fakes import _FakeDispatcher
 _MISSING = object()
 
 
+def _fallthrough_registry() -> MagicMock:
+    """``ActivityReporter`` mock whose ``CommentCache`` always falls through to ``gh``.
+
+    INV-7 of #1748 routes worker comment fetches through
+    ``Worker._resolved_top_level_comments`` / ``Worker._resolved_comment``,
+    which try the per-(repo, item) :class:`CommentCache` first and fall
+    back to ``gh.get_*`` on cache miss / unhydrated cache.  Tests that
+    stage their fixtures on ``gh`` rather than on the cache need the
+    registry's cache to report ``is_loaded=False`` and miss every
+    ``get`` so the fallback path consumes the staged ``gh`` returns.
+    """
+    registry: MagicMock = MagicMock(spec=ActivityReporter)
+    cache = MagicMock()
+    cache.is_loaded = False
+    cache.get.return_value = None
+    registry.get_comment_cache.return_value = cache
+    return registry
+
+
 def _enqueue_pr_comment(tmp_path: Path, *, pr_number: int = 1) -> None:
     FidoStore(tmp_path).enqueue_pr_comment(
         delivery_id=f"delivery-{pr_number}",
@@ -156,7 +175,7 @@ class WorkerThread(_WorkerThreadBase):
         **kwargs: object,
     ) -> None:
         if "registry" not in kwargs:
-            kwargs["registry"] = MagicMock(spec=ActivityReporter)
+            kwargs["registry"] = _fallthrough_registry()
         repo_cfg = kwargs.get("repo_cfg", _MISSING)
         if repo_cfg is _MISSING and kwargs.get("provider") is None:
             kwargs["repo_cfg"] = _default_repo_cfg(
@@ -270,7 +289,7 @@ class TestRepoNameFilter:
 
 class TestResolveGitDir:
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_returns_path(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(stdout="/some/repo/.git\n"))
@@ -375,7 +394,7 @@ class TestCreateContext:
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
         ctx = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).create_context(_run=self._mock_run(git_dir))
         assert isinstance(ctx, WorkerContext)
         assert ctx.work_dir == tmp_path
@@ -387,7 +406,7 @@ class TestCreateContext:
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
         ctx = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).create_context(_run=self._mock_run(git_dir))
         assert ctx.fido_dir.is_dir()
         ctx.lock_fd.close()
@@ -400,7 +419,7 @@ class TestCreateContext:
         try:
             with pytest.raises(LockHeld):
                 Worker(
-                    tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+                    tmp_path, MagicMock(), registry=_fallthrough_registry()
                 ).create_context(_run=self._mock_run(git_dir))
         finally:
             fd1.close()
@@ -469,7 +488,7 @@ class TestWorker:
             MagicMock(),
             config=config,
             repo_cfg=None,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert worker._config is config
 
@@ -483,7 +502,7 @@ class TestWorker:
             tmp_path,
             MagicMock(),
             repo_cfg=cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert worker._repo_cfg is cfg
 
@@ -498,7 +517,7 @@ class TestWorker:
                 work_dir=tmp_path,
                 provider=ProviderID.COPILOT_CLI,
             ),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert worker._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
 
@@ -514,14 +533,12 @@ class TestWorker:
                 provider=ProviderID.CODEX,
             ),
             issue_cache=MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert worker._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
 
     def test_config_defaults_to_none(self, tmp_path: Path) -> None:
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         assert worker._config is None
 
     def test_repo_cfg_defaults_to_none(self, tmp_path: Path) -> None:
@@ -530,7 +547,7 @@ class TestWorker:
             MagicMock(),
             repo_cfg=None,
             provider=MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert worker._repo_cfg is None
 
@@ -539,63 +556,59 @@ class TestWorker:
     def test_discover_returns_repo_context(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert isinstance(result, RepoContext)
 
     def test_discover_repo_field(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.repo == "alice/proj"
 
     def test_discover_owner_parsed(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.owner == "alice"
 
     def test_discover_repo_name_parsed(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="alice/proj")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.repo_name == "proj"
 
     def test_discover_gh_user(self, tmp_path: Path) -> None:
         gh = self._make_gh(user="fido")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.gh_user == "fido"
 
     def test_discover_default_branch(self, tmp_path: Path) -> None:
         gh = self._make_gh(branch="develop")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.default_branch == "develop"
 
     def test_discover_passes_cwd_to_get_repo_info(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).discover_repo_context()
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).discover_repo_context()
         gh.get_repo_info.assert_called_once_with(cwd=tmp_path)
 
     def test_discover_passes_cwd_to_get_default_branch(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).discover_repo_context()
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).discover_repo_context()
         gh.get_default_branch.assert_called_once_with(cwd=tmp_path)
 
     def test_discover_splits_on_first_slash_only(self, tmp_path: Path) -> None:
         gh = self._make_gh(repo="org/repo")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.owner == "org"
         assert result.repo_name == "repo"
@@ -607,7 +620,7 @@ class TestWorker:
             tmp_path,
             gh,
             membership=membership,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).discover_repo_context()
         assert result.membership is membership
         assert result.collaborators == frozenset({"alice", "bob"})
@@ -615,15 +628,13 @@ class TestWorker:
     def test_discover_default_membership_empty(self, tmp_path: Path) -> None:
         gh = self._make_gh()
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).discover_repo_context()
         assert result.collaborators == frozenset()
 
     def test_discover_does_not_call_get_collaborators(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).discover_repo_context()
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).discover_repo_context()
         gh.get_collaborators.assert_not_called()
 
     # --- set_status ---
@@ -649,7 +660,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=self._session(status="writing tests"),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).set_status("writing tests", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with("writing tests", "🐕", busy=True)
 
@@ -660,7 +671,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=self._session(status="napping", emoji="😴"),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).set_status("napping", busy=False, _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with("napping", "😴", busy=False)
 
@@ -673,7 +684,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=self._session(status="", emoji=":dog:"),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         assert gh.set_user_status.call_args[0][0] == "idle"
 
@@ -684,7 +695,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=self._session(status="Sniffing endpoints", emoji=""),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_called_once_with(
             "Sniffing endpoints", ":dog:", busy=True
@@ -698,7 +709,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=self._session(status=long_text),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ).set_status("something", _sub_dir_fn=lambda: tmp_path)
         called_text = gh.set_user_status.call_args[0][0]
         assert len(called_text) == 80
@@ -712,7 +723,7 @@ class TestWorker:
         (tmp_path / "persona.md").write_text("I am Fido.")
         with caplog.at_level(logging.INFO, logger="fido"):
             Worker(
-                tmp_path, gh, session=None, registry=MagicMock(spec=ActivityReporter)
+                tmp_path, gh, session=None, registry=_fallthrough_registry()
             ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         gh.set_user_status.assert_not_called()
         assert "no session available" in caplog.text
@@ -729,7 +740,7 @@ class TestWorker:
                 tmp_path,
                 gh,
                 session=self._session(status="", emoji=":dog:"),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ).set_status("idle", _sub_dir_fn=lambda: tmp_path)
         assert "falling back" in caplog.text
 
@@ -745,7 +756,7 @@ class TestWorker:
                 tmp_path,
                 gh,
                 session=self._session(status="fetching"),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ).set_status("fetching", _sub_dir_fn=lambda: tmp_path)
         assert "set_status" in caplog.text
 
@@ -766,7 +777,7 @@ class TestWorker:
         (tmp_path / "persona.md").write_text("I am Fido.")
         session = self._session(status="working")
         Worker(
-            tmp_path, gh, session=session, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, session=session, registry=_fallthrough_registry()
         ).set_status("working", _sub_dir_fn=lambda: tmp_path)
         assert session.prompt.call_args[1]["system_prompt"] is not None
 
@@ -890,9 +901,9 @@ class TestWorker:
         fido_dir.mkdir(parents=True)
         gh = self._make_issue_gh()
         assert (
-            Worker(
-                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-            ).get_current_issue(fido_dir, "owner/repo")
+            Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+                fido_dir, "owner/repo"
+            )
             is None
         )
 
@@ -902,9 +913,9 @@ class TestWorker:
         State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
         assert (
-            Worker(
-                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-            ).get_current_issue(fido_dir, "owner/repo")
+            Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+                fido_dir, "owner/repo"
+            )
             == 7
         )
 
@@ -914,7 +925,7 @@ class TestWorker:
         State(fido_dir).save({"issue": 7})
         gh = self._make_issue_gh(state="OPEN")
         result = Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, registry=_fallthrough_registry()
         ).get_current_issue(fido_dir, "owner/repo")
         assert isinstance(result, int)
 
@@ -924,9 +935,9 @@ class TestWorker:
         State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
         assert (
-            Worker(
-                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-            ).get_current_issue(fido_dir, "owner/repo")
+            Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+                fido_dir, "owner/repo"
+            )
             is None
         )
 
@@ -935,9 +946,9 @@ class TestWorker:
         fido_dir.mkdir(parents=True)
         State(fido_dir).save({"issue": 4})
         gh = self._make_issue_gh(state="CLOSED")
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).get_current_issue(fido_dir, "owner/repo")
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+            fido_dir, "owner/repo"
+        )
         assert State(fido_dir).load() == {}
 
     def test_get_issue_does_not_call_view_issue_when_no_state(
@@ -946,9 +957,9 @@ class TestWorker:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         gh = self._make_issue_gh()
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).get_current_issue(fido_dir, "owner/repo")
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+            fido_dir, "owner/repo"
+        )
         gh.view_issue.assert_not_called()
 
     def test_get_issue_calls_view_issue_with_correct_args(self, tmp_path: Path) -> None:
@@ -956,9 +967,9 @@ class TestWorker:
         fido_dir.mkdir(parents=True)
         State(fido_dir).save({"issue": 12})
         gh = self._make_issue_gh(state="OPEN")
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).get_current_issue(fido_dir, "alice/proj")
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+            fido_dir, "alice/proj"
+        )
         gh.view_issue.assert_called_once_with("alice/proj", 12)
 
     def test_get_issue_logs_info_when_closed(
@@ -971,9 +982,9 @@ class TestWorker:
         State(fido_dir).save({"issue": 9})
         gh = self._make_issue_gh(state="CLOSED")
         with caplog.at_level(logging.INFO, logger="fido"):
-            Worker(
-                tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-            ).get_current_issue(fido_dir, "owner/repo")
+            Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+                fido_dir, "owner/repo"
+            )
         assert "advancing" in caplog.text
 
     def test_get_issue_state_preserved_when_open(self, tmp_path: Path) -> None:
@@ -981,9 +992,9 @@ class TestWorker:
         fido_dir.mkdir(parents=True)
         State(fido_dir).save({"issue": 5})
         gh = self._make_issue_gh(state="OPEN")
-        Worker(
-            tmp_path, gh, registry=MagicMock(spec=ActivityReporter)
-        ).get_current_issue(fido_dir, "owner/repo")
+        Worker(tmp_path, gh, registry=_fallthrough_registry()).get_current_issue(
+            fido_dir, "owner/repo"
+        )
         assert State(fido_dir).load() == {"issue": 5}
 
     # --- run ---
@@ -1007,18 +1018,14 @@ class TestWorker:
     def test_create_session_instantiates_claude_session(self, tmp_path: Path) -> None:
         from fido import claude
 
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker.create_session()
         claude.ClaudeSession.assert_called_once()
 
     def test_create_session_passes_work_dir(self, tmp_path: Path) -> None:
         from fido import claude
 
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker.create_session()
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("work_dir") == tmp_path
@@ -1028,9 +1035,7 @@ class TestWorker:
 
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker.create_session()
         _, kwargs = claude.ClaudeSession.call_args
         assert kwargs.get("model") == "claude-opus-4-6"
@@ -1041,9 +1046,7 @@ class TestWorker:
 
         mock_session = MagicMock()
         claude.ClaudeSession.return_value = mock_session
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker.create_session()
         assert worker._provider.agent.session is mock_session  # pyright: ignore[reportPrivateUsage]
 
@@ -1054,7 +1057,7 @@ class TestWorker:
             tmp_path,
             MagicMock(),
             repo_cfg=_default_repo_cfg(tmp_path, repo_name="owner/repo"),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         worker._provider = None  # pyright: ignore[reportPrivateUsage]
         agent = worker._provider_agent
@@ -1090,7 +1093,7 @@ class TestWorker:
             repo_cfg=cfg,
             provider_factory=mock_factory,
             state_updater=updater,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         # Force _ensure_provider to create a new provider (clear existing).
         worker._provider = None  # pyright: ignore[reportPrivateUsage]
@@ -1126,7 +1129,7 @@ class TestWorker:
             repo_cfg=cfg,
             provider_factory=mock_factory,
             state_updater=updater,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert mock_factory.create_provider.call_args.kwargs["state_updater"] is updater
 
@@ -1135,7 +1138,7 @@ class TestWorker:
             tmp_path,
             MagicMock(),
             repo_cfg=None,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with pytest.raises(
             RuntimeError, match="worker provider requires explicit repo_cfg"
@@ -1155,39 +1158,33 @@ class TestWorker:
             MagicMock(),
             provider=provider,
             session=session,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         provider.agent.attach_session.assert_called_once_with(session)
         assert worker._provider.agent.session is session  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_calls_stop(self, tmp_path: Path) -> None:
         mock_session = MagicMock()
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker._provider.agent.attach_session(mock_session)  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
         mock_session.stop.assert_called_once()
 
     def test_stop_session_clears_session(self, tmp_path: Path) -> None:
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         worker._provider.agent.attach_session(MagicMock())  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()
         assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
 
     def test_stop_session_is_noop_when_none(self, tmp_path: Path) -> None:
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         assert worker._provider.agent.session is None  # pyright: ignore[reportPrivateUsage]
         worker.stop_session()  # must not raise
 
     def test_run_creates_session_with_fido_dir(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_create = MagicMock()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1230,7 +1227,7 @@ class TestWorker:
             tmp_path,
             gh,
             first_iteration=True,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with (
             patch.object(
@@ -1257,7 +1254,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         order: list[str] = []
 
         def mark_recover(*args: object, **kwargs: object) -> bool:
@@ -1318,7 +1315,7 @@ class TestWorker:
             gh,
             session=mock_session,
             session_issue=7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1354,7 +1351,7 @@ class TestWorker:
             gh,
             session=mock_session,
             session_issue=5,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1387,7 +1384,7 @@ class TestWorker:
             gh,
             session=mock_session,
             session_issue=7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1418,7 +1415,7 @@ class TestWorker:
             tmp_path,
             gh,
             session=mock_session,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1438,7 +1435,7 @@ class TestWorker:
 
     def test_run_returns_2_when_lock_held(self, tmp_path: Path) -> None:
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with patch.object(worker, "create_context", side_effect=LockHeld("held")):
             assert worker.run() == 2
 
@@ -1465,7 +1462,7 @@ class TestWorker:
     def test_run_returns_0_on_success(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1486,7 +1483,7 @@ class TestWorker:
         import logging
 
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with patch.object(worker, "create_context", side_effect=LockHeld("held")):
             with caplog.at_level(logging.WARNING, logger="fido"):
                 worker.run()
@@ -1499,7 +1496,7 @@ class TestWorker:
 
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1523,7 +1520,7 @@ class TestWorker:
 
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1545,7 +1542,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         mock_teardown = MagicMock()
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1565,7 +1562,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         mock_setup = MagicMock(return_value=("c", "s"))
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1582,7 +1579,7 @@ class TestWorker:
     def test_run_calls_get_current_issue(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_get_issue = MagicMock(return_value=None)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1600,7 +1597,7 @@ class TestWorker:
     def test_run_calls_find_next_issue_when_no_current(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_find = MagicMock(return_value=None)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1620,7 +1617,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix bug", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_find = MagicMock(return_value=None)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -1644,7 +1641,7 @@ class TestWorker:
     def test_run_returns_0_when_no_issue(self, tmp_path: Path) -> None:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1667,7 +1664,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_pickup = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1698,7 +1695,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_pickup = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1725,7 +1722,7 @@ class TestWorker:
             "body": "",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -1752,7 +1749,7 @@ class TestWorker:
             "body": "Issue body text",
             "state": "OPEN",
         }
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_focp = MagicMock(return_value=(42, "my-branch", False))
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -1781,7 +1778,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "New thing", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1815,7 +1812,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Old thing", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1848,7 +1845,7 @@ class TestWorker:
         """CI/thread/rescope checks are unreachable when no issue is selected."""
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_rescope = MagicMock()
         mock_ci = MagicMock(return_value=False)
         mock_threads = MagicMock(return_value=False)
@@ -1879,7 +1876,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         iteration = 0
 
         def focp_side_effect(*_a: object, **_kw: object) -> tuple[int, str, bool]:
@@ -1926,7 +1923,7 @@ class TestWorker:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Issue", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_execute = MagicMock(return_value=False)
         mock_merge = MagicMock(return_value=0)
         with (
@@ -1965,7 +1962,7 @@ class TestWorkerFindNextIssue:
             provider=ProviderID.CLAUDE_CODE
         )
         return Worker(
-            tmp_path, gh, provider=provider, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, provider=provider, registry=_fallthrough_registry()
         ), gh
 
     def _make_repo_ctx(
@@ -2032,7 +2029,7 @@ class TestWorkerFindNextIssue:
             gh,
             provider=provider,
             repo_name="owner/repo",
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         fido_dir = self._fido_dir(tmp_path)
 
@@ -2067,7 +2064,7 @@ class TestWorkerFindNextIssue:
             gh,
             provider=provider,
             repo_name="owner/repo",
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         fido_dir = self._fido_dir(tmp_path)
 
@@ -2526,9 +2523,7 @@ class TestIssueHasOpenSubIssues:
                 inventory,
                 snapshot_started_at=datetime(2026, 4, 19, tzinfo=timezone.utc),
             )
-        return Worker(
-            tmp_path, gh, issue_cache=cache, registry=MagicMock(spec=ActivityReporter)
-        )
+        return Worker(tmp_path, gh, issue_cache=cache, registry=_fallthrough_registry())
 
     def _issue(
         self,
@@ -3032,7 +3027,7 @@ class TestWorkerVerifyCachedIssueStillOpen:
             provider=ProviderID.CLAUDE_CODE
         )
         return Worker(
-            tmp_path, gh, provider=provider, registry=MagicMock(spec=ActivityReporter)
+            tmp_path, gh, provider=provider, registry=_fallthrough_registry()
         ), gh
 
     def test_returns_true_when_state_open(self, tmp_path: Path) -> None:
@@ -3068,7 +3063,7 @@ class TestWorkerPickFromCache:
             gh,
             provider=provider,
             issue_cache=cache,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ), gh
 
     def _repo_ctx(self) -> RepoContext:
@@ -3192,7 +3187,7 @@ class TestWorkerFindNextIssueCacheBranch:
             gh,
             provider=provider,
             issue_cache=cache,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
@@ -3229,7 +3224,7 @@ class TestWorkerPostPickupComment:
             tmp_path,
             gh,
             provider_agent=provider_agent,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ), gh
 
     def test_skips_when_pickup_marker_present(self, tmp_path: Path) -> None:
@@ -3432,7 +3427,7 @@ class TestSetupHooks:
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
         compact_cmd, sync_cmd = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).setup_hooks(fido_dir)
         assert compact_cmd.startswith("bash ")
         assert "sync_tasks_cli" in sync_cmd
@@ -3442,7 +3437,7 @@ class TestSetupHooks:
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
         compact_cmd, _ = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).setup_hooks(fido_dir)
         assert "compact.sh" in compact_cmd
 
@@ -3451,7 +3446,7 @@ class TestSetupHooks:
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
         _, sync_cmd = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).setup_hooks(fido_dir)
         assert "python -m fido.sync_tasks_cli" in sync_cmd
         assert "uv run" not in sync_cmd
@@ -3461,7 +3456,7 @@ class TestSetupHooks:
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
         _, sync_cmd = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
+            tmp_path, MagicMock(), registry=_fallthrough_registry()
         ).setup_hooks(fido_dir)
         assert str(tmp_path) in sync_cmd
 
@@ -3469,9 +3464,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        ).setup_hooks(fido_dir)
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry()).setup_hooks(
+            fido_dir
+        )
         assert (fido_dir / "compact.sh").exists()
 
     def test_adds_hooks_to_settings(self, tmp_path: Path) -> None:
@@ -3479,9 +3474,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        ).setup_hooks(fido_dir)
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry()).setup_hooks(
+            fido_dir
+        )
         settings = tmp_path / ".claude" / "settings.local.json"
         assert settings.exists()
         cfg = json.loads(settings.read_text())
@@ -3491,9 +3486,9 @@ class TestSetupHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        ).setup_hooks(fido_dir)
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry()).setup_hooks(
+            fido_dir
+        )
         exclude = tmp_path / ".git" / "info" / "exclude"
         assert ".claude/settings.local.json" in exclude.read_text()
 
@@ -3503,9 +3498,7 @@ class TestTeardownHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         compact_cmd, sync_cmd = worker.setup_hooks(fido_dir)
         worker.teardown_hooks(fido_dir, compact_cmd, sync_cmd)
         assert not (fido_dir / "compact.sh").exists()
@@ -3515,9 +3508,7 @@ class TestTeardownHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         (tmp_path / ".git" / "info").mkdir(parents=True)
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         compact_cmd, sync_cmd = worker.setup_hooks(fido_dir)
         worker.teardown_hooks(fido_dir, compact_cmd, sync_cmd)
         settings = tmp_path / ".claude" / "settings.local.json"
@@ -3528,17 +3519,17 @@ class TestTeardownHooks:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         # Should not raise even when compact.sh does not exist
-        Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        ).teardown_hooks(fido_dir, "bash /x/compact.sh", "bash sync.sh &")
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry()).teardown_hooks(
+            fido_dir, "bash /x/compact.sh", "bash sync.sh &"
+        )
 
     def test_noop_when_settings_missing(self, tmp_path: Path) -> None:
         fido_dir = tmp_path / ".git" / "fido"
         fido_dir.mkdir(parents=True)
         # No settings file created — should not raise
-        Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        ).teardown_hooks(fido_dir, "bash /x/compact.sh", "bash sync.sh &")
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry()).teardown_hooks(
+            fido_dir, "bash /x/compact.sh", "bash sync.sh &"
+        )
 
 
 class TestLoadState:
@@ -4209,7 +4200,7 @@ class TestFileAuxIssuesFromBundle:
         )
 
     def _make_worker(self, tmp_path: Path, gh: _RecordingGh) -> Worker:
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, gh, registry=_fallthrough_registry())
 
     def test_empty_bundle_files_nothing(self, tmp_path: Path) -> None:
         from fido.rocq.turn_outcome import CommitTaskComplete
@@ -4307,7 +4298,7 @@ class TestFileAuxIssuesFromBundle:
                 del repo, title, body, labels
                 raise RuntimeError("api down")
 
-        worker = Worker(tmp_path, _Failing(), registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, _Failing(), registry=_fallthrough_registry())
         bundle = TurnOutcomeBundle(
             outcome=CommitTaskComplete(summary="x"),
             insights=(Insight(title="T", hook="H", why="W"),),
@@ -4428,7 +4419,7 @@ class TestGit:
 
     def test_calls_subprocess_run_with_git_prefix(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
             ["status"], _run=mock_run
         )
         mock_run.assert_called_once()
@@ -4438,21 +4429,21 @@ class TestGit:
 
     def test_passes_work_dir_as_cwd(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
             ["status"], _run=mock_run
         )
         assert mock_run.call_args[1]["cwd"] == tmp_path
 
     def test_check_true_by_default(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
             ["status"], _run=mock_run
         )
         assert mock_run.call_args[1]["check"] is True
 
     def test_check_false_propagated(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=1))
-        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
             ["status"], check=False, _run=mock_run
         )
         assert mock_run.call_args[1]["check"] is False
@@ -4460,13 +4451,13 @@ class TestGit:
     def test_propagates_called_process_error(self, tmp_path: Path) -> None:
         mock_run = MagicMock(side_effect=subprocess.CalledProcessError(1, "git"))
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(
-                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-            )._git(["checkout", "no-such-branch"], _run=mock_run)
+            Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
+                ["checkout", "no-such-branch"], _run=mock_run
+            )
 
     def test_capture_output_and_text_set(self, tmp_path: Path) -> None:
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))._git(
+        Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
             ["log"], _run=mock_run
         )
         assert mock_run.call_args[1]["capture_output"] is True
@@ -4497,9 +4488,9 @@ class TestGit:
                 )
             return success
 
-        result = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )._git(["add", "-A"], _run=_run)
+        result = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
+            ["add", "-A"], _run=_run
+        )
         assert result is success
         assert len(calls) == 2
         assert not lock.exists()
@@ -4520,9 +4511,9 @@ class TestGit:
             )
         )
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(
-                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-            )._git(["add", "-A"], _run=mock_run)
+            Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
+                ["add", "-A"], _run=mock_run
+            )
         assert lock.exists()
         assert mock_run.call_count == 1
 
@@ -4534,9 +4525,9 @@ class TestGit:
             )
         )
         with pytest.raises(subprocess.CalledProcessError):
-            Worker(
-                tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-            )._git(["status"], _run=mock_run)
+            Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())._git(
+                ["status"], _run=mock_run
+            )
         assert mock_run.call_count == 1
 
 
@@ -4609,7 +4600,7 @@ class TestLocalBranchExists:
     """Tests for Worker._local_branch_exists (closes #828)."""
 
     def _worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_returns_true_on_exit_zero(self, tmp_path: Path) -> None:
         worker = self._worker(tmp_path)
@@ -4651,7 +4642,7 @@ class TestGitClean:
     """Tests for Worker.git_clean."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def _git_result(self, stdout: str = "") -> MagicMock:
         r = MagicMock()
@@ -5147,7 +5138,7 @@ class TestFindOrCreatePr:
             tmp_path,
             gh,
             provider_agent=provider_agent,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ), gh
 
     def _make_repo_ctx(
@@ -6248,7 +6239,7 @@ class TestApplySetupOutcome:
     that replaces the old ``./fido task add`` CLI flow (closes #1403)."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_tasks_planned_creates_tasks_in_order(self, tmp_path: Path) -> None:
         worker = self._make_worker(tmp_path)
@@ -6343,7 +6334,7 @@ class TestFinalizeSetupWithNoTasks:
                 tmp_path,
                 gh,
                 provider_agent=agent,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ),
             gh,
             agent,
@@ -7164,7 +7155,7 @@ class TestFinalizeSetupWithNoTasks:
             tmp_path,
             gh,
             provider_agent=mock_client,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         finalize_calls: list[dict] = []
 
@@ -7219,7 +7210,7 @@ class TestResetLocalWorkspaceAndRetryAck:
             tmp_path,
             gh,
             provider_agent=provider_agent,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         ), gh
 
     def _repo_ctx(self) -> RepoContext:
@@ -7458,7 +7449,7 @@ class TestSeedTasksFromPrBody:
 
     def _make_worker(self, tmp_path: Path) -> tuple["Worker", MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def _pr_with_queue(self, *task_titles: str, task_type: str = "spec") -> dict:
         lines = "\n".join(f"- [ ] {t} <!-- type:{task_type} -->" for t in task_titles)
@@ -7729,7 +7720,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "My task", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_seed = MagicMock()
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -7769,7 +7760,7 @@ class TestRunSeedTasksIntegration:
                 gh,
                 first_iteration=first,
                 dispatcher=mock_dispatcher,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             )
             with (
                 patch.object(
@@ -7822,7 +7813,7 @@ class TestRunSeedTasksIntegration:
             gh,
             first_iteration=True,
             dispatcher=mock_dispatcher,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -7864,7 +7855,7 @@ class TestRunSeedTasksIntegration:
             gh,
             first_iteration=True,
             dispatcher=mock_dispatcher,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -7890,7 +7881,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Done", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_seed = MagicMock()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -7923,7 +7914,7 @@ class TestRunSeedTasksIntegration:
         fido_dir.mkdir(parents=True)
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         # Persist initial state naming #201 as active.
         (fido_dir / "state.json").write_text(
             '{"issue": 201, "issue_title": "Parent", '
@@ -7970,7 +7961,7 @@ class TestRunSeedTasksIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Leaf", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
             patch.object(
@@ -7997,7 +7988,7 @@ class TestExtractRunId:
     """Tests for Worker._extract_run_id."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_extracts_id_from_standard_url(self, tmp_path: Path) -> None:
         w = self._make_worker(tmp_path)
@@ -8027,7 +8018,7 @@ class TestFilterCiThreads:
     """Tests for Worker._filter_ci_threads."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def _make_node(
         self,
@@ -8195,7 +8186,7 @@ class TestHandleMergeConflict:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         gh.get_pr.return_value = {"mergeStateStatus": "DIRTY"}
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -8348,7 +8339,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_handle_mc = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -8375,7 +8366,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -8399,7 +8390,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         mock_ci = MagicMock(return_value=False)
         with (
@@ -8423,7 +8414,7 @@ class TestRunHandleMergeConflictIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         mock_mc = MagicMock(return_value=False)
         with (
@@ -8451,7 +8442,7 @@ class TestHandleCi:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         gh.get_pr.return_value = {"mergeStateStatus": "BLOCKED"}
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -8910,7 +8901,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_handle_ci = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -8937,7 +8928,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -8960,7 +8951,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -8986,7 +8977,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Done", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_handle_ci = MagicMock(return_value=False)
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -9014,7 +9005,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         call_order: list[str] = []
 
@@ -9050,7 +9041,7 @@ class TestRunHandleCiIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         mock_handle_ci = MagicMock(return_value=True)
 
@@ -9078,7 +9069,7 @@ class TestFilterThreads:
     """Tests for Worker._filter_threads."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def _make_node(
         self,
@@ -9341,7 +9332,7 @@ class TestResolveAddressedThreads:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ),
             gh,
         )
@@ -9569,7 +9560,7 @@ class TestHandleThreads:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ),
             gh,
         )
@@ -10028,7 +10019,7 @@ class TestHandleThreads:
             tmp_path,
             gh,
             issue_cache=MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with pytest.raises(
             RuntimeError, match="thread handling requires explicit config and repo_cfg"
@@ -10115,7 +10106,7 @@ class TestHandleQueuedComments:
                 repo_cfg=repo_cfg,
                 repo_name="owner/repo",
                 issue_cache=MagicMock(),
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             ),
             gh,
         )
@@ -10473,7 +10464,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_threads = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -10498,7 +10489,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -10522,7 +10513,7 @@ class TestRunThreadsIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -10689,14 +10680,12 @@ class TestRescopeBeforePick:
                 MagicMock(),
                 config=config,
                 repo_cfg=cfg,
-                registry=MagicMock(spec=ActivityReporter),
+                registry=_fallthrough_registry(),
             )
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_skips_when_config_is_none(self, tmp_path: Path) -> None:
-        worker = Worker(
-            tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter)
-        )
+        worker = Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
         mock_tasks = MagicMock()
         mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
         worker._tasks = mock_tasks
@@ -10720,7 +10709,7 @@ class TestRescopeBeforePick:
             MagicMock(),
             config=config,
             repo_cfg=None,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         mock_tasks = MagicMock()
         mock_tasks.list.return_value = [self._pending(), self._pending("task2")]
@@ -10871,7 +10860,7 @@ class TestRunRescopeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         mock_rescope = MagicMock()
         with (
@@ -10902,7 +10891,7 @@ class TestRunRescopeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         call_order: list[str] = []
 
@@ -10938,7 +10927,7 @@ class TestEnsurePushed:
     """Tests for Worker.ensure_pushed."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def _git_result(
         self, returncode: int = 0, stdout: str = "", stderr: str = ""
@@ -11050,7 +11039,7 @@ class TestPushWithRetry:
     """Tests for Worker._push_with_retry."""
 
     def _make_worker(self, tmp_path: Path) -> Worker:
-        return Worker(tmp_path, MagicMock(), registry=MagicMock(spec=ActivityReporter))
+        return Worker(tmp_path, MagicMock(), registry=_fallthrough_registry())
 
     def test_returns_true_on_first_success(self, tmp_path: Path) -> None:
         worker = self._make_worker(tmp_path)
@@ -11155,7 +11144,7 @@ class TestExecuteTask:
         gh = MagicMock()
         gh.find_closed_prs_as_context.return_value = []
         gh.fetch_closed_sub_issues.return_value = []
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def _repo_ctx(self) -> RepoContext:
         return RepoContext(
@@ -13577,7 +13566,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_execute = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -13604,7 +13593,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -13629,7 +13618,7 @@ class TestRunExecuteTaskIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_execute = MagicMock(return_value=False)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -13839,7 +13828,7 @@ class TestSweepOrphanPrComments:
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
         return (
-            Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)),
+            Worker(tmp_path, gh, registry=_fallthrough_registry()),
             gh,
         )
 
@@ -13899,7 +13888,7 @@ class TestHandlePromoteMerge:
 
     def _make_worker(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def _repo_ctx(self, owner: str = "rhencke") -> RepoContext:
         return RepoContext(
@@ -15715,7 +15704,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_hpm = MagicMock(return_value=0)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -15743,7 +15732,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -15770,7 +15759,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         repo_ctx = self._make_mock_repo_ctx()
         with (
             patch.object(worker, "create_context", return_value=mock_ctx),
@@ -15797,7 +15786,7 @@ class TestRunPromoteMergeIntegration:
         mock_ctx = self._make_mock_ctx(tmp_path)
         gh = self._make_gh()
         gh.view_issue.return_value = {"title": "Fix it", "body": "", "state": "OPEN"}
-        worker = Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter))
+        worker = Worker(tmp_path, gh, registry=_fallthrough_registry())
         mock_hpm = MagicMock(return_value=0)
         repo_ctx = self._make_mock_repo_ctx()
         with (
@@ -16487,7 +16476,7 @@ class TestWorkerThread:
             tmp_path,
             "owner/repo",
             MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
 
     # ── constructor / attributes ──────────────────────────────────────────
@@ -16696,7 +16685,7 @@ class TestWorkerThread:
             tmp_path,
             "owner/myrepo",
             MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         wt._wake = MagicMock()
         captured: list[str] = []
@@ -17122,7 +17111,7 @@ class TestWorkerThread:
             MagicMock(),
             session=mock_session,
             session_issue=7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.current_provider().agent.session is mock_session
         assert wt._session_issue == 7
@@ -17139,7 +17128,7 @@ class TestWorkerThread:
             provider=provider,
             session=session,
             session_issue=7,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         provider.agent.attach_session.assert_called_once_with(session)
         assert wt.current_provider() is provider
@@ -17154,7 +17143,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             provider=provider,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.detach_provider() is provider
         assert wt.current_provider() is None
@@ -17174,7 +17163,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             provider=provider,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.recover_provider() is True
         provider.agent.recover_session.assert_called_once_with()
@@ -17250,7 +17239,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             provider=provider,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.session_dropped_count == 4
 
@@ -17268,7 +17257,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             provider=provider,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.session_sent_count == 42
 
@@ -17286,7 +17275,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             provider=provider,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.session_received_count == 38
 
@@ -17357,7 +17346,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             config=config,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt._config is config
 
@@ -17372,7 +17361,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             repo_cfg=cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt._repo_cfg is cfg
 
@@ -17388,7 +17377,7 @@ class TestWorkerThread:
                 work_dir=tmp_path,
                 provider=ProviderID.COPILOT_CLI,
             ),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert wt._provider.provider_id == ProviderID.COPILOT_CLI  # pyright: ignore[reportPrivateUsage]
@@ -17406,7 +17395,7 @@ class TestWorkerThread:
                 provider=ProviderID.CODEX,
             ),
             issue_cache=MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt._provider is not None  # pyright: ignore[reportPrivateUsage]
         assert wt._provider.provider_id == ProviderID.CODEX  # pyright: ignore[reportPrivateUsage]
@@ -17422,7 +17411,7 @@ class TestWorkerThread:
             MagicMock(),
             repo_cfg=None,
             provider=MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt._repo_cfg is None
 
@@ -17434,7 +17423,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             repo_cfg=None,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         assert wt.current_provider() is None
         assert wt._bootstrap_session is None  # pyright: ignore[reportPrivateUsage]
@@ -17445,7 +17434,7 @@ class TestWorkerThread:
             "owner/repo",
             MagicMock(),
             repo_cfg=None,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         with pytest.raises(
             RuntimeError, match="worker thread provider requires explicit repo_cfg"
@@ -17473,7 +17462,7 @@ class TestWorkerThread:
             MagicMock(),
             config=config,
             repo_cfg=cfg,
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
         )
         wt._wake = MagicMock()
         received_config: list = []
@@ -17549,7 +17538,7 @@ class TestWorkerThread:
             tmp_path,
             "owner/repo",
             MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
             state_updater=updater,
         )
         wt._wake = MagicMock()
@@ -17623,7 +17612,7 @@ class TestWorkerThread:
             tmp_path,
             "owner/repo",
             MagicMock(),
-            registry=MagicMock(spec=ActivityReporter),
+            registry=_fallthrough_registry(),
             repo_cfg=cfg,
             provider_factory=mock_factory,
             state_updater=updater,
@@ -17670,12 +17659,32 @@ class TestIsLeakedTaskComment:
         )
 
 
+class TestResolvedCommentFallback:
+    """INV-7: ``Worker._resolved_comment`` falls back to ``gh`` when the
+    worker was constructed without a registry — the production
+    composition root always provides one, but the constructor permits
+    None so test paths can opt out cheaply."""
+
+    def test_falls_back_to_gh_get_pull_comment_when_no_registry(
+        self, tmp_path: Path
+    ) -> None:
+        gh = MagicMock()
+        gh.get_pull_comment.return_value = {"id": 5, "body": "x"}
+        worker = Worker(tmp_path, gh)
+        from fido.comment_cache import KIND_PULLS
+
+        assert worker._resolved_comment(  # noqa: SLF001
+            "owner/repo", 7, KIND_PULLS, 5
+        ) == {"id": 5, "body": "x"}
+        gh.get_pull_comment.assert_called_once_with("owner/repo", 5)
+
+
 class TestLeakedCommentCleanup:
     """Fix for #669 — Worker snapshots and deletes leaked task-turn comments."""
 
     def _worker_with_gh(self, tmp_path: Path) -> tuple[Worker, MagicMock]:
         gh = MagicMock()
-        return Worker(tmp_path, gh, registry=MagicMock(spec=ActivityReporter)), gh
+        return Worker(tmp_path, gh, registry=_fallthrough_registry()), gh
 
     def test_snapshot_returns_only_fido_ids(self, tmp_path: Path) -> None:
         worker, gh = self._worker_with_gh(tmp_path)


### PR DESCRIPTION
## Summary

Two pieces, both refining how ``worker.py`` reads comments.

### 1. INV-7 worker.py migration

Migrated the ten comment-fetch sites in ``worker.py`` to the per-(repo, item) ``CommentCache``, then — after codex P1/P2 review on the first cut — reverted seven of them to direct ``gh.get_issue_comments`` calls:

* **3 cache-routed sites** (queued review-comment dispatch, queued issue-comment dispatch, ``handle_threads`` root lookup) — reads for *dispatch*, tolerate eventual consistency, real performance win on hits.
* **7 direct-gh sites** (idempotency dedupe gates, leak-cleanup snapshot/diff, non-PR issue scopes) — reads for *correctness* (read-your-writes / authoritative diff). Each carries an inline comment naming the codex follow-up and the reason.

### 2. ETag-validating ``requests.Session``

To make the seven authoritative-read sites actually cheap on the rate-limit budget, the underlying ``_TimeoutSession`` now does HTTP-level ETag caching:

* Stores ``(etag, last_modified, content)`` per URL in an ``OrderedDict``.
* On GET, injects ``If-None-Match`` / ``If-Modified-Since`` from the cache.
* On 304, synthesizes a 200 carrying the cached body so the rest of the codebase reads ``resp.json()`` uniformly.
* GitHub's 304 responses do not count against the primary rate limit — these reads stay correct and ~free.
* Non-GET methods bypass the cache. Thread-safe via an internal lock.
* ``GitHub.clear_repo_cache(repo)`` wipes per-repo entries; ``Worker`` calls it at the two PR-transition sites so the cache stays bounded by "URLs touched on the currently-active PR" — no LRU machinery needed.

## Scope (and what's deliberately not in this PR)

This PR ``refs #1761`` rather than ``closes`` it — the invariant text says "every comment-retrieval site reads from CommentCache", which the 7 reverted sites don't satisfy. The honest end-state is that ETag session has made CommentCache redundant: every read is now cached (transport-layer or in-process), so the right next step is to tear out CommentCache + ``CommentReconcileWatchdog`` + the registry / appstate / server wiring and revert the events.py and worker.py migration sites. That's tracked separately to keep this PR reviewable.

## Test plan
- [x] ``./fido ci`` green (4474 passed, 100% coverage)
- [x] New ``TestTimeoutSession`` tests cover: cache hit + 304 replay, ETag-only, Last-Modified-only, no-ETag bypass, non-GET bypass, bytes method/url, ``clear_repo_cache`` per-repo isolation, ``GitHub.clear_repo_cache`` delegation

Refs #1748, refs #1761.