### PR TITLE
Leaf: forbid unittest.mock.patch imports with temporary exemptions (closes #1222)

### DIFF
--- a/pyproject.ruff.toml
+++ b/pyproject.ruff.toml
@@ -220,6 +220,7 @@ select = [
   "PT031",
   "PTH124",
   "PTH210",
+  "TID251",
   "W",
 ]
 # PLC2401 = "non-ASCII characters in identifiers" — guards against the
@@ -227,6 +228,16 @@ select = [
 # U+043E vs ``Rescope`` with Latin ``o`` U+006F) that bit us once and is
 # invisible to a human reader.
 ignore = ["E501"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# unittest.mock.patch bypasses constructor-DI: it reaches into module internals
+# to swap names from outside, creating invisible coupling and making it impossible
+# to inject collaborators through the constructor.
+# Use constructor-DI instead: production code accepts collaborators via __init__;
+# tests construct the object with a MagicMock or hand-rolled fake at call time.
+"unittest.mock.patch" = {msg = "Use constructor-DI: accept collaborators via __init__ and pass fakes at construction time. Do not patch module-level names from outside."}
+"unittest.mock.patch.object" = {msg = "Use constructor-DI: accept collaborators via __init__ and pass fakes at construction time. Do not patch object attributes from outside."}
+"unittest.mock.patch.dict" = {msg = "Use constructor-DI: accept collaborators via __init__ and pass fakes at construction time. Do not patch dict entries from outside."}
 
 [tool.ruff.lint.per-file-ignores]
 # Generated Rocq extraction output is format-checked by CI, but lint has
@@ -238,3 +249,21 @@ ignore = ["E501"]
   "ANN001", "ANN002", "ANN003", "ANN201", "ANN202", "ANN204", "ANN206", "ANN401",
   "E741", "F401", "F403", "F405", "F541", "F811", "F821", "F841", "I001",
 ]
+# Temporary TID251 exemptions — existing mock.patch sites pending constructor-DI
+# migration under #1773. Do not add new files here; fix the root cause instead.
+"tests/test___main__.py" = ["TID251"]
+"tests/test_claude.py" = ["TID251"]
+"tests/test_color.py" = ["TID251"]
+"tests/test_coverage_fills.py" = ["TID251"]
+"tests/test_events.py" = ["TID251"]
+"tests/test_github.py" = ["TID251"]
+"tests/test_harness_commit.py" = ["TID251"]
+"tests/test_infra.py" = ["TID251"]
+"tests/test_main.py" = ["TID251"]
+"tests/test_server.py" = ["TID251"]
+"tests/test_status.py" = ["TID251"]
+"tests/test_sync_tasks_cli.py" = ["TID251"]
+"tests/test_tasks.py" = ["TID251"]
+"tests/test_tests_main.py" = ["TID251"]
+"tests/test_turn_outcome.py" = ["TID251"]
+"tests/test_worker.py" = ["TID251"]


### PR DESCRIPTION
## Summary

- Add ruff TID251 (banned-api) rule to reject new `unittest.mock.patch`, `patch.object`, and `patch.dict` usage
- Ban messages direct developers to constructor-DI and typed fakes
- Add per-file-ignores for 16 existing test files that still use `patch` — these are temporary exemptions, not permanent permissions

## Why

The codebase convention is constructor-DI with typed fakes, not `@patch` decorators that reach into module internals. This locks the door so no new `patch` usage enters the tree while existing sites are migrated separately.

Fixes #1222.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (1)</summary>

- [x] Add TID251 banned-api rule with per-file exemptions for existing test files <!-- type:spec -->
</details>
<!-- WORK_QUEUE_END -->