### PR TITLE
Leaf: forbid monkeypatch.setattr with temporary exemptions (closes #1774)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,12 @@ the pending task list based on dependency analysis.
   contract (`threading.Event`, `queue.Queue`, `threading.local`). In
   particular, `dict.setdefault`, attribute reads, and integer increments are
   **not** safe across threads without a lock. When in doubt, hold the lock.
+- **No `monkeypatch.setattr`** — banned and CI-enforced
+  (`tools/check_no_monkeypatch_setattr.py`). `monkeypatch.setattr` is
+  patching under another name; it reaches into module internals the same way
+  `unittest.mock.patch` does. Use constructor-DI and typed collaborators
+  instead (see #1773). The 14 existing dirty files carry temporary exemptions
+  and should be migrated over time.
 
 ## OO + constructor-DI architecture
 

--- a/models/Dockerfile
+++ b/models/Dockerfile
@@ -261,7 +261,9 @@ RUN ./pyproject ruff format --check .
 
 FROM python-ruff-base AS lint
 
+COPY tools/check_no_monkeypatch_setattr.py tools/
 RUN ./pyproject ruff check .
+RUN python tools/check_no_monkeypatch_setattr.py
 
 # Pyright stages: pyrightconfig.json sets ``include: ["src/fido"]`` so we only
 # need src + the extracted rocq stub directory. pyrightconfig.json is the
@@ -309,7 +311,7 @@ COPY src src
 COPY tests tests
 COPY sub sub
 COPY rocq-python-extraction rocq-python-extraction
-COPY tools/build_graph.sh tools/gen_workflows.py tools/measure_build_graph.py tools/
+COPY tools/build_graph.sh tools/gen_workflows.py tools/measure_build_graph.py tools/check_no_monkeypatch_setattr.py tools/
 COPY models/Dockerfile models/dune-project models/dune models/*.v models/
 COPY --from=model-format /workspace/src/fido/rocq /workspace/src/fido/rocq
 COPY .dockerignore .lsp.json docker-bake.hcl dune-workspace fido package.json package-lock.json ./

--- a/tools/build_graph.sh
+++ b/tools/build_graph.sh
@@ -109,6 +109,7 @@ rocq-python-extraction/dune-project
 rocq-python-extraction/rocq-python-extraction.opam
 src
 tests
+tools/check_no_monkeypatch_setattr.py
 tools/compose_pyproject.py
 tools/gen_workflows.py
 tools/measure_build_graph.py
@@ -174,6 +175,7 @@ src
 sub
 tests
 tools/build_graph.sh
+tools/check_no_monkeypatch_setattr.py
 tools/compose_pyproject.py
 tools/gen_workflows.py
 tools/measure_build_graph.py


### PR DESCRIPTION
Fixes #1774.

Add a CI-enforced guard (`tools/check_no_monkeypatch_setattr.py`) that rejects new `monkeypatch.setattr` usage, with temporary exemptions for the 14 existing dirty files. The guard runs in the lint Dockerfile stage alongside `ruff check`, and its failure message points at constructor-DI and typed collaborators as the correct alternative. Also documents the ban in CLAUDE.md conventions.

Fixes #1774.

---

## Work queue

<!-- WORK_QUEUE_START -->

<details><summary>Completed (4)</summary>

- [x] Document monkeypatch.setattr ban in CLAUDE.md conventions <!-- type:spec -->
- [x] Add monkeypatch.setattr guard script and wire into CI lint stage <!-- type:spec -->
- [x] [Add a test that asserts len("hello world") == 11.](https://github.com/FidoCanCode/home/pull/1791#issuecomment-4472758625) <!-- type:thread -->
- [x] [Add a test that asserts 1 == 1, and make it the first task to execute (before the guard script and other pending work).](https://github.com/FidoCanCode/home/pull/1791#issuecomment-4472760498) <!-- type:thread -->
</details>
<!-- WORK_QUEUE_END -->