### PR TITLE
INV-C / #1801: rescope prompt feeds raw intent batch with author identity

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1577,6 +1577,7 @@ def reply_to_comment(
             pr=int(info.get("pr", 0)),
             comment_id=int(info["comment_id"]),
             comment_type="pulls",
+            author=str(info.get("author", "")),
         )
 
     log.info(
@@ -1876,11 +1877,19 @@ def reply_to_issue_comment(
     )
     issue_target: CommentTarget | None = None
     if _cid and repo_full:
+        # action.thread carries the comment author (per
+        # ``_build_issue_comment_action``); fall back to "" when the
+        # call path didn't populate a thread dict (legacy synthetic
+        # paths).
+        issue_author = ""
+        if isinstance(action.thread, dict):
+            issue_author = str(action.thread.get("author", ""))
         issue_target = CommentTarget(
             repo=repo_full,
             pr=int(number) if number else 0,
             comment_id=int(_cid),
             comment_type="issues",
+            author=issue_author,
         )
 
     log.info("synthesis: calling for issue comment on PR #%s", number)

--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -443,10 +443,22 @@ class Prompts:
             # list passed in here; the prompt should always show them
             # chronologically so the "newer overrides older on
             # conflict" rule below has a stable referent.
+            #
+            # Per-intent author identity is rendered alongside the text
+            # (#1801 / INV-C) so Opus can apply the supersedence rule:
+            # when two intents conflict and BOTH are from the same
+            # author, the newer is a self-correction and no rescope
+            # reply-back is owed to the older (the commenter knows they
+            # overrode themselves).  Cross-author supersedence DOES
+            # warrant a reply-back to the older commenter — they need
+            # to know their ask was overridden by someone else.
             ordered_intents = sorted(intents, key=lambda i: i.timestamp)
             lines = [
-                f"- comment #{intent.comment_id} ({intent.timestamp}): "
-                f"{intent.change_request}"
+                (
+                    f"- comment #{intent.comment_id} "
+                    f"({intent.timestamp}, by @{intent.author or '?'}): "
+                    f"{intent.change_request}"
+                )
                 for intent in ordered_intents
             ]
             intents_block = (
@@ -457,6 +469,12 @@ class Prompts:
                 "via the appropriate operation on the existing task id.  "
                 "Intents that don't conflict stay independent and each get "
                 "their own operation.\n\n"
+                "Self-correction note: when an intent is superseded by another "
+                "from the *same* author, that's a self-correction — the "
+                "commenter already knows they overrode themselves.  Cross-"
+                "author supersedence is the case where a different commenter "
+                "overrides; only that case warrants a follow-up reply-back at "
+                "rescope time (the executor handles that downstream).\n\n"
             )
 
         return (

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -40,6 +40,11 @@ class CommentTarget:
     pr: int
     comment_id: int
     comment_type: str
+    author: str = ""
+    """GitHub login of the commenter (per #1801 / INV-C).  Forwarded
+    into the ``RescopeIntent`` so the rescope prompt can render
+    per-author attribution.  Empty when the caller didn't populate it
+    (legacy / synthetic test fixtures)."""
 
 
 class ReplyPoster(Protocol):
@@ -243,6 +248,7 @@ class SynthesisExecutor:
                 comment_id=target.comment_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 comment_type=target.comment_type,
+                author=target.author,
             )
             log.info(
                 "triggering rescope for comment %d: %s",

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -144,6 +144,14 @@ class RescopeIntent:
     ``"issues"`` for top-level PR/issue comments where the webhook
     handler already posted a triage reply (rescope notifier silently
     skips per #1724 codex P2 — same policy as ``_notify_thread_change``)."""
+    author: str = ""
+    """GitHub login of the commenter.  Rendered alongside the change
+    request in the rescope prompt so Opus can apply per-author
+    supersedence semantics (later #1803 / INV-E: suppress reply-back
+    when an intent was superseded by another from the same author —
+    the commenter already knows they overrode themselves).  Empty
+    string when the source path didn't populate it (legacy / synthetic
+    test fixtures pre-INV-C)."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -581,6 +581,50 @@ class TestRescopePrompt:
         # by a "newer wins" reading).
         assert "don't conflict" in result
 
+    def test_intents_block_renders_author_when_present(self) -> None:
+        # #1801 / INV-C: per-intent author identity is part of the
+        # input contract.  Opus needs it to apply the self-supersedence
+        # rule (#1803 / INV-E) — suppress reply-back when an intent
+        # was overridden by another from the same author.
+        tasks = [self._task("Do thing", task_id="1")]
+        intents = [
+            RescopeIntent(
+                change_request="Add logging",
+                comment_id=111,
+                timestamp="2024-01-15T10:00:00+00:00",
+                author="alice",
+            ),
+        ]
+        result = Prompts("").rescope_prompt(tasks, "", intents=intents)
+        assert "by @alice" in result
+
+    def test_intents_block_renders_unknown_author_marker_when_blank(self) -> None:
+        # Backward-compat: pre-#1801 intents have author="".  Render a
+        # ``?`` marker so Opus can tell "unknown author" from "real
+        # author" rather than seeing a silently-empty ``by @``.
+        tasks = [self._task("Do thing", task_id="1")]
+        intents = [
+            RescopeIntent("Add logging", 111, "2024-01-15T10:00:00+00:00"),
+        ]
+        result = Prompts("").rescope_prompt(tasks, "", intents=intents)
+        assert "by @?" in result
+
+    def test_intents_block_states_self_supersedence_rule(self) -> None:
+        # #1801 / INV-C: prompt must spell out that self-supersedence
+        # is a self-correction (no reply-back) while cross-author
+        # supersedence warrants follow-up.  This is the contract the
+        # downstream INV-E executor relies on Opus understanding.
+        tasks = [self._task("Do thing", task_id="1")]
+        intents = [
+            RescopeIntent("X", 111, "2024-01-15T10:00:00+00:00", author="alice"),
+        ]
+        result = Prompts("").rescope_prompt(tasks, "", intents=intents)
+        assert "Self-correction" in result
+        # "*same* author" — Markdown emphasis on "same" inside the
+        # prompt body — so we match the keyword fragments separately.
+        assert "same" in result and "author" in result
+        assert "Cross-author" in result
+
     def test_intents_block_header_announces_ordering(self) -> None:
         # The header line tells Opus the list is chronological so the
         # ordering itself is a signal, not just visual sugar.

--- a/tests/test_synthesis_executor.py
+++ b/tests/test_synthesis_executor.py
@@ -46,9 +46,14 @@ def _make_target(
     pr: int = 42,
     comment_id: int = 100,
     comment_type: str = "pulls",
+    author: str = "alice",
 ) -> CommentTarget:
     return CommentTarget(
-        repo=repo, pr=pr, comment_id=comment_id, comment_type=comment_type
+        repo=repo,
+        pr=pr,
+        comment_id=comment_id,
+        comment_type=comment_type,
+        author=author,
     )
 
 
@@ -173,6 +178,39 @@ class TestExecutorRescope:
         assert intent.change_request == "Add logging"
         assert intent.comment_id == 100  # from _make_target()
         assert intent.timestamp  # non-empty ISO timestamp
+
+    def test_rescope_intent_carries_author_from_target(self) -> None:
+        # #1801 / INV-C: author identity flows from the comment source
+        # through CommentTarget into RescopeIntent so the rescope
+        # prompt can render per-author attribution.
+        gh = _make_gh()
+        rescope = _make_rescope()
+        executor = SynthesisExecutor(gh, rescope=rescope)
+        target = _make_target(author="bob")
+
+        executor.execute(_make_response(change_request="Add tests"), target)
+
+        intent = rescope.trigger_rescope.call_args[0][0]
+        assert intent.author == "bob"
+
+    def test_rescope_intent_author_defaults_to_empty_when_unset(self) -> None:
+        # Backward-compat: a CommentTarget without ``author`` (legacy
+        # synthetic test fixtures) produces an intent with empty
+        # author rather than crashing.
+        gh = _make_gh()
+        rescope = _make_rescope()
+        executor = SynthesisExecutor(gh, rescope=rescope)
+        target = CommentTarget(
+            repo="owner/repo",
+            pr=1,
+            comment_id=42,
+            comment_type="pulls",
+        )
+
+        executor.execute(_make_response(change_request="Add tests"), target)
+
+        intent = rescope.trigger_rescope.call_args[0][0]
+        assert intent.author == ""
 
     def test_rescope_intent_comment_id_matches_target(self) -> None:
         gh = _make_gh()


### PR DESCRIPTION
Implements #1801 (INV-C of #1798 epic — intent-as-instruction).

## Slice 1: author plumbing + prompt rendering

Foundation slice. Wires per-comment author identity through the existing intent path so downstream INV-D (#1802) and INV-E (#1803) work has something to reference.

- `RescopeIntent.author` (default "" for backward compat)
- `CommentTarget.author` (default ""); both `events.py` CommentTarget sites populate from the action's `reply_to` / `thread` dict
- `SynthesisExecutor._maybe_trigger_rescope` forwards `target.author` into the intent
- `rescope_prompt` renders `by @<author>` on each intent line + adds explicit self-vs-cross-author supersedence rule

## What this does NOT change yet

The intent payload still contains a pre-parsed `change_request` field rather than raw comment text. That bigger reframe lands in subsequent slices once INV-D's verdict schema is in. Slice 1's goal is just to land author plumbing cleanly.

## Tests

- New: 5 tests covering author render, blank-author marker, supersedence-rule statement, intent-carries-author, default-empty-author
- 230 prompt + executor tests pass; 275 events tests pass

## Test plan

- [ ] CI green
- [ ] Manual: PR comment with explicit ask → rescope prompt shows `by @<author>` next to the change-request text