### PR TITLE
INV-D / #1802 slice 1: IntentVerdict dataclass + IntentOutcome literal

### DIFF
--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -1,6 +1,6 @@
 """Shared type definitions for fido."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal
 
@@ -191,10 +191,37 @@ class IntentVerdict:
 
     intent_comment_id: int
     outcome: IntentOutcome
-    ops: list[dict[str, Any]] = field(default_factory=list)
-    affected_task_ids: list[str] = field(default_factory=list)
+    ops: tuple[dict[str, Any], ...] = ()
+    affected_task_ids: tuple[str, ...] = ()
     by_intent_comment_id: int | None = None
     narrative: str | None = None
+
+    def __post_init__(self) -> None:
+        # codex P1 follow-up on #1802: enforce supersedence + outcome
+        # invariants at construction so a malformed verdict crashes at
+        # the boundary instead of leaking into the reply-back
+        # classifier (INV-E #1803) or future graph traversals.
+        if self.by_intent_comment_id == self.intent_comment_id:
+            raise ValueError(
+                f"IntentVerdict.by_intent_comment_id ({self.by_intent_comment_id}) "
+                "must not reference the verdict's own intent (self-supersedence "
+                "is meaningless); full-batch acyclicity is verified at apply time"
+            )
+        if self.outcome == "superseded" and self.by_intent_comment_id is None:
+            raise ValueError(
+                "IntentVerdict outcome='superseded' requires by_intent_comment_id "
+                "to name the superseding intent (INV-E #1803 cannot determine "
+                "self-vs-cross-author supersedence without it)"
+            )
+        if (
+            self.outcome in ("reshaped", "superseded")
+            and not (self.narrative or "").strip()
+        ):
+            raise ValueError(
+                f"IntentVerdict outcome={self.outcome!r} requires non-empty "
+                "narrative — reply-back posts narrative verbatim per "
+                "the voice-text-opus-not-templated convention"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -1,5 +1,6 @@
 """Shared type definitions for fido."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal
@@ -191,16 +192,38 @@ class IntentVerdict:
 
     intent_comment_id: int
     outcome: IntentOutcome
-    ops: tuple[dict[str, Any], ...] = ()
+    ops: tuple[Mapping[str, Any], ...] = ()
+    """Op records this intent contributed.  Coerced to a tuple of
+    :class:`~frozendict.frozendict` mappings in ``__post_init__`` so
+    both the outer sequence and each per-op mapping are deeply
+    immutable — callers cannot mutate ``verdict.ops`` or
+    ``verdict.ops[0]['op']`` after construction (codex P1 / P2 on
+    #1802)."""
     affected_task_ids: tuple[str, ...] = ()
     by_intent_comment_id: int | None = None
     narrative: str | None = None
 
     def __post_init__(self) -> None:
-        # codex P1 follow-up on #1802: enforce supersedence + outcome
-        # invariants at construction so a malformed verdict crashes at
-        # the boundary instead of leaking into the reply-back
-        # classifier (INV-E #1803) or future graph traversals.
+        # codex P1 / P2 on #1802: deep-freeze the payload collections
+        # so the "frozen snapshot" promise holds at the value level,
+        # not just the attribute level.  Callers (tests, the parser
+        # layer when it lands) can pass plain lists / dicts —
+        # ``deep_freeze`` coerces to ``tuple`` + ``frozendict``.
+        # Done before the validations below so a malformed verdict
+        # still gets the boundary error path.
+        from fido.frozen import deep_freeze
+
+        object.__setattr__(self, "ops", deep_freeze(list(self.ops)))
+        object.__setattr__(
+            self,
+            "affected_task_ids",
+            tuple(str(t) for t in self.affected_task_ids),
+        )
+
+        # codex P2 on #1802: enforce supersedence + outcome invariants
+        # at construction so a malformed verdict crashes at the
+        # boundary instead of leaking into the reply-back classifier
+        # (INV-E #1803) or future graph traversals.
         if self.by_intent_comment_id == self.intent_comment_id:
             raise ValueError(
                 f"IntentVerdict.by_intent_comment_id ({self.by_intent_comment_id}) "
@@ -212,6 +235,13 @@ class IntentVerdict:
                 "IntentVerdict outcome='superseded' requires by_intent_comment_id "
                 "to name the superseding intent (INV-E #1803 cannot determine "
                 "self-vs-cross-author supersedence without it)"
+            )
+        if self.outcome != "superseded" and self.by_intent_comment_id is not None:
+            raise ValueError(
+                f"IntentVerdict outcome={self.outcome!r} must not carry "
+                "by_intent_comment_id — only 'superseded' verdicts carry a "
+                "supersedence pointer (codex P2 on #1802: reject contradictory "
+                "metadata at the boundary)"
             )
         if (
             self.outcome in ("reshaped", "superseded")

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -204,13 +204,10 @@ class IntentVerdict:
     narrative: str | None = None
 
     def __post_init__(self) -> None:
-        # Type checks (codex P2 round 3 on #1802: dataclasses do NOT
-        # enforce annotations at runtime, so a parser typo like
-        # ``outcome="supersede"`` or ``intent_comment_id="123"`` would
-        # silently flow downstream.  Validate at the boundary so the
-        # malformed verdict crashes here instead of producing wrong
-        # reply-back behavior.  ``bool`` is rejected separately
-        # because it is an ``int`` subclass.)
+        # Scalar type checks first (codex P2 on #1802: dataclasses
+        # don't enforce annotations; a parser typo like
+        # ``intent_comment_id="123"`` would silently flow downstream).
+        # ``bool`` rejected separately — it's an ``int`` subclass.
         if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
             self.intent_comment_id, int
         ) or isinstance(self.intent_comment_id, bool):
@@ -234,10 +231,17 @@ class IntentVerdict:
                 "'honored', 'reshaped', 'superseded', 'no_op'; "
                 f"got {self.outcome!r}"
             )
-        # ``ops`` shape: must be a sequence of mappings.  A bare dict
-        # passed as ``ops`` would silently iterate as its keys ("op",
-        # "id", ...) and ``deep_freeze`` would store a tuple of strs
-        # instead of failing the contract.  Reject before coercion.
+        if self.narrative is not None and not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            self.narrative, str
+        ):
+            raise TypeError(
+                "IntentVerdict.narrative must be str or None, got "
+                f"{type(self.narrative).__name__}"
+            )
+
+        # Container-shape checks BEFORE materialization (codex P2
+        # round 4 on #1802: reject bare ``str`` / ``set`` / ``dict``
+        # that would silently mis-coerce).
         if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
             self.ops, Mapping
         ):
@@ -245,7 +249,32 @@ class IntentVerdict:
                 "IntentVerdict.ops must be a sequence of op mappings, "
                 "not a single mapping (did you mean to wrap in a tuple?)"
             )
-        for op in self.ops:
+        if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            self.affected_task_ids, str
+        ):
+            raise TypeError(
+                "IntentVerdict.affected_task_ids must be a sequence of str, "
+                "not a bare str (a string iterates as single chars and would "
+                f"be silently mis-stored as {tuple(self.affected_task_ids)!r})"
+            )
+        if isinstance(self.affected_task_ids, (set, frozenset)):
+            raise TypeError(
+                "IntentVerdict.affected_task_ids must be ordered "
+                "(docstring contract: 'in result-list order'); got "
+                f"{type(self.affected_task_ids).__name__}, which has "
+                "nondeterministic iteration order"
+            )
+
+        # Materialize collections ONCE before per-entry validation
+        # (codex P2 round 4 on #1802: a generator passed as ops /
+        # affected_task_ids would be exhausted by the validation
+        # loop, and the frozen tuple would silently end up empty —
+        # dropping all op/task attribution).
+        ops_seq = tuple(self.ops)
+        ids_seq = tuple(self.affected_task_ids)
+
+        # Per-entry type checks.
+        for op in ops_seq:
             if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
                 op, Mapping
             ):
@@ -253,10 +282,7 @@ class IntentVerdict:
                     "IntentVerdict.ops entries must be Mapping, got "
                     f"{type(op).__name__}"
                 )
-        # ``affected_task_ids``: each element must already be a string.
-        # Don't silently ``str(None)`` it — that produces ``"None"`` and
-        # hides upstream parser/schema bugs.
-        for tid in self.affected_task_ids:
+        for tid in ids_seq:
             if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
                 tid, str
             ):
@@ -265,15 +291,14 @@ class IntentVerdict:
                     f"got {type(tid).__name__}"
                 )
 
-        # codex P1 / P2 on #1802: deep-freeze the payload collections
-        # so the "frozen snapshot" promise holds at the value level,
-        # not just the attribute level.  Callers (tests, the parser
-        # layer when it lands) can pass plain lists / dicts —
-        # ``deep_freeze`` coerces to ``tuple`` + ``frozendict``.
+        # Deep-freeze the materialized collections so the "frozen
+        # snapshot" promise holds at the value level too — callers
+        # can pass plain lists/dicts; ``deep_freeze`` (#1748) coerces
+        # to ``tuple`` of ``frozendict``.
         from fido.frozen import deep_freeze
 
-        object.__setattr__(self, "ops", deep_freeze(list(self.ops)))
-        object.__setattr__(self, "affected_task_ids", tuple(self.affected_task_ids))
+        object.__setattr__(self, "ops", deep_freeze(list(ops_seq)))
+        object.__setattr__(self, "affected_task_ids", ids_seq)
 
         # codex P2 on #1802: enforce supersedence + outcome invariants
         # at construction so a malformed verdict crashes at the

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -332,6 +332,20 @@ class IntentVerdict:
                 "narrative — reply-back posts narrative verbatim per "
                 "the voice-text-opus-not-templated convention"
             )
+        if self.outcome == "no_op" and (self.ops or self.affected_task_ids):
+            # codex P2 round 5 on #1802: ``no_op`` docstring promises
+            # "produced no task changes".  A ``no_op`` verdict
+            # carrying ops or affected_task_ids is contradictory —
+            # downstream INV-E would classify the intent as
+            # non-material (skipping reply-back) while the verdict
+            # still claims task-change attribution.  Reject at the
+            # boundary.
+            raise ValueError(
+                "IntentVerdict outcome='no_op' must have empty ops and "
+                "affected_task_ids — got "
+                f"ops={list(self.ops)!r}, "
+                f"affected_task_ids={list(self.affected_task_ids)!r}"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -1,7 +1,8 @@
 """Shared type definitions for fido."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any, Literal
 
 
 class TaskType(StrEnum):
@@ -113,6 +114,87 @@ class TaskSnapshot:
     type: str
     status: str
     description: str = ""
+
+
+IntentOutcome = Literal["honored", "reshaped", "superseded", "no_op"]
+"""Per-intent verdict outcome (per #1798 / INV-D).
+
+  * ``honored`` — Opus produced ops that fulfill the intent as asked.
+  * ``reshaped`` — ops fulfill *part* of the intent; the original
+    framing changed (e.g. user asked for a feature, Opus split it
+    into prereq + feature).  Material change — INV-E (#1803) emits a
+    reply-back unless self-supersedence applies.
+  * ``superseded`` — another intent in the same batch overrode this
+    one (in whole or in part).  ``by_intent_comment_id`` names the
+    superseding intent.  Material when authors differ; self-
+    correction (no reply) when authors match.
+  * ``no_op`` — intent was acknowledged but produced no task changes
+    (e.g. commenter chatter, ack, or request already satisfied by an
+    existing pending task with no edits needed).
+"""
+
+
+@dataclass(frozen=True)
+class IntentVerdict:
+    """Per-intent verdict in a rescope batch result (#1798 / INV-D).
+
+    Replaces the older ``IntentDisposition`` material/aggregation
+    classifier.  Each :class:`RescopeIntent` in a rescope batch maps
+    to exactly one :class:`IntentVerdict`; the batch's full verdict
+    list is Opus's structured answer for "what did I do with each
+    ask?".
+
+    INV-E (#1803) downstream rule: post a reply-back for ``V`` iff
+    ``V.outcome`` materially changes the original ask (``reshaped``
+    or cross-author ``superseded``) AND not self-supersedence
+    (``V.by_intent_comment_id``'s intent has the same author as
+    ``V``).  ``honored`` and ``no_op`` never warrant reply-back —
+    they're either "got it as asked" or "nothing to do" and the
+    triage reply already covered the user-facing acknowledgement.
+
+    Attributes
+    ----------
+    intent_comment_id:
+        :attr:`RescopeIntent.comment_id` this verdict pertains to.
+        Each intent in the batch produces exactly one verdict.
+    outcome:
+        See :data:`IntentOutcome` for the four allowed values and
+        their reply-back implications.
+    ops:
+        Op records this intent contributed to the batch.  May be
+        empty when ``outcome`` is ``superseded`` (fully superseded —
+        the winning intent owns the resulting ops) or ``no_op``.
+        Two verdicts in the same batch MAY both name the same task
+        id in :attr:`affected_task_ids` when they're jointly honored
+        by the same task (the canonical 3+1 reviewer-pattern case:
+        three review comments asking the same fix plus a fourth
+        "just fix all of these" all attribute to one consolidated
+        task).
+    affected_task_ids:
+        Task ids this verdict touched, in result-list order.  MAY
+        overlap with other verdicts' :attr:`affected_task_ids` under
+        joint-honoring.
+    by_intent_comment_id:
+        When set, names another intent in the same batch that
+        (partially or fully) superseded this one.  Must reference a
+        :attr:`RescopeIntent.comment_id` from the same batch.
+        Required to be acyclic across the batch (INV-F / #1804 will
+        prove this in Rocq; runtime asserts here).
+    narrative:
+        Opus's prose explanation of what happened.  Verbatim source
+        for the optional reply-back posted by INV-E (#1803) —
+        per the project memory ``voice_text_opus_not_templated``,
+        Fido-voice text is per-call Opus prose, not templated.
+        Required when ``outcome`` is ``reshaped`` or ``superseded``
+        (reply-back needs prose); optional otherwise.
+    """
+
+    intent_comment_id: int
+    outcome: IntentOutcome
+    ops: list[dict[str, Any]] = field(default_factory=list)
+    affected_task_ids: list[str] = field(default_factory=list)
+    by_intent_comment_id: int | None = None
+    narrative: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -204,21 +204,76 @@ class IntentVerdict:
     narrative: str | None = None
 
     def __post_init__(self) -> None:
+        # Type checks (codex P2 round 3 on #1802: dataclasses do NOT
+        # enforce annotations at runtime, so a parser typo like
+        # ``outcome="supersede"`` or ``intent_comment_id="123"`` would
+        # silently flow downstream.  Validate at the boundary so the
+        # malformed verdict crashes here instead of producing wrong
+        # reply-back behavior.  ``bool`` is rejected separately
+        # because it is an ``int`` subclass.)
+        if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            self.intent_comment_id, int
+        ) or isinstance(self.intent_comment_id, bool):
+            raise TypeError(
+                "IntentVerdict.intent_comment_id must be int, got "
+                f"{type(self.intent_comment_id).__name__}"
+            )
+        if self.by_intent_comment_id is not None and (
+            not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                self.by_intent_comment_id, int
+            )
+            or isinstance(self.by_intent_comment_id, bool)
+        ):
+            raise TypeError(
+                "IntentVerdict.by_intent_comment_id must be int or None, got "
+                f"{type(self.by_intent_comment_id).__name__}"
+            )
+        if self.outcome not in ("honored", "reshaped", "superseded", "no_op"):
+            raise ValueError(
+                f"IntentVerdict.outcome must be one of "
+                "'honored', 'reshaped', 'superseded', 'no_op'; "
+                f"got {self.outcome!r}"
+            )
+        # ``ops`` shape: must be a sequence of mappings.  A bare dict
+        # passed as ``ops`` would silently iterate as its keys ("op",
+        # "id", ...) and ``deep_freeze`` would store a tuple of strs
+        # instead of failing the contract.  Reject before coercion.
+        if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            self.ops, Mapping
+        ):
+            raise TypeError(
+                "IntentVerdict.ops must be a sequence of op mappings, "
+                "not a single mapping (did you mean to wrap in a tuple?)"
+            )
+        for op in self.ops:
+            if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                op, Mapping
+            ):
+                raise TypeError(
+                    "IntentVerdict.ops entries must be Mapping, got "
+                    f"{type(op).__name__}"
+                )
+        # ``affected_task_ids``: each element must already be a string.
+        # Don't silently ``str(None)`` it — that produces ``"None"`` and
+        # hides upstream parser/schema bugs.
+        for tid in self.affected_task_ids:
+            if not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                tid, str
+            ):
+                raise TypeError(
+                    "IntentVerdict.affected_task_ids entries must be str, "
+                    f"got {type(tid).__name__}"
+                )
+
         # codex P1 / P2 on #1802: deep-freeze the payload collections
         # so the "frozen snapshot" promise holds at the value level,
         # not just the attribute level.  Callers (tests, the parser
         # layer when it lands) can pass plain lists / dicts —
         # ``deep_freeze`` coerces to ``tuple`` + ``frozendict``.
-        # Done before the validations below so a malformed verdict
-        # still gets the boundary error path.
         from fido.frozen import deep_freeze
 
         object.__setattr__(self, "ops", deep_freeze(list(self.ops)))
-        object.__setattr__(
-            self,
-            "affected_task_ids",
-            tuple(str(t) for t in self.affected_task_ids),
-        )
+        object.__setattr__(self, "affected_task_ids", tuple(self.affected_task_ids))
 
         # codex P2 on #1802: enforce supersedence + outcome invariants
         # at construction so a malformed verdict crashes at the

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,6 +7,8 @@ verdict drives the INV-E (#1803) reply-back classifier downstream.
 
 import dataclasses
 
+import pytest
+
 from fido.types import IntentVerdict
 
 
@@ -16,8 +18,8 @@ class TestIntentVerdictShape:
         v = IntentVerdict(intent_comment_id=42, outcome="honored")
         assert v.intent_comment_id == 42
         assert v.outcome == "honored"
-        assert v.ops == []
-        assert v.affected_task_ids == []
+        assert v.ops == ()
+        assert v.affected_task_ids == ()
         assert v.by_intent_comment_id is None
         assert v.narrative is None
 
@@ -25,14 +27,14 @@ class TestIntentVerdictShape:
         v = IntentVerdict(
             intent_comment_id=100,
             outcome="reshaped",
-            ops=[{"op": "rewrite", "id": "T1", "title": "new"}],
-            affected_task_ids=["T1"],
+            ops=({"op": "rewrite", "id": "T1", "title": "new"},),
+            affected_task_ids=("T1",),
             by_intent_comment_id=None,
             narrative="Folded the ask into the existing parser task.",
         )
         assert v.outcome == "reshaped"
-        assert v.ops == [{"op": "rewrite", "id": "T1", "title": "new"}]
-        assert v.affected_task_ids == ["T1"]
+        assert v.ops == ({"op": "rewrite", "id": "T1", "title": "new"},)
+        assert v.affected_task_ids == ("T1",)
         assert v.narrative is not None
 
     def test_supersedence_pointer_within_batch(self) -> None:
@@ -55,12 +57,12 @@ class TestIntentVerdictShape:
         v = IntentVerdict(
             intent_comment_id=10,
             outcome="superseded",
-            ops=[{"op": "new", "title": "Paint the surface", "type": "spec"}],
-            affected_task_ids=["T-paint"],
+            ops=({"op": "new", "title": "Paint the surface", "type": "spec"},),
+            affected_task_ids=("T-paint",),
             by_intent_comment_id=11,
             narrative="Paint kept; color component superseded by later comment.",
         )
-        assert v.ops != []
+        assert v.ops != ()
         assert v.by_intent_comment_id == 11
 
     def test_jointly_honored_intents_share_task_id(self) -> None:
@@ -68,15 +70,15 @@ class TestIntentVerdictShape:
         # same fix + a fourth "just fix all of these" all attribute
         # to ONE consolidated task.  Each verdict can list the same
         # task id in affected_task_ids.
-        verdicts = [
+        verdicts = tuple(
             IntentVerdict(
                 intent_comment_id=cid,
                 outcome="honored",
-                ops=[],
-                affected_task_ids=["T-fix-all"],
+                ops=(),
+                affected_task_ids=("T-fix-all",),
             )
             for cid in (1, 2, 3, 4)
-        ]
+        )
         for v in verdicts:
             assert "T-fix-all" in v.affected_task_ids
 
@@ -85,8 +87,8 @@ class TestIntentVerdictShape:
         # no affected tasks, no narrative needed.
         v = IntentVerdict(intent_comment_id=999, outcome="no_op")
         assert v.outcome == "no_op"
-        assert v.ops == []
-        assert v.affected_task_ids == []
+        assert v.ops == ()
+        assert v.affected_task_ids == ()
 
     def test_frozen(self) -> None:
         # Verdict shape is frozen — once Opus emits it, the runtime
@@ -99,11 +101,86 @@ class TestIntentVerdictShape:
         else:
             raise AssertionError("IntentVerdict must be frozen")
 
-    def test_default_factories_independent_per_instance(self) -> None:
-        # ``field(default_factory=list)`` guard: two default-constructed
-        # verdicts must not share the same ``ops`` / ``affected_task_ids``
-        # list object, or a mutation on one would corrupt the other.
+    def test_ops_is_tuple_not_list(self) -> None:
+        # codex P1 on #1802: deep immutability — ops as a list lets
+        # callers ``verdict.ops.append(...)`` past the frozen guard.
+        # Tuple makes the in-place mutation a TypeError at boundary.
+        v = IntentVerdict(intent_comment_id=1, outcome="honored")
+        assert isinstance(v.ops, tuple)
+        assert isinstance(v.affected_task_ids, tuple)
+
+    def test_default_collections_are_singleton_empty_tuples(self) -> None:
+        # Tuples are immutable so two verdicts sharing the default
+        # empty tuple is safe (no foot-gun like a shared default
+        # ``[]`` would have been).
         a = IntentVerdict(intent_comment_id=1, outcome="honored")
         b = IntentVerdict(intent_comment_id=2, outcome="honored")
-        assert a.ops is not b.ops
-        assert a.affected_task_ids is not b.affected_task_ids
+        assert a.ops == b.ops == ()
+        assert a.affected_task_ids == b.affected_task_ids == ()
+
+
+class TestIntentVerdictValidation:
+    def test_self_supersedence_rejected(self) -> None:
+        # codex P2 on #1802: by_intent_comment_id pointing at the
+        # verdict's own intent is meaningless and indicates a
+        # malformed batch.  Fail at construction.
+        with pytest.raises(ValueError, match="must not reference"):
+            IntentVerdict(
+                intent_comment_id=10,
+                outcome="superseded",
+                by_intent_comment_id=10,
+                narrative="self",
+            )
+
+    def test_superseded_outcome_requires_by_intent_comment_id(self) -> None:
+        # codex P2 on #1802: superseded outcome without a pointer is
+        # nonsense — INV-E can't tell self-vs-cross-author without it.
+        with pytest.raises(ValueError, match="by_intent_comment_id"):
+            IntentVerdict(
+                intent_comment_id=10,
+                outcome="superseded",
+                narrative="something",
+            )
+
+    def test_reshaped_outcome_requires_narrative(self) -> None:
+        # codex P2 on #1802: reshaped means material change → reply-back
+        # fires → reply needs prose.  Empty narrative is a contract
+        # violation at the boundary.
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(
+                intent_comment_id=10,
+                outcome="reshaped",
+                ops=({"op": "rewrite", "id": "T1", "title": "x"},),
+                affected_task_ids=("T1",),
+            )
+
+    def test_superseded_outcome_requires_narrative(self) -> None:
+        # Same reasoning as the reshaped case.
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(
+                intent_comment_id=10,
+                outcome="superseded",
+                by_intent_comment_id=11,
+                narrative="",
+            )
+
+    def test_superseded_whitespace_only_narrative_rejected(self) -> None:
+        # Narrative must be substantively non-empty.  "   " is empty
+        # for human-facing reply purposes.
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(
+                intent_comment_id=10,
+                outcome="superseded",
+                by_intent_comment_id=11,
+                narrative="   ",
+            )
+
+    def test_honored_outcome_allows_blank_narrative(self) -> None:
+        # honored never warrants reply-back; narrative is optional.
+        v = IntentVerdict(intent_comment_id=10, outcome="honored")
+        assert v.narrative is None
+
+    def test_no_op_outcome_allows_blank_narrative(self) -> None:
+        # no_op same as honored — never warrants reply-back.
+        v = IntentVerdict(intent_comment_id=10, outcome="no_op")
+        assert v.narrative is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -390,3 +390,23 @@ class TestIntentVerdictTypeChecks:
             affected_task_ids=ids_gen(),  # type: ignore[arg-type]
         )
         assert v.affected_task_ids == ("T1", "T2")
+
+    def test_no_op_rejects_non_empty_ops(self) -> None:
+        # codex P2 round 5 on #1802: ``no_op`` means "produced no task
+        # changes".  A no_op verdict carrying ops is contradictory and
+        # would mislead INV-E (skip reply-back) while still claiming
+        # task attribution.
+        with pytest.raises(ValueError, match="no_op.*must have empty ops"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="no_op",
+                ops=({"op": "rewrite", "id": "T1"},),
+            )
+
+    def test_no_op_rejects_non_empty_affected_task_ids(self) -> None:
+        with pytest.raises(ValueError, match="no_op.*must have empty"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="no_op",
+                affected_task_ids=("T1",),
+            )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -109,6 +109,42 @@ class TestIntentVerdictShape:
         assert isinstance(v.ops, tuple)
         assert isinstance(v.affected_task_ids, tuple)
 
+    def test_ops_list_input_coerced_to_tuple(self) -> None:
+        # codex P1 on #1802 (round 2): the tuple annotation isn't
+        # enforced at runtime.  Callers can pass a plain list; the
+        # post-init coerces.  Mutating the original list after
+        # construction MUST NOT bleed into the verdict.
+        original_ops = [{"op": "rewrite", "id": "T1"}]
+        v = IntentVerdict(
+            intent_comment_id=1,
+            outcome="reshaped",
+            ops=original_ops,  # type: ignore[arg-type]
+            affected_task_ids=["T1"],  # type: ignore[arg-type]
+            narrative="x",
+        )
+        original_ops.append({"op": "remove", "id": "T2"})
+        assert isinstance(v.ops, tuple)
+        assert len(v.ops) == 1
+        assert isinstance(v.affected_task_ids, tuple)
+
+    def test_op_payload_dicts_are_frozen(self) -> None:
+        # codex P2 on #1802: even with tuple ops, each ``dict`` was
+        # still mutable.  Deep-freeze coerces to frozendict so
+        # ``v.ops[0]["op"] = "x"`` raises at the boundary.
+        v = IntentVerdict(
+            intent_comment_id=1,
+            outcome="reshaped",
+            ops=({"op": "rewrite", "id": "T1"},),
+            affected_task_ids=("T1",),
+            narrative="x",
+        )
+        from collections.abc import Mapping
+
+        assert isinstance(v.ops[0], Mapping)
+        # frozendict raises TypeError on item assignment.
+        with pytest.raises((TypeError, AttributeError)):
+            v.ops[0]["op"] = "remove"  # type: ignore[index]
+
     def test_default_collections_are_singleton_empty_tuples(self) -> None:
         # Tuples are immutable so two verdicts sharing the default
         # empty tuple is safe (no foot-gun like a shared default
@@ -184,3 +220,33 @@ class TestIntentVerdictValidation:
         # no_op same as honored — never warrants reply-back.
         v = IntentVerdict(intent_comment_id=10, outcome="no_op")
         assert v.narrative is None
+
+    def test_by_intent_comment_id_rejected_on_honored(self) -> None:
+        # codex P2 round 2 on #1802: only ``superseded`` carries a
+        # supersedence pointer.  ``honored`` + ``by_intent_comment_id``
+        # is contradictory metadata; reject at boundary.
+        with pytest.raises(ValueError, match="by_intent_comment_id"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                by_intent_comment_id=2,
+            )
+
+    def test_by_intent_comment_id_rejected_on_reshaped(self) -> None:
+        # ``reshaped`` is Opus's reframing of a single intent — no
+        # other intent is involved, so the pointer is contradictory.
+        with pytest.raises(ValueError, match="by_intent_comment_id"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="reshaped",
+                by_intent_comment_id=2,
+                narrative="x",
+            )
+
+    def test_by_intent_comment_id_rejected_on_no_op(self) -> None:
+        with pytest.raises(ValueError, match="by_intent_comment_id"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="no_op",
+                by_intent_comment_id=2,
+            )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,109 @@
+"""Tests for shared type definitions in :mod:`fido.types`.
+
+Currently focused on :class:`IntentVerdict` (#1798 / INV-D) — the
+per-intent verdict shape Opus emits as part of a rescope batch.  The
+verdict drives the INV-E (#1803) reply-back classifier downstream.
+"""
+
+import dataclasses
+
+from fido.types import IntentVerdict
+
+
+class TestIntentVerdictShape:
+    def test_minimal_construction_with_outcome_honored(self) -> None:
+        """A fully-honored intent: just the intent id + outcome."""
+        v = IntentVerdict(intent_comment_id=42, outcome="honored")
+        assert v.intent_comment_id == 42
+        assert v.outcome == "honored"
+        assert v.ops == []
+        assert v.affected_task_ids == []
+        assert v.by_intent_comment_id is None
+        assert v.narrative is None
+
+    def test_construction_with_all_fields(self) -> None:
+        v = IntentVerdict(
+            intent_comment_id=100,
+            outcome="reshaped",
+            ops=[{"op": "rewrite", "id": "T1", "title": "new"}],
+            affected_task_ids=["T1"],
+            by_intent_comment_id=None,
+            narrative="Folded the ask into the existing parser task.",
+        )
+        assert v.outcome == "reshaped"
+        assert v.ops == [{"op": "rewrite", "id": "T1", "title": "new"}]
+        assert v.affected_task_ids == ["T1"]
+        assert v.narrative is not None
+
+    def test_supersedence_pointer_within_batch(self) -> None:
+        # "red" → "no, green" — red's verdict points at green's intent
+        # comment id.  by_intent_comment_id is set; ops may be empty
+        # (full supersedence) or partial (component supersedence).
+        v = IntentVerdict(
+            intent_comment_id=10,
+            outcome="superseded",
+            by_intent_comment_id=11,
+            narrative="Color request was overridden by a later comment.",
+        )
+        assert v.by_intent_comment_id == 11
+        assert v.outcome == "superseded"
+
+    def test_partial_supersedence_keeps_ops(self) -> None:
+        # "paint and make it red" → "no, green": the paint op survives
+        # (still honored), the color component is superseded.  Ops AND
+        # by_intent_comment_id coexist.
+        v = IntentVerdict(
+            intent_comment_id=10,
+            outcome="superseded",
+            ops=[{"op": "new", "title": "Paint the surface", "type": "spec"}],
+            affected_task_ids=["T-paint"],
+            by_intent_comment_id=11,
+            narrative="Paint kept; color component superseded by later comment.",
+        )
+        assert v.ops != []
+        assert v.by_intent_comment_id == 11
+
+    def test_jointly_honored_intents_share_task_id(self) -> None:
+        # Canonical 3+1 reviewer pattern: three comments asking the
+        # same fix + a fourth "just fix all of these" all attribute
+        # to ONE consolidated task.  Each verdict can list the same
+        # task id in affected_task_ids.
+        verdicts = [
+            IntentVerdict(
+                intent_comment_id=cid,
+                outcome="honored",
+                ops=[],
+                affected_task_ids=["T-fix-all"],
+            )
+            for cid in (1, 2, 3, 4)
+        ]
+        for v in verdicts:
+            assert "T-fix-all" in v.affected_task_ids
+
+    def test_no_op_outcome(self) -> None:
+        # Acknowledgement / "request already covered" verdict.  No ops,
+        # no affected tasks, no narrative needed.
+        v = IntentVerdict(intent_comment_id=999, outcome="no_op")
+        assert v.outcome == "no_op"
+        assert v.ops == []
+        assert v.affected_task_ids == []
+
+    def test_frozen(self) -> None:
+        # Verdict shape is frozen — once Opus emits it, the runtime
+        # must not mutate.  Catches accidental in-place edits.
+        v = IntentVerdict(intent_comment_id=1, outcome="honored")
+        try:
+            v.outcome = "reshaped"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:
+            raise AssertionError("IntentVerdict must be frozen")
+
+    def test_default_factories_independent_per_instance(self) -> None:
+        # ``field(default_factory=list)`` guard: two default-constructed
+        # verdicts must not share the same ``ops`` / ``affected_task_ids``
+        # list object, or a mutation on one would corrupt the other.
+        a = IntentVerdict(intent_comment_id=1, outcome="honored")
+        b = IntentVerdict(intent_comment_id=2, outcome="honored")
+        assert a.ops is not b.ops
+        assert a.affected_task_ids is not b.affected_task_ids

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -250,3 +250,69 @@ class TestIntentVerdictValidation:
                 outcome="no_op",
                 by_intent_comment_id=2,
             )
+
+
+class TestIntentVerdictTypeChecks:
+    def test_outcome_typo_rejected(self) -> None:
+        # codex P2 round 3 on #1802: Literal annotation isn't
+        # enforced at runtime — a parser typo like "supersede" must
+        # crash at the boundary.
+        with pytest.raises(ValueError, match="outcome must be one of"):
+            IntentVerdict(intent_comment_id=1, outcome="supersede")  # type: ignore[arg-type]
+
+    def test_intent_comment_id_must_be_int(self) -> None:
+        with pytest.raises(TypeError, match="intent_comment_id must be int"):
+            IntentVerdict(intent_comment_id="123", outcome="honored")  # type: ignore[arg-type]
+
+    def test_intent_comment_id_bool_rejected(self) -> None:
+        # ``bool`` is an ``int`` subclass in Python; reject it
+        # explicitly so ``True`` / ``False`` can't slip through as
+        # comment ids.
+        with pytest.raises(TypeError, match="intent_comment_id must be int"):
+            IntentVerdict(intent_comment_id=True, outcome="honored")  # type: ignore[arg-type]
+
+    def test_by_intent_comment_id_must_be_int_or_none(self) -> None:
+        with pytest.raises(TypeError, match="by_intent_comment_id must be int"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="superseded",
+                by_intent_comment_id="2",  # type: ignore[arg-type]
+                narrative="x",
+            )
+
+    def test_ops_single_mapping_input_rejected(self) -> None:
+        # codex P2 round 3 on #1802: a bare dict ``ops={"op":"keep"}``
+        # would iterate as its keys and produce a tuple of strings
+        # via ``deep_freeze(list(...))``.  Reject before coercion.
+        with pytest.raises(TypeError, match="sequence of op mappings"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                ops={"op": "keep", "id": "T1"},  # type: ignore[arg-type]
+            )
+
+    def test_ops_entry_must_be_mapping(self) -> None:
+        with pytest.raises(TypeError, match="ops entries must be Mapping"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                ops=("not a dict",),  # type: ignore[arg-type]
+            )
+
+    def test_affected_task_ids_entry_must_be_str(self) -> None:
+        with pytest.raises(TypeError, match="affected_task_ids entries must be str"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                affected_task_ids=(42,),  # type: ignore[arg-type]
+            )
+
+    def test_affected_task_ids_rejects_none_entry(self) -> None:
+        # Don't silently coerce ``None`` to ``"None"`` — that hides
+        # parser bugs.
+        with pytest.raises(TypeError, match="affected_task_ids entries must be str"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                affected_task_ids=(None,),  # type: ignore[arg-type]
+            )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,10 +6,14 @@ verdict drives the INV-E (#1803) reply-back classifier downstream.
 """
 
 import dataclasses
+from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
 from fido.types import IntentVerdict
+
+_ = (Iterator, Any)  # keep imports for type hints inside test bodies
 
 
 class TestIntentVerdictShape:
@@ -316,3 +320,73 @@ class TestIntentVerdictTypeChecks:
                 outcome="honored",
                 affected_task_ids=(None,),  # type: ignore[arg-type]
             )
+
+    def test_narrative_must_be_str_or_none(self) -> None:
+        # codex P2 round 4 on #1802: a non-str narrative would hit
+        # ``.strip()`` for reshaped/superseded and AttributeError
+        # instead of a clean boundary error.
+        with pytest.raises(TypeError, match="narrative must be str or None"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                narrative=42,  # type: ignore[arg-type]
+            )
+
+    def test_affected_task_ids_rejects_bare_str(self) -> None:
+        # codex P2 round 4 on #1802: ``affected_task_ids="T1"`` iterates
+        # as ('T', '1') and would silently be mis-stored.  Reject.
+        with pytest.raises(TypeError, match="not a bare str"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                affected_task_ids="T1",  # type: ignore[arg-type]
+            )
+
+    def test_affected_task_ids_rejects_set(self) -> None:
+        # codex P2 round 4 on #1802: docstring contract says ordered.
+        # Set iteration order is nondeterministic — would produce
+        # non-reproducible verdicts.
+        with pytest.raises(TypeError, match="must be ordered"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                affected_task_ids={"T1", "T2"},  # type: ignore[arg-type]
+            )
+
+    def test_affected_task_ids_rejects_frozenset(self) -> None:
+        with pytest.raises(TypeError, match="must be ordered"):
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                affected_task_ids=frozenset({"T1"}),  # type: ignore[arg-type]
+            )
+
+    def test_ops_generator_input_preserves_entries(self) -> None:
+        # codex P2 round 4 on #1802: a generator iterates once.  If
+        # the validation loop and the freeze pass each iterate, the
+        # second pass sees an exhausted iterator and silently stores
+        # an empty tuple.  Materialize once up-front.
+        def ops_gen() -> "Iterator[dict[str, Any]]":
+            yield {"op": "rewrite", "id": "T1"}
+            yield {"op": "remove", "id": "T2"}
+
+        v = IntentVerdict(
+            intent_comment_id=1,
+            outcome="reshaped",
+            ops=ops_gen(),  # type: ignore[arg-type]
+            affected_task_ids=("T1",),
+            narrative="x",
+        )
+        assert len(v.ops) == 2, "generator entries must not be silently dropped"
+
+    def test_affected_task_ids_generator_input_preserves_entries(self) -> None:
+        def ids_gen() -> "Iterator[str]":
+            yield "T1"
+            yield "T2"
+
+        v = IntentVerdict(
+            intent_comment_id=1,
+            outcome="honored",
+            affected_task_ids=ids_gen(),  # type: ignore[arg-type]
+        )
+        assert v.affected_task_ids == ("T1", "T2")


### PR DESCRIPTION
Implements first slice of #1802 (INV-D of #1798 epic).

## What this adds

Pure-type addition. No behavior change. Lays the contract that subsequent slices wire into the rescope output schema, parser, and reply-back paths.

- `IntentOutcome` literal: `honored | reshaped | superseded | no_op`
- `IntentVerdict` frozen dataclass with the locked epic shape:
  `{intent_comment_id, outcome, ops, affected_task_ids, by_intent_comment_id, narrative}`
- Default factories for `ops` / `affected_task_ids` (no shared-state foot-gun)

## Why slice now

The dataclass is the *contract* INV-E (#1803) and INV-F (#1804) reference. Landing it standalone keeps each subsequent slice tightly scoped: parser changes, apply changes, reply-back consumer, Rocq rewrite — each lands against an already-stable verdict shape.

## Tests

8 new tests in `tests/test_types.py`: minimal construction, all-fields, full + partial supersedence, joint-honor (3+1 reviewer-pattern), no-op, frozen invariant, default-factory independence.

## What's NOT in this slice

- Wiring verdicts into the rescope output schema (next slice)
- Parser that materializes Opus's JSON into `IntentVerdict` instances (next slice)
- Replacing the existing `IntentDisposition` classifier (later slice — they coexist while the new path is built up)
- Reply-back consumer (INV-E #1803)
- Rocq model rewrite (INV-F #1804)

## Test plan

- [ ] CI green
- [ ] No regression in existing `IntentDisposition` paths