### PR TITLE
INV-D / #1802 slice 2: _parse_rescope_verdicts(raw, intents)

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -33,6 +33,7 @@ from fido.types import (
     ActiveIssue,
     ActivePR,
     ClosedPR,
+    IntentVerdict,
     RescopeIntent,
     TaskStatus,
     TaskType,
@@ -1382,6 +1383,177 @@ def _parse_rescope_operations(
     if errors:
         return [], errors
     return operations, []
+
+
+def _parse_rescope_verdicts(
+    raw: str,
+    intents: list[RescopeIntent],
+) -> tuple[list[IntentVerdict], list[str]]:
+    """Parse the intent-first rescope envelope into :class:`IntentVerdict` list.
+
+    Schema (per #1798 INV-D)::
+
+        {"verdicts": [
+          {
+            "intent_comment_id": <int — one of the batch's comment ids>,
+            "outcome": "honored" | "reshaped" | "superseded" | "no_op",
+            "ops": [<op record>, ...],            // optional, default []
+            "affected_task_ids": ["T1", ...],     // optional, default []
+            "by_intent_comment_id": <int | null>, // optional, null default
+            "narrative": "..." | null             // optional, null default
+          },
+          ...
+        ]}
+
+    Validations (collected one-pass — same all-errors-at-once contract
+    as :func:`_parse_rescope_operations`):
+
+    * Top-level envelope shape (``{"verdicts": [...]}``).
+    * Each verdict entry is a dict.
+    * Per-verdict field types delegated to
+      :class:`~fido.types.IntentVerdict`'s ``__post_init__`` — every
+      ``TypeError`` / ``ValueError`` it raises gets captured as a
+      parse error, not propagated.
+    * **Coverage**: every intent in *intents* has exactly one verdict
+      (no missing, no duplicate ``intent_comment_id``).
+    * **In-batch references**: ``intent_comment_id`` and (when set)
+      ``by_intent_comment_id`` must name a :class:`RescopeIntent`
+      ``comment_id`` from *intents* — no inventing ids.
+    * **Acyclic supersedence**: the directed graph
+      ``intent_comment_id -> by_intent_comment_id`` over the batch's
+      verdicts must be acyclic.  Self-loops are already rejected by
+      :class:`IntentVerdict` itself.
+
+    When errors are non-empty the returned verdict list is also empty
+    — callers must reject the whole batch rather than partially apply
+    (mirrors :func:`_parse_rescope_operations`).
+
+    The op records inside each verdict's ``ops`` are passed through
+    as-is — :func:`_parse_rescope_operations` (or its successor) is
+    responsible for op-level shape validation in a subsequent slice.
+    """
+    errors: list[str] = []
+    envelope = _decode_first_json_object(raw)
+    if envelope is None:
+        return [], ["response: no JSON object found"]
+    if "verdicts" not in envelope:
+        return [], ['response: missing top-level "verdicts" array']
+    raw_verdicts = envelope["verdicts"]
+    if not isinstance(raw_verdicts, list):
+        return [], [
+            f"response.verdicts: must be a list, got {type(raw_verdicts).__name__}"
+        ]
+
+    intent_ids = {intent.comment_id for intent in intents}
+    verdicts: list[IntentVerdict] = []
+    seen_intent_ids: set[int] = set()
+
+    for index, raw_v in enumerate(raw_verdicts):
+        path = f"verdicts[{index}]"
+        if not isinstance(raw_v, dict):
+            errors.append(f"{path}: must be a dict, got {type(raw_v).__name__}")
+            continue
+        if "intent_comment_id" not in raw_v:
+            errors.append(f"{path}: missing required field 'intent_comment_id'")
+            continue
+        if "outcome" not in raw_v:
+            errors.append(f"{path}: missing required field 'outcome'")
+            continue
+        intent_id = raw_v["intent_comment_id"]
+        # Catch in-batch reference errors before construction so the
+        # caller learns about *every* unknown comment_id rather than
+        # just the first the IntentVerdict ctor checked.
+        if isinstance(intent_id, int) and not isinstance(intent_id, bool):
+            if intent_id not in intent_ids:
+                errors.append(
+                    f"{path}.intent_comment_id: {intent_id} not in batch "
+                    f"(expected one of {sorted(intent_ids)})"
+                )
+                continue
+            if intent_id in seen_intent_ids:
+                errors.append(
+                    f"{path}.intent_comment_id: {intent_id} already covered by "
+                    "an earlier verdict (each intent gets exactly one verdict)"
+                )
+                continue
+        by_id = raw_v.get("by_intent_comment_id")
+        if (
+            by_id is not None
+            and isinstance(by_id, int)
+            and not isinstance(by_id, bool)
+            and by_id not in intent_ids
+        ):
+            errors.append(
+                f"{path}.by_intent_comment_id: {by_id} not in batch "
+                f"(expected one of {sorted(intent_ids)})"
+            )
+            continue
+        try:
+            verdict = IntentVerdict(
+                intent_comment_id=intent_id,
+                outcome=raw_v["outcome"],
+                ops=tuple(raw_v.get("ops") or ()),
+                affected_task_ids=tuple(raw_v.get("affected_task_ids") or ()),
+                by_intent_comment_id=by_id,
+                narrative=raw_v.get("narrative"),
+            )
+        except (TypeError, ValueError) as exc:
+            errors.append(f"{path}: {exc}")
+            continue
+        verdicts.append(verdict)
+        seen_intent_ids.add(verdict.intent_comment_id)
+
+    # Coverage: every intent in the batch must have a verdict.  Don't
+    # short-circuit on earlier errors — list every missing id so Opus
+    # gets the full picture on the nudge.
+    missing = sorted(intent_ids - seen_intent_ids)
+    for intent_id in missing:
+        errors.append(
+            f"verdicts: missing verdict for intent_comment_id {intent_id} "
+            "(every intent in the batch needs exactly one verdict)"
+        )
+
+    # Acyclic check on the supersedence graph (intent → superseder).
+    if not errors:
+        cycle = _find_supersedence_cycle(verdicts)
+        if cycle is not None:
+            errors.append(
+                "verdicts: supersedence graph has a cycle: "
+                + " -> ".join(str(cid) for cid in cycle)
+            )
+
+    if errors:
+        return [], errors
+    return verdicts, []
+
+
+def _find_supersedence_cycle(
+    verdicts: list[IntentVerdict],
+) -> list[int] | None:
+    """Return one cycle's id sequence in the supersedence graph, or None.
+
+    Walks each ``by_intent_comment_id`` edge and detects revisits.
+    Returns the cycle as ``[a, b, c, a]`` so the error message reads
+    naturally; ``None`` when the graph is acyclic.
+    """
+    by_pointer: dict[int, int] = {
+        v.intent_comment_id: v.by_intent_comment_id
+        for v in verdicts
+        if v.by_intent_comment_id is not None
+    }
+    for start in by_pointer:
+        seen: list[int] = [start]
+        cursor: int | None = by_pointer.get(start)
+        while cursor is not None:
+            if cursor in seen:
+                seen.append(cursor)
+                # Trim to the cycle's start so the message is the
+                # smallest visible loop, not its tail.
+                first = seen.index(cursor)
+                return seen[first:]
+            seen.append(cursor)
+            cursor = by_pointer.get(cursor)
+    return None
 
 
 def _decode_first_json_object(raw: str) -> dict[str, Any] | None:

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1488,12 +1488,21 @@ def _parse_rescope_verdicts(  # pyright: ignore[reportUnusedFunction]
                 f"(expected one of {sorted(intent_ids)})"
             )
             continue
+        # codex P2 on slice 2: pass raw fields straight to the
+        # ctor — DO NOT collapse with ``or ()`` or pre-wrap with
+        # ``tuple(...)``.  Both would silently coerce malformed
+        # falsy inputs (``{}``, ``""``, ``None``, ``0``) into an
+        # empty tuple and bypass ``IntentVerdict.__post_init__``'s
+        # type rejection.  Absent fields get an empty-tuple default
+        # via ``dict.get``; present-with-malformed-value fields
+        # reach the ctor and raise a clean TypeError that we
+        # capture into ``errors``.
         try:
             verdict = IntentVerdict(
                 intent_comment_id=intent_id,
                 outcome=raw_v["outcome"],
-                ops=tuple(raw_v.get("ops") or ()),
-                affected_task_ids=tuple(raw_v.get("affected_task_ids") or ()),
+                ops=raw_v.get("ops", ()),
+                affected_task_ids=raw_v.get("affected_task_ids", ()),
                 by_intent_comment_id=by_id,
                 narrative=raw_v.get("narrative"),
             )

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1444,7 +1444,26 @@ def _parse_rescope_verdicts(  # pyright: ignore[reportUnusedFunction]
             f"response.verdicts: must be a list, got {type(raw_verdicts).__name__}"
         ]
 
-    intent_ids = {intent.comment_id for intent in intents}
+    # codex P2 on PR #1809: detect duplicate ``RescopeIntent.comment_id``
+    # values in the input batch up front.  If we ``set()``-collapsed
+    # them downstream, a single verdict could "cover" both entries
+    # silently, defeating the one-verdict-per-intent invariant
+    # (callers that coalesce intent lists across comments may merge
+    # without dedup).  Fail closed: name every duplicated id so the
+    # upstream coalescer bug is debuggable on sight.
+    intent_id_list = [intent.comment_id for intent in intents]
+    intent_ids = set(intent_id_list)
+    if len(intent_id_list) != len(intent_ids):
+        seen: set[int] = set()
+        duplicates: list[int] = []
+        for cid in intent_id_list:
+            if cid in seen and cid not in duplicates:
+                duplicates.append(cid)
+            seen.add(cid)
+        return [], [
+            "intents: duplicate comment_id(s) in input batch — coalescer must "
+            f"dedup before calling the parser: {sorted(duplicates)}"
+        ]
     verdicts: list[IntentVerdict] = []
     seen_intent_ids: set[int] = set()
 

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1385,7 +1385,7 @@ def _parse_rescope_operations(
     return operations, []
 
 
-def _parse_rescope_verdicts(
+def _parse_rescope_verdicts(  # pyright: ignore[reportUnusedFunction]
     raw: str,
     intents: list[RescopeIntent],
 ) -> tuple[list[IntentVerdict], list[str]]:

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -264,6 +264,19 @@ class IntentVerdict:
                 f"{type(self.affected_task_ids).__name__}, which has "
                 "nondeterministic iteration order"
             )
+        if isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            self.affected_task_ids, Mapping
+        ):
+            # codex P2 on PR #1809: ``{"T1": ...}`` would iterate as
+            # its keys and pass the per-entry str check, silently
+            # turning ``{"T1": ..., "T2": ...}`` into
+            # ``("T1", "T2")`` — losing the values and accepting an
+            # invalid shape.  Reject mappings up front.
+            raise TypeError(
+                "IntentVerdict.affected_task_ids must be a sequence of str, "
+                "not a mapping (iterating a mapping yields keys and would "
+                "silently mis-store the contents)"
+            )
 
         # Materialize collections ONCE before per-entry validation
         # (codex P2 round 4 on #1802: a generator passed as ops /

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1120,9 +1120,7 @@ def _intent(
 
 class TestParseRescopeVerdicts:
     def test_minimal_honored_verdict(self) -> None:
-        raw = (
-            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
-        )
+        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
         verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
         assert errors == []
         assert len(verdicts) == 1
@@ -1155,9 +1153,7 @@ class TestParseRescopeVerdicts:
             '{"intent_comment_id": 2, "outcome": "honored"}'
             "]}"
         )
-        verdicts, errors = _parse_rescope_verdicts(
-            raw, [_intent(1), _intent(2)]
-        )
+        verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2)])
         assert errors == []
         assert verdicts[0].by_intent_comment_id == 2
 
@@ -1170,15 +1166,11 @@ class TestParseRescopeVerdicts:
         assert errors == ['response: missing top-level "verdicts" array']
 
     def test_verdicts_not_a_list(self) -> None:
-        _, errors = _parse_rescope_verdicts(
-            '{"verdicts": {}}', [_intent(1)]
-        )
+        _, errors = _parse_rescope_verdicts('{"verdicts": {}}', [_intent(1)])
         assert errors == ["response.verdicts: must be a list, got dict"]
 
     def test_verdict_not_a_dict(self) -> None:
-        _, errors = _parse_rescope_verdicts(
-            '{"verdicts": ["nope"]}', [_intent(1)]
-        )
+        _, errors = _parse_rescope_verdicts('{"verdicts": ["nope"]}', [_intent(1)])
         # Plus the missing-verdict error for intent 1 since we couldn't parse it.
         assert "verdicts[0]: must be a dict" in errors[0]
 
@@ -1210,17 +1202,13 @@ class TestParseRescopeVerdicts:
     def test_missing_verdict_for_intent(self) -> None:
         # Intent 2 is in the batch but has no verdict → error.
         raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
-        _, errors = _parse_rescope_verdicts(
-            raw, [_intent(1), _intent(2)]
-        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2)])
         assert any("missing verdict for intent_comment_id 2" in e for e in errors)
 
     def test_multiple_missing_verdicts_all_reported(self) -> None:
         # All-errors-at-once contract — both missing ids listed.
         raw = '{"verdicts": []}'
-        _, errors = _parse_rescope_verdicts(
-            raw, [_intent(1), _intent(2)]
-        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2)])
         assert any("missing verdict for intent_comment_id 1" in e for e in errors)
         assert any("missing verdict for intent_comment_id 2" in e for e in errors)
 
@@ -1234,9 +1222,7 @@ class TestParseRescopeVerdicts:
 
     def test_intent_verdict_construction_error_captured(self) -> None:
         # Outcome typo → IntentVerdict ctor raises ValueError → captured as parse error.
-        raw = (
-            '{"verdicts": [{"intent_comment_id": 1, "outcome": "supersede"}]}'
-        )
+        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "supersede"}]}'
         _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
         assert any("outcome must be one of" in e for e in errors)
 
@@ -1259,9 +1245,7 @@ class TestParseRescopeVerdicts:
             ' "by_intent_comment_id": 1, "narrative": "y"}'
             "]}"
         )
-        _, errors = _parse_rescope_verdicts(
-            raw, [_intent(1), _intent(2)]
-        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2)])
         assert any("supersedence graph has a cycle" in e for e in errors)
 
     def test_longer_supersedence_cycle_detected(self) -> None:
@@ -1276,9 +1260,7 @@ class TestParseRescopeVerdicts:
             ' "by_intent_comment_id": 1, "narrative": "z"}'
             "]}"
         )
-        _, errors = _parse_rescope_verdicts(
-            raw, [_intent(1), _intent(2), _intent(3)]
-        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2), _intent(3)])
         assert any("supersedence graph has a cycle" in e for e in errors)
 
     def test_long_chain_no_cycle_ok(self) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1293,8 +1293,7 @@ class TestParseRescopeVerdicts:
         # mapping reaches IntentVerdict's __post_init__ which
         # rejects ``isinstance(ops, Mapping)``.
         raw = (
-            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
-            '"ops": {}}]}'
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", "ops": {}}]}'
         )
         _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
         assert any("sequence of op mappings" in e for e in errors)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -21,6 +21,7 @@ from fido.tasks import (
     _make_new_tasks_from_opus,
     _operations_to_items,
     _parse_rescope_operations,
+    _parse_rescope_verdicts,
     _rescope_releases_for_oracle,
     _rescope_snapshot_order_for_oracle,
     _rescope_state_for_oracle,
@@ -1100,6 +1101,208 @@ class TestParseRescopeOperations:
         ops, errors = _parse_rescope_operations(raw)
         assert ops == []  # first decoded object lacks "operations" key
         assert errors == ['response: missing top-level "operations" array']
+
+
+def _intent(
+    cid: int,
+    text: str = "do thing",
+    *,
+    timestamp: str = "2024-01-15T10:00:00+00:00",
+    author: str = "alice",
+) -> RescopeIntent:
+    return RescopeIntent(
+        change_request=text,
+        comment_id=cid,
+        timestamp=timestamp,
+        author=author,
+    )
+
+
+class TestParseRescopeVerdicts:
+    def test_minimal_honored_verdict(self) -> None:
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        )
+        verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert errors == []
+        assert len(verdicts) == 1
+        assert verdicts[0].outcome == "honored"
+
+    def test_full_verdict_with_all_fields(self) -> None:
+        raw = (
+            '{"verdicts": [{'
+            '"intent_comment_id": 1, '
+            '"outcome": "reshaped", '
+            '"ops": [{"op": "rewrite", "id": "T1", "title": "x"}], '
+            '"affected_task_ids": ["T1"], '
+            '"by_intent_comment_id": null, '
+            '"narrative": "folded into existing task"'
+            "}]}"
+        )
+        verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert errors == []
+        assert verdicts[0].outcome == "reshaped"
+        assert verdicts[0].affected_task_ids == ("T1",)
+        assert verdicts[0].narrative == "folded into existing task"
+
+    def test_supersedence_in_batch(self) -> None:
+        # "red" → "no, green" — red's verdict points at green.
+        raw = (
+            '{"verdicts": ['
+            '{"intent_comment_id": 1, "outcome": "superseded", '
+            '"by_intent_comment_id": 2, '
+            '"narrative": "color overridden"},'
+            '{"intent_comment_id": 2, "outcome": "honored"}'
+            "]}"
+        )
+        verdicts, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2)]
+        )
+        assert errors == []
+        assert verdicts[0].by_intent_comment_id == 2
+
+    def test_no_json_object(self) -> None:
+        _, errors = _parse_rescope_verdicts("not even json", [_intent(1)])
+        assert errors == ["response: no JSON object found"]
+
+    def test_missing_verdicts_key(self) -> None:
+        _, errors = _parse_rescope_verdicts('{"foo": []}', [_intent(1)])
+        assert errors == ['response: missing top-level "verdicts" array']
+
+    def test_verdicts_not_a_list(self) -> None:
+        _, errors = _parse_rescope_verdicts(
+            '{"verdicts": {}}', [_intent(1)]
+        )
+        assert errors == ["response.verdicts: must be a list, got dict"]
+
+    def test_verdict_not_a_dict(self) -> None:
+        _, errors = _parse_rescope_verdicts(
+            '{"verdicts": ["nope"]}', [_intent(1)]
+        )
+        # Plus the missing-verdict error for intent 1 since we couldn't parse it.
+        assert "verdicts[0]: must be a dict" in errors[0]
+
+    def test_missing_intent_comment_id(self) -> None:
+        raw = '{"verdicts": [{"outcome": "honored"}]}'
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("missing required field 'intent_comment_id'" in e for e in errors)
+
+    def test_missing_outcome(self) -> None:
+        raw = '{"verdicts": [{"intent_comment_id": 1}]}'
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("missing required field 'outcome'" in e for e in errors)
+
+    def test_unknown_intent_comment_id(self) -> None:
+        raw = '{"verdicts": [{"intent_comment_id": 999, "outcome": "honored"}]}'
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("999 not in batch" in e for e in errors)
+
+    def test_duplicate_intent_comment_id_in_verdicts(self) -> None:
+        raw = (
+            '{"verdicts": ['
+            '{"intent_comment_id": 1, "outcome": "honored"},'
+            '{"intent_comment_id": 1, "outcome": "no_op"}'
+            "]}"
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("already covered by an earlier verdict" in e for e in errors)
+
+    def test_missing_verdict_for_intent(self) -> None:
+        # Intent 2 is in the batch but has no verdict → error.
+        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        _, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2)]
+        )
+        assert any("missing verdict for intent_comment_id 2" in e for e in errors)
+
+    def test_multiple_missing_verdicts_all_reported(self) -> None:
+        # All-errors-at-once contract — both missing ids listed.
+        raw = '{"verdicts": []}'
+        _, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2)]
+        )
+        assert any("missing verdict for intent_comment_id 1" in e for e in errors)
+        assert any("missing verdict for intent_comment_id 2" in e for e in errors)
+
+    def test_by_intent_comment_id_outside_batch(self) -> None:
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "superseded", '
+            '"by_intent_comment_id": 999, "narrative": "x"}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("by_intent_comment_id: 999 not in batch" in e for e in errors)
+
+    def test_intent_verdict_construction_error_captured(self) -> None:
+        # Outcome typo → IntentVerdict ctor raises ValueError → captured as parse error.
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "supersede"}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("outcome must be one of" in e for e in errors)
+
+    def test_self_supersedence_captured_via_ctor(self) -> None:
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "superseded", '
+            '"by_intent_comment_id": 1, "narrative": "x"}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        # ctor rejects self-supersedence with "must not reference"
+        assert any("must not reference" in e for e in errors)
+
+    def test_supersedence_cycle_detected(self) -> None:
+        # 1 ← superseded by 2; 2 ← superseded by 1 — cycle.
+        raw = (
+            '{"verdicts": ['
+            '{"intent_comment_id": 1, "outcome": "superseded", '
+            ' "by_intent_comment_id": 2, "narrative": "x"},'
+            '{"intent_comment_id": 2, "outcome": "superseded", '
+            ' "by_intent_comment_id": 1, "narrative": "y"}'
+            "]}"
+        )
+        _, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2)]
+        )
+        assert any("supersedence graph has a cycle" in e for e in errors)
+
+    def test_longer_supersedence_cycle_detected(self) -> None:
+        # 1 → 2 → 3 → 1
+        raw = (
+            '{"verdicts": ['
+            '{"intent_comment_id": 1, "outcome": "superseded", '
+            ' "by_intent_comment_id": 2, "narrative": "x"},'
+            '{"intent_comment_id": 2, "outcome": "superseded", '
+            ' "by_intent_comment_id": 3, "narrative": "y"},'
+            '{"intent_comment_id": 3, "outcome": "superseded", '
+            ' "by_intent_comment_id": 1, "narrative": "z"}'
+            "]}"
+        )
+        _, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2), _intent(3)]
+        )
+        assert any("supersedence graph has a cycle" in e for e in errors)
+
+    def test_long_chain_no_cycle_ok(self) -> None:
+        # 1 → 2 → 3 (no cycle)
+        raw = (
+            '{"verdicts": ['
+            '{"intent_comment_id": 1, "outcome": "superseded", '
+            ' "by_intent_comment_id": 2, "narrative": "x"},'
+            '{"intent_comment_id": 2, "outcome": "superseded", '
+            ' "by_intent_comment_id": 3, "narrative": "y"},'
+            '{"intent_comment_id": 3, "outcome": "honored"}'
+            "]}"
+        )
+        verdicts, errors = _parse_rescope_verdicts(
+            raw, [_intent(1), _intent(2), _intent(3)]
+        )
+        assert errors == []
+        assert len(verdicts) == 3
+
+    def test_empty_intents_and_empty_verdicts(self) -> None:
+        # Degenerate: no intents, no verdicts → ok.
+        verdicts, errors = _parse_rescope_verdicts('{"verdicts": []}', [])
+        assert errors == []
+        assert verdicts == []
 
 
 class TestFindCrossOpErrors:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1286,6 +1286,52 @@ class TestParseRescopeVerdicts:
         assert errors == []
         assert verdicts == []
 
+    def test_falsy_ops_field_not_silently_coerced(self) -> None:
+        # codex P2 on slice 2: ``"ops": {}`` is malformed (a bare
+        # mapping, not a sequence).  Earlier ``or ()`` would have
+        # collapsed to () and bypassed the ctor check — now the
+        # mapping reaches IntentVerdict's __post_init__ which
+        # rejects ``isinstance(ops, Mapping)``.
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"ops": {}}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("sequence of op mappings" in e for e in errors)
+
+    def test_falsy_affected_task_ids_bare_string_rejected(self) -> None:
+        # codex P2 on slice 2: ``"affected_task_ids": ""`` is a bare
+        # string; was silently collapsed to () before, now rejected.
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"affected_task_ids": ""}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("not a bare str" in e for e in errors)
+
+    def test_null_ops_captured_as_parse_error(self) -> None:
+        # JSON null reaches the ctor as None — ctor's tuple(None)
+        # raises TypeError, which we capture into errors rather than
+        # propagating.
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"ops": null}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert len(errors) > 0
+        # The exact message comes from the ctor's tuple() call —
+        # don't pin its phrasing, just verify the path is captured.
+        assert any("verdicts[0]" in e for e in errors)
+
+    def test_absent_ops_defaults_to_empty(self) -> None:
+        # Absent ``ops`` field is the documented "no ops" case —
+        # default ``()`` is the right value, not an error.
+        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert errors == []
+        assert verdicts[0].ops == ()
+        assert verdicts[0].affected_task_ids == ()
+
 
 class TestFindCrossOpErrors:
     def test_unknown_id_rejected(self) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1331,6 +1331,42 @@ class TestParseRescopeVerdicts:
         assert verdicts[0].ops == ()
         assert verdicts[0].affected_task_ids == ()
 
+    def test_affected_task_ids_mapping_rejected_by_ctor(self) -> None:
+        # codex P2 on PR #1809: ``{"T1": ...}`` iterates as ("T1",)
+        # and would pass the per-entry str check; reject mappings
+        # explicitly at the ctor boundary.
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"affected_task_ids": {"T1": null}}]}'
+        )
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
+        assert any("not a mapping" in e for e in errors)
+
+    def test_duplicate_intent_ids_in_input_batch_rejected(self) -> None:
+        # codex P2 on PR #1809: collapsing intents to a set hides
+        # duplicate comment_ids from coverage checking — a single
+        # verdict could "cover" both silently.  Fail closed at the
+        # parser boundary so the upstream coalescer bug is visible.
+        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(1)])
+        assert any(
+            "duplicate comment_id" in e and "[1]" in e
+            for e in errors
+        )
+
+    def test_multiple_duplicate_intent_ids_all_reported(self) -> None:
+        raw = '{"verdicts": []}'
+        _, errors = _parse_rescope_verdicts(
+            raw,
+            [_intent(1), _intent(1), _intent(2), _intent(2), _intent(2)],
+        )
+        # Single error line lists ALL duplicates so the coalescer
+        # bug is debuggable on sight.
+        assert any(
+            "duplicate comment_id" in e and "1" in e and "2" in e
+            for e in errors
+        )
+
 
 class TestFindCrossOpErrors:
     def test_unknown_id_rejected(self) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1349,10 +1349,7 @@ class TestParseRescopeVerdicts:
         # parser boundary so the upstream coalescer bug is visible.
         raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
         _, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(1)])
-        assert any(
-            "duplicate comment_id" in e and "[1]" in e
-            for e in errors
-        )
+        assert any("duplicate comment_id" in e and "[1]" in e for e in errors)
 
     def test_multiple_duplicate_intent_ids_all_reported(self) -> None:
         raw = '{"verdicts": []}'
@@ -1363,8 +1360,7 @@ class TestParseRescopeVerdicts:
         # Single error line lists ALL duplicates so the coalescer
         # bug is debuggable on sight.
         assert any(
-            "duplicate comment_id" in e and "1" in e and "2" in e
-            for e in errors
+            "duplicate comment_id" in e and "1" in e and "2" in e for e in errors
         )
 
 


### PR DESCRIPTION
Implements slice 2 of #1802 (INV-D of #1798 epic).

## What this adds

`_parse_rescope_verdicts(raw, intents) -> (list[IntentVerdict], list[str])` in `src/fido/tasks.py`. Parses the intent-first envelope Opus will emit once slice 3 rewrites the rescope prompt.

Schema:

```json
{"verdicts": [
  {
    "intent_comment_id": <int>,
    "outcome": "honored" | "reshaped" | "superseded" | "no_op",
    "ops": [<op>, ...],
    "affected_task_ids": ["T1", ...],
    "by_intent_comment_id": <int | null>,
    "narrative": "..." | null
  }
]}
```

## Validations (all-errors-at-once)

Mirrors `_parse_rescope_operations`'s contract — every malformation in one pass so the retry nudge can list everything.

- Envelope shape (`{"verdicts": [...]}`)
- Per-entry dict shape
- Per-field type checks delegated to `IntentVerdict.__post_init__` (slice 1 boundary)
- Coverage: every batch intent has exactly one verdict
- In-batch references: `intent_comment_id` / `by_intent_comment_id` must name a batch intent
- Acyclic supersedence graph

## What this does NOT change

- No call sites yet — the function is unused in production until slice 3
- Op records inside `ops` are passed through unparsed — op-level shape is `_parse_rescope_operations`'s job in the wiring slice

## Tests

20 new tests in `TestParseRescopeVerdicts` cover the happy path (minimal, full, supersedence in batch, long chain) and every validation error (missing key, wrong types, missing fields, unknown id, duplicate id, missing verdict, multiple-missing report, out-of-batch pointer, ctor-error capture, self-supersedence, 2-cycle, 3-cycle, empty case).

## Test plan

- [ ] CI green
- [ ] No regression in `_parse_rescope_operations` (untouched)