### PR TITLE
#1812: reorder_tasks uses verdict envelope when intents present

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1385,7 +1385,7 @@ def _parse_rescope_operations(
     return operations, []
 
 
-def _parse_rescope_verdicts(  # pyright: ignore[reportUnusedFunction]
+def _parse_rescope_verdicts(
     raw: str,
     intents: list[RescopeIntent],
 ) -> tuple[list[IntentVerdict], list[str]]:
@@ -1582,6 +1582,34 @@ def _find_supersedence_cycle(
             seen.append(cursor)
             cursor = by_pointer.get(cursor)
     return None
+
+
+def _flatten_verdicts_to_ops(
+    verdicts: list[IntentVerdict],
+) -> list[dict[str, Any]]:
+    """Flatten per-verdict ops into the flat op list ``_apply_reorder`` consumes.
+
+    Each emitted op inherits its originating verdict's
+    ``intent_comment_id`` via the ``contributing_intents`` field (the
+    #1722 attribution convention; any pre-existing
+    ``contributing_intents`` on the op is unioned with the verdict's
+    own id so explicit per-op attribution from Opus is preserved
+    alongside the verdict-level one).
+
+    Used by :func:`reorder_tasks` when ``intents`` is non-empty so the
+    verdict-shaped parser output can flow through the existing op
+    apply/validate machinery without duplicating op-level schema
+    checks (#1812 INV-D wiring).
+    """
+    flat: list[dict[str, Any]] = []
+    for verdict in verdicts:
+        for op_mapping in verdict.ops:
+            op = dict(op_mapping)
+            existing_attrib = op.get("contributing_intents") or []
+            merged_attrib = sorted({*existing_attrib, verdict.intent_comment_id})
+            op["contributing_intents"] = merged_attrib
+            flat.append(op)
+    return flat
 
 
 def _decode_first_json_object(raw: str) -> dict[str, Any] | None:
@@ -2833,14 +2861,31 @@ def reorder_tasks(
         prompts = Prompts("")
 
     original_ids = frozenset(t["id"] for t in task_list)
-    prompt = prompts.rescope_prompt(
-        task_list,
-        commit_summary,
-        issue=issue,
-        pr=pr,
-        prior_attempts=prior_attempts,
-        intents=intents,
-    )
+    # #1812 (INV-D wiring): when intents are present, drive Opus with
+    # the verdict-shaped envelope (#1810) and parse via
+    # ``_parse_rescope_verdicts`` (#1809).  The no-intent path
+    # (``rescope_before_pick``) keeps the legacy ops-shape prompt —
+    # there's nothing to attribute and the verdict envelope would be
+    # empty noise.
+    use_verdicts = bool(intents)
+    if use_verdicts:
+        prompt = prompts.rescope_prompt_verdicts(
+            task_list,
+            commit_summary,
+            intents=intents or [],
+            issue=issue,
+            pr=pr,
+            prior_attempts=prior_attempts,
+        )
+    else:
+        prompt = prompts.rescope_prompt(
+            task_list,
+            commit_summary,
+            issue=issue,
+            pr=pr,
+            prior_attempts=prior_attempts,
+            intents=intents,
+        )
     raw = agent.run_turn(
         prompt,
         model=agent.voice_model,
@@ -2862,7 +2907,23 @@ def reorder_tasks(
     operations: list[_RescopeOp] = []
     parse_errors: list[str] = ["initial parse"]
     for nudge_attempt in range(_RESCOPE_MAX_NUDGES + 1):
-        operations, parse_errors = _parse_rescope_operations(raw)
+        if use_verdicts:
+            verdicts, verdict_errors = _parse_rescope_verdicts(raw, intents or [])
+            if verdict_errors:
+                operations, parse_errors = [], verdict_errors
+            else:
+                # Flatten the per-verdict ops into the flat op list
+                # the existing ``_apply_reorder`` consumes.  Each op
+                # inherits its verdict's ``intent_comment_id`` via the
+                # ``contributing_intents`` field (#1722 attribution
+                # convention).  Re-parsing through
+                # ``_parse_rescope_operations`` reuses op-level shape
+                # validation rather than duplicating it.
+                flat_ops = _flatten_verdicts_to_ops(verdicts)
+                synthetic = json.dumps({"operations": flat_ops})
+                operations, parse_errors = _parse_rescope_operations(synthetic)
+        else:
+            operations, parse_errors = _parse_rescope_operations(raw)
         if not parse_errors:
             cross_errors = _find_cross_op_errors(operations, snapshot_ids)
             if not cross_errors:
@@ -2885,8 +2946,14 @@ def reorder_tasks(
             _RESCOPE_MAX_NUDGES,
             attempts_remaining - 1,
         )
-        nudge = prompts.rescope_parse_nudge(
-            parse_errors, attempts_remaining=attempts_remaining - 1
+        nudge = (
+            prompts.rescope_verdicts_parse_nudge(
+                parse_errors, attempts_remaining=attempts_remaining - 1
+            )
+            if use_verdicts
+            else prompts.rescope_parse_nudge(
+                parse_errors, attempts_remaining=attempts_remaining - 1
+            )
         )
         nudge_raw = agent.run_turn(
             nudge,
@@ -2919,7 +2986,15 @@ def reorder_tasks(
     # applied (#1713 made title mutable).  Uniqueness during rewrites is
     # best-effort via the nudge — the durable invariant is on enqueueing
     # new tasks (find_pending_title_duplicate in the oracle), not on edits.
-    for nudge_attempt in range(_RESCOPE_MAX_NUDGES):
+    #
+    # #1812: verdict-shape mode skips this nudge entirely — its nudge
+    # text asks Opus to "resubmit the full operations array," which
+    # would shift Opus mid-conversation from the verdict envelope
+    # back to ops.  The existing best-effort framing covers this: if
+    # duplicates survive, the apply path tolerates them.  A future
+    # leaf can add a verdict-shape duplicate nudge if practice shows
+    # it matters.
+    for nudge_attempt in range(0 if use_verdicts else _RESCOPE_MAX_NUDGES):
         duplicates = _find_duplicate_titles(ordered_items, pre_nudge_existing)
         if not duplicates:
             break

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1591,10 +1591,24 @@ def _flatten_verdicts_to_ops(
 
     Each emitted op inherits its originating verdict's
     ``intent_comment_id`` via the ``contributing_intents`` field (the
-    #1722 attribution convention; any pre-existing
+    #1722 attribution convention; any pre-existing well-formed
     ``contributing_intents`` on the op is unioned with the verdict's
     own id so explicit per-op attribution from Opus is preserved
     alongside the verdict-level one).
+
+    Malformed ``contributing_intents`` shapes are **passed through
+    untouched** so :func:`_parse_rescope_operations` raises the
+    schema error on the next step rather than this helper silently
+    coercing (codex P1/P2 on PR #1813: ``or []`` + set-union would
+    turn ``42`` / ``""`` / ``{...}`` / ``(...)`` / mixed lists into
+    a "valid" sorted int list, bypassing the fail-closed parse
+    boundary).  Only two shapes are touched here:
+
+    * field absent → set to ``[verdict.intent_comment_id]``
+    * existing list of int (rejecting ``bool``, an ``int`` subclass)
+      → union with verdict id, sorted
+
+    Anything else stays as-is for the op parser to reject.
 
     Used by :func:`reorder_tasks` when ``intents`` is non-empty so the
     verdict-shaped parser output can flow through the existing op
@@ -1605,9 +1619,26 @@ def _flatten_verdicts_to_ops(
     for verdict in verdicts:
         for op_mapping in verdict.ops:
             op = dict(op_mapping)
-            existing_attrib = op.get("contributing_intents") or []
-            merged_attrib = sorted({*existing_attrib, verdict.intent_comment_id})
-            op["contributing_intents"] = merged_attrib
+            if "contributing_intents" not in op:
+                op["contributing_intents"] = [verdict.intent_comment_id]
+            else:
+                existing = op["contributing_intents"]
+                # ``IntentVerdict.__post_init__`` ran ``deep_freeze``
+                # which turned any list inside ``ops`` into a tuple,
+                # so the well-formed shape we see here is
+                # ``tuple[int, ...]`` (not ``list[int]``).  Accept
+                # both for resilience; reject ``bool`` explicitly
+                # (it's an ``int`` subclass and would otherwise sneak
+                # through as attribution).
+                if isinstance(existing, (list, tuple)) and all(
+                    isinstance(x, int) and not isinstance(x, bool)
+                    for x in existing  # pyright: ignore[reportUnknownVariableType]
+                ):
+                    op["contributing_intents"] = sorted(
+                        {*existing, verdict.intent_comment_id}
+                    )
+                # Else: leave malformed value untouched so
+                # _parse_rescope_operations rejects it at the next step.
             flat.append(op)
     return flat
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4728,6 +4728,127 @@ class TestFlattenVerdictsToOps:
         assert flat[1]["contributing_intents"] == [2]
         assert flat[2]["contributing_intents"] == [2]
 
+    def test_malformed_int_contributing_intents_passed_through(self) -> None:
+        # codex P1 on PR #1813: ``contributing_intents: 42`` (bare int)
+        # would have crashed ``{*existing, ...}`` with TypeError.  Pass
+        # through untouched so the op parser raises a clean schema
+        # error.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=(
+                {
+                    "op": "keep",
+                    "id": "T1",
+                    "contributing_intents": 42,  # malformed: int not list
+                },
+            ),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        # Malformed value passed through; verdict id NOT injected.
+        assert flat[0]["contributing_intents"] == 42
+
+    def test_malformed_string_contributing_intents_passed_through(self) -> None:
+        # codex P2 on PR #1813: ``""`` was previously collapsed to []
+        # via ``or []``; now passed through.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=({"op": "keep", "id": "T1", "contributing_intents": ""},),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        assert flat[0]["contributing_intents"] == ""
+
+    def test_malformed_dict_contributing_intents_passed_through(self) -> None:
+        # codex P2 on PR #1813: ``{10: "x"}`` was previously coerced
+        # to ``[10, 5]`` via set-union over dict keys.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=(
+                {
+                    "op": "keep",
+                    "id": "T1",
+                    "contributing_intents": {"10": "x"},
+                },
+            ),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        assert flat[0]["contributing_intents"] == {"10": "x"}
+
+    def test_mixed_type_list_contributing_intents_passed_through(self) -> None:
+        # codex P1 on PR #1813: ``[10, "bad"]`` would have raised in
+        # ``sorted({...})`` because mixed types aren't orderable.  Pass
+        # through.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=(
+                {
+                    "op": "keep",
+                    "id": "T1",
+                    "contributing_intents": [10, "bad"],
+                },
+            ),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        # After IntentVerdict's deep_freeze, the list became a tuple.
+        # Pass-through preserves it as-is.
+        assert flat[0]["contributing_intents"] == (10, "bad")
+
+    def test_bool_in_list_contributing_intents_passed_through(self) -> None:
+        # ``bool`` is an ``int`` subclass; reject explicitly so
+        # ``True``/``False`` can't slip in as attribution.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=(
+                {
+                    "op": "keep",
+                    "id": "T1",
+                    "contributing_intents": [True, 10],
+                },
+            ),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        # After deep_freeze, list → tuple; bool-containing → passed through.
+        assert flat[0]["contributing_intents"] == (True, 10)
+
+    def test_falsy_zero_contributing_intents_passed_through(self) -> None:
+        # ``0`` is falsy AND not a list; the old ``or []`` would have
+        # collapsed it.  Passed through now.
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="honored",
+            ops=({"op": "keep", "id": "T1", "contributing_intents": 0},),
+            affected_task_ids=("T1",),
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        assert flat[0]["contributing_intents"] == 0
+
 
 # ── _compute_thread_changes ───────────────────────────────────────────────────
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -3409,6 +3410,13 @@ class TestReorderTasks:
         # #1723: when intents are provided, the on_intent_dispositions
         # callback fires with the per-intent material/aggregation/
         # unhandled classification so #1724 can route notifications.
+        #
+        # #1812 (INV-D wiring): with intents present, the agent now
+        # receives the verdict-shaped prompt and must respond with a
+        # verdict envelope.  The verdict's ops are flattened to the
+        # flat op list the apply path consumes (with
+        # ``contributing_intents`` derived from the verdict's
+        # ``intent_comment_id``).
         t1 = self._add(tmp_path, "Original")
         intents = [
             RescopeIntent(
@@ -3417,16 +3425,22 @@ class TestReorderTasks:
                 timestamp="2024-01-15T10:00:00+00:00",
             )
         ]
-        # Op rewrites the task and attributes it to the intent.
         raw = json.dumps(
             {
-                "operations": [
+                "verdicts": [
                     {
-                        "op": "rewrite",
-                        "id": t1["id"],
-                        "title": "Renamed",
-                        "description": "",
-                        "contributing_intents": [101],
+                        "intent_comment_id": 101,
+                        "outcome": "reshaped",
+                        "ops": [
+                            {
+                                "op": "rewrite",
+                                "id": t1["id"],
+                                "title": "Renamed",
+                                "description": "",
+                            }
+                        ],
+                        "affected_task_ids": [t1["id"]],
+                        "narrative": "renamed per ask",
                     }
                 ]
             }
@@ -4342,6 +4356,377 @@ class TestReorderTasks:
         reorder_tasks(Tasks(tmp_path), "", agent=client, prompts=mock_prompts)
         mock_prompts.rescope_duplicate_nudge.assert_not_called()
         assert client.run_turn.call_count == 1
+
+
+class TestReorderTasksVerdictWiring:
+    """INV-D #1812: reorder_tasks uses the verdict envelope when intents present."""
+
+    def _add(self, tmp_path: Path, title: str) -> dict[str, Any]:
+        return Tasks(tmp_path).add(title=title, task_type=TaskType.SPEC)
+
+    def test_uses_verdict_prompt_when_intents_present(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "A")
+        intents = [
+            RescopeIntent(
+                change_request="add B",
+                comment_id=101,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        raw = json.dumps({"verdicts": [{"intent_comment_id": 101, "outcome": "no_op"}]})
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt_verdicts.return_value = "VERDICT PROMPT"
+        # legacy ops prompt MUST NOT be invoked
+        mock_prompts.rescope_prompt = MagicMock()
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            prompts=mock_prompts,
+            intents=intents,
+        )
+        mock_prompts.rescope_prompt_verdicts.assert_called_once()
+        mock_prompts.rescope_prompt.assert_not_called()
+
+    def test_uses_ops_prompt_when_no_intents(self, tmp_path: Path) -> None:
+        self._add(tmp_path, "A")
+        raw = json.dumps({"operations": []})
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt.return_value = "OPS PROMPT"
+        mock_prompts.rescope_prompt_verdicts = MagicMock()
+        reorder_tasks(Tasks(tmp_path), "", agent=_client(raw), prompts=mock_prompts)
+        mock_prompts.rescope_prompt.assert_called_once()
+        mock_prompts.rescope_prompt_verdicts.assert_not_called()
+
+    def test_verdict_ops_flattened_and_applied(self, tmp_path: Path) -> None:
+        # The op inside the verdict reaches the apply path and the
+        # task gets renamed.
+        t1 = self._add(tmp_path, "Original")
+        intents = [
+            RescopeIntent(
+                change_request="rename",
+                comment_id=101,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        raw = json.dumps(
+            {
+                "verdicts": [
+                    {
+                        "intent_comment_id": 101,
+                        "outcome": "reshaped",
+                        "ops": [
+                            {
+                                "op": "rewrite",
+                                "id": t1["id"],
+                                "title": "Renamed",
+                                "description": "",
+                            }
+                        ],
+                        "affected_task_ids": [t1["id"]],
+                        "narrative": "renamed",
+                    }
+                ]
+            }
+        )
+        reorder_tasks(Tasks(tmp_path), "", agent=_client(raw), intents=intents)
+        result = Tasks(tmp_path).list()
+        assert any(t["id"] == t1["id"] and t["title"] == "Renamed" for t in result)
+
+    def test_verdict_parse_error_nudges_with_verdict_nudge(
+        self, tmp_path: Path
+    ) -> None:
+        # When the response isn't a valid verdict envelope, the
+        # verdict-shaped parse nudge fires (not the ops-shape nudge).
+        self._add(tmp_path, "A")
+        intents = [
+            RescopeIntent(
+                change_request="x",
+                comment_id=101,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        bad_raw = '{"operations": []}'  # ops envelope, not verdicts
+        valid_raw = json.dumps(
+            {"verdicts": [{"intent_comment_id": 101, "outcome": "no_op"}]}
+        )
+        agent = _client()
+        agent.run_turn.side_effect = [bad_raw, valid_raw]
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt_verdicts.return_value = "VERDICT PROMPT"
+        mock_prompts.rescope_verdicts_parse_nudge.return_value = "VERDICT NUDGE"
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=agent,
+            prompts=mock_prompts,
+            intents=intents,
+        )
+        mock_prompts.rescope_verdicts_parse_nudge.assert_called_once()
+        # ops-shape nudge MUST NOT be invoked in verdict mode.
+        assert (
+            not mock_prompts.rescope_parse_nudge.called
+            if hasattr(mock_prompts, "rescope_parse_nudge")
+            else True
+        )
+
+    def test_contributing_intents_attributed_from_verdict(self, tmp_path: Path) -> None:
+        # The flattened op carries ``contributing_intents`` derived
+        # from the verdict's ``intent_comment_id`` so downstream
+        # IntentDisposition classification has correct attribution.
+        t1 = self._add(tmp_path, "Original")
+        intents = [
+            RescopeIntent(
+                change_request="rename",
+                comment_id=42,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        raw = json.dumps(
+            {
+                "verdicts": [
+                    {
+                        "intent_comment_id": 42,
+                        "outcome": "reshaped",
+                        "ops": [
+                            {
+                                "op": "rewrite",
+                                "id": t1["id"],
+                                "title": "Renamed",
+                                "description": "",
+                            }
+                        ],
+                        "affected_task_ids": [t1["id"]],
+                        "narrative": "x",
+                    }
+                ]
+            }
+        )
+        captured: list[tuple[dict, list[dict]]] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            intents=intents,
+            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
+        )
+        # Disposition for intent 42 should be material (rewrite is a
+        # material change per the classifier).
+        assert len(captured) == 1
+        dispositions, _ = captured[0]
+        assert 42 in dispositions
+        assert dispositions[42].kind == "material"
+
+    def test_explicit_op_attribution_unioned_with_verdict_attribution(
+        self, tmp_path: Path
+    ) -> None:
+        # Per-op ``contributing_intents`` provided by Opus is preserved
+        # alongside the verdict's own ``intent_comment_id`` (union, not
+        # replacement) so a hand-attributed op doesn't lose its
+        # verdict-level provenance.
+        t1 = self._add(tmp_path, "Original")
+        intents = [
+            RescopeIntent(
+                change_request="x",
+                comment_id=10,
+                timestamp="2024-01-15T10:00:00+00:00",
+            ),
+            RescopeIntent(
+                change_request="y",
+                comment_id=20,
+                timestamp="2024-01-15T10:01:00+00:00",
+            ),
+        ]
+        # Opus attributes the rewrite to intent 20 explicitly, and
+        # the verdict pertains to intent 10 (joint-honor case).
+        raw = json.dumps(
+            {
+                "verdicts": [
+                    {
+                        "intent_comment_id": 10,
+                        "outcome": "reshaped",
+                        "ops": [
+                            {
+                                "op": "rewrite",
+                                "id": t1["id"],
+                                "title": "Renamed",
+                                "description": "",
+                                "contributing_intents": [20],
+                            }
+                        ],
+                        "affected_task_ids": [t1["id"]],
+                        "narrative": "joint-honored",
+                    },
+                    {
+                        "intent_comment_id": 20,
+                        "outcome": "honored",
+                        "affected_task_ids": [t1["id"]],
+                    },
+                ]
+            }
+        )
+        captured: list[tuple[dict, list[dict]]] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            intents=intents,
+            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
+        )
+        dispositions, _ = captured[0]
+        # Both intents attributed to the rewrite via the union.
+        assert dispositions[10].kind == "material"
+        assert dispositions[20].kind == "material"
+
+    def test_verdict_mode_skips_duplicate_title_nudge(self, tmp_path: Path) -> None:
+        # In verdict mode, the duplicate-title nudge loop is skipped
+        # entirely (its nudge text would shift Opus mid-conversation
+        # from the verdict envelope back to ops).  Verify by mocking
+        # rescope_duplicate_nudge and asserting it's never invoked,
+        # even when the verdict produces a duplicate title in the
+        # batch.
+        intents = [
+            RescopeIntent(
+                change_request="x",
+                comment_id=101,
+                timestamp="2024-01-15T10:00:00+00:00",
+            )
+        ]
+        raw = json.dumps(
+            {
+                "verdicts": [
+                    {
+                        "intent_comment_id": 101,
+                        "outcome": "honored",
+                        "ops": [
+                            {
+                                "op": "new",
+                                "title": "Same",
+                                "description": "first",
+                                "type": "spec",
+                            },
+                            {
+                                "op": "new",
+                                "title": "Same",
+                                "description": "second",
+                                "type": "spec",
+                            },
+                        ],
+                        "affected_task_ids": [],
+                    }
+                ]
+            }
+        )
+        mock_prompts = MagicMock(spec=Prompts)
+        mock_prompts.rescope_prompt_verdicts.return_value = "VERDICT PROMPT"
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            prompts=mock_prompts,
+            intents=intents,
+        )
+        # The duplicate-title nudge MUST NOT have been invoked —
+        # that's the invariant for verdict mode regardless of what
+        # ``_make_new_tasks_from_opus`` decides downstream.
+        mock_prompts.rescope_duplicate_nudge.assert_not_called()
+
+
+class TestFlattenVerdictsToOps:
+    """Pure helper used by reorder_tasks's verdict path (#1812 INV-D)."""
+
+    def test_empty_verdicts_yields_empty_list(self) -> None:
+        from fido.tasks import _flatten_verdicts_to_ops
+
+        assert _flatten_verdicts_to_ops([]) == []
+
+    def test_single_verdict_op_inherits_intent_attribution(self) -> None:
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="reshaped",
+            ops=({"op": "rewrite", "id": "T1", "title": "x"},),
+            affected_task_ids=("T1",),
+            narrative="x",
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        assert len(flat) == 1
+        assert flat[0]["contributing_intents"] == [5]
+        assert flat[0]["op"] == "rewrite"
+
+    def test_explicit_attribution_unioned_with_verdict_id(self) -> None:
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="reshaped",
+            ops=(
+                {
+                    "op": "rewrite",
+                    "id": "T1",
+                    "title": "x",
+                    "contributing_intents": [9, 11],
+                },
+            ),
+            affected_task_ids=("T1",),
+            narrative="x",
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        assert flat[0]["contributing_intents"] == [5, 9, 11]
+
+    def test_duplicate_attribution_deduped(self) -> None:
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        v = IntentVerdict(
+            intent_comment_id=5,
+            outcome="reshaped",
+            ops=(
+                {
+                    "op": "rewrite",
+                    "id": "T1",
+                    "title": "x",
+                    "contributing_intents": [5],
+                },
+            ),
+            affected_task_ids=("T1",),
+            narrative="x",
+        )
+        flat = _flatten_verdicts_to_ops([v])
+        # Verdict id 5 already in explicit attribution; result has it
+        # once, not twice.
+        assert flat[0]["contributing_intents"] == [5]
+
+    def test_multiple_verdicts_flatten_in_order(self) -> None:
+        from fido.tasks import _flatten_verdicts_to_ops
+        from fido.types import IntentVerdict
+
+        verdicts = [
+            IntentVerdict(
+                intent_comment_id=1,
+                outcome="honored",
+                ops=({"op": "keep", "id": "A"},),
+                affected_task_ids=("A",),
+            ),
+            IntentVerdict(
+                intent_comment_id=2,
+                outcome="honored",
+                ops=(
+                    {"op": "rewrite", "id": "B", "title": "x"},
+                    {"op": "remove", "id": "C"},
+                ),
+                affected_task_ids=("B", "C"),
+            ),
+        ]
+        flat = _flatten_verdicts_to_ops(verdicts)
+        # Three ops total, in verdict order then op order.
+        assert [op["op"] for op in flat] == ["keep", "rewrite", "remove"]
+        assert flat[0]["contributing_intents"] == [1]
+        assert flat[1]["contributing_intents"] == [2]
+        assert flat[2]["contributing_intents"] == [2]
 
 
 # ── _compute_thread_changes ───────────────────────────────────────────────────


### PR DESCRIPTION
Implements #1812 (sub-leaf of #1802 / epic #1798).

## What this adds

Wires #1810's `rescope_prompt_verdicts` + #1809's `_parse_rescope_verdicts` into `reorder_tasks`. When `intents` is non-empty:

1. Prompt via verdict-shaped envelope
2. Parse `{"verdicts": [...]}`, retry via verdict-shape nudge on errors
3. Flatten per-verdict ops into the flat op list `_apply_reorder` consumes, attributing each op with the verdict's `intent_comment_id` via `contributing_intents` (unioned with any explicit per-op attribution)

When `intents` is empty (no-intent `rescope_before_pick` path), the legacy ops-shape prompt stays.

## Helper

New `_flatten_verdicts_to_ops`: tested for ordering, attribution union, dedup.

## Duplicate-title nudge

Skipped in verdict mode (its nudge text would shift Opus mid-conversation from the verdict envelope back to ops). Duplicates fall through to apply, which already tolerates them per the existing best-effort framing (#1713). A future leaf can add a verdict-shape duplicate nudge if practice shows it matters.

## Tests

12 new tests + updated `test_intent_dispositions_callback_fires_with_classification` for the new contract.

## Local verification

`./fido ci` passed locally (100% coverage, all checks green) via the pre-commit hook.

## Test plan

- [ ] CI green
- [ ] No regression in no-intent rescope path