### PR TITLE
#1814: backfill_missed_pr_comments routes through synthesis path

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1394,6 +1394,9 @@ class Dispatcher:
         pr_number: int,
         *,
         gh_user: str,
+        registry: ActivityReporter,
+        agent: ProviderAgent | None = None,
+        prompts: Prompts | None = None,
     ) -> int:
         """Replay ``issue_comment`` webhooks we may have missed while fido was
         down (fix for #794).  Returns the number of comments inspected.
@@ -1403,15 +1406,38 @@ class Dispatcher:
         iteration by ``Worker.handle_threads``, so the worker loop backfills
         those on its own — only issue-comments are invisible to the loop.
 
-        Idempotent: comments with a completed SQLite claim are skipped — Fido
-        already replied to them.  Comments handled with a task (ACT/DO) are
-        additionally deduped by :func:`create_task` via ``comment_id`` in
-        ``tasks.json``.  This method is intended to run **once per
-        WorkerThread lifetime** (at startup) — not every iteration.
+        Each missed comment is routed through the live synthesis path
+        (``reply_to_issue_comment``) — same as a fresh webhook delivery
+        — so synthesis emits a triage reply, classifies the comment,
+        and (when ``change_request`` is present) triggers rescope with
+        a :class:`RescopeIntent`.  Replaces the pre-#1814 path that
+        called :func:`events.create_task` to write a thread-type task
+        row directly to ``tasks.json``: under #1798's intent-as-
+        instruction model, tasks come into existence only via Opus ops
+        in a rescope apply, never from raw comment text.
+
+        Idempotent: comments with a completed SQLite claim are
+        skipped — Fido already replied to them.
+        ``reply_to_issue_comment`` itself claims the comment via
+        ``FidoStore.prepare_reply``, so re-entry is safe.  This method
+        is intended to run **once per WorkerThread lifetime** (at
+        startup) — not every iteration.
+
+        Synthesis failures per comment are logged and the loop
+        continues — one malformed comment shouldn't poison the whole
+        backfill.
         """
         repo_cfg = self._repo_cfg
         log.info("backfill: scanning PR #%s for missed top-level comments", pr_number)
         comments = self._gh.get_issue_comments(repo_cfg.name, pr_number)
+        if not comments:
+            log.info("backfill: PR #%s — inspected 0 comments", pr_number)
+            return 0
+        # Fetch PR metadata once for the Action context — every per-
+        # comment Action carries the same pr_title/pr_body.
+        pr_data = self._gh.get_pr(repo_cfg.name, pr_number)
+        pr_title = pr_data.get("title", "")
+        pr_body = pr_data.get("body", "") or ""
         for c in comments:
             user = (c.get("user") or {}).get("login", "")
             if not user:
@@ -1429,23 +1455,28 @@ class Dispatcher:
             if FidoStore(repo_cfg.work_dir).is_claimed_or_completed(int(comment_id)):
                 log.info("backfill: comment %s already claimed — skipping", comment_id)
                 continue
-            body = c.get("body", "") or ""
-            is_bot = user.endswith("[bot]")
-            thread = {
-                "repo": repo_cfg.name,
-                "pr": pr_number,
-                "comment_id": comment_id,
-                "url": c.get("html_url", ""),
-                "author": user,
-                "comment_type": "issues",
-            }
-            prompt = (
-                f"PR top-level comment on #{pr_number} by {user} "
-                f"({'bot' if is_bot else 'human/owner'}):\n\n{body}"
+            action = _build_issue_comment_action(
+                repo=repo_cfg.name,
+                pr_number=pr_number,
+                pr_title=pr_title,
+                pr_body=pr_body,
+                comment=c,
             )
-            create_task(
-                prompt, self._config, repo_cfg, self._gh, thread=thread, dispatcher=self
-            )
+            try:
+                reply_to_issue_comment(
+                    action,
+                    self._config,
+                    repo_cfg,
+                    self._gh,
+                    registry,
+                    agent=agent,
+                    prompts=prompts,
+                )
+            except Exception:
+                log.exception(
+                    "backfill: synthesis failed for comment %s — continuing",
+                    comment_id,
+                )
         log.info("backfill: PR #%s — inspected %d comments", pr_number, len(comments))
         return len(comments)
 

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -4593,12 +4593,17 @@ class Worker:
             self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             if self._first_iteration and not pr_is_fresh:
                 # One-shot replay of missed issue_comment webhooks (fix #794).
-                # Runs only on the first iteration per WorkerThread lifetime so
-                # the steady-state loop stays fast; create_task dedups on
-                # comment_id so re-tasking already-handled comments is a no-op.
+                # Runs only on the first iteration per WorkerThread lifetime
+                # so the steady-state loop stays fast.  Post-#1814 the
+                # backfill routes each missed comment through the synthesis
+                # path; ``FidoStore.prepare_reply`` dedups on comment_id so
+                # re-entry on already-handled comments is a no-op.
                 self._dispatcher.backfill_missed_pr_comments(
                     pr_number,
                     gh_user=repo_ctx.gh_user,
+                    registry=self._registry,
+                    agent=self._provider_agent,
+                    prompts=self._get_prompts(),
                 )
                 self._first_iteration = False
             if pr_is_fresh:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -50,8 +50,28 @@ class _FakeDispatcher:
             raise self._dispatch_side_effect
         return self._dispatch_return
 
-    def backfill_missed_pr_comments(self, pr_number: int, *, gh_user: str) -> int:
-        self.backfill_calls.append({"pr_number": pr_number, "gh_user": gh_user})
+    def backfill_missed_pr_comments(
+        self,
+        pr_number: int,
+        *,
+        gh_user: str,
+        registry: object = None,
+        agent: object = None,
+        prompts: object = None,
+    ) -> int:
+        # ``registry``/``agent``/``prompts`` arrived with #1814 so the
+        # backfill can route through the live synthesis path
+        # (``reply_to_issue_comment``).  This fake records them so
+        # tests asserting on call shape can verify the worker is
+        # passing the right collaborators.
+        del agent, prompts
+        self.backfill_calls.append(
+            {
+                "pr_number": pr_number,
+                "gh_user": gh_user,
+                "registry": registry,
+            }
+        )
         if callable(self._backfill_side_effect):
             return self._backfill_side_effect(pr_number, gh_user=gh_user)
         if isinstance(self._backfill_side_effect, BaseException):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5875,138 +5875,181 @@ class TestBackfillMissedPrComments:
             "html_url": f"https://github.com/owner/repo/pull/1#issuecomment-{comment_id}",
         }
 
-    def test_creates_task_for_allowed_collaborator_comment(
+    def _gh_with_pr(self, comments: list[dict]) -> MagicMock:
+        """Default GH mock for backfill tests: get_issue_comments returns
+        the given list, get_pr returns a stub PR for Action context."""
+        mock_gh = MagicMock()
+        mock_gh.get_issue_comments.return_value = comments
+        mock_gh.get_pr.return_value = {"title": "PR title", "body": "PR body"}
+        mock_gh.is_thread_resolved_for_comment.return_value = False
+        return mock_gh
+
+    def _registry(self) -> MagicMock:
+        return MagicMock()
+
+    def test_routes_allowed_collaborator_comment_through_synthesis(
         self, tmp_path: Path
     ) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [self._comment(100)]
-        mock_gh.is_thread_resolved_for_comment.return_value = False
+        # #1814 / INV-B slice 1: backfill calls reply_to_issue_comment
+        # (the live synthesis path), not events.create_task.  The
+        # Action's thread metadata carries the comment id + author.
+        mock_gh = self._gh_with_pr([self._comment(100)])
         cfg = self._cfg(tmp_path)
         repo_cfg = self._repo_cfg(tmp_path)
-        with patch("fido.events.create_task") as mock_create:
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             count = Dispatcher(cfg, repo_cfg, mock_gh).backfill_missed_pr_comments(
-                1, gh_user="fidocancode"
+                1, gh_user="fidocancode", registry=self._registry()
             )
         assert count == 1
-        mock_create.assert_called_once()
-        _, kwargs = mock_create.call_args
-        assert kwargs["thread"]["comment_id"] == 100
-        assert kwargs["thread"]["comment_type"] == "issues"
-        assert kwargs["thread"]["author"] == "rhencke"
+        mock_reply.assert_called_once()
+        action = mock_reply.call_args.args[0]
+        assert action.thread["comment_id"] == 100
+        assert action.thread["comment_type"] == "issues"
+        assert action.thread["author"] == "rhencke"
+
+    def test_does_not_call_legacy_create_task(self, tmp_path: Path) -> None:
+        # #1814 / INV-B slice 1 anti-regression: events.create_task is
+        # never invoked from backfill in the new path (still exists
+        # as a function; slice 2 removes it once we confirm zero
+        # callers).
+        mock_gh = self._gh_with_pr([self._comment(100)])
+        with (
+            patch("fido.events.create_task") as mock_create,
+            patch("fido.events.reply_to_issue_comment"),
+        ):
+            Dispatcher(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        mock_create.assert_not_called()
 
     def test_skips_fido_own_comments(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="fidocancode", body="my own reply")
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr(
+            [self._comment(100, user="fidocancode", body="my own reply")]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="FidoCanCode")
-        mock_create.assert_not_called()
+            ).backfill_missed_pr_comments(
+                1, gh_user="FidoCanCode", registry=self._registry()
+            )
+        mock_reply.assert_not_called()
 
     def test_skips_by_gh_user_case_insensitive(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="Alice", body="mine")
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr([self._comment(100, user="Alice", body="mine")])
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="alice")
-        mock_create.assert_not_called()
+            ).backfill_missed_pr_comments(1, gh_user="alice", registry=self._registry())
+        mock_reply.assert_not_called()
 
     def test_skips_fido_literal_name_even_if_gh_user_mismatch(
         self, tmp_path: Path
     ) -> None:
         """Defense in depth: even if ``gh_user`` is misconfigured, comments
         from the literal fido account must never trigger a backfill task."""
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="fido-can-code", body="my reply")
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr(
+            [self._comment(100, user="fido-can-code", body="my reply")]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="mis-configured-bot")
-        mock_create.assert_not_called()
+            ).backfill_missed_pr_comments(
+                1, gh_user="mis-configured-bot", registry=self._registry()
+            )
+        mock_reply.assert_not_called()
 
     def test_skips_non_allowed_users(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="random-stranger")
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr([self._comment(100, user="random-stranger")])
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path, collaborators=frozenset({"rhencke"})),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
-        mock_create.assert_not_called()
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        mock_reply.assert_not_called()
 
     def test_allows_configured_bots(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="dependabot[bot]", body="bump dep")
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr(
+            [self._comment(100, user="dependabot[bot]", body="bump dep")]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path, allowed_bots=frozenset({"dependabot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
-        assert mock_create.call_count == 1
-        _, kwargs = mock_create.call_args
-        assert "bot" in kwargs["thread"]["author"]
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        assert mock_reply.call_count == 1
+        action = mock_reply.call_args.args[0]
+        assert "bot" in action.thread["author"]
 
     def test_prompt_marks_bot_vs_human(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, user="rhencke", body="human msg"),
-            self._comment(101, user="bot[bot]", body="bot msg"),
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr(
+            [
+                self._comment(100, user="rhencke", body="human msg"),
+                self._comment(101, user="bot[bot]", body="bot msg"),
+            ]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path, allowed_bots=frozenset({"bot[bot]"})),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
-        prompts = [c.args[0] for c in mock_create.call_args_list]
-        assert any("human/owner" in p for p in prompts)
-        assert any("(bot)" in p for p in prompts)
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        actions = [c.args[0] for c in mock_reply.call_args_list]
+        # Action.is_bot reflects the per-comment user marker; the
+        # prompt format remains stable for synthesis classification.
+        assert any(not a.is_bot for a in actions)
+        assert any(a.is_bot for a in actions)
 
     def test_skips_empty_login_and_missing_id(self, tmp_path: Path) -> None:
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            {"id": 1, "user": {"login": ""}, "body": "x"},
-            {"id": None, "user": {"login": "rhencke"}, "body": "x"},
-            {"id": 2, "user": None, "body": "x"},
-        ]
-        with patch("fido.events.create_task") as mock_create:
+        mock_gh = self._gh_with_pr(
+            [
+                {"id": 1, "user": {"login": ""}, "body": "x"},
+                {"id": None, "user": {"login": "rhencke"}, "body": "x"},
+                {"id": 2, "user": None, "body": "x"},
+            ]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
-        mock_create.assert_not_called()
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        mock_reply.assert_not_called()
 
     def test_empty_comment_list_is_noop(self, tmp_path: Path) -> None:
         mock_gh = MagicMock()
         mock_gh.get_issue_comments.return_value = []
-        with patch("fido.events.create_task") as mock_create:
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             count = Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
         assert count == 0
-        mock_create.assert_not_called()
+        mock_reply.assert_not_called()
+        # Also: with zero comments, no need to fetch PR metadata.
+        mock_gh.get_pr.assert_not_called()
 
     def test_skips_already_claimed_comments(self, tmp_path: Path) -> None:
         """Comments with a durable SQLite claim are not re-queued on restart.
@@ -6014,29 +6057,55 @@ class TestBackfillMissedPrComments:
         reply_to_issue_comment completes comment ids in SQLite after posting;
         backfill must honour that durable claim and skip re-queueing.
         """
-        mock_gh = MagicMock()
-        mock_gh.get_issue_comments.return_value = [
-            self._comment(100, body="already answered"),
-            self._comment(200, body="not yet handled"),
-        ]
-        mock_gh.is_thread_resolved_for_comment.return_value = False
+        mock_gh = self._gh_with_pr(
+            [
+                self._comment(100, body="already answered"),
+                self._comment(200, body="not yet handled"),
+            ]
+        )
         promise = FidoStore(tmp_path).prepare_reply(
             owner="webhook", comment_type="issues", anchor_comment_id=100
         )
         assert promise is not None
         FidoStore(tmp_path).ack_promise(promise.promise_id)
 
-        with patch("fido.events.create_task") as mock_create:
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
             Dispatcher(
                 self._cfg(tmp_path),
                 self._repo_cfg(tmp_path),
                 mock_gh,
-            ).backfill_missed_pr_comments(1, gh_user="fidocancode")
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
 
-        # Only comment 200 (unclaimed) should be queued.
-        assert mock_create.call_count == 1
-        _, kwargs = mock_create.call_args
-        assert kwargs["thread"]["comment_id"] == 200
+        # Only comment 200 (unclaimed) should be routed through synthesis.
+        assert mock_reply.call_count == 1
+        action = mock_reply.call_args.args[0]
+        assert action.thread["comment_id"] == 200
+
+    def test_synthesis_failure_per_comment_does_not_break_loop(
+        self, tmp_path: Path
+    ) -> None:
+        # #1814: per-comment exceptions are logged and the loop
+        # continues — one malformed comment shouldn't poison the
+        # whole backfill.
+        mock_gh = self._gh_with_pr(
+            [
+                self._comment(100, body="first"),
+                self._comment(200, body="second"),
+            ]
+        )
+        with patch("fido.events.reply_to_issue_comment") as mock_reply:
+            mock_reply.side_effect = [RuntimeError("synth failed"), ("ACT", [])]
+            count = Dispatcher(
+                self._cfg(tmp_path),
+                self._repo_cfg(tmp_path),
+                mock_gh,
+            ).backfill_missed_pr_comments(
+                1, gh_user="fidocancode", registry=self._registry()
+            )
+        assert count == 2
+        assert mock_reply.call_count == 2
 
 
 class TestLaunchSync:
@@ -7606,7 +7675,7 @@ class TestDispatcher:
         mock_gh.get_issue_comments.return_value = []
         repo_cfg = _repo_cfg(tmp_path)
         d = Dispatcher(cfg, repo_cfg, mock_gh)
-        count = d.backfill_missed_pr_comments(42, gh_user="fido")
+        count = d.backfill_missed_pr_comments(42, gh_user="fido", registry=MagicMock())
         mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
         assert count == 0
 


### PR DESCRIPTION
Implements #1814 (sub-leaf of #1800 / epic #1798).

## What this changes

`Dispatcher.backfill_missed_pr_comments` handles each missed top-level PR comment by building an `Action` (via the existing `_build_issue_comment_action` helper that the live webhook path uses) and calling `reply_to_issue_comment` — the live synthesis path. Missed comments now get the same triage reply + intent classification as fresh deliveries, instead of being short-circuited into `events.create_task` writing a thread-task row to `tasks.json`.

Per #1798's intent-as-instruction model, tasks come into existence only via Opus ops in a rescope apply — never from raw comment text.

## Signature

`backfill_missed_pr_comments` now takes:
- `registry` (required — `reply_to_issue_comment` needs it)
- optional `agent` / `prompts` (worker passes its session-attached agent + persona prompts for reuse)

Per-comment exceptions are caught + logged so one malformed comment doesn't poison the whole loop.

## What this slice does NOT include

- Deletion of `events.create_task` — separate slice 2 (it's now dead code in production; slice 2 confirms no callers and removes it + its tests).
- Migration of pre-deploy thread tasks (#1805).

## Tests

12 backfill tests rewritten to patch `reply_to_issue_comment` and assert on Action shape. Plus 2 new:
- `test_does_not_call_legacy_create_task` — regression guard
- `test_synthesis_failure_per_comment_does_not_break_loop` — exception-isolation contract

`tests/fakes.py` updated for the new `registry`/`agent`/`prompts` kwargs.

`./fido ci` passed locally via pre-commit hook (100% coverage, all checks green).

## Test plan

- [ ] CI green
- [ ] No regression in webhook delivery path
- [ ] Confirm slice 2 has zero remaining callers of `create_task`