### PR TITLE
INV-E (#1803): same-author self-supersedence suppresses rescope reply-back

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -46,7 +46,7 @@ from fido.tasks import (
     Tasks,
     thread_comment_author_for_auto_resolve_oracle,
 )
-from fido.types import ActiveIssue, ActivePR, RescopeIntent, TaskType
+from fido.types import ActiveIssue, ActivePR, IntentVerdict, RescopeIntent, TaskType
 from fido.worker import ActivityReporter
 
 log = logging.getLogger(__name__)
@@ -2482,7 +2482,14 @@ def _build_on_intent_dispositions(
     gh: GitHub,
     agent: ProviderAgent | None,
     prompts: Prompts | None,
-) -> Callable[[dict[int, IntentDisposition], list[dict[str, Any]]], None]:
+) -> Callable[
+    [
+        dict[int, IntentDisposition],
+        list[dict[str, Any]],
+        list[IntentVerdict],
+    ],
+    None,
+]:
     """Build the per-iteration intent-dispositions callback (#1724).
 
     Each rescope iteration may carry a different ``current_intents``
@@ -2499,9 +2506,11 @@ def _build_on_intent_dispositions(
     def on_intent_dispositions(
         dispositions: dict[int, IntentDisposition],
         result: list[dict[str, Any]],
+        verdicts: list[IntentVerdict],
     ) -> None:
         if pr_ctx is None:
             return
+        verdict_by_cid = {v.intent_comment_id: v for v in verdicts}
         # Dispositions dict iteration order is intent-timestamp
         # ascending (the classifier sorts) — we fire notifications in
         # the same order so the chronological story reads top to
@@ -2514,8 +2523,28 @@ def _build_on_intent_dispositions(
             intent = intents_by_cid.get(cid)
             if intent is None or disposition.kind == "aggregation":
                 continue
-            if disposition.kind == "unhandled" and not _has_earlier_attributed_sibling(
-                intent, intents, dispositions
+            verdict = verdict_by_cid.get(cid)
+            is_supersedence = (
+                verdict is not None and verdict.by_intent_comment_id is not None
+            )
+            if is_supersedence:
+                # INV-E (#1803): supersedence has its own reply policy
+                # — same author = silent (they already know what they
+                # meant), cross-author = always notify (the displaced
+                # reviewer must hear their ask was overridden).  This
+                # bypasses the older "unhandled-with-only-later-
+                # attributed silent" rule because supersedence is a
+                # different relationship than implicit cover.
+                assert verdict is not None  # narrowed by is_supersedence
+                if _is_self_supersedence(verdict, intent, intents_by_cid):
+                    log.info(
+                        "skipping reply-back for self-superseded intent %s (INV-E)",
+                        cid,
+                    )
+                    continue
+            elif (
+                disposition.kind == "unhandled"
+                and not _has_earlier_attributed_sibling(intent, intents, dispositions)
             ):
                 # Either no other intents touched anything, or every
                 # attributed sibling is strictly newer than this one.
@@ -2538,6 +2567,31 @@ def _build_on_intent_dispositions(
             )
 
     return on_intent_dispositions
+
+
+def _is_self_supersedence(
+    verdict: IntentVerdict,
+    intent: RescopeIntent,
+    intents_by_cid: dict[int, RescopeIntent],
+) -> bool:
+    """True iff *verdict* names a superseding intent with the same author.
+
+    INV-E (#1803): when one commenter says "red" then "green" in the
+    same batch and Opus marks the first verdict superseded by the
+    second, Fido must NOT post a reply explaining the supersedence —
+    the commenter already knows.  Cross-author supersedence still
+    warrants a reply so the displaced reviewer sees that their ask
+    was overridden by someone else's later comment.
+
+    Caller must have already established ``verdict.by_intent_comment_id
+    is not None``; ``intents_by_cid`` must contain the superseding
+    intent (the verdict parser validates batch membership).  Empty
+    ``intent.author`` returns ``False`` so unauthored intents (test
+    scaffolding) never accidentally match.
+    """
+    assert verdict.by_intent_comment_id is not None  # narrowed by caller
+    by_intent = intents_by_cid[verdict.by_intent_comment_id]
+    return bool(intent.author) and intent.author == by_intent.author
 
 
 def _has_earlier_attributed_sibling(

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2850,7 +2850,12 @@ def reorder_tasks(
     _on_changes: Callable[[list[dict[str, Any]]], None] | None = None,
     _on_inprogress_affected: Callable[[str], None] | None = None,
     _on_intent_dispositions: Callable[
-        [dict[int, IntentDisposition], list[dict[str, Any]]], None
+        [
+            dict[int, IntentDisposition],
+            list[dict[str, Any]],
+            list[IntentVerdict],
+        ],
+        None,
     ]
     | None = None,
     _on_done: Callable[[], None] | None = None,
@@ -2937,6 +2942,11 @@ def reorder_tasks(
     )
     operations: list[_RescopeOp] = []
     parse_errors: list[str] = ["initial parse"]
+    # Hoisted across nudge iterations so the final successful parse is
+    # available to the post-apply ``_on_intent_dispositions`` callback —
+    # INV-E (#1803) needs verdict.by_intent_comment_id + the superseding
+    # intent's author to decide reply-back suppression.
+    verdicts: list[IntentVerdict] = []
     for nudge_attempt in range(_RESCOPE_MAX_NUDGES + 1):
         if use_verdicts:
             verdicts, verdict_errors = _parse_rescope_verdicts(raw, intents or [])
@@ -3196,7 +3206,9 @@ def reorder_tasks(
         # the full disposition map even for batches that produced no
         # thread-change records.
         _on_intent_dispositions(
-            _classify_rescope_intents(pre_rescope, result, intents), result
+            _classify_rescope_intents(pre_rescope, result, intents),
+            result,
+            verdicts,
         )
 
     if inprogress_affected and _on_inprogress_affected is not None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -50,7 +50,7 @@ from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import SynthesisExhaustedError
 from fido.synthesis_executor import CommentTarget
 from fido.tasks import IntentDisposition
-from fido.types import ActiveIssue, ActivePR, RescopeIntent
+from fido.types import ActiveIssue, ActivePR, IntentVerdict, RescopeIntent
 from fido.worker import ActivityReporter
 from tests.fakes import _FakeDispatcher
 
@@ -4592,11 +4592,12 @@ class TestBuildOnIntentDispositions:
             sub_dir=tmp_path / "sub",
         )
 
-    def _intent(self, comment_id: int, ts: str) -> RescopeIntent:
+    def _intent(self, comment_id: int, ts: str, author: str = "") -> RescopeIntent:
         return RescopeIntent(
             change_request=f"req {comment_id}",
             comment_id=comment_id,
             timestamp=ts,
+            author=author,
         )
 
     def _disposition(
@@ -4625,7 +4626,7 @@ class TestBuildOnIntentDispositions:
             agent=_client("nope"),
             prompts=Prompts("p"),
         )
-        cb({101: self._disposition()}, [])
+        cb({101: self._disposition()}, [], [])
         mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_aggregation_filtered_material_and_unhandled_fire(
@@ -4662,6 +4663,7 @@ class TestBuildOnIntentDispositions:
                 202: self._disposition(kind="material"),
                 303: self._disposition(kind="unhandled", affected=[]),
             },
+            [],
             [],
         )
         # 101 silent (aggregation); 202 + 303 both fire — in
@@ -4709,6 +4711,7 @@ class TestBuildOnIntentDispositions:
                 303: self._disposition(),
             },
             [],
+            [],
         )
         comment_ids = [
             c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
@@ -4737,7 +4740,7 @@ class TestBuildOnIntentDispositions:
             agent=_client("nope"),
             prompts=Prompts("p"),
         )
-        cb({101: self._disposition()}, [])
+        cb({101: self._disposition()}, [], [])
         mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_unhandled_with_only_later_attributed_silently_skips(
@@ -4773,6 +4776,7 @@ class TestBuildOnIntentDispositions:
                 101: self._disposition(kind="unhandled", affected=[]),
                 202: self._disposition(kind="material"),
             },
+            [],
             [],
         )
         # 101 silent (older unhandled, only later attributed); 202
@@ -4814,6 +4818,7 @@ class TestBuildOnIntentDispositions:
                 202: self._disposition(kind="unhandled", affected=[]),
             },
             [],
+            [],
         )
         comment_ids = [
             c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
@@ -4845,7 +4850,7 @@ class TestBuildOnIntentDispositions:
             agent=_client("text"),
             prompts=Prompts("p"),
         )
-        cb({101: self._disposition(kind="unhandled", affected=[])}, [])
+        cb({101: self._disposition(kind="unhandled", affected=[])}, [], [])
         mock_gh.reply_to_review_comment.assert_not_called()
 
     def test_unhandled_silent_when_only_unhandled_siblings(
@@ -4880,8 +4885,118 @@ class TestBuildOnIntentDispositions:
                 202: self._disposition(kind="unhandled", affected=[]),
             },
             [],
+            [],
         )
         mock_gh.reply_to_review_comment.assert_not_called()
+
+    def test_self_supersedence_suppresses_reply_back(self, tmp_path: Path) -> None:
+        # INV-E (#1803): when the same commenter says "red" then
+        # "green" in the same batch and Opus marks the first verdict
+        # superseded by the second, NO reply-back fires — they
+        # already know.  The "green" verdict itself still reports
+        # normally via its own disposition.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        red = self._intent(101, "2024-01-15T10:00:00+00:00", author="rhencke")
+        green = self._intent(202, "2024-01-15T10:01:00+00:00", author="rhencke")
+        cb = _build_on_intent_dispositions(
+            intents=[red, green],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("Reply text"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="unhandled", affected=[]),
+                202: self._disposition(kind="material"),
+            },
+            [],
+            [
+                IntentVerdict(
+                    intent_comment_id=101,
+                    outcome="superseded",
+                    by_intent_comment_id=202,
+                    narrative="overridden by the commenter's own later ask",
+                ),
+                IntentVerdict(
+                    intent_comment_id=202,
+                    outcome="reshaped",
+                    ops=({"op": "rewrite", "id": "t1", "title": "do green"},),
+                    affected_task_ids=("t1",),
+                    narrative="acted on the later ask",
+                ),
+            ],
+        )
+        # Only the superseding (green) verdict notifies; the
+        # self-superseded one (red) is silent.
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        assert comment_ids == [202]
+
+    def test_cross_author_supersedence_still_replies(self, tmp_path: Path) -> None:
+        # INV-E (#1803) inverse: when the superseding intent comes
+        # from a DIFFERENT author, the original commenter must still
+        # hear that their ask got overridden — they don't know
+        # what the other reviewer said.
+        cfg = self._cfg(tmp_path)
+        mock_gh = MagicMock()
+        pr = ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+        alice = self._intent(101, "2024-01-15T10:00:00+00:00", author="alice")
+        bob = self._intent(202, "2024-01-15T10:01:00+00:00", author="bob")
+        cb = _build_on_intent_dispositions(
+            intents=[alice, bob],
+            repo="owner/repo",
+            pr_ctx=pr,
+            config=cfg,
+            repo_cfg=cfg.repos["owner/repo"],
+            gh=mock_gh,
+            agent=_client("Reply text"),
+            prompts=Prompts("p"),
+        )
+        cb(
+            {
+                101: self._disposition(kind="unhandled", affected=[]),
+                202: self._disposition(kind="material"),
+            },
+            [],
+            [
+                IntentVerdict(
+                    intent_comment_id=101,
+                    outcome="superseded",
+                    by_intent_comment_id=202,
+                    narrative="overridden by bob's later ask",
+                ),
+                IntentVerdict(
+                    intent_comment_id=202,
+                    outcome="reshaped",
+                    ops=({"op": "rewrite", "id": "t1", "title": "bob's ask"},),
+                    affected_task_ids=("t1",),
+                    narrative="acted on bob's ask",
+                ),
+            ],
+        )
+        # Both fire: alice hears she was overridden by bob; bob
+        # hears his ask landed.
+        comment_ids = [
+            c.args[3] for c in mock_gh.reply_to_review_comment.call_args_list
+        ]
+        assert comment_ids == [101, 202]
 
 
 class TestBackfillMissedPrComments:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3451,7 +3451,7 @@ class TestReorderTasks:
             "",
             agent=_client(raw),
             intents=intents,
-            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
+            _on_intent_dispositions=lambda d, r, _v: captured.append((d, r)),
         )
         assert len(captured) == 1
         dispositions, result_tasks = captured[0]
@@ -3472,7 +3472,7 @@ class TestReorderTasks:
             Tasks(tmp_path),
             "",
             agent=_client(raw),
-            _on_intent_dispositions=lambda _d, _r: called.append(1),
+            _on_intent_dispositions=lambda _d, _r, _v: called.append(1),
         )
         assert called == []
 
@@ -4508,7 +4508,7 @@ class TestReorderTasksVerdictWiring:
             "",
             agent=_client(raw),
             intents=intents,
-            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
+            _on_intent_dispositions=lambda d, r, _v: captured.append((d, r)),
         )
         # Disposition for intent 42 should be material (rewrite is a
         # material change per the classifier).
@@ -4571,7 +4571,7 @@ class TestReorderTasksVerdictWiring:
             "",
             agent=_client(raw),
             intents=intents,
-            _on_intent_dispositions=lambda d, r: captured.append((d, r)),
+            _on_intent_dispositions=lambda d, r, _v: captured.append((d, r)),
         )
         dispositions, _ = captured[0]
         # Both intents attributed to the rewrite via the union.


### PR DESCRIPTION
Closes #1803 (leaf of epic #1798).

## What

When one commenter says "red" then "green" in the same rescope batch and Opus marks the first verdict superseded by the second, Fido must NOT post a reply explaining the supersedence — they already know.  Cross-author supersedence still warrants a reply so the displaced reviewer hears that their ask got overridden.

## How

The per-iteration ``_on_intent_dispositions`` callback now receives the parsed ``IntentVerdict`` list alongside the dispositions and result task list.  ``_build_on_intent_dispositions`` checks each intent's verdict before falling through to the existing material/aggregation/unhandled rules:

- ``by_intent_comment_id`` set + same author → silent (INV-E).
- ``by_intent_comment_id`` set + different author → notify (bypasses the older "unhandled-with-only-later-attributed silent" rule because supersedence is a different relationship than implicit cover).
- No verdict / no ``by_intent_comment_id`` → existing rules unchanged.

Verdicts are captured across the parse-nudge loop in ``reorder_tasks`` so the final successful parse is what the callback sees.

## Test plan

- [x] ``./fido ci`` clean locally — all tests + 100% coverage.
- [x] New tests cover self-supersedence (silent) and cross-author supersedence (notifies).
- [ ] CI green on the PR.