### PR TITLE
fix(rescope): #1843 — propagate source-comment anchor to rescope-spawned tasks

### DIFF
--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -249,6 +249,8 @@ class SynthesisExecutor:
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 comment_type=target.comment_type,
                 author=target.author,
+                repo=target.repo,
+                pr_number=target.pr,
             )
             log.info(
                 "triggering rescope for comment %d: %s",

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2133,6 +2133,34 @@ def _operations_to_items(operations: list[_RescopeOp]) -> list[dict[str, Any]]:
     return items
 
 
+def _derive_thread_from_intents(
+    op_intent_ids: list[int],
+    intents: list[RescopeIntent] | None,
+) -> dict[str, Any] | None:
+    """Build a ``thread`` anchor for a rescope-spawned new task (#1843).
+
+    Picks the first intent in *op_intent_ids* that resolves to a
+    :class:`RescopeIntent` carrying ``repo`` + ``pr_number`` + ``comment_id``
+    and returns ``{"repo", "pr", "comment_id"}``.  Returns ``None`` when no
+    intent has the full context populated — synthetic test fixtures and
+    legacy intents pre-#1843 may lack ``repo``/``pr_number`` and the
+    caller leaves the task unanchored in that case.
+    """
+    if not op_intent_ids or not intents:
+        return None
+    by_cid = {i.comment_id: i for i in intents}
+    for cid in op_intent_ids:
+        intent = by_cid.get(cid)
+        if intent is None or not intent.repo or intent.pr_number <= 0:
+            continue
+        return {
+            "repo": intent.repo,
+            "pr": intent.pr_number,
+            "comment_id": intent.comment_id,
+        }
+    return None
+
+
 def _make_new_tasks_from_opus(
     ordered_items: list[dict[str, Any]],
     snapshot_ids: frozenset[str],
@@ -2204,6 +2232,16 @@ def _make_new_tasks_from_opus(
         op_intents = item.get("contributing_intents") or []
         if op_intents:
             task["contributing_intents"] = list(op_intents)
+        # #1843: derive the thread anchor from the first contributing
+        # intent that has repo + pr_number + comment_id populated.
+        # Pre-INV-B the old ``events.create_task`` set ``thread`` directly;
+        # in the intent path the rescope spawns the task and the only
+        # carrier of the originating PR is the ``RescopeIntent`` itself.
+        # Without this, reply-back has no idea where to post follow-ups
+        # on the new task.
+        thread = _derive_thread_from_intents(op_intents, intents)
+        if thread is not None:
+            task["thread"] = thread
         new_tasks.append(task)
     return new_tasks
 

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -398,6 +398,16 @@ class RescopeIntent:
     the commenter already knows they overrode themselves).  Empty
     string when the source path didn't populate it (legacy / synthetic
     test fixtures pre-INV-C)."""
+    repo: str = ""
+    """``owner/repo`` slug of the PR this intent was filed against.
+    Carried through to rescope so any new task the rescope creates
+    can populate its ``thread`` anchor (#1843) — without this, reply-
+    back has no idea where to post follow-ups.  Empty string for
+    synthetic test fixtures that don't simulate a real PR context."""
+    pr_number: int = 0
+    """GitHub PR number this intent was filed against.  Same use as
+    :attr:`repo` — anchors the new task's ``thread`` field.  ``0`` for
+    synthetic fixtures."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2697,6 +2697,58 @@ class TestMakeNewTasksFromOpus:
         assert len(result) == 1
         assert result[0]["title"] == "Genuinely new spec"
 
+    def test_thread_anchor_derived_from_contributing_intent(self) -> None:
+        # #1843: a brand-new task spawned by rescope carries the
+        # originating intent's PR-context as its ``thread`` anchor so
+        # reply-back can route follow-ups back to the source comment.
+        from fido.tasks import _make_new_tasks_from_opus
+
+        intent = RescopeIntent(
+            change_request="add hello",
+            comment_id=4489194431,
+            timestamp="2026-05-19T15:13:00+00:00",
+            repo="FidoCanCode/home",
+            pr_number=1842,
+        )
+        ordered = [
+            {
+                "title": "Add 'hello' to the readme",
+                "description": "exercise",
+                "type": "spec",
+                "contributing_intents": [4489194431],
+            }
+        ]
+        result = _make_new_tasks_from_opus(ordered, frozenset(), intents=[intent])
+        assert len(result) == 1
+        assert result[0]["thread"] == {
+            "repo": "FidoCanCode/home",
+            "pr": 1842,
+            "comment_id": 4489194431,
+        }
+
+    def test_thread_anchor_absent_when_intent_lacks_pr_context(self) -> None:
+        # Legacy intents (pre-#1843) don't carry repo/pr_number — the
+        # task gets created without a thread anchor.  Better than a
+        # half-populated thread that breaks downstream lookups.
+        from fido.tasks import _make_new_tasks_from_opus
+
+        intent = RescopeIntent(
+            change_request="orphan",
+            comment_id=99,
+            timestamp="2026-05-19T15:13:00+00:00",
+        )
+        ordered = [
+            {
+                "title": "Orphan task",
+                "description": "no pr context",
+                "type": "spec",
+                "contributing_intents": [99],
+            }
+        ]
+        result = _make_new_tasks_from_opus(ordered, frozenset(), intents=[intent])
+        assert len(result) == 1
+        assert "thread" not in result[0]
+
 
 # ── _find_duplicate_titles ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #1843.

## What

When INV-B (#1817) removed \`events.create_task(thread=...)\`, comment-driven tasks lost their \`thread\` anchor.  The intent path was supposed to carry that through but ``_RescopeOpNew`` and its materializer only kept ``contributing_intents`` — the new task landed in ``tasks.json`` with no ``thread`` field, so reply-back had no idea where to post follow-ups.

Observed on PR #1842: comment-driven \"Add 'hello' to the readme\" task was created with ``contributing_intents: [4489194431]`` but no ``thread``.

## How

- ``RescopeIntent`` gains ``repo`` + ``pr_number`` so it's self-contained PR context.  Synthesis populates both from the ``CommentTarget`` it already had.
- New helper ``_derive_thread_from_intents`` in ``tasks.py``: walks an op's ``contributing_intents`` and returns the first intent's ``{repo, pr, comment_id}`` triple, falling back to ``None`` for legacy / synthetic fixtures.
- ``_make_new_tasks_from_opus`` calls the helper and writes ``task[\"thread\"]`` when a thread is derivable.

## Scope

- Doesn't touch the preempt bug (#1844) — that lands separately.
- Doesn't change behaviour for existing tasks (only affects rescope-spawned new tasks).
- Existing intents without ``repo``/``pr_number`` (synthetic fixtures, pre-#1843 test data) silently skip the anchor derivation — same shape as before.

## Test plan

- [x] ``./fido ci`` clean: 4485 tests, 100% coverage.
- [x] Two new tests in ``TestMakeNewTasksFromOpus``: anchor derived from intent, anchor absent when intent lacks PR context.
- [ ] CI green.