### PR TITLE
fix(rescope): #1844 — honor Opus's interleaved new-task position and demote in-progress when displaced

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2654,23 +2654,29 @@ def _inprogress_was_demoted(
     in-progress row to pending and fires ``_on_inprogress_affected`` so
     the worker aborts and re-picks.
 
-    Eligibility mirrors the picker's filter in ``worker._pick_next_task``,
-    delegated to the rocq oracle wherever possible to avoid duplicated
-    magic — ASK:/DEFER: classification is title-prefix-driven (see
-    #1848) and lives in ``_rescope_task_kind_for_oracle``, which the
-    oracle's ``task_executable`` then evaluates for runnability.  CI
-    rows are excluded explicitly because this helper is only called for
-    non-CI in-progress rows; CI preempt has its own path pre-#1846.
+    Eligibility mirrors the picker's filter in
+    :func:`fido.worker._pick_next_task` *exactly*:
+
+    - status in ``{pending, in_progress}`` (skip completed/blocked).
+    - ``type != \"ci\"`` (the picker prioritises ``type == \"ci\"``
+      separately; this helper is only invoked for non-CI in-progress
+      rows so CI preempt has its own path pre-#1846).  We use the raw
+      ``type`` field rather than the title-prefix-aware oracle kind
+      classifier because the picker does (codex P2 round 3 on this PR
+      — a ``\"CI FAILURE:\"`` titled row with ``type: \"spec\"`` is
+      runnable per the picker, so it must count as demotion here).
+    - title not starting ``\"ask:\"`` / ``\"defer:\"`` (case-insensitive)
+      — the picker filters them; the magic-prefix smell that motivates
+      this duplication is #1848.
     """
     skip_statuses = (str(TaskStatus.COMPLETED), str(TaskStatus.BLOCKED))
     inprogress_id = inprogress_row.get("id")
     for task in result:
         if task.get("status") in skip_statuses:
             continue
-        kind = _rescope_task_kind_for_oracle(task)
-        if isinstance(kind, rescope_oracle.TaskCI):
+        if task.get("type") == "ci":
             continue
-        if not rescope_oracle.task_executable(kind):
+        if task.get("title", "").lower().startswith(("ask:", "defer:")):
             continue
         return task.get("id") != inprogress_id
     return False
@@ -2726,40 +2732,52 @@ def _apply_reorder(
     if not any(slot is not None for slot in new_task_slots):
         return oracle_result
 
-    # #1844: interleave new tasks at the position Opus assigned in
-    # ordered_items, not unconditionally at the end of pending.  Walk
-    # ordered_items: for each existing-id item use the oracle's
-    # transformed version (carries merges/splits/rewrites); for each
-    # null-id item pull the slot at the corresponding declaration
-    # position (codex P2 — slots are aligned with null-id positions so
-    # a dropped slot doesn't shift later new tasks into earlier
-    # positions).  After the interleave, enforce the two structural
-    # invariants the picker depends on: CI tasks first, completed
-    # tasks last.
+    # #1844: inject new tasks at the positions Opus declared in
+    # ``ordered_items``.  Walk ``oracle_result`` (which carries every
+    # existing task in oracle order, including omitted ones the model
+    # treated as KeepTask) and inject new tasks RELATIVE to the
+    # existing tasks Opus did name.  For each null-id slot, the "after
+    # anchor" is the id of the last existing-id item that appeared
+    # before it in ``ordered_items`` (or ``None`` if Opus put the new
+    # task before any existing-id mention).  Omitted snapshot tasks
+    # stay at their oracle position untouched (codex P1 on this PR —
+    # earlier interleave appended them after every explicit item,
+    # silently demoting tasks Opus hadn't moved).
     completed_status = str(TaskStatus.COMPLETED)
-    oracle_by_id = {t["id"]: t for t in oracle_result}
-    interleaved: list[dict[str, Any]] = []
-    seen_ids: set[str] = set()
+    after_anchor: dict[str | None, list[dict[str, Any]]] = {}
+    last_existing: str | None = None
     null_slot_idx = 0
     for item in ordered_items:
         item_id = item.get("id")
-        if item_id and item_id in oracle_by_id and item_id not in seen_ids:
-            interleaved.append(oracle_by_id[item_id])
-            seen_ids.add(item_id)
-        elif item_id is None:
-            if null_slot_idx < len(new_task_slots):
-                slot = new_task_slots[null_slot_idx]
-                if slot is not None:
-                    interleaved.append(slot)
-            null_slot_idx += 1
-    # Oracle tasks that weren't in ordered_items (post-snapshot tasks
-    # added between batches) get appended in their oracle order.
-    for t in oracle_result:
-        if t["id"] not in seen_ids:
-            interleaved.append(t)
-            seen_ids.add(t["id"])
+        if item_id is not None:
+            last_existing = item_id
+            continue
+        if null_slot_idx < len(new_task_slots):
+            slot = new_task_slots[null_slot_idx]
+            if slot is not None:
+                after_anchor.setdefault(last_existing, []).append(slot)
+        null_slot_idx += 1
+
+    interleaved: list[dict[str, Any]] = []
+    # Insert new tasks anchored before any existing (Opus put them at
+    # the head of ``ordered_items`` before mentioning any id).
+    interleaved.extend(after_anchor.pop(None, []))
+    for existing in oracle_result:
+        interleaved.append(existing)
+        interleaved.extend(after_anchor.pop(existing["id"], []))
+    # Any after_anchor entries still keyed on an id we never saw in
+    # oracle_result would indicate a parser/validator bug — the
+    # cross-op validator rejects ordered_items items that reference
+    # unknown ids before we get here, so the only valid anchors are
+    # ``None`` (head) or an id present in oracle_result.  Per the
+    # fail-fast convention we don't paper over them.
+    assert not after_anchor, (
+        f"after_anchor has unresolved keys: {sorted(k for k in after_anchor if k is not None)!r}"
+    )
+
     # Structural sort: CI first (preserving relative order), pending
-    # next (preserving interleaved order), completed last.
+    # next (preserving interleaved order), completed last.  Backstop
+    # until #1846 retires the CI-in-tasks.json shape entirely.
     ci = [
         t
         for t in interleaved

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2649,28 +2649,28 @@ def _inprogress_was_demoted(
     """Return True iff *inprogress_row* is no longer at the front of the
     runnable-pending block of *result* (#1844).
 
-    A new task landing ahead of the in-progress one is Opus's signal that
-    the new task should preempt.  The caller demotes the in-progress row
-    to pending and fires ``_on_inprogress_affected`` so the worker aborts
-    and re-picks.
+    A new runnable task landing ahead of the in-progress one is Opus's
+    signal that the new task should preempt.  The caller demotes the
+    in-progress row to pending and fires ``_on_inprogress_affected`` so
+    the worker aborts and re-picks.
 
-    Tasks the picker would skip (completed, blocked, CI) are ignored:
-
-    - **Completed** rows don't compete for picker attention.
-    - **Blocked** rows are pending-but-paused; the picker walks past them
-      until they unblock, so they don't represent a demotion either
-      (codex P1 on PR #1847).
-    - **CI** rows are excluded both ways: this helper is only called
-      for non-CI in-progress rows (CI preempt has its own path pre-#1846)
-      so a CI new task landing ahead doesn't count as demotion through
-      this signal.
+    Eligibility mirrors the picker's filter in ``worker._pick_next_task``,
+    delegated to the rocq oracle wherever possible to avoid duplicated
+    magic — ASK:/DEFER: classification is title-prefix-driven (see
+    #1848) and lives in ``_rescope_task_kind_for_oracle``, which the
+    oracle's ``task_executable`` then evaluates for runnability.  CI
+    rows are excluded explicitly because this helper is only called for
+    non-CI in-progress rows; CI preempt has its own path pre-#1846.
     """
     skip_statuses = (str(TaskStatus.COMPLETED), str(TaskStatus.BLOCKED))
     inprogress_id = inprogress_row.get("id")
     for task in result:
         if task.get("status") in skip_statuses:
             continue
-        if task.get("type") == "ci":
+        kind = _rescope_task_kind_for_oracle(task)
+        if isinstance(kind, rescope_oracle.TaskCI):
+            continue
+        if not rescope_oracle.task_executable(kind):
             continue
         return task.get("id") != inprogress_id
     return False

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2166,7 +2166,7 @@ def _make_new_tasks_from_opus(
     snapshot_ids: frozenset[str],
     current: list[dict[str, Any]] | None = None,
     intents: list[RescopeIntent] | None = None,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any] | None]:
     """Create fresh task dicts for items Opus returned with a null or absent id.
 
     Items with a non-null id (whether in the snapshot or not) are not treated
@@ -2175,8 +2175,14 @@ def _make_new_tasks_from_opus(
     ``"id"`` key is absent or explicitly ``null`` are promoted to new tasks.
 
     Each new task receives a UUIDv7 id, ``status: "pending"``, and
-    ``type: "spec"`` unless Opus specified a different type.  Items with
-    blank titles are silently skipped.
+    ``type: "spec"`` unless Opus specified a different type.
+
+    Returns a list aligned with the null-id positions in *ordered_items*
+    (codex P2 on PR #1847): one entry per null-id item, in declaration
+    order.  Entry is the new task dict when the item was materialized,
+    ``None`` when the item was dropped (blank title OR dedup-suppressed).
+    The caller (``_apply_reorder``) walks this list positionally so a
+    dropped slot doesn't shift later new tasks into earlier positions.
 
     Dedup against post-snapshot thread tasks (#1337): when *current* and
     *intents* are provided, any rescope intent whose ``comment_id`` is already
@@ -2198,7 +2204,7 @@ def _make_new_tasks_from_opus(
             if intent.comment_id in post_snapshot_lineage:
                 covered_intents += 1
 
-    new_tasks: list[dict[str, Any]] = []
+    slots: list[dict[str, Any] | None] = []
     skipped = 0
     for item in ordered_items:
         if "id" in item and item["id"] is not None:
@@ -2209,6 +2215,7 @@ def _make_new_tasks_from_opus(
         # normalization Tasks.add applies, so PR-body round-tripping holds.
         title = _effective_title(item, {})
         if not title:
+            slots.append(None)
             continue
         if skipped < covered_intents:
             log.info(
@@ -2217,6 +2224,7 @@ def _make_new_tasks_from_opus(
                 title[:80],
             )
             skipped += 1
+            slots.append(None)
             continue
         task: dict[str, Any] = {
             "id": str(uuid.uuid7()),
@@ -2242,8 +2250,8 @@ def _make_new_tasks_from_opus(
         thread = _derive_thread_from_intents(op_intents, intents)
         if thread is not None:
             task["thread"] = thread
-        new_tasks.append(task)
-    return new_tasks
+        slots.append(task)
+    return slots
 
 
 def _validate_rescope_batch(
@@ -2635,6 +2643,39 @@ def _find_duplicate_titles(
     return duplicates
 
 
+def _inprogress_was_demoted(
+    inprogress_row: dict[str, Any], result: list[dict[str, Any]]
+) -> bool:
+    """Return True iff *inprogress_row* is no longer at the front of the
+    runnable-pending block of *result* (#1844).
+
+    A new task landing ahead of the in-progress one is Opus's signal that
+    the new task should preempt.  The caller demotes the in-progress row
+    to pending and fires ``_on_inprogress_affected`` so the worker aborts
+    and re-picks.
+
+    Tasks the picker would skip (completed, blocked, CI) are ignored:
+
+    - **Completed** rows don't compete for picker attention.
+    - **Blocked** rows are pending-but-paused; the picker walks past them
+      until they unblock, so they don't represent a demotion either
+      (codex P1 on PR #1847).
+    - **CI** rows are excluded both ways: this helper is only called
+      for non-CI in-progress rows (CI preempt has its own path pre-#1846)
+      so a CI new task landing ahead doesn't count as demotion through
+      this signal.
+    """
+    skip_statuses = (str(TaskStatus.COMPLETED), str(TaskStatus.BLOCKED))
+    inprogress_id = inprogress_row.get("id")
+    for task in result:
+        if task.get("status") in skip_statuses:
+            continue
+        if task.get("type") == "ci":
+            continue
+        return task.get("id") != inprogress_id
+    return False
+
+
 def _apply_reorder(
     current: list[dict[str, Any]],
     ordered_items: list[dict[str, Any]],
@@ -2679,25 +2720,58 @@ def _apply_reorder(
         current, ordered_items, snapshot_ids, oracle_result, split_child_ids
     )
 
-    new_tasks = _make_new_tasks_from_opus(
+    new_task_slots = _make_new_tasks_from_opus(
         ordered_items, snapshot_ids, current=current, intents=intents
     )
-    if not new_tasks:
+    if not any(slot is not None for slot in new_task_slots):
         return oracle_result
 
-    # Merge new tasks into oracle result: CI tasks first (in both groups),
-    # then non-CI pending (oracle then new), then completed at end.
+    # #1844: interleave new tasks at the position Opus assigned in
+    # ordered_items, not unconditionally at the end of pending.  Walk
+    # ordered_items: for each existing-id item use the oracle's
+    # transformed version (carries merges/splits/rewrites); for each
+    # null-id item pull the slot at the corresponding declaration
+    # position (codex P2 — slots are aligned with null-id positions so
+    # a dropped slot doesn't shift later new tasks into earlier
+    # positions).  After the interleave, enforce the two structural
+    # invariants the picker depends on: CI tasks first, completed
+    # tasks last.
     completed_status = str(TaskStatus.COMPLETED)
-    oracle_pending = [t for t in oracle_result if t.get("status") != completed_status]
-    oracle_completed = [t for t in oracle_result if t.get("status") == completed_status]
-
-    ci_new = [t for t in new_tasks if t.get("type") == "ci"]
-    non_ci_new = [t for t in new_tasks if t.get("type") != "ci"]
-
-    ci_oracle = [t for t in oracle_pending if t.get("type") == "ci"]
-    non_ci_oracle = [t for t in oracle_pending if t.get("type") != "ci"]
-
-    return ci_oracle + ci_new + non_ci_oracle + non_ci_new + oracle_completed
+    oracle_by_id = {t["id"]: t for t in oracle_result}
+    interleaved: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    null_slot_idx = 0
+    for item in ordered_items:
+        item_id = item.get("id")
+        if item_id and item_id in oracle_by_id and item_id not in seen_ids:
+            interleaved.append(oracle_by_id[item_id])
+            seen_ids.add(item_id)
+        elif item_id is None:
+            if null_slot_idx < len(new_task_slots):
+                slot = new_task_slots[null_slot_idx]
+                if slot is not None:
+                    interleaved.append(slot)
+            null_slot_idx += 1
+    # Oracle tasks that weren't in ordered_items (post-snapshot tasks
+    # added between batches) get appended in their oracle order.
+    for t in oracle_result:
+        if t["id"] not in seen_ids:
+            interleaved.append(t)
+            seen_ids.add(t["id"])
+    # Structural sort: CI first (preserving relative order), pending
+    # next (preserving interleaved order), completed last.
+    ci = [
+        t
+        for t in interleaved
+        if t.get("type") == "ci" and t.get("status") != completed_status
+    ]
+    pending_non_ci = [
+        t
+        for t in interleaved
+        if t.get("type") != "ci" and t.get("status") != completed_status
+    ]
+    completed = [t for t in interleaved if t.get("status") == completed_status]
+    return ci + pending_non_ci + completed
 
 
 def _merge_source_ids(ordered_items: list[dict[str, Any]]) -> set[str]:
@@ -3138,6 +3212,28 @@ def reorder_tasks(
                                 "Opus — reset to pending: %s",
                                 inprogress_in_result.get("title", "")[:60],
                             )
+                    elif inprogress_in_result.get("type") != "ci" and (
+                        _inprogress_was_demoted(inprogress_in_result, result)
+                    ):
+                        # #1844: a NEW task landed ahead of the in-progress
+                        # one (no modification to the in-progress row itself,
+                        # but Opus placed something else before it).  Treat
+                        # as preempt: demote in-progress to pending so the
+                        # picker re-picks against the new front of queue.
+                        #
+                        # Only fires for non-CI in-progress rows (codex P1
+                        # on this PR): CI preempt has its own path pre-#1846
+                        # and the demotion helper skips CI rows during its
+                        # walk, so calling it for a CI in-progress would
+                        # always return False anyway.
+                        inprogress_affected = True
+                        inprogress_in_result["status"] = str(TaskStatus.PENDING)
+                        log.info(
+                            "reorder_tasks: in-progress task demoted by "
+                            "rescope (a later-arriving task took position 0) "
+                            "— reset to pending: %s",
+                            inprogress_in_result.get("title", "")[:60],
+                        )
             # Slice-assign so JsonFileStore.modify writes the recomputed
             # list back (it persists the same dict/list object it yielded).
             current[:] = result

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4063,6 +4063,150 @@ class TestReorderTasks:
         result = Tasks(tmp_path).list()
         assert result[0]["status"] == str(TaskStatus.IN_PROGRESS)
 
+    def test_on_inprogress_affected_called_when_new_task_demotes_inprogress(
+        self, tmp_path: Path
+    ) -> None:
+        # #1844: a comment-driven new task lands at position 0 in Opus's
+        # ordered_items, ahead of the in-progress task.  The reorder
+        # interleaves the new task at Opus's position; the in-progress
+        # is no longer first in the pending block, so it's demoted to
+        # pending and the on_inprogress_affected callback fires so the
+        # worker aborts its turn and re-picks against the new front.
+        t1 = self._add(tmp_path, "Current task")
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [
+                # null-id at position 0 = new task placed ahead of t1.
+                {"id": None, "title": "Higher-priority new ask"},
+                {"id": t1["id"]},
+            ]
+        )
+        affected: list[str] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_inprogress_affected=lambda task_id: affected.append(task_id),
+        )
+        assert affected == [t1["id"]]
+        result = Tasks(tmp_path).list()
+        assert result[0]["title"] == "Higher-priority new ask"
+        # t1 is demoted to pending; worker will re-pick it after the
+        # new task completes.
+        t1_after = next(t for t in result if t["id"] == t1["id"])
+        assert t1_after["status"] == str(TaskStatus.PENDING)
+
+    def test_inprogress_not_demoted_when_new_task_lands_after(
+        self, tmp_path: Path
+    ) -> None:
+        # Inverse: the new task lands after the in-progress one.  No
+        # demotion, no preempt callback.
+        t1 = self._add(tmp_path, "Current task")
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [
+                {"id": t1["id"]},
+                {"id": None, "title": "Later ask"},
+            ]
+        )
+        affected: list[str] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_inprogress_affected=lambda task_id: affected.append(task_id),
+        )
+        assert affected == []
+        result = Tasks(tmp_path).list()
+        assert result[0]["id"] == t1["id"]
+        assert result[0]["status"] == str(TaskStatus.IN_PROGRESS)
+
+    def test_inprogress_demoted_helper_skips_completed_at_front(self) -> None:
+        # #1844: a completed task at the front of result doesn't count
+        # as a demotion (the picker skips completed).
+        from fido.tasks import _inprogress_was_demoted
+
+        ip = {"id": "ip", "status": "in_progress", "type": "spec"}
+        result = [
+            {"id": "done", "status": "completed", "type": "spec"},
+            ip,
+        ]
+        assert _inprogress_was_demoted(ip, result) is False
+
+    def test_inprogress_demoted_helper_skips_ask_and_defer_prefixed(
+        self,
+    ) -> None:
+        # codex P2 on PR #1847: ASK:/DEFER: title-prefixed tasks aren't
+        # runnable (the picker filters them out), so a leading ASK: or
+        # DEFER: row doesn't count as demotion.
+        from fido.tasks import _inprogress_was_demoted
+
+        ip = {"id": "ip", "status": "in_progress", "type": "spec", "title": "Real work"}
+        result = [
+            {
+                "id": "ask1",
+                "status": "pending",
+                "type": "spec",
+                "title": "ASK: should we...",
+            },
+            {
+                "id": "defer1",
+                "status": "pending",
+                "type": "spec",
+                "title": "DEFER: maybe later",
+            },
+            ip,
+        ]
+        assert _inprogress_was_demoted(ip, result) is False
+
+    def test_inprogress_demoted_helper_returns_false_when_only_ci_remain(
+        self,
+    ) -> None:
+        # #1844: edge case — in-progress task IS the only non-CI item
+        # but it doesn't appear in result (defensive; shouldn't happen
+        # in practice).  The helper walks past every CI / completed
+        # entry and returns False rather than crashing.
+        from fido.tasks import _inprogress_was_demoted
+
+        ip = {"id": "ip", "status": "in_progress", "type": "ci"}
+        result = [
+            {"id": "ci1", "status": "pending", "type": "ci"},
+            {"id": "done", "status": "completed", "type": "spec"},
+        ]
+        assert _inprogress_was_demoted(ip, result) is False
+
+    def test_inprogress_demotion_skips_intervening_ci_and_completed(
+        self, tmp_path: Path
+    ) -> None:
+        # The demotion check only looks at non-CI, non-completed tasks
+        # ahead of the in-progress one.  A completed task at position 0
+        # doesn't count as a demotion (it's a no-op for the picker), and
+        # CI tasks are intentionally skipped (pre-#1846 they always come
+        # first via the structural invariant + the existing CI preempt
+        # path handles them).
+        ci = self._add(tmp_path, "Fix CI", task_type=TaskType.CI)
+        done = self._add(tmp_path, "Already done")
+        Tasks(tmp_path).update(done["id"], TaskStatus.COMPLETED)
+        t1 = self._add(tmp_path, "Current task")
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [
+                {"id": ci["id"]},
+                {"id": t1["id"]},
+                {"id": done["id"], "status": "completed"},
+            ]
+        )
+        affected: list[str] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_inprogress_affected=lambda task_id: affected.append(task_id),
+        )
+        # CI at front + completed at end is the existing invariant; t1
+        # is first non-CI pending so NOT demoted.
+        assert affected == []
+
     def test_on_inprogress_affected_called_when_anchor_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4207,6 +4207,70 @@ class TestReorderTasks:
         # is first non-CI pending so NOT demoted.
         assert affected == []
 
+    def test_omitted_snapshot_task_keeps_position_when_new_task_added(
+        self, tmp_path: Path
+    ) -> None:
+        # codex P1 round 3 on #1847: a snapshot task Opus didn't
+        # mention (omitted ⇒ KeepTask) must keep its snapshot position
+        # even when another item in ordered_items spawns a new task.
+        # Earlier interleave appended every "unseen" oracle task at
+        # the end of the list, silently demoting omitted tasks behind
+        # every explicit item.
+        t1 = self._add(tmp_path, "First")
+        self._add(tmp_path, "Second — Opus doesn't mention")
+        t3 = self._add(tmp_path, "Third")
+        # Opus emits only t1 and t3, plus a new task after t3.
+        # t2 is omitted ⇒ KeepTask ⇒ should stay at position 1.
+        raw = self._response(
+            [
+                {"id": t1["id"]},
+                {"id": t3["id"]},
+                {"id": None, "title": "Brand new"},
+            ]
+        )
+        reorder_tasks(Tasks(tmp_path), "", agent=_client(raw))
+        result = Tasks(tmp_path).list()
+        titles = [t["title"] for t in result]
+        # t2 stays at position 1 (between t1 and t3), new task goes
+        # after t3 (its anchor in ordered_items).
+        assert titles == [
+            "First",
+            "Second — Opus doesn't mention",
+            "Third",
+            "Brand new",
+        ]
+
+    def test_inprogress_demoted_by_ci_failure_titled_spec_task(
+        self, tmp_path: Path
+    ) -> None:
+        # codex P2 round 3 on #1847: ``"CI FAILURE:"`` title with
+        # ``type: "spec"`` is treated as a normal runnable pending task
+        # by the picker (CI prioritisation looks at ``type`` only).
+        # The demotion check must match — a new such row landing ahead
+        # of the in-progress one must demote.
+        t1 = self._add(tmp_path, "Current task")
+        Tasks(tmp_path).update(t1["id"], TaskStatus.IN_PROGRESS)
+        raw = self._response(
+            [
+                # spec-typed new task with a CI-flavored title prefix
+                # — picker sees runnable, so we must too.
+                {
+                    "id": None,
+                    "title": "CI FAILURE: looks like CI but spec type",
+                    "type": "spec",
+                },
+                {"id": t1["id"]},
+            ]
+        )
+        affected: list[str] = []
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=_client(raw),
+            _on_inprogress_affected=lambda task_id: affected.append(task_id),
+        )
+        assert affected == [t1["id"]]
+
     def test_on_inprogress_affected_called_when_anchor_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2603,14 +2603,17 @@ class TestMakeNewTasksFromOpus:
         assert result[0]["type"] == "ci"
 
     def test_skips_blank_title(self) -> None:
+        # #1844 codex P2: slot is preserved at null-id position so the
+        # interleave doesn't shift later items into earlier positions.
+        # Blank-title items materialize as ``None`` rather than vanishing.
         items = [{"title": "", "description": "no title"}]
         result = _make_new_tasks_from_opus(items, frozenset())
-        assert result == []
+        assert result == [None]
 
     def test_skips_whitespace_only_title(self) -> None:
         items = [{"title": "   ", "description": "no title"}]
         result = _make_new_tasks_from_opus(items, frozenset())
-        assert result == []
+        assert result == [None]
 
     def test_multiple_new_tasks(self) -> None:
         items = [
@@ -2668,7 +2671,10 @@ class TestMakeNewTasksFromOpus:
         result = _make_new_tasks_from_opus(
             items, snapshot_ids, current=current, intents=intents
         )
-        assert result == [], "covered intent must drop the duplicate (#1337)"
+        # #1844 codex P2: the dropped null-id slot is represented as
+        # ``None`` rather than absent so the interleave preserves
+        # positional alignment for later new tasks.
+        assert result == [None], "covered intent must drop the duplicate (#1337)"
 
     def test_does_not_dedup_when_lineage_does_not_match_intent(self) -> None:
         """When no post-snapshot thread task covers the intent, Opus's null-id
@@ -2695,6 +2701,7 @@ class TestMakeNewTasksFromOpus:
             items, snapshot_ids, current=current, intents=intents
         )
         assert len(result) == 1
+        assert result[0] is not None
         assert result[0]["title"] == "Genuinely new spec"
 
     def test_thread_anchor_derived_from_contributing_intent(self) -> None:
@@ -2720,6 +2727,7 @@ class TestMakeNewTasksFromOpus:
         ]
         result = _make_new_tasks_from_opus(ordered, frozenset(), intents=[intent])
         assert len(result) == 1
+        assert result[0] is not None
         assert result[0]["thread"] == {
             "repo": "FidoCanCode/home",
             "pr": 1842,
@@ -2747,7 +2755,50 @@ class TestMakeNewTasksFromOpus:
         ]
         result = _make_new_tasks_from_opus(ordered, frozenset(), intents=[intent])
         assert len(result) == 1
+        assert result[0] is not None
         assert "thread" not in result[0]
+
+    def test_dropped_slot_preserves_alignment_for_later_new_tasks(self) -> None:
+        # #1844 codex P2: a dropped duplicate slot at the front must
+        # not shift later kept new tasks into the dropped position.
+        # ``_apply_reorder`` walks the aligned list positionally and
+        # this test pins the per-slot alignment so the interleave can
+        # rely on it.
+        snapshot_ids = frozenset({"orig-1"})
+        current = [
+            {"id": "orig-1", "title": "Original", "status": "pending"},
+            {
+                "id": "post-snapshot-2",
+                "title": "Duplicate of the covered intent",
+                "status": "in_progress",
+                "type": "thread",
+                "thread": {
+                    "comment_id": 4371338003,
+                    "lineage_comment_ids": [4371338003],
+                },
+            },
+        ]
+        intents = [
+            RescopeIntent(
+                comment_id=4371338003,
+                change_request="covered by the post-snapshot task",
+                timestamp="2026-05-04T13:15:44Z",
+            ),
+        ]
+        # Two null-id items: the first matches the covered intent and
+        # is dropped, the second is a genuine new task.  Result must
+        # be [None, dict] — same length as the count of null-id items.
+        items = [
+            {"title": "Duplicate"},
+            {"title": "Genuine new"},
+        ]
+        result = _make_new_tasks_from_opus(
+            items, snapshot_ids, current=current, intents=intents
+        )
+        assert len(result) == 2
+        assert result[0] is None
+        assert result[1] is not None
+        assert result[1]["title"] == "Genuine new"
 
 
 # ── _find_duplicate_titles ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1844.

## What

Two structural fixes that together let a comment-driven new task preempt the in-progress task.

### 1. Honor Opus's interleaved order in \`_apply_reorder\`

The old sort \`ci_oracle + ci_new + non_ci_oracle + non_ci_new + completed\` unconditionally appended new tasks after every existing pending task, so even when Opus put a null-id new task at position 0 it landed after the in-progress task.

Now we walk \`ordered_items\` in Opus's order and substitute oracle-transformed entries for existing ids and materialized new-task dicts for null-id items.  Structural invariants (CI first, completed last) stay as a backstop until #1846 (the architectural CI-isn't-a-task rework) lands.

### 2. Detect in-progress demotion in \`reorder_tasks\`

New helper \`_inprogress_was_demoted\` walks the result and reports True when the in-progress task is no longer first among non-CI pending tasks.  When the existing modify/complete checks don't fire but the helper does, demote the in-progress row to pending and fire \`_on_inprogress_affected\` so the worker aborts its turn and re-picks against the new front of queue.

## Observed

PR #1842, rhencke at 15:13:57: \"Add a task to put 'hello' in the readme as the first task, and remove 'hello' as the last task.\"

The rescope queued both tasks but appended them after the in-progress \`check_no_magicmock.py\` task, and Fido kept working uninterrupted.  Both bugs above combined to swallow the preempt request.

## Scope

- Doesn't touch the source-comment anchor bug (#1843) — that lands separately on PR #1845.
- Doesn't tackle the architectural \"ci is not a task\" rework (#1846).
- Keeps the CI-first / completed-last backstop sort; per Rob's \"Opus is sole arbiter\" direction those will go in #1846's wake.

## Test plan

- [x] \`./fido ci\` clean: 4488 tests, 100% coverage.
- [x] New tests in \`TestReorderTasks\`:
  - \`test_on_inprogress_affected_called_when_new_task_demotes_inprogress\` — Opus puts new task at position 0; in-progress demoted, callback fires.
  - \`test_inprogress_not_demoted_when_new_task_lands_after\` — new task at position 1; no demotion.
  - \`test_inprogress_demotion_skips_intervening_ci_and_completed\` — CI front + completed end + in-progress first non-CI pending → no demotion.
  - \`test_inprogress_demoted_helper_skips_completed_at_front\` — completed-at-front isn't a demotion.
  - \`test_inprogress_demoted_helper_returns_false_when_only_ci_remain\` — edge case (in-progress not in result block of non-CI pending) returns False rather than crashing.
- [ ] CI green.