### PR TITLE
fix(synthesis): #1850 — carry system_prompt into verification turns

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -864,18 +864,46 @@ class Prompts:
         before responding, so it can write an informed reply *and* a meaningful
         change_request intent, without being able to modify files or run mutations.
         """
-        active = ""
-        if issue is not None:
-            active = render_active_context(issue, pr, [], None, []) + "\n\n"
         return (
-            f"{self.persona}\n\n"
-            f"{active}"
+            f"{self._synthesis_base_system_prompt(issue, pr)}"
             "You are responding to a GitHub PR comment with a single structured "
             "JSON response.  "
             f"{TRIAGE_CLAUSE}  "
             "Output ONLY the JSON object — no preamble, no trailing text, "
             "no explanation outside the JSON fields."
         )
+
+    def synthesis_followup_system_prompt(
+        self,
+        issue: ActiveIssue | None = None,
+        pr: ActivePR | None = None,
+    ) -> str:
+        """Return the system prompt for follow-up turns after :meth:`synthesis_system_prompt` (#1850).
+
+        Shares the persona and active-work framing with the main synthesis
+        turn so the agent stays anchored in synthesis-reply mode, but DROPS
+        the JSON-only directive — the verify / derive follow-ups want
+        plain-text answers (a single ``Yes`` or ``No`` then a one-sentence
+        request).  Without this, reusing the JSON-only prompt would either
+        starve those checks (``startswith("no")`` fails on a JSON wrapper)
+        or push the model toward the wrong shape.
+        """
+        return (
+            f"{self._synthesis_base_system_prompt(issue, pr)}"
+            "You are in a synthesis follow-up turn — a brief plain-text "
+            "question about the reply you just produced.  Answer exactly "
+            "as asked: no JSON, no markdown, no preamble."
+        )
+
+    def _synthesis_base_system_prompt(
+        self,
+        issue: ActiveIssue | None,
+        pr: ActivePR | None,
+    ) -> str:
+        active = ""
+        if issue is not None:
+            active = render_active_context(issue, pr, [], None, []) + "\n\n"
+        return f"{self.persona}\n\n{active}"
 
     def synthesis_prompt(
         self,

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -68,7 +68,7 @@ _DERIVE_CHANGE_REQUEST_PROMPT: str = (
 def _check_and_promote(
     response: CommentResponse,
     agent: ProviderAgent,
-    system_prompt: str,
+    followup_system_prompt: str,
 ) -> CommentResponse:
     """Run a verification turn to detect unrecorded change requests.
 
@@ -90,12 +90,15 @@ def _check_and_promote(
     This enforces the invariant: prose promises must correspond to queued
     tasks (fixes #1218).
 
-    *system_prompt* anchors both follow-up turns in synthesis-reply mode
-    (#1850).  Without it, the bare Yes/No prompt arrives in the worker's
+    *followup_system_prompt* (#1850) anchors both turns in synthesis-reply
+    mode.  Without it, the bare Yes/No prompt arrives in the worker's
     persistent session against whatever task framing the prior turn left
     behind — the agent reads it as task continuation and goes off running
-    unrelated tools.  Passing the same system prompt the initial synthesis
-    turn used keeps every turn under one framing.
+    unrelated tools.  It must be the *follow-up* variant
+    (:meth:`fido.prompts.Prompts.synthesis_followup_system_prompt`), not
+    the main synthesis system prompt — the latter demands a JSON-only
+    reply which would break the ``startswith("no")`` check (codex P1
+    on #1851).
     """
     if response.change_request is not None:
         return response
@@ -104,7 +107,7 @@ def _check_and_promote(
         verify_raw = agent.run_turn(
             _VERIFY_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
-            system_prompt=system_prompt,
+            system_prompt=followup_system_prompt,
             retry_on_preempt=True,
         )
         if not (verify_raw or "").strip().lower().startswith("no"):
@@ -117,7 +120,7 @@ def _check_and_promote(
         derived_raw = agent.run_turn(
             _DERIVE_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
-            system_prompt=system_prompt,
+            system_prompt=followup_system_prompt,
             retry_on_preempt=True,
         )
         derived = (derived_raw or "").strip()
@@ -307,6 +310,9 @@ def call_synthesis(
         Prompt builder (``Prompts`` instance).
     """
     system_prompt = prompts.synthesis_system_prompt(issue=issue, pr=pr)
+    followup_system_prompt = prompts.synthesis_followup_system_prompt(
+        issue=issue, pr=pr
+    )
     base_user_prompt = prompts.synthesis_prompt(
         comment_body, is_bot=is_bot, context=context
     )
@@ -349,7 +355,9 @@ def call_synthesis(
 
         if attempt > 0:
             log.info("synthesis: succeeded on attempt %d/%d", attempt + 1, MAX_RETRIES)
-        return _check_and_promote(response, agent, system_prompt=system_prompt)
+        return _check_and_promote(
+            response, agent, followup_system_prompt=followup_system_prompt
+        )
 
     raise SynthesisExhaustedError(
         f"synthesis exhausted {MAX_RETRIES} retries without a valid CommentResponse "

--- a/src/fido/synthesis_call.py
+++ b/src/fido/synthesis_call.py
@@ -66,7 +66,9 @@ _DERIVE_CHANGE_REQUEST_PROMPT: str = (
 
 
 def _check_and_promote(
-    response: CommentResponse, agent: ProviderAgent
+    response: CommentResponse,
+    agent: ProviderAgent,
+    system_prompt: str,
 ) -> CommentResponse:
     """Run a verification turn to detect unrecorded change requests.
 
@@ -87,6 +89,13 @@ def _check_and_promote(
 
     This enforces the invariant: prose promises must correspond to queued
     tasks (fixes #1218).
+
+    *system_prompt* anchors both follow-up turns in synthesis-reply mode
+    (#1850).  Without it, the bare Yes/No prompt arrives in the worker's
+    persistent session against whatever task framing the prior turn left
+    behind — the agent reads it as task continuation and goes off running
+    unrelated tools.  Passing the same system prompt the initial synthesis
+    turn used keeps every turn under one framing.
     """
     if response.change_request is not None:
         return response
@@ -95,6 +104,7 @@ def _check_and_promote(
         verify_raw = agent.run_turn(
             _VERIFY_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt=system_prompt,
             retry_on_preempt=True,
         )
         if not (verify_raw or "").strip().lower().startswith("no"):
@@ -107,6 +117,7 @@ def _check_and_promote(
         derived_raw = agent.run_turn(
             _DERIVE_CHANGE_REQUEST_PROMPT,
             allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt=system_prompt,
             retry_on_preempt=True,
         )
         derived = (derived_raw or "").strip()
@@ -338,7 +349,7 @@ def call_synthesis(
 
         if attempt > 0:
             log.info("synthesis: succeeded on attempt %d/%d", attempt + 1, MAX_RETRIES)
-        return _check_and_promote(response, agent)
+        return _check_and_promote(response, agent, system_prompt=system_prompt)
 
     raise SynthesisExhaustedError(
         f"synthesis exhausted {MAX_RETRIES} retries without a valid CommentResponse "

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1707,6 +1707,53 @@ class TestSynthesisSystemPrompt:
         assert "JSON" in result
 
 
+# ── Prompts.synthesis_followup_system_prompt ─────────────────────────────────
+
+
+class TestSynthesisFollowupSystemPrompt:
+    def test_includes_persona(self) -> None:
+        result = Prompts("I am Fido.").synthesis_followup_system_prompt()
+        assert "I am Fido." in result
+
+    def test_drops_json_only_directive(self) -> None:
+        """#1850 codex P1: the follow-up turn asks for a plain Yes/No
+        answer.  Reusing the JSON-only directive from the main synthesis
+        prompt would push the model toward wrapping its answer in JSON,
+        and ``startswith("no")`` would then fail on a ``{...`` reply."""
+        result = Prompts("persona").synthesis_followup_system_prompt()
+        # The main synthesis prompt says "Output ONLY the JSON object";
+        # the follow-up must NOT carry that directive.
+        assert "Output ONLY the JSON" not in result
+        assert "structured JSON response" not in result
+        # And it must explicitly steer the model away from JSON output.
+        assert "no JSON" in result
+
+    def test_active_context_included_when_issue_given(self) -> None:
+        """Same active-context anchoring as the main synthesis prompt —
+        the follow-up still needs the active issue/PR to reason about
+        what was queued."""
+        issue = ActiveIssue(number=7, title="Fix crash", body="some body")
+        result = Prompts("persona").synthesis_followup_system_prompt(issue=issue)
+        assert "## Active issue" in result
+        assert "#7: Fix crash" in result
+
+    def test_active_context_no_pr_section_when_pr_is_none(self) -> None:
+        issue = ActiveIssue(number=7, title="Fix crash", body="")
+        result = Prompts("persona").synthesis_followup_system_prompt(
+            issue=issue, pr=None
+        )
+        assert "## Active PR" not in result
+
+    def test_active_context_includes_pr_when_given(self) -> None:
+        issue = ActiveIssue(number=7, title="Fix crash", body="")
+        pr = ActivePR(
+            number=42, title="Fix the crash", body="", url="https://example/42"
+        )
+        result = Prompts("persona").synthesis_followup_system_prompt(issue=issue, pr=pr)
+        assert "## Active PR" in result
+        assert "PR #42: Fix the crash" in result
+
+
 # ── Prompts.synthesis_prompt ─────────────────────────────────────────────────
 
 

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -58,9 +58,11 @@ def _make_agent(return_value: str | list[str]) -> MagicMock:
 def _make_prompts(
     system: str = "sys",
     user: str = "user",
+    followup_system: str = "followup-sys",
 ) -> MagicMock:
     prompts = MagicMock()
     prompts.synthesis_system_prompt.return_value = system
+    prompts.synthesis_followup_system_prompt.return_value = followup_system
     prompts.synthesis_prompt.return_value = user
     return prompts
 
@@ -728,33 +730,43 @@ class TestCallSynthesisVerificationTurn:
         _, kwargs = agent.run_turn.call_args_list[2]
         assert kwargs.get("allowed_tools") == READ_ONLY_ALLOWED_TOOLS
 
-    def test_verify_turn_carries_synthesis_system_prompt(self) -> None:
-        """#1850: the verify turn must pass the same ``system_prompt`` the
-        initial synthesis turn used.  The worker's persistent ClaudeSession
-        has no anchor across turns — a bare Yes/No prompt against task
-        framing is read as task continuation, and the agent goes off
-        running unrelated tools (observed on PR #1842, 84-second turn
-        before the reply landed)."""
+    def test_verify_turn_carries_followup_system_prompt(self) -> None:
+        """#1850: the verify turn must pass the *follow-up* synthesis
+        system prompt, not the main one.  The worker's persistent
+        ClaudeSession has no anchor across turns — a bare Yes/No prompt
+        against task framing is read as task continuation, and the agent
+        goes off running unrelated tools (observed on PR #1842, 84-second
+        turn before the reply landed).  The follow-up variant strips the
+        JSON-only directive so ``startswith("no")`` actually works
+        (codex P1)."""
         raw = _make_raw(reply_text="Looks fine.", change_request=None)
         agent = _make_agent([raw, "Yes"])
-        prompts = _make_prompts(system="SYNTHESIS_SYS")
+        prompts = _make_prompts(
+            system="SYNTHESIS_JSON_ONLY", followup_system="SYNTHESIS_FOLLOWUP"
+        )
 
         call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
+        # First turn: main synthesis with the JSON-only system prompt.
+        _, synth_kwargs = agent.run_turn.call_args_list[0]
+        assert synth_kwargs.get("system_prompt") == "SYNTHESIS_JSON_ONLY"
+        # Second turn: verify with the follow-up system prompt.
         _, verify_kwargs = agent.run_turn.call_args_list[1]
-        assert verify_kwargs.get("system_prompt") == "SYNTHESIS_SYS"
+        assert verify_kwargs.get("system_prompt") == "SYNTHESIS_FOLLOWUP"
 
-    def test_derive_turn_carries_synthesis_system_prompt(self) -> None:
+    def test_derive_turn_carries_followup_system_prompt(self) -> None:
         """#1850: the derive turn (after a No verify) must also carry the
-        synthesis ``system_prompt`` so the agent stays in reply mode."""
+        follow-up synthesis system prompt — same plain-text framing."""
         raw = _make_raw(reply_text="Looks fine.", change_request=None)
         agent = _make_agent([raw, "No", "Add missing tests"])
-        prompts = _make_prompts(system="SYNTHESIS_SYS")
+        prompts = _make_prompts(
+            system="SYNTHESIS_JSON_ONLY", followup_system="SYNTHESIS_FOLLOWUP"
+        )
 
         call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
 
         _, derive_kwargs = agent.run_turn.call_args_list[2]
-        assert derive_kwargs.get("system_prompt") == "SYNTHESIS_SYS"
+        assert derive_kwargs.get("system_prompt") == "SYNTHESIS_FOLLOWUP"
 
     def test_verify_turn_exception_returns_original_response(self) -> None:
         """A transport error in the verify turn must not discard the synthesis result."""

--- a/tests/test_synthesis_call.py
+++ b/tests/test_synthesis_call.py
@@ -728,6 +728,34 @@ class TestCallSynthesisVerificationTurn:
         _, kwargs = agent.run_turn.call_args_list[2]
         assert kwargs.get("allowed_tools") == READ_ONLY_ALLOWED_TOOLS
 
+    def test_verify_turn_carries_synthesis_system_prompt(self) -> None:
+        """#1850: the verify turn must pass the same ``system_prompt`` the
+        initial synthesis turn used.  The worker's persistent ClaudeSession
+        has no anchor across turns — a bare Yes/No prompt against task
+        framing is read as task continuation, and the agent goes off
+        running unrelated tools (observed on PR #1842, 84-second turn
+        before the reply landed)."""
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "Yes"])
+        prompts = _make_prompts(system="SYNTHESIS_SYS")
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        _, verify_kwargs = agent.run_turn.call_args_list[1]
+        assert verify_kwargs.get("system_prompt") == "SYNTHESIS_SYS"
+
+    def test_derive_turn_carries_synthesis_system_prompt(self) -> None:
+        """#1850: the derive turn (after a No verify) must also carry the
+        synthesis ``system_prompt`` so the agent stays in reply mode."""
+        raw = _make_raw(reply_text="Looks fine.", change_request=None)
+        agent = _make_agent([raw, "No", "Add missing tests"])
+        prompts = _make_prompts(system="SYNTHESIS_SYS")
+
+        call_synthesis("comment", is_bot=False, agent=agent, prompts=prompts)
+
+        _, derive_kwargs = agent.run_turn.call_args_list[2]
+        assert derive_kwargs.get("system_prompt") == "SYNTHESIS_SYS"
+
     def test_verify_turn_exception_returns_original_response(self) -> None:
         """A transport error in the verify turn must not discard the synthesis result."""
         raw = _make_raw(reply_text="Original reply.", change_request=None)


### PR DESCRIPTION
## Summary

Fixes #1850 — synthesis verification turn was running un-anchored on the worker's persistent ``ClaudeSession`` and burning ~80s on unrelated task work before the reply could land.

Two-line behaviour change: ``_check_and_promote`` now takes ``system_prompt`` and passes it on both the verify and derive ``run_turn`` calls.  The synthesis turn already anchored itself with that system prompt; the follow-ups now do too, so every synthesis turn shares one framing.

See #1850 for the full root-cause trace (journald timeline for PR #1842's \"Yesss\" reply).

## Test plan

- [x] New ``test_verify_turn_carries_synthesis_system_prompt`` — Yes-verify path
- [x] New ``test_derive_turn_carries_synthesis_system_prompt`` — No-verify path
- [x] Existing 78 tests in ``test_synthesis_call.py`` pass
- [ ] ``./fido ci`` — full coverage run
- [ ] Dogfood on next reply-without-change-request comment (e.g. a celebration) — should land in ~5s rather than ~90s