### PR TITLE
HOL-3 (#1897): require non-empty narrative on every IntentVerdict outcome

### DIFF
--- a/src/fido/prompts.py
+++ b/src/fido/prompts.py
@@ -660,26 +660,31 @@ class Prompts:
             '    "ops": [<op record>, ...],\n'
             '    "affected_task_ids": ["<task-id>", ...],\n'
             '    "by_intent_comment_id": <int | null>,\n'
-            '    "narrative": "<prose explanation>" | null\n'
+            '    "narrative": "<prose explanation>"   // REQUIRED on every outcome (HOL-3 / #1897)\n'
             "  }\n\n"
             "Outcome semantics (drives whether INV-E posts a follow-up "
             "reply-back):\n"
             "  honored    — ops fulfill the intent as asked.  Triage "
-            "already replied, no follow-up.\n"
+            "already replied, no follow-up.  Narrative still REQUIRED — "
+            "it lands in the per-task narrative chain so future rescopes "
+            "see why each task got the work it has.\n"
             "  reshaped   — ops fulfill part of the intent, framing "
             "changed (e.g. split into prereq + feature).  Material — "
-            "reply-back required.  Narrative MUST be non-empty.\n"
+            "reply-back required.  Narrative REQUIRED.\n"
             "  superseded — another intent in this batch overrode this "
             "one in whole or part.  Set ``by_intent_comment_id`` to "
             "the winning intent's comment id.  Material when authors "
             "differ; self-correction (no reply) when same author.  "
-            "Narrative MUST be non-empty.  ``ops`` may be non-empty "
+            "Narrative REQUIRED.  ``ops`` may be non-empty "
             'for *partial* supersedence (e.g. "paint and make it '
             'red" → "no, green": keep the paint op, supersede only '
             "the color component).\n"
             "  no_op      — intent acknowledged but produces no task "
             "changes (chat ack, or request already satisfied).  ``ops`` "
-            "and ``affected_task_ids`` MUST be empty.\n\n"
+            "and ``affected_task_ids`` MUST be empty.  Narrative "
+            "REQUIRED — the user's request is being dropped, so the "
+            "reason has to land in the reply-back; without a narrative "
+            "we'd silently drop the ask (PR #1890 / HOL-3).\n\n"
             "Op schema (each entry of a verdict's ``ops`` array):\n"
             '  {"op": "keep", "id": "<existing-id>"}\n'
             "      — leave the task unchanged\n"
@@ -753,8 +758,7 @@ class Prompts:
             '    "ops": [<op>, ...],\n'
             '    "affected_task_ids": ["<task-id>", ...],\n'
             '    "by_intent_comment_id": <int | null — only when superseded>,\n'
-            '    "narrative": "<prose>" | null '
-            "(required when reshaped/superseded)\n"
+            '    "narrative": "<prose>"                 // REQUIRED on every outcome\n'
             "  }\n\n"
             "Op schema (recap):\n"
             '  {"op": "keep", "id": "<existing-id>"}\n'

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -1461,7 +1461,7 @@ def _parse_rescope_verdicts(
             "ops": [<op record>, ...],            // optional, default []
             "affected_task_ids": ["T1", ...],     // optional, default []
             "by_intent_comment_id": <int | null>, // optional, null default
-            "narrative": "..." | null             // optional, null default
+            "narrative": "..."                    // REQUIRED on every outcome (HOL-3 / #1897)
           },
           ...
         ]}

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -183,11 +183,14 @@ class IntentVerdict:
         prove this in Rocq; runtime asserts here).
     narrative:
         Opus's prose explanation of what happened.  Verbatim source
-        for the optional reply-back posted by INV-E (#1803) —
-        per the project memory ``voice_text_opus_not_templated``,
+        for the reply-back posted by INV-E (#1803) and the per-task
+        narrative chain Opus reads on subsequent rescopes (#1894
+        HOL-8) — per the project memory ``voice_text_opus_not_templated``,
         Fido-voice text is per-call Opus prose, not templated.
-        Required when ``outcome`` is ``reshaped`` or ``superseded``
-        (reply-back needs prose); optional otherwise.
+        Required on every outcome (HOL-3 / #1897): without a
+        narrative on ``honored`` and ``no_op`` verdicts the per-task
+        lineage loses history and the no_op-silent-drop pattern can
+        recur (PR #1890).
     """
 
     intent_comment_id: int
@@ -336,13 +339,12 @@ class IntentVerdict:
                 "supersedence pointer (codex P2 on #1802: reject contradictory "
                 "metadata at the boundary)"
             )
-        if (
-            self.outcome in ("reshaped", "superseded")
-            and not (self.narrative or "").strip()
-        ):
+        if not (self.narrative or "").strip():
             raise ValueError(
                 f"IntentVerdict outcome={self.outcome!r} requires non-empty "
-                "narrative — reply-back posts narrative verbatim per "
+                "narrative on every outcome (HOL-3 / #1897) — the per-task "
+                "narrative chain (#1894 HOL-8) accumulates every verdict's "
+                "narrative and Fido-voice reply-back posts it verbatim per "
                 "the voice-text-opus-not-templated convention"
             )
         if self.outcome == "no_op" and (self.ops or self.affected_task_ids):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -768,10 +768,13 @@ class TestRescopePromptVerdicts:
         result = Prompts("").rescope_prompt_verdicts(
             [self._task()], "", intents=[self._intent(1)]
         )
-        # honored / no_op explicitly do NOT warrant reply-back
+        # honored explicitly does NOT warrant reply-back
         assert "no follow-up" in result
-        # reshaped / superseded are material → narrative required
-        assert "Narrative MUST be non-empty" in result
+        # HOL-3 / #1897: narrative is REQUIRED on every outcome —
+        # honored / reshaped / superseded / no_op all carry one.
+        assert "Narrative REQUIRED" in result
+        # The no_op narrative IS the reply-back reason (PR #1890 fix).
+        assert "PR #1890" in result
 
     def test_supersedence_constraints_stated(self) -> None:
         result = Prompts("").rescope_prompt_verdicts(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1121,7 +1121,10 @@ def _intent(
 
 class TestParseRescopeVerdicts:
     def test_minimal_honored_verdict(self) -> None:
-        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"narrative": "as asked"}]}'
+        )
         verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
         assert errors == []
         assert len(verdicts) == 1
@@ -1151,7 +1154,8 @@ class TestParseRescopeVerdicts:
             '{"intent_comment_id": 1, "outcome": "superseded", '
             '"by_intent_comment_id": 2, '
             '"narrative": "color overridden"},'
-            '{"intent_comment_id": 2, "outcome": "honored"}'
+            '{"intent_comment_id": 2, "outcome": "honored", '
+            '"narrative": "winning color request honored"}'
             "]}"
         )
         verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1), _intent(2)])
@@ -1193,8 +1197,8 @@ class TestParseRescopeVerdicts:
     def test_duplicate_intent_comment_id_in_verdicts(self) -> None:
         raw = (
             '{"verdicts": ['
-            '{"intent_comment_id": 1, "outcome": "honored"},'
-            '{"intent_comment_id": 1, "outcome": "no_op"}'
+            '{"intent_comment_id": 1, "outcome": "honored", "narrative": "x"},'
+            '{"intent_comment_id": 1, "outcome": "no_op", "narrative": "y"}'
             "]}"
         )
         _, errors = _parse_rescope_verdicts(raw, [_intent(1)])
@@ -1272,7 +1276,7 @@ class TestParseRescopeVerdicts:
             ' "by_intent_comment_id": 2, "narrative": "x"},'
             '{"intent_comment_id": 2, "outcome": "superseded", '
             ' "by_intent_comment_id": 3, "narrative": "y"},'
-            '{"intent_comment_id": 3, "outcome": "honored"}'
+            '{"intent_comment_id": 3, "outcome": "honored", "narrative": "z"}'
             "]}"
         )
         verdicts, errors = _parse_rescope_verdicts(
@@ -1326,7 +1330,10 @@ class TestParseRescopeVerdicts:
     def test_absent_ops_defaults_to_empty(self) -> None:
         # Absent ``ops`` field is the documented "no ops" case —
         # default ``()`` is the right value, not an error.
-        raw = '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored"}]}'
+        raw = (
+            '{"verdicts": [{"intent_comment_id": 1, "outcome": "honored", '
+            '"narrative": "x"}]}'
+        )
         verdicts, errors = _parse_rescope_verdicts(raw, [_intent(1)])
         assert errors == []
         assert verdicts[0].ops == ()
@@ -4752,7 +4759,15 @@ class TestReorderTasksVerdictWiring:
         ]
         bad_raw = '{"operations": []}'  # ops envelope, not verdicts
         valid_raw = json.dumps(
-            {"verdicts": [{"intent_comment_id": 101, "outcome": "no_op"}]}
+            {
+                "verdicts": [
+                    {
+                        "intent_comment_id": 101,
+                        "outcome": "no_op",
+                        "narrative": "nothing to do",
+                    }
+                ]
+            }
         )
         agent = _client()
         agent.run_turn.side_effect = [bad_raw, valid_raw]
@@ -4865,6 +4880,7 @@ class TestReorderTasksVerdictWiring:
                         "intent_comment_id": 20,
                         "outcome": "honored",
                         "affected_task_ids": [t1["id"]],
+                        "narrative": "joint-honored sibling",
                     },
                 ]
             }
@@ -5015,6 +5031,7 @@ class TestFlattenVerdictsToOps:
                 outcome="honored",
                 ops=({"op": "keep", "id": "A"},),
                 affected_task_ids=("A",),
+                narrative="x",
             ),
             IntentVerdict(
                 intent_comment_id=2,
@@ -5024,6 +5041,7 @@ class TestFlattenVerdictsToOps:
                     {"op": "remove", "id": "C"},
                 ),
                 affected_task_ids=("B", "C"),
+                narrative="x",
             ),
         ]
         flat = _flatten_verdicts_to_ops(verdicts)
@@ -5052,6 +5070,7 @@ class TestFlattenVerdictsToOps:
                 },
             ),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         # Malformed value passed through; verdict id NOT injected.
@@ -5068,6 +5087,7 @@ class TestFlattenVerdictsToOps:
             outcome="honored",
             ops=({"op": "keep", "id": "T1", "contributing_intents": ""},),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         assert flat[0]["contributing_intents"] == ""
@@ -5089,6 +5109,7 @@ class TestFlattenVerdictsToOps:
                 },
             ),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         assert flat[0]["contributing_intents"] == {"10": "x"}
@@ -5111,6 +5132,7 @@ class TestFlattenVerdictsToOps:
                 },
             ),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         # After IntentVerdict's deep_freeze, the list became a tuple.
@@ -5134,6 +5156,7 @@ class TestFlattenVerdictsToOps:
                 },
             ),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         # After deep_freeze, list → tuple; bool-containing → passed through.
@@ -5150,6 +5173,7 @@ class TestFlattenVerdictsToOps:
             outcome="honored",
             ops=({"op": "keep", "id": "T1", "contributing_intents": 0},),
             affected_task_ids=("T1",),
+            narrative="x",
         )
         flat = _flatten_verdicts_to_ops([v])
         assert flat[0]["contributing_intents"] == 0

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -18,14 +18,20 @@ _ = (Iterator, Any)  # keep imports for type hints inside test bodies
 
 class TestIntentVerdictShape:
     def test_minimal_construction_with_outcome_honored(self) -> None:
-        """A fully-honored intent: just the intent id + outcome."""
-        v = IntentVerdict(intent_comment_id=42, outcome="honored")
+        """A fully-honored intent: id + outcome + narrative.
+
+        HOL-3 (#1897): narrative is required on every outcome — without
+        it the per-task narrative chain (#1894 HOL-8) loses history.
+        """
+        v = IntentVerdict(
+            intent_comment_id=42, outcome="honored", narrative="As requested."
+        )
         assert v.intent_comment_id == 42
         assert v.outcome == "honored"
         assert v.ops == ()
         assert v.affected_task_ids == ()
         assert v.by_intent_comment_id is None
-        assert v.narrative is None
+        assert v.narrative == "As requested."
 
     def test_construction_with_all_fields(self) -> None:
         v = IntentVerdict(
@@ -80,6 +86,7 @@ class TestIntentVerdictShape:
                 outcome="honored",
                 ops=(),
                 affected_task_ids=("T-fix-all",),
+                narrative="Jointly honored by the consolidated task.",
             )
             for cid in (1, 2, 3, 4)
         )
@@ -88,16 +95,23 @@ class TestIntentVerdictShape:
 
     def test_no_op_outcome(self) -> None:
         # Acknowledgement / "request already covered" verdict.  No ops,
-        # no affected tasks, no narrative needed.
-        v = IntentVerdict(intent_comment_id=999, outcome="no_op")
+        # no affected tasks — but narrative IS required (HOL-3 / #1897)
+        # because no_op is the requestor's "your ask was dropped"
+        # signal; without a reason the user has no idea what happened.
+        v = IntentVerdict(
+            intent_comment_id=999,
+            outcome="no_op",
+            narrative="Already covered by an in-flight task.",
+        )
         assert v.outcome == "no_op"
         assert v.ops == ()
         assert v.affected_task_ids == ()
+        assert v.narrative == "Already covered by an in-flight task."
 
     def test_frozen(self) -> None:
         # Verdict shape is frozen — once Opus emits it, the runtime
         # must not mutate.  Catches accidental in-place edits.
-        v = IntentVerdict(intent_comment_id=1, outcome="honored")
+        v = IntentVerdict(intent_comment_id=1, outcome="honored", narrative="x")
         try:
             v.outcome = "reshaped"  # type: ignore[misc]
         except dataclasses.FrozenInstanceError:
@@ -109,7 +123,7 @@ class TestIntentVerdictShape:
         # codex P1 on #1802: deep immutability — ops as a list lets
         # callers ``verdict.ops.append(...)`` past the frozen guard.
         # Tuple makes the in-place mutation a TypeError at boundary.
-        v = IntentVerdict(intent_comment_id=1, outcome="honored")
+        v = IntentVerdict(intent_comment_id=1, outcome="honored", narrative="x")
         assert isinstance(v.ops, tuple)
         assert isinstance(v.affected_task_ids, tuple)
 
@@ -153,8 +167,8 @@ class TestIntentVerdictShape:
         # Tuples are immutable so two verdicts sharing the default
         # empty tuple is safe (no foot-gun like a shared default
         # ``[]`` would have been).
-        a = IntentVerdict(intent_comment_id=1, outcome="honored")
-        b = IntentVerdict(intent_comment_id=2, outcome="honored")
+        a = IntentVerdict(intent_comment_id=1, outcome="honored", narrative="x")
+        b = IntentVerdict(intent_comment_id=2, outcome="honored", narrative="x")
         assert a.ops == b.ops == ()
         assert a.affected_task_ids == b.affected_task_ids == ()
 
@@ -183,9 +197,8 @@ class TestIntentVerdictValidation:
             )
 
     def test_reshaped_outcome_requires_narrative(self) -> None:
-        # codex P2 on #1802: reshaped means material change → reply-back
-        # fires → reply needs prose.  Empty narrative is a contract
-        # violation at the boundary.
+        # reshaped means material change → reply-back fires → reply
+        # needs prose.  Empty narrative is a contract violation.
         with pytest.raises(ValueError, match="narrative"):
             IntentVerdict(
                 intent_comment_id=10,
@@ -215,15 +228,30 @@ class TestIntentVerdictValidation:
                 narrative="   ",
             )
 
-    def test_honored_outcome_allows_blank_narrative(self) -> None:
-        # honored never warrants reply-back; narrative is optional.
-        v = IntentVerdict(intent_comment_id=10, outcome="honored")
-        assert v.narrative is None
+    def test_honored_outcome_requires_narrative(self) -> None:
+        # HOL-3 / #1897: narrative is required on EVERY outcome (not
+        # just reshaped/superseded).  The per-task narrative chain
+        # (#1894 HOL-8) accumulates one entry per verdict; without a
+        # honored-narrative, future rescopes can't reason about WHY a
+        # task got the work it has.
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(intent_comment_id=10, outcome="honored")
 
-    def test_no_op_outcome_allows_blank_narrative(self) -> None:
-        # no_op same as honored — never warrants reply-back.
-        v = IntentVerdict(intent_comment_id=10, outcome="no_op")
-        assert v.narrative is None
+    def test_no_op_outcome_requires_narrative(self) -> None:
+        # HOL-3 / #1897: no_op without narrative is the PR #1890 bug
+        # — Rob's intent silently dropped.  The narrative IS the
+        # reply-back reason ("why am I skipping this?").
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(intent_comment_id=10, outcome="no_op")
+
+    def test_honored_whitespace_only_narrative_rejected(self) -> None:
+        # Same substantively-non-empty rule as reshaped/superseded.
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(intent_comment_id=10, outcome="honored", narrative="  ")
+
+    def test_no_op_whitespace_only_narrative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="narrative"):
+            IntentVerdict(intent_comment_id=10, outcome="no_op", narrative="\t\n")
 
     def test_by_intent_comment_id_rejected_on_honored(self) -> None:
         # codex P2 round 2 on #1802: only ``superseded`` carries a
@@ -388,6 +416,7 @@ class TestIntentVerdictTypeChecks:
             intent_comment_id=1,
             outcome="honored",
             affected_task_ids=ids_gen(),  # type: ignore[arg-type]
+            narrative="x",
         )
         assert v.affected_task_ids == ("T1", "T2")
 
@@ -401,6 +430,7 @@ class TestIntentVerdictTypeChecks:
                 intent_comment_id=1,
                 outcome="no_op",
                 ops=({"op": "rewrite", "id": "T1"},),
+                narrative="x",
             )
 
     def test_no_op_rejects_non_empty_affected_task_ids(self) -> None:
@@ -409,4 +439,5 @@ class TestIntentVerdictTypeChecks:
                 intent_comment_id=1,
                 outcome="no_op",
                 affected_task_ids=("T1",),
+                narrative="x",
             )


### PR DESCRIPTION
## Summary

Closes #1897.  First implementation slice of epic #1894.

Tightens ``IntentVerdict.__post_init__`` so the non-empty narrative check fires on every outcome (``honored``, ``reshaped``, ``superseded``, ``no_op``), not just reshaped/superseded.  Directly closes the PR #1890 no_op-silent-drop failure mode at the data layer: Opus can no longer emit a verdict that drops an intent without a written reason.

Also updates the rescope_prompt_verdicts and parser nudge prompts so Opus understands narrative is required everywhere, with explicit per-outcome reasoning.

Parser change is structural — ``_parse_rescope_verdicts`` already catches every TypeError/ValueError from the ctor, so the tightening propagates automatically.

## Test plan

- [x] New tests pin the rule per outcome: ``test_honored_outcome_requires_narrative``, ``test_no_op_outcome_requires_narrative``, plus whitespace-only variants
- [x] Two prior "allows blank narrative" tests replaced (they documented the bug)
- [x] Existing IntentVerdict ctors updated to pass narrative where the test relies on the ctor SUCCEEDING; ctors whose tests check earlier validation rules stay narrative-less so the test still fires on the intended rule
- [x] Parser-side fixtures in ``TestParseRescopeVerdicts`` and reorder-wiring tests updated to include ``narrative`` on every verdict
- [x] ``test_outcome_semantics_distinguish_reply_back`` updated to assert the new "Narrative REQUIRED on every outcome" prompt text
- [x] ``./fido ci`` clean — 4527 tests, 100% coverage

## Follow-ups

HOL-5 (``TaskStatus.SKIPPED``) and HOL-6 (no_op → skipped marker task) build on this; they're what makes the no_op narrative actually visible as a queue artifact.