### PR TITLE
HOL-4 (#1898): mechanical reply-prose claim validators

### DIFF
--- a/src/fido/reply_prose_validators.py
+++ b/src/fido/reply_prose_validators.py
@@ -1,0 +1,232 @@
+"""Mechanical claim-grounding validators for reply prose (HOL-4 / #1898).
+
+When Fido's reply prose mentions a commit SHA, an issue/PR number, or a
+GitHub URL, the referenced entity must actually exist.  PR #1858's
+recurring "the work is in a recent commit" lies — the prose claimed a
+SHA that wasn't in git — fall under this shape.
+
+This module is the **mechanical** validator: regex-extracts the claims
+out of prose, calls a cheap existence check on each, and returns a list
+of errors.  It does NOT decide what to do with the errors — the caller
+(synthesis flow, reply-emission path) decides whether to fail closed,
+retry, or surface the errors back to the LLM.
+
+The richer LLM critic (HOL-18 / #1912) layers on top: it catches
+semantic claim drift the regex can't see (e.g. "I refactored module X"
+when the diff didn't touch X).  Together they form Layer 1 + Layer 2
+of #1894's critic-gated architecture.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Protocol
+
+# ── claim shapes ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class CommitClaim:
+    """One ``commit <sha>`` reference extracted from reply prose.
+
+    ``sha`` is the literal token matched (7-40 hex chars).  ``offset``
+    is the byte offset of the SHA within the prose, for error
+    reporting.
+    """
+
+    sha: str
+    offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class IssueOrPrNumberClaim:
+    """One ``#<number>`` reference extracted from reply prose.
+
+    Issues and PRs share GitHub's numeric namespace per repo, so the
+    existence check uses the issues endpoint (which returns PRs too).
+    """
+
+    number: int
+    offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubUrlClaim:
+    """One full ``https://github.com/...`` reference extracted from prose.
+
+    Covers ``commit/<sha>``, ``issues/<n>``, and ``pull/<n>`` URLs.
+    The ``kind`` field tells the validator which existence check to
+    run.
+    """
+
+    repo: str  # "owner/name"
+    kind: str  # "commit" | "issue" | "pr"
+    ref: str  # SHA for commit, str(number) for issue/pr
+    offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimError:
+    """One validation failure: the prose claim doesn't resolve.
+
+    ``message`` is human-readable (suitable for nudging the LLM or for
+    surfacing to a reviewer); ``offset`` is the offset of the failing
+    claim within the original prose, for highlighting.
+    """
+
+    message: str
+    offset: int
+
+
+# ── existence-checker protocol ──────────────────────────────────────────────
+
+
+class ClaimChecker(Protocol):
+    """Existence-check collaborator for claim validators.
+
+    Production wires this to a thin :class:`~fido.github.GitHub`-backed
+    adapter; tests pass hand-rolled fakes per the project's
+    no-MagicMock rule.  Each method returns ``True`` iff the referenced
+    entity exists in the given repo.
+    """
+
+    def commit_exists(self, repo: str, sha: str) -> bool: ...
+
+    def issue_or_pr_exists(self, repo: str, number: int) -> bool: ...
+
+
+# ── regex extractors ────────────────────────────────────────────────────────
+
+# ``commit a1b2c3d`` / ``commit a1b2c3d4e5f6...`` — 7 to 40 hex chars
+# after the word ``commit`` (case-insensitive), bounded by word break.
+# Bare backticks are tolerated around the SHA (the markdown form Fido
+# writes most of the time): ``commit `a1b2c3d` `` matches the SHA.
+_COMMIT_SHA_PATTERN = re.compile(
+    r"\bcommit\s+`?([0-9a-f]{7,40})`?\b",
+    re.IGNORECASE,
+)
+
+# ``#123`` — numeric issue / PR reference.  Must be preceded by either
+# the start of the string or whitespace / punctuation so we don't match
+# ``foo#123`` (a colour code, anchor fragment, etc.).
+_ISSUE_PR_NUMBER_PATTERN = re.compile(
+    r"(?:^|(?<=[\s(\[]))#([1-9][0-9]*)\b",
+)
+
+# ``https://github.com/owner/repo/commit/<sha>`` etc.  ``kind`` group
+# distinguishes commit vs issues vs pull.  Trailing slash + fragment +
+# query are tolerated; the captured ref is the bare SHA / number.
+_GITHUB_URL_PATTERN = re.compile(
+    r"https://github\.com/([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)/"
+    r"(commit|issues|pull)/"
+    r"([0-9a-f]{7,40}|[1-9][0-9]*)\b",
+    re.IGNORECASE,
+)
+
+
+def extract_commit_claims(text: str) -> list[CommitClaim]:
+    """Return every ``commit <sha>`` claim found in *text*."""
+    return [
+        CommitClaim(sha=m.group(1).lower(), offset=m.start(1))
+        for m in _COMMIT_SHA_PATTERN.finditer(text)
+    ]
+
+
+def extract_issue_or_pr_number_claims(text: str) -> list[IssueOrPrNumberClaim]:
+    """Return every ``#<number>`` claim found in *text*.
+
+    Numbers that are obviously not issue / PR refs — addresses inside
+    URLs like ``#discussion_r123`` or ``#issuecomment-456`` — are
+    naturally excluded by the leading-word-break requirement (the URL
+    fragment introducer ``#`` isn't preceded by whitespace / brackets).
+    """
+    return [
+        IssueOrPrNumberClaim(number=int(m.group(1)), offset=m.start(1))
+        for m in _ISSUE_PR_NUMBER_PATTERN.finditer(text)
+    ]
+
+
+def extract_github_url_claims(text: str) -> list[GitHubUrlClaim]:
+    """Return every ``https://github.com/...`` claim found in *text*."""
+    out: list[GitHubUrlClaim] = []
+    for m in _GITHUB_URL_PATTERN.finditer(text):
+        kind_token = m.group(2).lower()
+        kind = (
+            "pr"
+            if kind_token == "pull"
+            else ("commit" if kind_token == "commit" else "issue")
+        )
+        ref = m.group(3).lower() if kind == "commit" else m.group(3)
+        out.append(
+            GitHubUrlClaim(repo=m.group(1), kind=kind, ref=ref, offset=m.start())
+        )
+    return out
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+
+def validate_reply_prose_claims(
+    text: str,
+    *,
+    repo: str,
+    checker: ClaimChecker,
+) -> list[ClaimError]:
+    """Validate every claim in *text* against *checker*.
+
+    Walks the three claim families:
+
+    1. ``commit <sha>`` references (interpreted against *repo*).
+    2. ``#<number>`` references (interpreted against *repo*).
+    3. Full ``https://github.com/...`` URLs (interpreted against the
+       URL's own ``owner/name``; *repo* is ignored for these).
+
+    Returns the list of failures.  Empty list means every claim
+    resolved — the prose is grounded.  Callers decide whether to fail
+    closed (block posting) or retry (nudge the LLM with the errors).
+    """
+    errors: list[ClaimError] = []
+
+    for commit in extract_commit_claims(text):
+        if not checker.commit_exists(repo, commit.sha):
+            errors.append(
+                ClaimError(
+                    message=(
+                        f"reply prose claims commit {commit.sha} in {repo}, "
+                        "but the commit does not exist"
+                    ),
+                    offset=commit.offset,
+                )
+            )
+
+    for ref in extract_issue_or_pr_number_claims(text):
+        if not checker.issue_or_pr_exists(repo, ref.number):
+            errors.append(
+                ClaimError(
+                    message=(
+                        f"reply prose claims issue/PR #{ref.number} in {repo}, "
+                        "but the issue/PR does not exist"
+                    ),
+                    offset=ref.offset,
+                )
+            )
+
+    for url in extract_github_url_claims(text):
+        exists = (
+            checker.commit_exists(url.repo, url.ref)
+            if url.kind == "commit"
+            else checker.issue_or_pr_exists(url.repo, int(url.ref))
+        )
+        if not exists:
+            errors.append(
+                ClaimError(
+                    message=(
+                        f"reply prose claims {url.kind} {url.ref} in {url.repo}, "
+                        "but the entity does not exist"
+                    ),
+                    offset=url.offset,
+                )
+            )
+
+    return errors

--- a/tests/test_reply_prose_validators.py
+++ b/tests/test_reply_prose_validators.py
@@ -1,0 +1,286 @@
+"""Tests for the mechanical reply-prose claim validators (HOL-4 / #1898)."""
+
+from dataclasses import dataclass, field
+
+from fido.reply_prose_validators import (
+    ClaimError,
+    CommitClaim,
+    GitHubUrlClaim,
+    IssueOrPrNumberClaim,
+    extract_commit_claims,
+    extract_github_url_claims,
+    extract_issue_or_pr_number_claims,
+    validate_reply_prose_claims,
+)
+
+# ── hand-rolled ClaimChecker fakes (no MagicMock per project memory) ──────────
+#
+# ``ClaimChecker`` in production is a :class:`typing.Protocol`; this fake
+# implements the same method signatures via duck typing rather than
+# subclassing (Protocols don't make sense as runtime base classes).
+
+
+@dataclass
+class _StaticChecker:
+    """Checker that returns True for the configured (repo, ref) pairs.
+
+    Two sets: ``commits`` keyed by ``(repo, sha)`` and ``issues_prs``
+    keyed by ``(repo, number)``.  Any lookup not in either set returns
+    False.
+    """
+
+    commits: set[tuple[str, str]] = field(default_factory=set)
+    issues_prs: set[tuple[str, int]] = field(default_factory=set)
+    calls: list[tuple[str, str, str | int]] = field(default_factory=list)
+
+    def commit_exists(self, repo: str, sha: str) -> bool:
+        self.calls.append(("commit", repo, sha))
+        return (repo, sha) in self.commits
+
+    def issue_or_pr_exists(self, repo: str, number: int) -> bool:
+        self.calls.append(("issue_or_pr", repo, number))
+        return (repo, number) in self.issues_prs
+
+
+# ── extract_commit_claims ─────────────────────────────────────────────────────
+
+
+class TestExtractCommitClaims:
+    def test_empty_text_returns_empty(self) -> None:
+        assert extract_commit_claims("") == []
+
+    def test_no_commit_word_returns_empty(self) -> None:
+        # "abc1234" alone is not a claim — must follow the word ``commit``.
+        assert extract_commit_claims("see abc1234") == []
+
+    def test_short_sha_seven_chars(self) -> None:
+        result = extract_commit_claims("Done in commit abc1234.")
+        assert result == [CommitClaim(sha="abc1234", offset=len("Done in commit "))]
+
+    def test_long_sha_forty_chars(self) -> None:
+        sha = "0" * 40
+        result = extract_commit_claims(f"see commit {sha} for details")
+        assert result == [CommitClaim(sha=sha, offset=len("see commit "))]
+
+    def test_sha_in_backticks_extracted(self) -> None:
+        # Fido's voice usually wraps refs in backticks.
+        result = extract_commit_claims("Landed in commit `a1b2c3d`.")
+        assert result == [CommitClaim(sha="a1b2c3d", offset=len("Landed in commit `"))]
+
+    def test_multiple_commit_claims(self) -> None:
+        text = "First commit abc1234, then commit def5678."
+        result = extract_commit_claims(text)
+        assert [c.sha for c in result] == ["abc1234", "def5678"]
+
+    def test_case_insensitive_commit_word(self) -> None:
+        result = extract_commit_claims("See Commit abc1234.")
+        assert [c.sha for c in result] == ["abc1234"]
+
+    def test_sha_lowercased(self) -> None:
+        # SHAs in the wild can be upper or mixed case; normalise.
+        result = extract_commit_claims("see commit ABC1234")
+        assert [c.sha for c in result] == ["abc1234"]
+
+    def test_too_short_sha_not_matched(self) -> None:
+        # < 7 chars — not a valid SHA.
+        assert extract_commit_claims("commit abc123") == []
+
+    def test_too_long_sha_not_matched(self) -> None:
+        # > 40 chars — not a valid SHA.
+        assert extract_commit_claims("commit " + "0" * 41) == []
+
+
+# ── extract_issue_or_pr_number_claims ─────────────────────────────────────────
+
+
+class TestExtractIssueOrPrNumberClaims:
+    def test_empty_text_returns_empty(self) -> None:
+        assert extract_issue_or_pr_number_claims("") == []
+
+    def test_basic_number_claim(self) -> None:
+        result = extract_issue_or_pr_number_claims("see #1858 for context")
+        assert result == [IssueOrPrNumberClaim(number=1858, offset=len("see #"))]
+
+    def test_multiple_number_claims(self) -> None:
+        result = extract_issue_or_pr_number_claims("filed #1894 closes #1855")
+        assert [c.number for c in result] == [1894, 1855]
+
+    def test_number_at_start_of_string(self) -> None:
+        # No preceding whitespace, but start-of-string is a valid boundary.
+        result = extract_issue_or_pr_number_claims("#1 done")
+        assert [c.number for c in result] == [1]
+
+    def test_number_after_open_paren(self) -> None:
+        result = extract_issue_or_pr_number_claims("queue (#1234) is open")
+        assert [c.number for c in result] == [1234]
+
+    def test_number_after_open_bracket(self) -> None:
+        result = extract_issue_or_pr_number_claims("[#42]")
+        assert [c.number for c in result] == [42]
+
+    def test_url_fragment_not_matched(self) -> None:
+        # ``foo#discussion_r123`` is a URL fragment, not an issue ref.
+        # The leading-whitespace requirement excludes it.
+        result = extract_issue_or_pr_number_claims("see http://x/y#discussion_r123")
+        assert result == []
+
+    def test_anchored_to_identifier_not_matched(self) -> None:
+        # ``foo#123`` glued to an identifier — not what we mean.
+        result = extract_issue_or_pr_number_claims("color foo#abc")
+        assert result == []
+
+    def test_zero_prefixed_not_matched(self) -> None:
+        # ``#01234`` is not a real issue id.
+        result = extract_issue_or_pr_number_claims("see #01234")
+        assert result == []
+
+    def test_zero_alone_not_matched(self) -> None:
+        # ``#0`` is not a valid GitHub issue id.
+        result = extract_issue_or_pr_number_claims("see #0")
+        assert result == []
+
+
+# ── extract_github_url_claims ─────────────────────────────────────────────────
+
+
+class TestExtractGitHubUrlClaims:
+    def test_empty_text_returns_empty(self) -> None:
+        assert extract_github_url_claims("") == []
+
+    def test_commit_url_extracted(self) -> None:
+        text = "see https://github.com/FidoCanCode/home/commit/abc1234 for the fix"
+        result = extract_github_url_claims(text)
+        assert result == [
+            GitHubUrlClaim(
+                repo="FidoCanCode/home", kind="commit", ref="abc1234", offset=4
+            )
+        ]
+
+    def test_issue_url_extracted(self) -> None:
+        text = "filed https://github.com/FidoCanCode/home/issues/1894"
+        result = extract_github_url_claims(text)
+        assert result == [
+            GitHubUrlClaim(repo="FidoCanCode/home", kind="issue", ref="1894", offset=6)
+        ]
+
+    def test_pull_url_normalized_to_pr(self) -> None:
+        # GitHub URLs use ``/pull/`` but we normalise to ``"pr"`` kind.
+        text = "see https://github.com/FidoCanCode/home/pull/1929"
+        result = extract_github_url_claims(text)
+        assert [(c.kind, c.ref) for c in result] == [("pr", "1929")]
+
+    def test_multiple_urls_in_one_text(self) -> None:
+        text = (
+            "compare https://github.com/FidoCanCode/home/commit/abc1234 "
+            "with https://github.com/FidoCanCode/home/pull/1929"
+        )
+        result = extract_github_url_claims(text)
+        assert [(c.kind, c.ref) for c in result] == [
+            ("commit", "abc1234"),
+            ("pr", "1929"),
+        ]
+
+    def test_owner_repo_with_dots_and_dashes(self) -> None:
+        text = "https://github.com/some-owner/repo.name/issues/1"
+        result = extract_github_url_claims(text)
+        assert result == [
+            GitHubUrlClaim(repo="some-owner/repo.name", kind="issue", ref="1", offset=0)
+        ]
+
+    def test_commit_sha_lowercased(self) -> None:
+        text = "https://github.com/o/r/commit/ABC1234"
+        result = extract_github_url_claims(text)
+        assert [c.ref for c in result] == ["abc1234"]
+
+
+# ── validate_reply_prose_claims (integration) ──────────────────────────────────
+
+
+class TestValidateReplyProseClaims:
+    def test_empty_text_no_errors(self) -> None:
+        checker = _StaticChecker()
+        assert validate_reply_prose_claims("", repo="o/r", checker=checker) == []
+        # No work done either.
+        assert checker.calls == []
+
+    def test_existing_commit_no_error(self) -> None:
+        checker = _StaticChecker(commits={("o/r", "abc1234")})
+        result = validate_reply_prose_claims(
+            "Done in commit abc1234.", repo="o/r", checker=checker
+        )
+        assert result == []
+        assert checker.calls == [("commit", "o/r", "abc1234")]
+
+    def test_missing_commit_yields_error(self) -> None:
+        checker = _StaticChecker()  # no commits configured
+        result = validate_reply_prose_claims(
+            "Done in commit deadbeef.", repo="o/r", checker=checker
+        )
+        assert len(result) == 1
+        assert isinstance(result[0], ClaimError)
+        assert "commit deadbeef" in result[0].message
+        assert "o/r" in result[0].message
+
+    def test_existing_issue_pr_no_error(self) -> None:
+        checker = _StaticChecker(issues_prs={("o/r", 1858)})
+        result = validate_reply_prose_claims("see #1858", repo="o/r", checker=checker)
+        assert result == []
+
+    def test_missing_issue_yields_error(self) -> None:
+        checker = _StaticChecker()
+        result = validate_reply_prose_claims("see #9999", repo="o/r", checker=checker)
+        assert len(result) == 1
+        assert "#9999" in result[0].message
+
+    def test_github_url_validated_against_url_owner_not_repo_arg(self) -> None:
+        # URL carries its OWN owner/name — repo= arg is ignored for URLs.
+        # An existing commit in the URL's own repo passes even if it
+        # doesn't exist in the repo= arg.
+        checker = _StaticChecker(commits={("other/repo", "abc1234")})
+        result = validate_reply_prose_claims(
+            "see https://github.com/other/repo/commit/abc1234",
+            repo="o/r",
+            checker=checker,
+        )
+        assert result == []
+
+    def test_multiple_failures_each_reported(self) -> None:
+        checker = _StaticChecker()  # nothing exists
+        text = (
+            "Done in commit abc1234, see also #9999 and "
+            "https://github.com/o/r/pull/12345 for context"
+        )
+        result = validate_reply_prose_claims(text, repo="o/r", checker=checker)
+        assert len(result) == 3
+        # Errors are returned in extraction order: commit, then #N, then URL.
+        assert "commit abc1234" in result[0].message
+        assert "#9999" in result[1].message
+        assert "pull" in result[2].message or "pr" in result[2].message
+
+    def test_mixed_existing_and_missing_only_missing_reported(self) -> None:
+        checker = _StaticChecker(
+            commits={("o/r", "abc1234")},
+            issues_prs={("o/r", 1858)},
+        )
+        text = "fixed in commit abc1234 (related to #1858, follow-up #9999)"
+        result = validate_reply_prose_claims(text, repo="o/r", checker=checker)
+        assert len(result) == 1
+        assert "#9999" in result[0].message
+
+    def test_offset_points_at_failing_claim(self) -> None:
+        checker = _StaticChecker()
+        text = "abcd commit deadbeef wxyz"
+        result = validate_reply_prose_claims(text, repo="o/r", checker=checker)
+        assert len(result) == 1
+        # Offset is the start of the SHA token itself.
+        assert text[result[0].offset : result[0].offset + 8] == "deadbeef"
+
+    def test_real_world_prose_no_false_positives(self) -> None:
+        # A typical Fido reply: prose plus a fido marker, no claim refs.
+        checker = _StaticChecker()
+        text = (
+            "Got it — I'll add the typed Protocol collaborator and remove "
+            "the callable slot.\n\n<!-- fido:reply-promise:abc -->"
+        )
+        result = validate_reply_prose_claims(text, repo="o/r", checker=checker)
+        assert result == []


### PR DESCRIPTION
## Summary

Closes #1898.  Layer 1 of #1894.

Pure-function validators that extract ``commit <sha>`` / ``#<number>`` / ``https://github.com/...`` claims from reply prose via regex and delegate existence checks to a typed ``ClaimChecker`` Protocol.  Returns ``ClaimError`` list with offsets.  Caller decides what to do.

Closes the recurring PR #1858 pattern of "the work is in a recent commit" lies at the mechanical layer.  HOL-18 (LLM critic) layers on top for semantic drift the regex can't see.

No production wiring in this slice — deliberate, HOL-18 composes the validator into the synthesis retry loop.

## Test plan

- [x] 37 tests cover each extractor's edge cases (short/long SHA, backticks, word boundaries, URL fragments excluded, dotted owner/repo names, case-insensitivity, etc.)
- [x] Integration tests cover existing / missing / multi-failure / mixed / offset-points-at-claim / real-world-prose-with-no-false-positives
- [x] Hand-rolled ``_StaticChecker`` dataclass — no MagicMock per project memory; records every call
- [x] ``./fido ci`` clean — 4562 tests, 100% coverage