### PR TITLE
HOL-5 (#1899): add TaskStatus.SKIPPED + oracle projections

### DIFF
--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -60,7 +60,13 @@ def _task_kind_for_oracle(task: dict[str, Any]) -> task_store_oracle.TaskKind:
 
 def _task_status_for_oracle(task: dict[str, Any]) -> task_store_oracle.TaskStatus:
     match task.get("status", TaskStatus.PENDING):
-        case TaskStatus.COMPLETED | "completed":
+        case TaskStatus.COMPLETED | "completed" | TaskStatus.SKIPPED | "skipped":
+            # SKIPPED (HOL-5 / #1899) projects to StatusCompleted at the
+            # oracle boundary: both are terminal for the picker (never
+            # selected, never block).  The SKIPPED-vs-COMPLETED
+            # distinction matters only for UI rendering (HOL-7) and
+            # reply-back narrative; the oracle's terminal predicate
+            # treats them identically.
             return task_store_oracle.StatusCompleted()
         case TaskStatus.BLOCKED | "blocked":
             return task_store_oracle.StatusBlocked()
@@ -79,7 +85,11 @@ def _thread_task_status_for_oracle(
     task: dict[str, Any],
 ) -> thread_resolve_oracle.TaskStatus:
     match task.get("status", TaskStatus.PENDING):
-        case TaskStatus.COMPLETED | "completed":
+        case TaskStatus.COMPLETED | "completed" | TaskStatus.SKIPPED | "skipped":
+            # SKIPPED (HOL-5 / #1899) projects to StatusCompleted: a
+            # skipped marker task doesn't block thread auto-resolve any
+            # more than a completed task does (auto-resolve already
+            # treats both as terminal via this projection).
             return thread_resolve_oracle.StatusCompleted()
         case TaskStatus.BLOCKED | "blocked":
             return thread_resolve_oracle.StatusBlocked()
@@ -354,7 +364,10 @@ def _rescope_task_status_for_oracle(
     task: dict[str, Any],
 ) -> rescope_oracle.TaskStatus:
     match task.get("status", TaskStatus.PENDING):
-        case TaskStatus.COMPLETED | "completed":
+        case TaskStatus.COMPLETED | "completed" | TaskStatus.SKIPPED | "skipped":
+            # SKIPPED (HOL-5 / #1899) projects to StatusCompleted: the
+            # rescope oracle's snapshot order treats both as terminal
+            # (already-handled tasks the rescope shouldn't re-touch).
             return rescope_oracle.StatusCompleted()
         case TaskStatus.BLOCKED | "blocked":
             return rescope_oracle.StatusBlocked()
@@ -2669,7 +2682,11 @@ def _inprogress_was_demoted(
       — the picker filters them; the magic-prefix smell that motivates
       this duplication is #1848.
     """
-    skip_statuses = (str(TaskStatus.COMPLETED), str(TaskStatus.BLOCKED))
+    skip_statuses = (
+        str(TaskStatus.COMPLETED),
+        str(TaskStatus.BLOCKED),
+        str(TaskStatus.SKIPPED),  # HOL-5 / #1899
+    )
     inprogress_id = inprogress_row.get("id")
     for task in result:
         if task.get("status") in skip_statuses:

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -17,6 +17,15 @@ class TaskStatus(StrEnum):
     COMPLETED = "completed"
     IN_PROGRESS = "in_progress"
     BLOCKED = "blocked"
+    # SKIPPED (HOL-5 / #1899): marker status for tasks created from
+    # ``no_op`` rescope verdicts.  Carries the verdict narrative so the
+    # requestor's "why was my ask dropped?" question has an answer on
+    # the queue; treated as terminal by the picker (never picked,
+    # never blocks) but distinct from COMPLETED so the PR-body
+    # formatter can render it under its own "Skipped" block (HOL-7).
+    # See PR #1890 for the no_op-silent-drop failure that motivated
+    # this status, and epic #1894 for the broader gate architecture.
+    SKIPPED = "skipped"
 
 
 @dataclass(frozen=True)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -929,7 +929,11 @@ def _ci_oracle_task_kind(task: Mapping[str, object]) -> ci_oracle.TaskKind:
 
 def _ci_oracle_task_status(task: Mapping[str, object]) -> ci_oracle.TaskStatus:
     match task.get("status", TaskStatus.PENDING):
-        case TaskStatus.COMPLETED | "completed":
+        case TaskStatus.COMPLETED | "completed" | TaskStatus.SKIPPED | "skipped":
+            # SKIPPED (HOL-5 / #1899) projects to StatusCompleted: the
+            # CI oracle's terminal predicate treats both as "no longer
+            # needs work" so a skipped marker task can't be a barrier
+            # to CI work going first.
             return ci_oracle.StatusCompleted()
         case TaskStatus.BLOCKED | "blocked":
             return ci_oracle.StatusBlocked()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -129,6 +129,22 @@ class TestTaskStoreOracleAdapter:
         )
         assert isinstance(_task_status_for_oracle({}), oracle.StatusPending)
 
+    def test_task_status_skipped_maps_to_completed_at_oracle(self) -> None:
+        # HOL-5 / #1899: SKIPPED projects to StatusCompleted at the
+        # oracle boundary — terminal for picker purposes.  The
+        # SKIPPED-vs-COMPLETED distinction is retained at the Python
+        # layer for UI (HOL-7) and reply-back narrative; the oracle
+        # only needs to know terminal vs not.  Both string and enum
+        # forms map.
+        assert isinstance(
+            _task_status_for_oracle({"status": TaskStatus.SKIPPED}),
+            oracle.StatusCompleted,
+        )
+        assert isinstance(
+            _task_status_for_oracle({"status": "skipped"}),
+            oracle.StatusCompleted,
+        )
+
     def test_task_source_comment_maps_thread_metadata(self) -> None:
         assert _task_source_comment_for_oracle({"thread": {"comment_id": "42"}}) == 42
         assert _task_source_comment_for_oracle({"thread": {}}) is None
@@ -223,6 +239,16 @@ class TestRescopeOracleAdapter:
             == "StatusBlocked"
         )
         assert type(_rescope_task_status_for_oracle({})).__name__ == "StatusPending"
+        # HOL-5 / #1899: SKIPPED projects to StatusCompleted in the
+        # rescope oracle too — the snapshot-order computation treats it
+        # as already-terminal, so the rescope won't try to re-mutate a
+        # skipped marker.
+        assert (
+            type(
+                _rescope_task_status_for_oracle({"status": TaskStatus.SKIPPED})
+            ).__name__
+            == "StatusCompleted"
+        )
         assert (
             _rescope_task_source_comment_for_oracle({"thread": {"comment_id": "42"}})
             == 42
@@ -4130,6 +4156,19 @@ class TestReorderTasks:
         ip = {"id": "ip", "status": "in_progress", "type": "spec"}
         result = [
             {"id": "done", "status": "completed", "type": "spec"},
+            ip,
+        ]
+        assert _inprogress_was_demoted(ip, result) is False
+
+    def test_inprogress_demoted_helper_skips_skipped_at_front(self) -> None:
+        # HOL-5 / #1899: SKIPPED is also terminal — a skipped marker
+        # task at the front of result must not count as demotion (the
+        # picker walks past it).  Same rule as completed.
+        from fido.tasks import _inprogress_was_demoted
+
+        ip = {"id": "ip", "status": "in_progress", "type": "spec"}
+        result = [
+            {"id": "skipped1", "status": "skipped", "type": "spec"},
             ip,
         ]
         assert _inprogress_was_demoted(ip, result) is False

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -410,3 +410,40 @@ class TestIntentVerdictTypeChecks:
                 outcome="no_op",
                 affected_task_ids=("T1",),
             )
+
+
+# ── TaskStatus.SKIPPED (HOL-5 / #1899) ───────────────────────────────────────
+
+
+class TestTaskStatusSkipped:
+    """HOL-5 (#1899): SKIPPED enum value for no_op marker tasks.
+
+    Pinned at the type layer; the projections into the per-oracle
+    TaskStatus types are exercised by tests/test_tasks.py and
+    tests/test_worker.py — there's no extra wiring to test here other
+    than membership + value.
+    """
+
+    def test_skipped_member_present(self) -> None:
+        from fido.types import TaskStatus
+
+        assert hasattr(TaskStatus, "SKIPPED")
+
+    def test_skipped_string_value(self) -> None:
+        from fido.types import TaskStatus
+
+        # Wire-format value is the lowercase string we write into
+        # tasks.json — same convention as the other members.
+        assert str(TaskStatus.SKIPPED) == "skipped"
+
+    def test_skipped_distinct_from_completed_and_blocked(self) -> None:
+        # The whole point of SKIPPED is to be distinguishable from
+        # COMPLETED for UI/lineage purposes, and from BLOCKED because
+        # SKIPPED is terminal (never picked, never unblockable) while
+        # BLOCKED is pending-but-paused.
+        from fido.types import TaskStatus
+
+        assert TaskStatus.SKIPPED != TaskStatus.COMPLETED
+        assert TaskStatus.SKIPPED != TaskStatus.BLOCKED
+        assert TaskStatus.SKIPPED != TaskStatus.PENDING
+        assert TaskStatus.SKIPPED != TaskStatus.IN_PROGRESS

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -10422,6 +10422,19 @@ class TestPickNextTask:
         pending = self._task("Pending task")
         assert _pick_next_task([completed, pending]) is pending
 
+    def test_ignores_skipped_when_selecting(self) -> None:
+        # HOL-5 / #1899: SKIPPED is terminal — picker walks past it
+        # the same way it walks past completed.  Skipped marker tasks
+        # (from no_op rescope verdicts) must never become work.
+        skipped = self._task("Dropped ask", status="skipped")
+        pending = self._task("Real work")
+        assert _pick_next_task([skipped, pending]) is pending
+
+    def test_returns_none_when_only_skipped(self) -> None:
+        # An all-skipped queue has no work — never pick.
+        skipped = self._task("Dropped ask", status="skipped")
+        assert _pick_next_task([skipped]) is None
+
     def test_task_with_spec_type_not_prioritised(self) -> None:
         """A task with spec type is not treated as thread-originated."""
         spec = self._task("Regular task", task_type="spec")


### PR DESCRIPTION
## Summary

Closes #1899.  Prerequisite for HOL-6 (no_op verdict reducer creates a SKIPPED marker task) which closes today's PR #1890 no_op-silent-drop at the data layer.

New ``TaskStatus.SKIPPED`` enum value — terminal for the picker, distinct from COMPLETED/BLOCKED at the Python layer, projects to oracle's ``StatusCompleted`` so existing terminal predicates work unchanged.

## Test plan

- [x] ``TestTaskStatusSkipped`` — member + string value + distinctness
- [x] Oracle projection tests for task_store + rescope oracles
- [x] ``_inprogress_was_demoted`` skips skipped-at-front
- [x] ``_pick_next_task`` ignores skipped + returns None when only-skipped
- [x] ``./fido ci`` clean — 4532 tests, 100% coverage

## Follow-ups

HOL-6 (#1900) creates the marker task; HOL-7 (#1901) renders SKIPPED in the PR body; HOL-25/HOL-28 use the carried narrative in per-thread reply prose.