### PR TITLE
HOL-21 of #1894: unified stuck-on-critic sentinel (closes #1915)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -412,6 +412,131 @@ _BUG_REPO = "FidoCanCode/home"
 _BUG_LABEL = "Bug"
 
 
+@dataclass(frozen=True)
+class StuckOnCriticContext:
+    """HOL-21 / #1915: context bundle for ``_file_stuck_on_critic_bug``.
+
+    Every critic that detects exhaustion (HOL-15..HOL-19) builds one
+    of these and hands it to the shared filing helper.  The shape is
+    deliberately critic-agnostic so the bug body, idempotency
+    marker, and title template are all uniform across emission
+    points — the auto-filed bug is recognizably the same shape
+    whether it came from intent-coverage exhaustion on a triage
+    reply or task-completion exhaustion on a worker commit.
+
+    Fields:
+
+    - ``emission_point``: short label identifying which critic
+      exhausted (``"intent-coverage"``, ``"task-completion"``, etc.).
+      Part of the idempotency key so two different critics
+      exhausting on the same target still file separate bugs.
+    - ``source_repo`` / ``source_pr``: where the exhaustion happened.
+    - ``target_kind`` / ``target_id``: what the critic was working on
+      when it exhausted (``"comment"``/``"task"``).  Part of the
+      idempotency key.
+    - ``source_link``: clickable URL to the target.
+    - ``gaps``: every failed verdict's gap text, in order.
+    - ``attempts_preview``: per-attempt response preview when
+      available (HOL-15/18 carry these; HOL-17 task-completion may
+      use the per-attempt commit summary instead; HOL-16/19 leave
+      empty when their exhaustion paths land).
+    """
+
+    emission_point: str
+    source_repo: str
+    source_pr: int
+    target_kind: str
+    target_id: str
+    source_link: str
+    gaps: tuple[str, ...]
+    attempts_preview: tuple[str, ...] = ()
+
+
+def _file_stuck_on_critic_bug(ctx: StuckOnCriticContext, *, gh: GitHub) -> str | None:
+    """HOL-21 / #1915: file (idempotently) a bug on :data:`_BUG_REPO`
+    for a critic exhaustion.
+
+    Returns the bug URL on success (whether newly filed or reused
+    from an idempotency-marker hit), or ``None`` when both the
+    marker search AND the create call fail — caller decides whether
+    to soften the BLOCKED-comment wording (no URL to cite) or carry
+    on silently.
+
+    Idempotency marker keyed on
+    ``(emission_point, source_repo, source_pr, target_kind, target_id)``
+    so retry attempts of the same exhaustion route reuse the
+    existing bug instead of spamming ``_BUG_REPO`` with duplicates.
+    Two different critics exhausting on the same target file
+    SEPARATE bugs because the emission point is part of the key —
+    different root causes warrant separate tickets.
+    """
+    bug_marker = (
+        f"<!-- critic-exhaustion: {ctx.emission_point}:"
+        f"{ctx.source_repo}#{ctx.source_pr}:"
+        f"{ctx.target_kind}:{ctx.target_id} -->"
+    )
+    bug_title = (
+        f"Bug: {ctx.emission_point} critic exhausted "
+        f"on {ctx.source_repo}#{ctx.source_pr} {ctx.target_kind} {ctx.target_id}"
+    )
+    gap_lines = (
+        "\n".join(f"  {i + 1}. {gap}" for i, gap in enumerate(ctx.gaps))
+        or "  (no gaps recorded)"
+    )
+    if ctx.attempts_preview:
+        attempts_block = "\n".join(
+            f"  {i + 1}. {preview!r}" for i, preview in enumerate(ctx.attempts_preview)
+        )
+    else:
+        attempts_block = "  (no per-attempt previews recorded)"
+    bug_body = (
+        f"## Critic exhaustion\n\n"
+        f"- Critic: `{ctx.emission_point}`\n"
+        f"- Source: {ctx.source_link}\n"
+        f"- Source repo / PR: `{ctx.source_repo}#{ctx.source_pr}`\n"
+        f"- Target: `{ctx.target_kind} {ctx.target_id}`\n"
+        f"- Attempts: {len(ctx.gaps)}\n\n"
+        f"## Critic gaps (one per attempt)\n\n{gap_lines}\n\n"
+        f"## Per-attempt previews\n\n{attempts_block}\n\n"
+        f"{bug_marker}\n"
+    )
+    try:
+        existing_bugs = gh.search_issues(_BUG_REPO, f'"{bug_marker}" in:body is:issue')
+    except Exception as search_exc:
+        log.warning(
+            "stuck-on-critic[%s]: bug-marker search failed (%s) — "
+            "proceeding to file (may create a duplicate)",
+            ctx.emission_point,
+            search_exc,
+        )
+        existing_bugs = []
+    if existing_bugs:
+        url = existing_bugs[0].get("html_url")
+        log.info(
+            "stuck-on-critic[%s]: existing bug found for %s#%d %s %s — reusing %s",
+            ctx.emission_point,
+            ctx.source_repo,
+            ctx.source_pr,
+            ctx.target_kind,
+            ctx.target_id,
+            url,
+        )
+        return str(url) if url else None
+    try:
+        return str(gh.create_issue(_BUG_REPO, bug_title, bug_body, labels=[_BUG_LABEL]))
+    except Exception as file_exc:
+        log.warning(
+            "stuck-on-critic[%s]: failed to auto-file bug for %s#%d %s %s (%s)",
+            ctx.emission_point,
+            ctx.source_repo,
+            ctx.source_pr,
+            ctx.target_kind,
+            ctx.target_id,
+            file_exc,
+        )
+        return None
+
+
 def _route_critic_exhausted_blocked(
     exc: "SynthesisCriticExhaustedError",
     target: CommentTarget,
@@ -458,74 +583,24 @@ def _route_critic_exhausted_blocked(
     """
     source_link = _insight_source_link(target)
 
-    bug_title = (
-        f"Bug: synthesis {exc.label} critic exhausted "
-        f"on {target.repo}#{target.pr} comment {target.comment_id}"
+    # HOL-21 / #1915: bug-filing is shared infrastructure now —
+    # ``_file_stuck_on_critic_bug`` handles the body, idempotency
+    # marker, and URL return for ALL critic exhaustion routes
+    # (synthesis critics here + per-leaf retry budgets for HOL-16/
+    # HOL-17/HOL-19 in their own modules).
+    bug_url = _file_stuck_on_critic_bug(
+        StuckOnCriticContext(
+            emission_point=exc.label,
+            source_repo=target.repo,
+            source_pr=target.pr,
+            target_kind="comment",
+            target_id=str(target.comment_id),
+            source_link=source_link,
+            gaps=tuple(exc.critic_gaps),
+            attempts_preview=tuple(exc.synthesis_attempts),
+        ),
+        gh=gh,
     )
-    gap_lines = "\n".join(f"  {i + 1}. {gap}" for i, gap in enumerate(exc.critic_gaps))
-    attempt_lines = "\n".join(
-        f"  {i + 1}. {preview!r}" for i, preview in enumerate(exc.synthesis_attempts)
-    )
-    # Codex on PR #1932: idempotency marker keyed on
-    # ``(critic_label, source_repo, source_pr, source_comment_id)``
-    # so a retry of this route (e.g. comment-post failed and the
-    # promise stayed claimed) doesn't file a SECOND bug for the same
-    # exhaustion.  Without this, transient GitHub failures spamming
-    # ``_BUG_REPO`` with duplicate Bug issues that obscure real
-    # incidents.  Two different critics exhausting on the same
-    # comment file separate bugs (different root causes) because the
-    # label is part of the key.
-    bug_marker = (
-        f"<!-- critic-exhaustion: {exc.label}:"
-        f"{target.repo}#{target.pr}:{target.comment_id} -->"
-    )
-    bug_body = (
-        f"## Critic exhaustion\n\n"
-        f"- Critic: `{exc.label}`\n"
-        f"- Source comment: {source_link}\n"
-        f"- Source repo / PR: `{target.repo}#{target.pr}`\n"
-        f"- Source comment id: `{target.comment_id}`\n"
-        f"- Attempts: {len(exc.synthesis_attempts)}\n\n"
-        f"## Critic gaps (one per attempt)\n\n{gap_lines}\n\n"
-        f"## Synthesis attempts (reply_text preview)\n\n{attempt_lines}\n\n"
-        f"{bug_marker}\n"
-    )
-    bug_url: str | None = None
-    try:
-        existing_bugs = gh.search_issues(_BUG_REPO, f'"{bug_marker}" in:body is:issue')
-    except Exception as search_exc:
-        log.warning(
-            "critic-exhausted route: bug-marker search failed (%s) — "
-            "proceeding to file (may create a duplicate)",
-            search_exc,
-        )
-        existing_bugs = []
-    if existing_bugs:
-        bug_url = existing_bugs[0].get("html_url")
-        log.info(
-            "critic-exhausted route: existing bug found for %s#%d "
-            "comment %d critic=%s — reusing %s",
-            target.repo,
-            target.pr,
-            target.comment_id,
-            exc.label,
-            bug_url,
-        )
-    else:
-        try:
-            bug_url = gh.create_issue(
-                _BUG_REPO, bug_title, bug_body, labels=[_BUG_LABEL]
-            )
-        except Exception as file_exc:
-            log.warning(
-                "critic-exhausted route: failed to auto-file bug for "
-                "%s#%d comment %d (%s) — BLOCKED comment will note the "
-                "filing failure instead of claiming a URL",
-                target.repo,
-                target.pr,
-                target.comment_id,
-                file_exc,
-            )
 
     if bug_url:
         filing_line = f"Auto-filed against `{_BUG_REPO}` for follow-up: {bug_url}"

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -414,7 +414,7 @@ _BUG_LABEL = "Bug"
 
 @dataclass(frozen=True)
 class StuckOnCriticContext:
-    """HOL-21 / #1915: context bundle for ``_file_stuck_on_critic_bug``.
+    """HOL-21 / #1915: context bundle for ``file_stuck_on_critic_bug``.
 
     Every critic that detects exhaustion (HOL-15..HOL-19) builds one
     of these and hands it to the shared filing helper.  The shape is
@@ -452,7 +452,7 @@ class StuckOnCriticContext:
     attempts_preview: tuple[str, ...] = ()
 
 
-def _file_stuck_on_critic_bug(ctx: StuckOnCriticContext, *, gh: GitHub) -> str | None:
+def file_stuck_on_critic_bug(ctx: StuckOnCriticContext, *, gh: GitHub) -> str | None:
     """HOL-21 / #1915: file (idempotently) a bug on :data:`_BUG_REPO`
     for a critic exhaustion.
 
@@ -584,11 +584,11 @@ def _route_critic_exhausted_blocked(
     source_link = _insight_source_link(target)
 
     # HOL-21 / #1915: bug-filing is shared infrastructure now —
-    # ``_file_stuck_on_critic_bug`` handles the body, idempotency
+    # ``file_stuck_on_critic_bug`` handles the body, idempotency
     # marker, and URL return for ALL critic exhaustion routes
     # (synthesis critics here + per-leaf retry budgets for HOL-16/
     # HOL-17/HOL-19 in their own modules).
-    bug_url = _file_stuck_on_critic_bug(
+    bug_url = file_stuck_on_critic_bug(
         StuckOnCriticContext(
             emission_point=exc.label,
             source_repo=target.repo,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1101,6 +1101,22 @@ def ci_ready_for_review(
 
 _BODY_TAG_RE = re.compile(r"<body>\s*(.*?)\s*</body>", re.DOTALL | re.IGNORECASE)
 
+# HOL-21 / #1915: task-completion critic re-park budget.  Each
+# failed critic verdict re-parks the task IN_PROGRESS and appends
+# ``CRITIC: <gap>`` to the description for the next worker turn.
+# After this many failures on the SAME task, escalate to BLOCKED +
+# auto-file bug instead of cycling indefinitely.  Matches the
+# spirit of ``MAX_RETRIES`` for synthesis-critic exhaustion (HOL-
+# 20) — same shape of "give up after N, file a bug for follow-up".
+_HOL17_MAX_REPARK_BUDGET = 3
+
+# Matches the ``CRITIC: <gap-text>`` lines appended to a task
+# description on each failed task-completion critic verdict.  Used
+# by the re-park-budget check above to count prior failures and by
+# the escalation path to build the gap chain for the auto-filed
+# bug body.
+_CRITIC_GAP_RE = re.compile(r"^CRITIC: (.+)$", re.MULTILINE)
+
 
 def _extract_body(raw: str | None) -> str:
     """Extract content between <body>...</body> tags from provider output.
@@ -3393,21 +3409,45 @@ class Worker:
         )
 
     def _handle_task_completion_critic_failure(
-        self, task: dict[str, Any], gap: str
+        self,
+        task: dict[str, Any],
+        gap: str,
+        *,
+        repo: str | None = None,
+        pr_number: int | None = None,
     ) -> None:
-        """HOL-17 / #1911: handle a failed task-completion critic verdict.
+        """HOL-17 / #1911 + HOL-21 / #1915: handle a failed task-
+        completion critic verdict.
 
-        Reverses the just-landed commit (``git reset --soft HEAD~1`` —
+        On the first ``_HOL17_MAX_REPARK_BUDGET`` failures: reverse
+        the just-landed commit (``git reset --soft HEAD~1`` —
         changes remain staged so the worker's next turn sees them),
-        appends the critic gap to the task description so the next
-        worker turn has guidance, and marks the task IN_PROGRESS so
+        append the critic gap to the task description so the next
+        worker turn has guidance, and mark the task IN_PROGRESS so
         the picker re-selects it on the next cycle.
 
+        When the budget is exhausted (the task description already
+        carries ``_HOL17_MAX_REPARK_BUDGET`` ``CRITIC:`` markers
+        from prior failures): stop re-parking, mark the task BLOCKED,
+        post a BLOCKED comment on the PR, auto-file a bug via the
+        shared HOL-21 ``file_stuck_on_critic_bug`` helper.  The
+        task no longer cycles indefinitely on the same complaint —
+        a human (or a future re-decomposition rescope) has to
+        intervene.
+
         The reset is destructive on the LOCAL commit only — nothing
-        was pushed yet, so no remote state changes.  The staged
-        changes survive: the worker can refine them, ``git restore
-        --staged`` selected files to drop scope-creep, or amend its
-        approach based on the gap.
+        was pushed yet, so no remote state changes.  In the re-park
+        case the staged changes survive: the worker can refine them
+        or amend.  In the escalation case the staged changes are
+        discarded (``git reset --hard HEAD``) because there's no
+        retry to keep them for.
+
+        ``repo`` / ``pr_number`` are optional only for legacy callers
+        (and the migrating tests); production paths pass them so the
+        escalation branch can post the BLOCKED comment and build the
+        bug-file source link.  When omitted on the escalation path
+        we still file the bug (with a placeholder source link) but
+        skip the PR comment.
         """
         log.warning(
             "task-completion critic FAILED for %s — soft-resetting "
@@ -3421,6 +3461,29 @@ class Worker:
         # corruption rather than papering over it with an in_progress
         # task that has a phantom commit ahead of upstream.
         self._git(["reset", "--soft", "HEAD~1"])
+        # HOL-21 / #1915: count the trailing CRITIC: markers in the
+        # task description to see whether this failure exhausts the
+        # re-park budget.  Each prior re-park appended one ``CRITIC:
+        # <gap>`` line; the current gap is in ``gap`` and not yet
+        # appended.  ``prior_gaps + 1`` is therefore the total number
+        # of critic failures including this one.
+        existing_desc = (task.get("description") or "").rstrip()
+        prior_gaps = _CRITIC_GAP_RE.findall(existing_desc)
+        if len(prior_gaps) + 1 > _HOL17_MAX_REPARK_BUDGET:
+            log.warning(
+                "task-completion critic budget exhausted for %s (%d "
+                "prior failures + current): escalating to BLOCKED + "
+                "auto-file bug",
+                task["id"],
+                len(prior_gaps),
+            )
+            self._escalate_task_completion_critic_exhausted(
+                task=task,
+                gap_chain=(*prior_gaps, gap),
+                repo=repo,
+                pr_number=pr_number,
+            )
+            return
         # Append the critic gap to the task description so the next
         # worker turn reads it as guidance.  Markdown bullet under a
         # CRITIC: header keeps existing description content intact.
@@ -3494,6 +3557,116 @@ class Worker:
         # next cycle.
         with self._state.modify() as state:
             state.pop("current_task_id", None)
+
+    def _escalate_task_completion_critic_exhausted(
+        self,
+        *,
+        task: dict[str, Any],
+        gap_chain: tuple[str, ...],
+        repo: str | None,
+        pr_number: int | None,
+    ) -> None:
+        """HOL-21 / #1915: end the re-park cycle when the task-
+        completion critic has rejected the same task
+        ``_HOL17_MAX_REPARK_BUDGET`` times in a row.
+
+        Side effects:
+
+        1. Discard the staged changes from the just-rolled-back
+           commit (``git reset --hard HEAD``).  No retry is coming,
+           so leaving the staged diff would feed it to the next
+           unrelated task.
+        2. Mark the task BLOCKED so the picker skips it.  Clear
+           ``current_task_id`` so the next worker cycle picks fresh.
+        3. Auto-file a bug on ``_BUG_REPO`` via the shared HOL-21
+           helper (idempotent — repeated escalation on the same
+           task reuses the existing bug rather than spamming).
+        4. When ``repo`` / ``pr_number`` are known, post a BLOCKED
+           comment on the PR pointing at the bug.  Best-effort: a
+           transient GitHub failure here mustn't crash the worker
+           loop, the BLOCKED task status + bug filing are already
+           the durable signals.
+        """
+        # Local import to avoid the worker → events → worker cycle
+        # at module-import time (events.py imports Worker types).
+        from fido.events import (
+            StuckOnCriticContext,
+            file_stuck_on_critic_bug,
+        )
+
+        self._git(["reset", "--hard", "HEAD"])
+
+        with self._tasks.modify() as live:
+            for live_task in live:
+                if live_task["id"] != task["id"]:
+                    continue
+                live_task["status"] = str(TaskStatus.BLOCKED)
+                # Append the final gap to the description so the
+                # BLOCKED record carries the full retry trace too
+                # (the bug body has it, but readers of tasks.json
+                # see it without leaving the file).
+                existing = (live_task.get("description") or "").rstrip()
+                final_gap = gap_chain[-1] if gap_chain else "(no gap recorded)"
+                appended_marker = (
+                    f"CRITIC EXHAUSTED ({len(gap_chain)} attempts): {final_gap}"
+                )
+                live_task["description"] = (
+                    f"{existing}\n\n{appended_marker}" if existing else appended_marker
+                )
+                break
+
+        with self._state.modify() as state:
+            state.pop("current_task_id", None)
+
+        # Build the source link from whatever PR context we have.
+        if repo and pr_number:
+            source_link = f"https://github.com/{repo}/pull/{pr_number}"
+        else:
+            source_link = "(worker context — no PR link available)"
+
+        bug_url = file_stuck_on_critic_bug(
+            StuckOnCriticContext(
+                emission_point="task-completion",
+                source_repo=repo or "(unknown)",
+                source_pr=pr_number or 0,
+                target_kind="task",
+                target_id=str(task["id"]),
+                source_link=source_link,
+                gaps=tuple(gap_chain),
+            ),
+            gh=self.gh,
+        )
+
+        if repo and pr_number:
+            blocked_body = (
+                f"**BLOCKED**: task-completion critic exhausted "
+                f"{len(gap_chain)} attempts on task `{task['id']}` "
+                f"({task.get('title', '(no title)')!r}).\n\n"
+                f"The Layer 2 critic kept rejecting the commit.  Final gap:\n\n"
+                f"> {gap_chain[-1] if gap_chain else '(no gap recorded)'}\n\n"
+            )
+            if bug_url:
+                blocked_body += (
+                    f"Auto-filed against `FidoCanCode/home` for follow-up: {bug_url}\n"
+                )
+            else:
+                blocked_body += (
+                    "Auto-filing against `FidoCanCode/home` FAILED — see "
+                    "Fido logs for the full gap chain.\n"
+                )
+            try:
+                self.gh.comment_issue(repo, pr_number, blocked_body)
+            except Exception as exc:
+                log.warning(
+                    "HOL-21: failed to post BLOCKED comment on %s#%d "
+                    "for task %s (%s) — task is still marked BLOCKED, "
+                    "bug at %s",
+                    repo,
+                    pr_number,
+                    task["id"],
+                    exc,
+                    bug_url or "(none)",
+                )
 
     def _finish_task(
         self,
@@ -4368,7 +4541,10 @@ class Worker:
                         )
                         if not completion_verdict.passed:
                             self._handle_task_completion_critic_failure(
-                                task, completion_verdict.gap
+                                task,
+                                completion_verdict.gap,
+                                repo=repo_ctx.repo,
+                                pr_number=pr_number,
                             )
                             # Rob review on PR #1932: the rolled-back turn
                             # may have leaked top-level PR comments via the

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7032,6 +7032,124 @@ class TestGitHubInsightFiler:
         assert captured["recent_count"] == _INSIGHT_RECENT_LIMIT
 
 
+class TestFileStuckOnCriticBug:
+    """HOL-21 / #1915: shared bug-file helper for ALL critic
+    exhaustion routes (HOL-15..HOL-19).  Pulled out of
+    ``_route_critic_exhausted_blocked`` so per-leaf retry budgets
+    for HOL-16/HOL-17/HOL-19 can call it without duplicating the
+    idempotency-marker + body templating logic."""
+
+    def _ctx(
+        self,
+        *,
+        emission_point: str = "task-completion",
+        target_kind: str = "task",
+        target_id: str = "t-9",
+        attempts_preview: tuple[str, ...] = (),
+    ) -> object:
+        from fido.events import StuckOnCriticContext
+
+        return StuckOnCriticContext(
+            emission_point=emission_point,
+            source_repo="owner/repo",
+            source_pr=42,
+            target_kind=target_kind,
+            target_id=target_id,
+            source_link="https://github.com/owner/repo/pull/42",
+            gaps=("g1", "g2", "g3"),
+            attempts_preview=attempts_preview,
+        )
+
+    def test_files_new_bug_with_idempotency_marker(self) -> None:
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/1000"
+
+        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/1000"
+        body = gh.create_issue.call_args.args[2]
+        assert "<!-- critic-exhaustion: task-completion:" in body
+        assert "owner/repo#42:task:t-9 -->" in body
+        for gap in ("g1", "g2", "g3"):
+            assert gap in body
+        title = gh.create_issue.call_args.args[1]
+        assert "task-completion critic exhausted" in title
+        # Default empty attempts_preview → sentinel line in body.
+        assert "(no per-attempt previews recorded)" in body
+
+    def test_reuses_existing_bug_on_marker_hit(self) -> None:
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = [
+            {"html_url": "https://github.com/FidoCanCode/home/issues/2000"}
+        ]
+
+        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/2000"
+        gh.create_issue.assert_not_called()
+
+    def test_search_failure_falls_through_to_create(self) -> None:
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.side_effect = RuntimeError("503")
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/3000"
+
+        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/3000"
+
+    def test_create_failure_returns_none(self) -> None:
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.side_effect = RuntimeError("500")
+
+        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url is None
+
+    def test_emission_point_part_of_idempotency_key(self) -> None:
+        """Two different critics exhausting on the same target file
+        SEPARATE bugs because the emission_point is in the marker."""
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        _file_stuck_on_critic_bug(self._ctx(emission_point="task-completion"), gh=gh)
+        intent_body = gh.create_issue.call_args.args[2]
+        gh.reset_mock()
+        gh.search_issues.return_value = []
+
+        _file_stuck_on_critic_bug(self._ctx(emission_point="task-creation"), gh=gh)
+        creation_body = gh.create_issue.call_args.args[2]
+
+        assert "task-completion:" in intent_body
+        assert "task-creation:" in creation_body
+        assert "task-completion:" not in creation_body
+
+    def test_attempts_preview_when_provided(self) -> None:
+        """When the caller has per-attempt previews (HOL-15/18 path
+        always does), they're rendered in the bug body."""
+        from fido.events import _file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        _file_stuck_on_critic_bug(
+            self._ctx(attempts_preview=("preview-A", "preview-B")), gh=gh
+        )
+        body = gh.create_issue.call_args.args[2]
+        assert "preview-A" in body
+        assert "preview-B" in body
+        assert "(no per-attempt previews recorded)" not in body
+
+
 class TestRouteCriticExhaustedBlocked:
     """HOL-20 / #1914: critic-exhaustion route — BLOCKED PR comment +
     auto-filed bug carrying the full retry trace."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7061,13 +7061,13 @@ class TestFileStuckOnCriticBug:
         )
 
     def test_files_new_bug_with_idempotency_marker(self) -> None:
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.return_value = []
         gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/1000"
 
-        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
         assert url == "https://github.com/FidoCanCode/home/issues/1000"
         body = gh.create_issue.call_args.args[2]
         assert "<!-- critic-exhaustion: task-completion:" in body
@@ -7080,52 +7080,52 @@ class TestFileStuckOnCriticBug:
         assert "(no per-attempt previews recorded)" in body
 
     def test_reuses_existing_bug_on_marker_hit(self) -> None:
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.return_value = [
             {"html_url": "https://github.com/FidoCanCode/home/issues/2000"}
         ]
 
-        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
         assert url == "https://github.com/FidoCanCode/home/issues/2000"
         gh.create_issue.assert_not_called()
 
     def test_search_failure_falls_through_to_create(self) -> None:
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.side_effect = RuntimeError("503")
         gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/3000"
 
-        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
         assert url == "https://github.com/FidoCanCode/home/issues/3000"
 
     def test_create_failure_returns_none(self) -> None:
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.return_value = []
         gh.create_issue.side_effect = RuntimeError("500")
 
-        url = _file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
         assert url is None
 
     def test_emission_point_part_of_idempotency_key(self) -> None:
         """Two different critics exhausting on the same target file
         SEPARATE bugs because the emission_point is in the marker."""
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.return_value = []
         gh.create_issue.return_value = "https://x/issues/1"
 
-        _file_stuck_on_critic_bug(self._ctx(emission_point="task-completion"), gh=gh)
+        file_stuck_on_critic_bug(self._ctx(emission_point="task-completion"), gh=gh)
         intent_body = gh.create_issue.call_args.args[2]
         gh.reset_mock()
         gh.search_issues.return_value = []
 
-        _file_stuck_on_critic_bug(self._ctx(emission_point="task-creation"), gh=gh)
+        file_stuck_on_critic_bug(self._ctx(emission_point="task-creation"), gh=gh)
         creation_body = gh.create_issue.call_args.args[2]
 
         assert "task-completion:" in intent_body
@@ -7135,13 +7135,13 @@ class TestFileStuckOnCriticBug:
     def test_attempts_preview_when_provided(self) -> None:
         """When the caller has per-attempt previews (HOL-15/18 path
         always does), they're rendered in the bug body."""
-        from fido.events import _file_stuck_on_critic_bug
+        from fido.events import file_stuck_on_critic_bug
 
         gh = MagicMock()
         gh.search_issues.return_value = []
         gh.create_issue.return_value = "https://x/issues/1"
 
-        _file_stuck_on_critic_bug(
+        file_stuck_on_critic_bug(
             self._ctx(attempts_preview=("preview-A", "preview-B")), gh=gh
         )
         body = gh.create_issue.call_args.args[2]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12833,7 +12833,7 @@ class TestExecuteTask:
         # re-park logic.
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope arrives "now".
             worker._tasks._task_list[0]["status"] = "completed"
             real_handler(t, gap)
@@ -12884,7 +12884,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope removed the task entirely.
             worker._tasks._task_list.clear()
             real_handler(t, gap)
@@ -12938,7 +12938,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope flipped the row to COMPLETED before the
             # critic-failure handler reached its re-park step.  Forces
             # the no-repark branch — which must then hard-reset to drop
@@ -12997,7 +12997,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Row removed by concurrent rescope.
             worker._tasks._task_list.clear()
             real_handler(t, gap)
@@ -13007,6 +13007,244 @@ class TestExecuteTask:
 
         assert ["reset", "--soft", "HEAD~1"] in git_calls
         assert ["reset", "--hard", "HEAD"] in git_calls
+
+    def test_task_completion_critic_exhaustion_escalates_to_blocked(
+        self, tmp_path: Path
+    ) -> None:
+        """HOL-21 / #1915: after ``_HOL17_MAX_REPARK_BUDGET`` consecutive
+        critic failures on the same task, stop re-parking — mark the
+        task BLOCKED, auto-file a bug, post a BLOCKED comment on the
+        PR.  Without this the task cycles indefinitely on the same
+        complaint and blocks the queue."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        # Seed the description with N prior CRITIC: markers so this
+        # failure is the N+1-th — exhausts the budget.
+        prior_markers = "\n\n".join(
+            f"CRITIC: prior gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET)
+        )
+        task["description"] = f"Original.\n\n{prior_markers}"
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "final straw"}'
+        )
+        gh.search_issues.return_value = []  # no existing bug
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/9001"
+        gh.comment_issue.return_value = {"id": 1}
+
+        git_calls: list[list[str]] = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            git_calls.append(args)
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        # Soft reset still fired (commit rolled back).
+        assert ["reset", "--soft", "HEAD~1"] in git_calls
+        # Hard reset fired (no retry coming, drop staged changes).
+        assert ["reset", "--hard", "HEAD"] in git_calls
+        # Task is BLOCKED, not IN_PROGRESS.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        # Description carries the CRITIC EXHAUSTED marker with attempt count.
+        assert "CRITIC EXHAUSTED" in affected["description"]
+        assert "final straw" in affected["description"]
+        # Bug filed on FidoCanCode/home.
+        gh.create_issue.assert_called_once()
+        bug_args = gh.create_issue.call_args.args
+        assert bug_args[0] == "FidoCanCode/home"
+        assert "task-completion critic exhausted" in bug_args[1]
+        # All prior gaps + the final straw are in the bug body.
+        bug_body = bug_args[2]
+        for i in range(_HOL17_MAX_REPARK_BUDGET):
+            assert f"prior gap {i}" in bug_body
+        assert "final straw" in bug_body
+        # BLOCKED comment posted on the source PR.
+        comment_call = gh.comment_issue.call_args
+        assert comment_call.args[0] == "owner/repo"
+        assert comment_call.args[1] == 1
+        assert "BLOCKED" in comment_call.args[2]
+        assert "task-completion critic exhausted" in comment_call.args[2]
+        # current_task_id cleared so the picker moves on.
+        with worker._state.modify() as state:
+            assert state.get("current_task_id") is None
+
+    def test_task_completion_critic_exhaustion_handles_helper_failures(
+        self, tmp_path: Path
+    ) -> None:
+        """HOL-21 escalation must survive transient GitHub failures
+        in the bug-file + BLOCKED-comment steps.  The task is still
+        marked BLOCKED locally so the picker stops cycling it; the
+        external signals are best-effort.  Also exercises the
+        sibling-task path in the modify loop (covers the
+        ``if live_task["id"] != task["id"]: continue`` arm)."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        sibling = self._pending_task("Sibling")
+        sibling["id"] = "t-sibling"
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        task["description"] = "\n\n".join(
+            f"CRITIC: gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET)
+        )
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [sibling, task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "final"}'
+        )
+        gh.search_issues.return_value = []
+        gh.create_issue.side_effect = RuntimeError("bug file 500")
+        gh.comment_issue.side_effect = RuntimeError("comment 503")
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        # The BLOCKED comment wording reflects "filing FAILED" since
+        # the helper returned None (covers the no-URL branch).
+        comment_args = gh.comment_issue.call_args.args
+        assert "FAILED" in comment_args[2]
+
+    def test_task_completion_critic_exhaustion_without_pr_context(
+        self, tmp_path: Path
+    ) -> None:
+        """Direct unit test for the escalation helper covering the
+        no-PR-context branch (legacy callers / migrating tests pass
+        repo=None, pr_number=None).  Bug still files (with a
+        placeholder source link), BLOCKED comment is skipped."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+
+        worker, gh = self._make_worker(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["status"] = "in_progress"
+        worker._tasks._task_list = [task]
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        git_calls: list[list[str]] = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            git_calls.append(args)
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout="", stderr=""
+            )
+
+        worker._git = git_stub
+        worker._escalate_task_completion_critic_exhausted(
+            task=task,
+            gap_chain=("g1", "g2", "g3", "g4"),
+            repo=None,
+            pr_number=None,
+        )
+
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        gh.create_issue.assert_called_once()
+        gh.comment_issue.assert_not_called()
+        assert ["reset", "--hard", "HEAD"] in git_calls
+
+    def test_task_completion_critic_repark_just_below_budget(
+        self, tmp_path: Path
+    ) -> None:
+        """Budget boundary: at exactly ``_HOL17_MAX_REPARK_BUDGET - 1``
+        prior failures, the next failure re-parks normally (not
+        escalation).  Pins the off-by-one so a future tweak to the
+        budget doesn't accidentally escalate one attempt early."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        # One fewer than the budget — this failure will be the LAST
+        # re-park (the next would escalate).
+        prior_markers = "\n\n".join(
+            f"CRITIC: gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 1)
+        )
+        task["description"] = f"Orig.\n\n{prior_markers}"
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "one more"}'
+        )
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        # Task re-parked, NOT escalated.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.IN_PROGRESS)
+        assert "CRITIC EXHAUSTED" not in affected["description"]
+        # No bug filed on the budget-boundary case.
+        gh.create_issue.assert_not_called()
 
     def test_task_completion_critic_failure_cleans_up_leaked_comments(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

HOL-21 / #1915: unified ``stuck-on-critic`` sentinel infrastructure + the one critic that has a real indefinite-cycle problem in practice.

**Phase 1 (commit ``28d7e74``)** — extract shared ``file_stuck_on_critic_bug`` helper out of HOL-20's ``_route_critic_exhausted_blocked``.  ``StuckOnCriticContext`` carries critic-agnostic fields; idempotency marker keyed on ``(emission_point, repo, pr, target_kind, target_id)`` so two different critics on the same target file separate bugs.  Pure refactor — HOL-15/18 routing unchanged.

**Phase 2 (commit ``c36e64f``)** — HOL-17 task-completion re-park budget.  Before this commit a task whose completion-critic kept rejecting it would cycle indefinitely (each re-park appended ``CRITIC: <gap>`` to the description and reset to IN_PROGRESS).  Now bounded: after ``_HOL17_MAX_REPARK_BUDGET`` (=3) failures, the escalation helper marks the task BLOCKED, clears ``current_task_id``, files a bug via the shared helper, and posts a BLOCKED comment on the source PR.  Idempotent — repeated escalation on the same task reuses the bug rather than spamming.

## Why no Phase 3 / Phase 4 for HOL-16 + HOL-19

- **HOL-16 (task-creation critic)** runs per-item in a rescope batch.  There's no natural cross-batch "exhaustion" — each batch is one Opus call.  A real retry budget would need persistent per-``intent_comment_id`` counters (SQLite / state.json), which is non-trivial new infrastructure for a problem we don't currently observe in production.  The HOL-16 critic already fails-open per call.
- **HOL-19 (insight-filing critic)** is short-circuited by the per-comment idempotency marker before the critic runs on a replay.  "Exhaustion" doesn't fit the access pattern — once the marker is recorded, the critic doesn't see the same input twice.

Both are filed as follow-up issues so a future leaf can add persistent counters if/when the indefinite-cycle pattern actually appears in production.  The shared ``StuckOnCriticContext`` + ``file_stuck_on_critic_bug`` infrastructure (Phase 1) is in place so those leaves are small when they land.

## Test plan

- [x] ``./fido ci`` green, 100% coverage, 4846 tests pass.
- [x] Phase 1: 6 ``TestFileStuckOnCriticBug`` tests covering helper contract (new-bug, marker-hit reuse, search-failure, create-failure, emission-point in key, attempts-preview rendering).
- [x] Phase 2: ``test_task_completion_critic_exhaustion_escalates_to_blocked`` (full escalation path), ``test_task_completion_critic_repark_just_below_budget`` (off-by-one), ``test_task_completion_critic_exhaustion_handles_helper_failures`` (transient GitHub failures don't undo local BLOCKED), ``test_task_completion_critic_exhaustion_without_pr_context`` (legacy callers).
- [x] HOL-20 routing tests still pass (Phase 1's refactor preserves HOL-15/18 behaviour).