### PR TITLE
HOL-22 of #1894: eager-eyes scoped to same review submission (closes #1875)

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -782,6 +782,14 @@ def build_review_comment_action(
             "comment_type": "pulls",
             "lineage_key": lineage_key,
             "lineage_comment_ids": list(lineage_comment_ids),
+            # HOL-22 / #1916: identifies the GitHub review submission
+            # this comment belongs to.  The eager-eyes predicate uses
+            # it to detect "same-submission batch" vs "solo comment
+            # arriving during an unrelated batch" (closes #1875).
+            # None for review comments that aren't part of a
+            # submission (e.g. single-line comments without a
+            # review wrapper); the predicate's fallback handles that.
+            "pull_request_review_id": comment.get("pull_request_review_id"),
         },
         comment_body=body,
         is_bot=is_bot,

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -832,13 +832,33 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 _eyes_ctype = str(_eyes_comment_info.get("comment_type", "issues"))
                 _eyes_cid = _eyes_comment_info.get("comment_id")
                 if _eyes_repo and isinstance(_eyes_cid, int):
+                    # HOL-22 / #1916: pull the review submission id (if
+                    # any) so the predicate scopes "batched with this"
+                    # to comments from the SAME submission rather than
+                    # any open comment in the repo (closes #1875).
+                    _eyes_review_id_raw = _eyes_comment_info.get(
+                        "pull_request_review_id"
+                    )
+                    _eyes_review_id = (
+                        int(_eyes_review_id_raw)
+                        if isinstance(_eyes_review_id_raw, int)
+                        else None
+                    )
                     if FidoStore(repo_cfg.work_dir).has_other_open_pr_comments(
-                        repo=_eyes_repo, exclude_comment_id=_eyes_cid
+                        repo=_eyes_repo,
+                        exclude_comment_id=_eyes_cid,
+                        review_id=_eyes_review_id,
                     ):
                         log.debug(
                             "eager eyes skipped for comment %d — repo has "
-                            "other open comments; worker posts eyes on claim",
+                            "other open comments from %s; worker posts eyes "
+                            "on claim",
                             _eyes_cid,
+                            (
+                                f"review {_eyes_review_id}"
+                                if _eyes_review_id is not None
+                                else "the same repo (no review-id scoping)"
+                            ),
                         )
                     else:
                         try:

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -665,7 +665,13 @@ class FidoStore:
             ).fetchall()
         return [int(row[0]) for row in rows]
 
-    def has_other_open_pr_comments(self, *, repo: str, exclude_comment_id: int) -> bool:
+    def has_other_open_pr_comments(
+        self,
+        *,
+        repo: str,
+        exclude_comment_id: int,
+        review_id: int | None = None,
+    ) -> bool:
         """Return whether *repo* has any other open queue entries.
 
         "Open" means ``state IN ('pending', 'in_progress', 'retryable_failed')``
@@ -674,20 +680,52 @@ class FidoStore:
         comment for the same repo, this comment is part of a batch and the
         worker will post eyes when it claims the comment in pickup order
         (#1662).
+
+        HOL-22 / #1916: when ``review_id`` is provided (the incoming
+        comment is part of a specific GitHub review submission), only
+        OTHER queue entries from the SAME review submission count as
+        "batched with this comment".  A solo human comment queued
+        behind an unrelated batch from a different review submission
+        is no longer falsely classified as batched — it still gets
+        the sub-1s eyes ack (closes #1875).  When ``review_id`` is
+        None (top-level PR comments, issue comments, anything not
+        from a review), fall back to the legacy "any other open"
+        check.
         """
         self.ensure_schema()
         with closing(self._connect()) as conn:
-            row = conn.execute(
-                """
-                SELECT 1
-                FROM pr_comment_queue
-                WHERE repo = ?
-                  AND comment_id != ?
-                  AND state IN ('pending', 'in_progress', 'retryable_failed')
-                LIMIT 1
-                """,
-                (repo, int(exclude_comment_id)),
-            ).fetchone()
+            if review_id is None:
+                row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM pr_comment_queue
+                    WHERE repo = ?
+                      AND comment_id != ?
+                      AND state IN ('pending', 'in_progress', 'retryable_failed')
+                    LIMIT 1
+                    """,
+                    (repo, int(exclude_comment_id)),
+                ).fetchone()
+            else:
+                # Filter on the JSON-encoded payload's
+                # ``pull_request_review_id`` so only comments from the
+                # SAME review submission count.  Rows without that
+                # field (e.g. queued before HOL-22 landed, or
+                # non-review comment types) compare as NULL and are
+                # correctly excluded — they're "not part of this
+                # review", which is exactly what we want.
+                row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM pr_comment_queue
+                    WHERE repo = ?
+                      AND comment_id != ?
+                      AND state IN ('pending', 'in_progress', 'retryable_failed')
+                      AND json_extract(payload_json, '$.pull_request_review_id') = ?
+                    LIMIT 1
+                    """,
+                    (repo, int(exclude_comment_id), int(review_id)),
+                ).fetchone()
         return row is not None
 
     def claim_next_pr_comment(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -929,6 +929,104 @@ def test_has_other_open_pr_comments_scopes_by_repo(tmp_path: Path) -> None:
     )
 
 
+def test_has_other_open_pr_comments_review_id_scopes_to_same_submission(
+    tmp_path: Path,
+) -> None:
+    """HOL-22 / #1916: when ``review_id`` is provided, only OTHER
+    queue entries from the SAME review submission count as
+    "batched with this comment".  A solo human comment queued
+    behind an unrelated batch from a DIFFERENT review submission
+    still gets sub-1s eager-eyes (closes #1875)."""
+    store = FidoStore(tmp_path)
+    # Batch from review submission 12345.
+    store.enqueue_pr_comment(
+        delivery_id="delivery-batch-a",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=1001,
+        author="bot",
+        is_bot=True,
+        body="batch a",
+        github_created_at="2026-04-30T10:00:00Z",
+        payload_json='{"pull_request_review_id": 12345}',
+    )
+    # Solo human comment from a DIFFERENT submission 67890.
+    solo = store.enqueue_pr_comment(
+        delivery_id="delivery-solo",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=1002,
+        author="rob",
+        is_bot=False,
+        body="solo human",
+        github_created_at="2026-04-30T10:00:01Z",
+        payload_json='{"pull_request_review_id": 67890}',
+    )
+    # With review-id scoping: no other open comment from the solo's
+    # submission → eager-eyes fires.
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=solo.comment_id,
+            review_id=67890,
+        )
+        is False
+    )
+    # Legacy unscoped call (review_id=None) still sees the batch
+    # comment → eager-eyes skipped.
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=solo.comment_id,
+        )
+        is True
+    )
+
+
+def test_has_other_open_pr_comments_review_id_detects_same_submission_batch(
+    tmp_path: Path,
+) -> None:
+    """HOL-22 sibling: when another open comment IS from the same
+    review submission, the scoped predicate returns True so eyes
+    is correctly skipped (the worker posts eyes on claim instead)."""
+    store = FidoStore(tmp_path)
+    # Two comments from the same review submission 99999.
+    store.enqueue_pr_comment(
+        delivery_id="delivery-batch-first",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=2001,
+        author="rob",
+        is_bot=False,
+        body="batch first",
+        github_created_at="2026-04-30T10:00:00Z",
+        payload_json='{"pull_request_review_id": 99999}',
+    )
+    sibling = store.enqueue_pr_comment(
+        delivery_id="delivery-batch-sibling",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=2002,
+        author="rob",
+        is_bot=False,
+        body="batch sibling",
+        github_created_at="2026-04-30T10:00:01Z",
+        payload_json='{"pull_request_review_id": 99999}',
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=sibling.comment_id,
+            review_id=99999,
+        )
+        is True
+    )
+
+
 def test_recover_in_progress_pr_comments_requeues_abandoned_claim(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Refines the eager-eyes skip predicate so a solo human comment landing during an unrelated review batch still gets sub-1s ack.

## Test plan

- [x] New ``test_has_other_open_pr_comments_review_id_scopes_to_same_submission`` covers the closes-#1875 scenario.
- [x] Sibling test covers the still-skip-when-same-submission boundary.
- [x] Legacy unscoped predicate behaviour preserved (no review_id → any open counts).
- [x] ``./fido ci`` green, 100% coverage held, 4838 tests pass.