### PR TITLE
Epic #1894: holistic gate architecture — 13 commits, all leaves + codex review + 2 follow-ups

### DIFF
--- a/src/fido/critics.py
+++ b/src/fido/critics.py
@@ -15,6 +15,8 @@ output from shipping.
 
 import logging
 import re
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -31,6 +33,7 @@ from fido.synthesis_call import extract_json_objects
 log = logging.getLogger(__name__)
 
 __all__ = [
+    "InsightDedupTransportCounter",
     "InsightDedupVerdict",
     "ReplyProseVerdict",
     "TaskCompletionVerdict",
@@ -642,6 +645,69 @@ def _parse_insight_dedup_verdict(
     )
 
 
+class InsightDedupTransportCounter:
+    """HOL-19 follow-up / #1935: process-local consecutive-transport-
+    failure counter for ``run_insight_dedup_critic``.
+
+    Each ``run_insight_dedup_critic`` call updates the counter:
+    transport failures (the ``except Exception`` arm — RuntimeError,
+    network blips, model unavailable) bump it; a verdict-shape-valid
+    response resets it.  Parse failures don't reset (no clean signal
+    that the critic infrastructure is healthy) and don't bump (might
+    just be one bad model turn).
+
+    When the counter crosses ``threshold`` consecutive failures, the
+    injected ``escalator`` callback is invoked with the failure count.
+    Production wiring escalates via ``file_stuck_on_critic_bug`` with
+    ``emission_point="insight-dedup-transport"``.
+
+    Thread-safe under free-threaded Python: a lock guards every read-
+    modify cycle so two simultaneous critic calls can't both observe
+    "below threshold" and both miss an escalation.
+
+    Process-local persistence per the issue body ("a flaky day would
+    still trigger the bug within a session") — survives across critic
+    calls in one Fido process, resets on restart.
+    """
+
+    def __init__(
+        self,
+        *,
+        threshold: int = 3,
+        escalator: Callable[[int], None] | None = None,
+    ) -> None:
+        self._threshold = threshold
+        self._escalator = escalator
+        self._consecutive_failures = 0
+        self._already_escalated = False
+        self._lock = threading.Lock()
+
+    def record_transport_failure(self) -> None:
+        escalator: Callable[[int], None] | None = None
+        count = 0
+        with self._lock:
+            self._consecutive_failures += 1
+            if (
+                self._consecutive_failures >= self._threshold
+                and not self._already_escalated
+                and self._escalator is not None
+            ):
+                self._already_escalated = True
+                escalator = self._escalator
+                count = self._consecutive_failures
+        # Fire the escalator OUTSIDE the lock — it may touch GitHub
+        # and we don't want a slow API call holding the counter lock.
+        # ``_already_escalated`` set under the lock prevents duplicate
+        # fires from concurrent at-threshold transitions.
+        if escalator is not None:
+            escalator(count)
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+            self._already_escalated = False
+
+
 def run_insight_dedup_critic(
     proposed_insight: dict[str, str],
     recent_insights: list[dict[str, str]],
@@ -649,6 +715,7 @@ def run_insight_dedup_critic(
     agent: ProviderAgent,
     prompts: Prompts,
     critic_system_prompt: str,
+    transport_counter: InsightDedupTransportCounter | None = None,
 ) -> InsightDedupVerdict:
     """Ask Opus whether ``proposed_insight`` near-duplicates any of
     ``recent_insights``.
@@ -683,6 +750,11 @@ def run_insight_dedup_critic(
             "insight-dedup critic transport failure (%s) — failing open",
             exc,
         )
+        # HOL-19 follow-up / #1935: count transport failures so a
+        # cross-comment pattern (the critic infra itself is broken,
+        # not "this insight is duplicate") can escalate to a bug.
+        if transport_counter is not None:
+            transport_counter.record_transport_failure()
         return InsightDedupVerdict()
 
     objs = extract_json_objects(raw or "")
@@ -716,6 +788,12 @@ def run_insight_dedup_critic(
                     len(allowed_urls),
                 )
                 continue
+            # HOL-19 follow-up / #1935: a verdict-shape-valid response
+            # means the critic infra is healthy — reset the
+            # transport-failure counter.  Parse failures don't reset
+            # (no clean health signal).
+            if transport_counter is not None:
+                transport_counter.record_success()
             return verdict
         if obj.get("is_duplicate") is True:
             saw_malformed_dup = True

--- a/src/fido/critics.py
+++ b/src/fido/critics.py
@@ -721,13 +721,21 @@ class TaskCreationDropCounter:
     the streak and can prevent the exhaustion bug from ever filing.
     The default backend (no ``store=`` passed) is in-memory, suitable
     for tests; production wires ``store=FidoStore(work_dir)``.
+
+    Codex P1 follow-up: the escalator returns ``True`` on successful
+    bug file/reuse, ``False`` when ``file_stuck_on_critic_bug``
+    failed (e.g. transient GitHub error).  The durable
+    ``escalated=1`` latch is set ONLY after a successful return — a
+    transient failure at the first threshold crossing leaves the
+    latch clear so the next drop retries the escalation instead of
+    suppressing it forever across restarts.
     """
 
     def __init__(
         self,
         *,
         threshold: int = 3,
-        escalator: Callable[[int, int], None] | None = None,
+        escalator: Callable[[int, int], bool] | None = None,
         store: TaskCreationDropStore | None = None,
     ) -> None:
         self._threshold = threshold
@@ -745,8 +753,9 @@ class TaskCreationDropCounter:
             and not already_escalated
             and self._escalator is not None
         ):
-            self._store.mark_task_creation_drop_escalated(intent_comment_id)
-            self._escalator(intent_comment_id, count)
+            # Fire FIRST; only set the durable latch on success.
+            if self._escalator(intent_comment_id, count):
+                self._store.mark_task_creation_drop_escalated(intent_comment_id)
 
     def reset_inactive_intents(self, active_intent_ids: set[int]) -> None:
         """Drop counters for any intent_comment_id NOT in
@@ -785,7 +794,7 @@ class InsightDedupTransportCounter:
         self,
         *,
         threshold: int = 3,
-        escalator: Callable[[int], None] | None = None,
+        escalator: Callable[[int], bool] | None = None,
     ) -> None:
         self._threshold = threshold
         self._escalator = escalator
@@ -794,7 +803,16 @@ class InsightDedupTransportCounter:
         self._lock = threading.Lock()
 
     def record_transport_failure(self) -> None:
-        escalator: Callable[[int], None] | None = None
+        # Codex P1 follow-up on PR #1938: the escalator returns
+        # ``True`` on successful bug file/reuse, ``False`` on
+        # transient failure.  We tentatively claim the latch under
+        # the lock to suppress concurrent at-threshold races, then
+        # RELEASE it if the escalator reports failure — otherwise a
+        # transient GitHub error would permanently suppress future
+        # escalations.  Net behaviour: the next transport failure
+        # retries the escalation; a successful prior fire still
+        # latches durably.
+        escalator: Callable[[int], bool] | None = None
         count = 0
         with self._lock:
             self._consecutive_failures += 1
@@ -806,12 +824,10 @@ class InsightDedupTransportCounter:
                 self._already_escalated = True
                 escalator = self._escalator
                 count = self._consecutive_failures
-        # Fire the escalator OUTSIDE the lock — it may touch GitHub
-        # and we don't want a slow API call holding the counter lock.
-        # ``_already_escalated`` set under the lock prevents duplicate
-        # fires from concurrent at-threshold transitions.
         if escalator is not None:
-            escalator(count)
+            if not escalator(count):
+                with self._lock:
+                    self._already_escalated = False
 
     def record_success(self) -> None:
         with self._lock:

--- a/src/fido/critics.py
+++ b/src/fido/critics.py
@@ -18,7 +18,7 @@ import re
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 from urllib.parse import urlparse
 
 from fido.prompts import Prompts
@@ -646,9 +646,61 @@ def _parse_insight_dedup_verdict(
     )
 
 
+class TaskCreationDropStore(Protocol):
+    """Minimal backend interface for :class:`TaskCreationDropCounter`.
+
+    Allows the counter to use ``FidoStore`` in production for durable
+    cross-restart accounting (#1934 acceptance criterion), and an
+    in-memory ``_InMemoryTaskCreationDropStore`` in tests that don't
+    need durability.
+    """
+
+    def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]: ...
+
+    def mark_task_creation_drop_escalated(self, intent_comment_id: int) -> None: ...
+
+    def reset_inactive_task_creation_drops(
+        self, active_intent_ids: set[int]
+    ) -> int: ...
+
+
+class _InMemoryTaskCreationDropStore:
+    """In-memory backend for tests.  Same semantics as the SQLite-
+    backed ``FidoStore`` implementation but loses state on restart.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[int, int] = {}
+        self._escalated: set[int] = set()
+        self._lock = threading.Lock()
+
+    def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]:
+        with self._lock:
+            self._counts[intent_comment_id] = self._counts.get(intent_comment_id, 0) + 1
+            return (
+                self._counts[intent_comment_id],
+                intent_comment_id in self._escalated,
+            )
+
+    def mark_task_creation_drop_escalated(self, intent_comment_id: int) -> None:
+        with self._lock:
+            self._escalated.add(intent_comment_id)
+
+    def reset_inactive_task_creation_drops(self, active_intent_ids: set[int]) -> int:
+        with self._lock:
+            cleared = 0
+            for cid in list(self._counts):
+                if cid not in active_intent_ids:
+                    self._counts.pop(cid, None)
+                    self._escalated.discard(cid)
+                    cleared += 1
+            return cleared
+
+
 class TaskCreationDropCounter:
-    """HOL-16 follow-up / #1934: process-local per-``intent_comment_id``
-    drop counter for the task-creation critic.
+    """HOL-16 follow-up / #1934: per-``intent_comment_id`` drop counter
+    for the task-creation critic, backed by a durable
+    :class:`TaskCreationDropStore` (production: ``FidoStore``).
 
     Each ``_apply_task_creation_verdicts`` call records every drop
     attributed to an intent_comment_id (via the item's
@@ -657,18 +709,18 @@ class TaskCreationDropCounter:
     fires once and is suppressed until the counter resets for that
     intent.
 
-    Reset rule (per the #1934 issue body): when an intent's
-    contributing tasks reach zero — either the comment was successfully
-    covered by another task that DID land, or the system moved on and
-    no live proposal carries the intent anymore.  Callers invoke
-    ``reset_inactive_intents`` after each batch apply with the set of
-    intent ids that still appear in live task ``contributing_intents``.
+    Reset rule: when an intent's contributing tasks reach zero —
+    either the comment was successfully covered by another task that
+    DID land, or the system moved on and no live proposal carries the
+    intent anymore.  Callers invoke ``reset_inactive_intents`` after
+    each batch apply with the set of intent ids that still appear in
+    live task ``contributing_intents``.
 
-    Thread-safe: a lock guards every read-modify cycle.
-
-    Process-local persistence per the issue body ("isn't worth building
-    until we observe the pattern in production").  Survives across
-    rescope batches in one Fido process, resets on restart.
+    Codex P2 on PR #1938 (#1934 acceptance criterion): persistence in
+    a durable store — without it, a Fido restart between drops loses
+    the streak and can prevent the exhaustion bug from ever filing.
+    The default backend (no ``store=`` passed) is in-memory, suitable
+    for tests; production wires ``store=FidoStore(work_dir)``.
     """
 
     def __init__(
@@ -676,41 +728,32 @@ class TaskCreationDropCounter:
         *,
         threshold: int = 3,
         escalator: Callable[[int, int], None] | None = None,
+        store: TaskCreationDropStore | None = None,
     ) -> None:
         self._threshold = threshold
         self._escalator = escalator
-        self._drops_by_intent: dict[int, int] = {}
-        self._already_escalated: set[int] = set()
-        self._lock = threading.Lock()
+        self._store: TaskCreationDropStore = (
+            store if store is not None else _InMemoryTaskCreationDropStore()
+        )
 
     def record_drop(self, intent_comment_id: int) -> None:
-        escalator: Callable[[int, int], None] | None = None
-        count = 0
-        with self._lock:
-            self._drops_by_intent[intent_comment_id] = (
-                self._drops_by_intent.get(intent_comment_id, 0) + 1
-            )
-            count = self._drops_by_intent[intent_comment_id]
-            if (
-                count >= self._threshold
-                and intent_comment_id not in self._already_escalated
-                and self._escalator is not None
-            ):
-                self._already_escalated.add(intent_comment_id)
-                escalator = self._escalator
-        if escalator is not None:
-            escalator(intent_comment_id, count)
+        count, already_escalated = self._store.bump_task_creation_drop(
+            intent_comment_id
+        )
+        if (
+            count >= self._threshold
+            and not already_escalated
+            and self._escalator is not None
+        ):
+            self._store.mark_task_creation_drop_escalated(intent_comment_id)
+            self._escalator(intent_comment_id, count)
 
     def reset_inactive_intents(self, active_intent_ids: set[int]) -> None:
         """Drop counters for any intent_comment_id NOT in
         *active_intent_ids* — those intents have no live contributing
         tasks anymore, so the drop streak is broken.
         """
-        with self._lock:
-            for cid in list(self._drops_by_intent):
-                if cid not in active_intent_ids:
-                    self._drops_by_intent.pop(cid, None)
-                    self._already_escalated.discard(cid)
+        self._store.reset_inactive_task_creation_drops(active_intent_ids)
 
 
 class InsightDedupTransportCounter:

--- a/src/fido/critics.py
+++ b/src/fido/critics.py
@@ -37,6 +37,7 @@ __all__ = [
     "InsightDedupVerdict",
     "ReplyProseVerdict",
     "TaskCompletionVerdict",
+    "TaskCreationDropCounter",
     "TaskCreationProposedSplit",
     "TaskCreationVerdict",
     "run_insight_dedup_critic",
@@ -643,6 +644,73 @@ def _parse_insight_dedup_verdict(
         duplicate_url=url.strip(),
         rationale=rationale,
     )
+
+
+class TaskCreationDropCounter:
+    """HOL-16 follow-up / #1934: process-local per-``intent_comment_id``
+    drop counter for the task-creation critic.
+
+    Each ``_apply_task_creation_verdicts`` call records every drop
+    attributed to an intent_comment_id (via the item's
+    ``contributing_intents``).  When the per-intent count crosses
+    ``threshold``, the injected ``escalator(intent_comment_id, count)``
+    fires once and is suppressed until the counter resets for that
+    intent.
+
+    Reset rule (per the #1934 issue body): when an intent's
+    contributing tasks reach zero — either the comment was successfully
+    covered by another task that DID land, or the system moved on and
+    no live proposal carries the intent anymore.  Callers invoke
+    ``reset_inactive_intents`` after each batch apply with the set of
+    intent ids that still appear in live task ``contributing_intents``.
+
+    Thread-safe: a lock guards every read-modify cycle.
+
+    Process-local persistence per the issue body ("isn't worth building
+    until we observe the pattern in production").  Survives across
+    rescope batches in one Fido process, resets on restart.
+    """
+
+    def __init__(
+        self,
+        *,
+        threshold: int = 3,
+        escalator: Callable[[int, int], None] | None = None,
+    ) -> None:
+        self._threshold = threshold
+        self._escalator = escalator
+        self._drops_by_intent: dict[int, int] = {}
+        self._already_escalated: set[int] = set()
+        self._lock = threading.Lock()
+
+    def record_drop(self, intent_comment_id: int) -> None:
+        escalator: Callable[[int, int], None] | None = None
+        count = 0
+        with self._lock:
+            self._drops_by_intent[intent_comment_id] = (
+                self._drops_by_intent.get(intent_comment_id, 0) + 1
+            )
+            count = self._drops_by_intent[intent_comment_id]
+            if (
+                count >= self._threshold
+                and intent_comment_id not in self._already_escalated
+                and self._escalator is not None
+            ):
+                self._already_escalated.add(intent_comment_id)
+                escalator = self._escalator
+        if escalator is not None:
+            escalator(intent_comment_id, count)
+
+    def reset_inactive_intents(self, active_intent_ids: set[int]) -> None:
+        """Drop counters for any intent_comment_id NOT in
+        *active_intent_ids* — those intents have no live contributing
+        tasks anymore, so the drop streak is broken.
+        """
+        with self._lock:
+            for cid in list(self._drops_by_intent):
+                if cid not in active_intent_ids:
+                    self._drops_by_intent.pop(cid, None)
+                    self._already_escalated.discard(cid)
 
 
 class InsightDedupTransportCounter:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -93,11 +93,17 @@ class _BackgroundRescopeTrigger:
         agent: ProviderAgent,
         prompts: Prompts,
         dispatcher: "Dispatcher",
+        store: "FidoStore",
     ) -> None:
         self._registry = registry
         self._agent = agent
         self._prompts = prompts
         self._dispatcher = dispatcher
+        # Codex P1 (ninth round) on PR #1938: durable dedup store
+        # injected at construction so the trigger has its own
+        # collaborator instead of reaching into the dispatcher's
+        # private ``_repo_cfg`` (single-root composition rule).
+        self._store = store
 
     def trigger_rescope(self, intent: RescopeIntent) -> None:
         """Trigger :meth:`Dispatcher.reorder_tasks_background` with the given rescope intent.
@@ -107,7 +113,25 @@ class _BackgroundRescopeTrigger:
         changed.  The full intent (including *comment_id* and *timestamp*) is
         forwarded so the rescoper can reference the originating comment and
         accumulate multiple concurrent intents correctly.
+
+        Codex P1 (ninth round) on PR #1938: the rescope trigger is
+        now durably idempotent per ``intent.comment_id``.  Without
+        this, a replay of an already-acked reply (artifact recorded,
+        but ``execute_effects_only`` re-running because of the
+        unified replay-runs-everything path) would re-fire
+        rescope/preempt every pass.  ``FidoStore.claim_rescope_trigger``
+        atomically inserts the comment_id into a durable set and
+        returns ``True`` only on the first claim; subsequent calls
+        (this Fido process or a different one after restart) get
+        ``False`` and skip the trigger.
         """
+        if not self._store.claim_rescope_trigger(intent.comment_id):
+            log.info(
+                "RescopeTrigger: rescope already triggered for comment %d "
+                "(durable dedup) — skipping",
+                intent.comment_id,
+            )
+            return
         log.info(
             "RescopeTrigger: triggering background rescope for comment %d: %s",
             intent.comment_id,
@@ -2264,6 +2288,7 @@ class Dispatcher:
             agent=agent,
             prompts=prompts,
             dispatcher=self,
+            store=FidoStore(repo_cfg.work_dir),
         )
         executor = (
             _executor
@@ -2489,34 +2514,24 @@ class Dispatcher:
         if direct_promise is not None:
             FidoStore(repo_cfg.work_dir).ack_promise(direct_promise.promise_id)
 
+        # Codex P1 (ninth round) on PR #1938: always run the full
+        # post-reply effects sequence — even on the replay branch
+        # (existing_artifact_id is not None).  The previous eighth-
+        # round fix skipped effects on replay to avoid re-firing
+        # rescope; that traded the duplicate-rescope bug for a
+        # "crashed mid-effects → effects never run on replay" bug.
+        # Now ``_BackgroundRescopeTrigger.trigger_rescope`` is
+        # durably idempotent (via
+        # ``FidoStore.claim_rescope_trigger``), so replay can safely
+        # re-run eyes/emoji/rescope/insight-file: the rescope dedup
+        # is enforced inside the trigger, and the other effects are
+        # idempotent or already-marker-deduped.
         if target is not None:
-            if existing_artifact_id is None:
-                # Original (non-replay) pass: run the full post-reply
-                # effects sequence — eyes removal, final emoji,
-                # rescope trigger, and (when ``insights_already_filed``
-                # is False) the insight filing retry that didn't get
-                # to land pre-reply.
-                executor.execute_effects_only(
-                    synthesis_response,
-                    target,
-                    insights_already_filed=pre_reply_insights_filed,
-                )
-            else:
-                # Codex P1 (eighth round) on PR #1938: replay path.
-                # The original pass already ran the full post-reply
-                # sequence — eyes/emoji/rescope all fired against the
-                # now-already-recorded reply artifact.  Running
-                # ``execute_effects_only`` again would re-trigger
-                # ``trigger_rescope``, which is NOT idempotent — one
-                # actionable comment would rescope/preempt every time
-                # the replay path runs.  Retry ONLY the insight
-                # filing.
-                _safe_retry_file_insights(
-                    executor,
-                    synthesis_response,
-                    target,
-                    where=(f"PR #{info.get('pr')} comment {info.get('comment_id')}"),
-                )
+            executor.execute_effects_only(
+                synthesis_response,
+                target,
+                insights_already_filed=pre_reply_insights_filed,
+            )
 
         return (category, titles)
 
@@ -2608,6 +2623,7 @@ class Dispatcher:
             agent=agent,
             prompts=prompts,
             dispatcher=self,
+            store=FidoStore(repo_cfg.work_dir),
         )
         executor = (
             _executor
@@ -2764,23 +2780,16 @@ class Dispatcher:
         if direct_promise is not None:
             FidoStore(repo_cfg.work_dir).ack_promise(direct_promise.promise_id)
 
-        # Codex P1 (eighth round) on PR #1938: split original vs.
-        # replay paths — see the matching comment on
-        # ``reply_to_comment``.
+        # Codex P1 (ninth round) on PR #1938: always run full
+        # effects — see the matching comment on ``reply_to_comment``.
+        # ``trigger_rescope`` is durably idempotent, so replay can
+        # re-run safely.
         if issue_target is not None:
-            if existing_artifact_id is None:
-                executor.execute_effects_only(
-                    synthesis_response,
-                    issue_target,
-                    insights_already_filed=pre_reply_insights_filed,
-                )
-            else:
-                _safe_retry_file_insights(
-                    executor,
-                    synthesis_response,
-                    issue_target,
-                    where=f"{repo_full} #{number} comment {comment_id}",
-                )
+            executor.execute_effects_only(
+                synthesis_response,
+                issue_target,
+                insights_already_filed=pre_reply_insights_filed,
+            )
 
         log.info(
             "reply_to_issue_comment: complete for PR #%s (category=%s)",
@@ -3906,33 +3915,6 @@ def _intent_arrival_indices(intents: list[RescopeIntent]) -> dict[int, int]:
     """
     ordered = sorted(intents, key=lambda i: i.timestamp)
     return {intent.comment_id: idx for idx, intent in enumerate(ordered)}
-
-
-def _safe_retry_file_insights(
-    executor: "SynthesisExecutor",
-    response: "CommentResponse",
-    target: "CommentTarget",
-    *,
-    where: str,
-) -> None:
-    """HOL-26 / #1920 (codex P1 eighth round on PR #1938): wrap
-    :meth:`SynthesisExecutor.retry_file_insights` in a best-effort
-    guard for the replay-path insight-only retry.
-
-    Catches and logs — the original reply post landed in a prior
-    pass, so a failure here just leaves the insight not-yet-filed
-    (HOL-18's claim-grounding critic remains the verification
-    backstop).
-    """
-    try:
-        executor.retry_file_insights(response, target)
-    except Exception:
-        log.exception(
-            "HOL-26: insight-filing replay retry failed for %s — "
-            "original reply remains posted; HOL-18 prose-grounding "
-            "critic is the verification backstop",
-            where,
-        )
 
 
 def _safe_file_insights_pre_reply(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -42,7 +42,7 @@ from fido.store import (
     ReplyPromiseRecord,
     append_reply_promise_markers,
 )
-from fido.synthesis import Insight
+from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import (
     SynthesisCriticExhaustedError,
     SynthesisExhaustedError,
@@ -2454,7 +2454,12 @@ class Dispatcher:
             # apply.  Matching ``insights_already_filed=True`` on the
             # effects call prevents double-filing.
             if target is not None:
-                executor.file_insights_pre_reply(synthesis_response, target)
+                _safe_file_insights_pre_reply(
+                    executor,
+                    synthesis_response,
+                    target,
+                    where=f"PR #{info.get('pr')} comment {info.get('comment_id')}",
+                )
             log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
             posted = gh.reply_to_review_comment(
                 info["repo"], info["pr"], body, info["comment_id"]
@@ -2706,10 +2711,14 @@ class Dispatcher:
                 promise_ids=promise_ids,
             )
             # HOL-26 / #1920: file insights BEFORE the reply post.  See
-            # the matching comment on the review-comment path; the
-            # invariant is the same.
+            # the matching comment on the review-comment path.
             if issue_target is not None:
-                executor.file_insights_pre_reply(synthesis_response, issue_target)
+                _safe_file_insights_pre_reply(
+                    executor,
+                    synthesis_response,
+                    issue_target,
+                    where=f"{repo_full} #{number} comment {comment_id}",
+                )
             log.info("posting issue comment reply on PR #%s: %s", number, body[:80])
             posted = gh.comment_issue(repo_full, number, body)
             log.info("reply posted on PR #%s", number)
@@ -3825,6 +3834,37 @@ def _intent_arrival_indices(intents: list[RescopeIntent]) -> dict[int, int]:
     """
     ordered = sorted(intents, key=lambda i: i.timestamp)
     return {intent.comment_id: idx for idx, intent in enumerate(ordered)}
+
+
+def _safe_file_insights_pre_reply(
+    executor: "SynthesisExecutor",
+    response: "CommentResponse",
+    target: "CommentTarget",
+    *,
+    where: str,
+) -> None:
+    """HOL-26 / #1920 (codex P1 sixth round on PR #1938): wrap
+    :meth:`SynthesisExecutor.file_insights_pre_reply` in a best-
+    effort guard so a transient GitHub failure inside the insight-
+    filer (marker search or issue create) does NOT drop the
+    user-visible reply.
+
+    The reply is the primary user-facing artifact; insight filing is
+    bookkeeping.  HOL-18's claim-grounding critic remains the
+    verification-layer backstop for prose that references a
+    not-yet-filed insight.
+
+    *where* is a free-form locator (PR/comment string) for the log
+    line so a transient failure is greppable to its source path.
+    """
+    try:
+        executor.file_insights_pre_reply(response, target)
+    except Exception:
+        log.exception(
+            "HOL-26: file_insights_pre_reply failed for %s — "
+            "proceeding with reply post",
+            where,
+        )
 
 
 def _hol25_verdict_framing(verdict: IntentVerdict) -> str:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -114,21 +114,40 @@ class _BackgroundRescopeTrigger:
         forwarded so the rescoper can reference the originating comment and
         accumulate multiple concurrent intents correctly.
 
-        Codex P1 (ninth round) on PR #1938: the rescope trigger is
-        now durably idempotent per ``intent.comment_id``.  Without
-        this, a replay of an already-acked reply (artifact recorded,
-        but ``execute_effects_only`` re-running because of the
-        unified replay-runs-everything path) would re-fire
-        rescope/preempt every pass.  ``FidoStore.claim_rescope_trigger``
-        atomically inserts the comment_id into a durable set and
-        returns ``True`` only on the first claim; subsequent calls
-        (this Fido process or a different one after restart) get
-        ``False`` and skip the trigger.
+        Codex P1 (ninth/tenth rounds) on PR #1938: rescope trigger
+        is now durably idempotent per ``intent.comment_id`` via the
+        ``rescope_intent_outbox`` table.
+
+        - ``claim_rescope_intent`` atomically inserts the full intent
+          payload with ``state='pending'``; returns True only on the
+          first claim.  False on any existing entry (pending or
+          applied) means a prior caller is already handling it.
+        - The ``_on_done`` callback wired into
+          ``reorder_tasks_background`` calls
+          ``mark_rescope_intent_applied`` ONLY after the background
+          rescope's work has durably landed in tasks.json — so the
+          applied-state advances after success, not after the claim.
+        - A synchronous failure of ``reorder_tasks_background``
+          (thread-start error, etc.) releases the pending claim so
+          the next trigger retries.
+        - Crash-after-thread-start residual: the intent stays in
+          ``state='pending'`` and is surfaced by
+          ``pending_rescope_intents()`` for a future startup-replay
+          recovery wiring (follow-up — payload persistence is the
+          enabling step shipped here).
         """
-        if not self._store.claim_rescope_trigger(intent.comment_id):
+        if not self._store.claim_rescope_intent(
+            intent_comment_id=intent.comment_id,
+            change_request=intent.change_request,
+            intent_timestamp=intent.timestamp,
+            author=intent.author,
+            comment_type=intent.comment_type,
+            repo=intent.repo,
+            pr_number=intent.pr_number,
+        ):
             log.info(
-                "RescopeTrigger: rescope already triggered for comment %d "
-                "(durable dedup) — skipping",
+                "RescopeTrigger: rescope already claimed for comment %d "
+                "(durable outbox) — skipping",
                 intent.comment_id,
             )
             return
@@ -137,13 +156,24 @@ class _BackgroundRescopeTrigger:
             intent.comment_id,
             intent.change_request[:80],
         )
-        self._dispatcher.reorder_tasks_background(
-            intent.change_request,
-            self._registry,
-            agent=self._agent,
-            prompts=self._prompts,
-            intents=[intent],
-        )
+
+        def _mark_applied() -> None:
+            self._store.mark_rescope_intent_applied(intent.comment_id)
+
+        try:
+            self._dispatcher.reorder_tasks_background(
+                intent.change_request,
+                self._registry,
+                agent=self._agent,
+                prompts=self._prompts,
+                intents=[intent],
+                _on_done=_mark_applied,
+            )
+        except Exception:
+            # Synchronous failure between claim and dispatch start:
+            # release the pending claim so the next trigger fires.
+            self._store.release_rescope_intent_claim(intent.comment_id)
+            raise
 
 
 _INSIGHT_REPO = INSIGHT_REPO
@@ -3062,6 +3092,8 @@ class Dispatcher:
         prompts: Prompts,
         rewrite_fn: Callable[..., None],
         sync_fn: Callable[[Path, Any], None] | None = None,
+        *,
+        after_apply: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         """Build the kwargs dict for a :func:`~fido.tasks.reorder_tasks` call."""
         from fido.tasks import sync_tasks as _real_sync_tasks
@@ -3083,6 +3115,14 @@ class Dispatcher:
                 _state=State(work_dir / ".git" / "fido"),
                 _tasks=Tasks(work_dir),
             )
+            # Codex P1 (tenth round) on PR #1938: chain the
+            # caller-supplied after-apply hook (e.g. the rescope
+            # outbox's ``mark_rescope_intent_applied``) AFTER
+            # tasks.json has been synced + the PR description
+            # rewritten.  The applied-marker fires only on
+            # successful completion of the durable apply.
+            if after_apply is not None:
+                after_apply()
 
         def on_inprogress_affected(task_id: str) -> None:
             log.info(
@@ -3281,6 +3321,7 @@ class Dispatcher:
         agent: ProviderAgent | None = None,
         prompts: Prompts | None = None,
         _release_untriaged_on_finish: bool = False,
+        _on_done: Callable[[], None] | None = None,
     ) -> None:
         """Run :func:`~fido.tasks.reorder_tasks` in a daemon background thread.
 
@@ -3338,6 +3379,7 @@ class Dispatcher:
             prompts,
             rewrite_fn,
             self._sync_fn,
+            after_apply=_on_done,
         )
 
         with _reorder_coalesce_lock:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -731,6 +731,29 @@ _reorder_coalesce: dict[str, dict[str, Any]] = {}
 _reorder_coalesce_lock = threading.Lock()
 
 
+def _chain_on_done(
+    prev: Callable[[], None] | None,
+    new: Callable[[], None] | None,
+) -> Callable[[], None] | None:
+    """Chain two ``_on_done`` callbacks so both run after the batch lands.
+
+    Used when coalescing rescope triggers into a single pending batch:
+    every originating caller's after-apply hook must fire (e.g. so the
+    rescope outbox advances every coalesced intent to ``applied``), not
+    just the latest caller's.
+    """
+    if prev is None:
+        return new
+    if new is None:
+        return prev
+
+    def chained() -> None:
+        prev()
+        new()
+
+    return chained
+
+
 class WebhookIngressOracle:
     """Per-process at-least-once delivery vs exactly-once dispatch oracle.
 
@@ -3434,12 +3457,26 @@ class Dispatcher:
                 # Coalesce: latest commit_summary and kwargs win; intents accumulate
                 # so every originating comment is tracked even when multiple
                 # comment-triggered rescopes arrive during the same Opus call.
+                #
+                # Codex P1 (thirteenth round) on PR #1938: chain ``_on_done``
+                # callbacks across coalesced callers so every originating
+                # intent's after-apply hook fires when the batch lands.
+                # Without chaining, only the latest caller's
+                # ``mark_rescope_intent_applied`` runs and intermediate
+                # coalesced intents stay durably ``pending`` forever — a
+                # later restart re-runs them and duplicates task/reply
+                # effects.
                 existing = entry["pending"]
                 if existing is None:
                     entry["pending"] = (commit_summary, kwargs, list(intents or []))
                 else:
                     accumulated = list(existing[2]) + list(intents or [])
-                    entry["pending"] = (commit_summary, kwargs, accumulated)
+                    merged_kwargs = dict(kwargs)
+                    merged_kwargs["_on_done"] = _chain_on_done(
+                        existing[1].get("_on_done"),
+                        kwargs.get("_on_done"),
+                    )
+                    entry["pending"] = (commit_summary, merged_kwargs, accumulated)
                 return
             entry["running"] = True
             entry["pending"] = None

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2436,6 +2436,13 @@ class Dispatcher:
         root_comment_id = (
             thread_comments[0]["id"] if thread_comments else info["comment_id"]
         )
+        # Codex P2 seventh round on PR #1938: track whether the pre-
+        # reply insight file succeeded.  False both when we didn't
+        # try (existing artifact / no target) AND when the try raised
+        # — either way the post-reply effects must run their own
+        # ``_file_insights`` pass so a transient pre-reply failure
+        # doesn't permanently lose the insight.
+        pre_reply_insights_filed = False
         existing_artifact_id = _existing_reply_artifact(repo_cfg, promise_ids)
         if existing_artifact_id is None:
             _claim_reply_outbox_effects(
@@ -2447,18 +2454,13 @@ class Dispatcher:
             )
             # HOL-26 / #1920: file insights BEFORE the reply post so any
             # claim in the reply body about a filed insight is true at
-            # the moment of posting.  Sequenced here (not inside
-            # executor.execute_effects_only below) because the
-            # production reply path threads the outbox protocol through
-            # its own post — the convenience execute() chain doesn't
-            # apply.  Matching ``insights_already_filed=True`` on the
-            # effects call prevents double-filing.
+            # the moment of posting.
             if target is not None:
-                _safe_file_insights_pre_reply(
+                pre_reply_insights_filed = _safe_file_insights_pre_reply(
                     executor,
                     synthesis_response,
                     target,
-                    where=f"PR #{info.get('pr')} comment {info.get('comment_id')}",
+                    where=(f"PR #{info.get('pr')} comment {info.get('comment_id')}"),
                 )
             log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
             posted = gh.reply_to_review_comment(
@@ -2494,7 +2496,9 @@ class Dispatcher:
         # path could share its eyes-removal helper.
         if target is not None:
             executor.execute_effects_only(
-                synthesis_response, target, insights_already_filed=True
+                synthesis_response,
+                target,
+                insights_already_filed=pre_reply_insights_filed,
             )
 
         return (category, titles)
@@ -2701,6 +2705,8 @@ class Dispatcher:
 
         promise_ids = _reply_promise_ids(context)
         body = append_reply_promise_markers(body, promise_ids)
+        # Codex P2 seventh round on PR #1938 — see review-comment path.
+        pre_reply_insights_filed = False
         existing_artifact_id = _existing_reply_artifact(repo_cfg, promise_ids)
         if existing_artifact_id is None:
             _claim_reply_outbox_effects(
@@ -2713,7 +2719,7 @@ class Dispatcher:
             # HOL-26 / #1920: file insights BEFORE the reply post.  See
             # the matching comment on the review-comment path.
             if issue_target is not None:
-                _safe_file_insights_pre_reply(
+                pre_reply_insights_filed = _safe_file_insights_pre_reply(
                     executor,
                     synthesis_response,
                     issue_target,
@@ -2747,7 +2753,9 @@ class Dispatcher:
         # eyes-removal helper.
         if issue_target is not None:
             executor.execute_effects_only(
-                synthesis_response, issue_target, insights_already_filed=True
+                synthesis_response,
+                issue_target,
+                insights_already_filed=pre_reply_insights_filed,
             )
 
         log.info(
@@ -2899,7 +2907,7 @@ class Dispatcher:
 
     def notify_terminal_task_thread(
         self,
-        task: dict[str, Any],
+        new_tasks: list[dict[str, Any]],
         anchor_intent: RescopeIntent,
         *,
         pr: int,
@@ -2931,23 +2939,54 @@ class Dispatcher:
 
         The caller is responsible for:
 
-        - Verifying the task just transitioned from non-terminal to
-          terminal (so this method fires exactly once per terminal
-          transition).
+        - Verifying the thread just transitioned from non-all-terminal
+          to all-terminal (so this method fires exactly once per
+          thread closing).
         - Constructing *anchor_intent* from the task's primary thread
           (``task["thread"]``) with the correct ``comment_type``.
 
+        Codex P1+P2 (seventh round) on PR #1938: this method now
+        receives ``new_tasks`` (the live post-completion snapshot)
+        and builds completed/skipped lists from EVERY task anchored
+        at ``anchor_intent.comment_id``.  The previous shape took a
+        single task argument and gated on its ``status`` — which was
+        broken on both axes:
+
+        1. The worker passed a pre-completion snapshot of the task,
+           so the dispatcher saw stale ``status="in_progress"`` and
+           returned early.
+        2. Even with a fresh row, building the closing summary from
+           only ONE task lost the sibling tasks that shared the
+           thread; the user got "T2 done" with no mention of T1.
+
         Best-effort post: transport failures log but do not propagate.
         """
-        status = str(task.get("status"))
-        completed = [task] if status == TaskStatus.COMPLETED.value else []
-        skipped = [task] if status == TaskStatus.SKIPPED.value else []
-        if not completed and not skipped:
+        terminal = {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
+        anchored = [
+            t
+            for t in new_tasks
+            if (t.get("thread") or {}).get("comment_id") == anchor_intent.comment_id
+        ]
+        completed = [
+            t for t in anchored if str(t.get("status")) == TaskStatus.COMPLETED.value
+        ]
+        skipped = [
+            t for t in anchored if str(t.get("status")) == TaskStatus.SKIPPED.value
+        ]
+        non_terminal = [t for t in anchored if str(t.get("status")) not in terminal]
+        if non_terminal:
             log.info(
-                "notify_terminal_task_thread: task %s is not in a "
-                "terminal status (%r) — skipping",
-                task.get("id"),
-                status,
+                "notify_terminal_task_thread: anchor %s still has "
+                "non-terminal tasks (%r) — skipping",
+                anchor_intent.comment_id,
+                [t.get("id") for t in non_terminal],
+            )
+            return
+        if not anchored:
+            log.info(
+                "notify_terminal_task_thread: no tasks anchored at "
+                "comment %s — skipping",
+                anchor_intent.comment_id,
             )
             return
         framing = _hol28_terminal_thread_framing(anchor_intent, completed, skipped)
@@ -2964,14 +3003,17 @@ class Dispatcher:
                 self._repo_cfg.name, pr, body, anchor_intent.comment_id
             )
             log.info(
-                "notified terminal task thread for task %s at comment %s",
-                task.get("id"),
+                "notified terminal task thread at comment %s "
+                "(%d completed, %d skipped across %d sibling tasks)",
                 anchor_intent.comment_id,
+                len(completed),
+                len(skipped),
+                len(anchored),
             )
         except Exception:
             log.exception(
-                "failed to notify terminal task thread for task %s",
-                task.get("id"),
+                "failed to notify terminal task thread at comment %s",
+                anchor_intent.comment_id,
             )
 
     def _make_reorder_kwargs(
@@ -3842,12 +3884,21 @@ def _safe_file_insights_pre_reply(
     target: "CommentTarget",
     *,
     where: str,
-) -> None:
+) -> bool:
     """HOL-26 / #1920 (codex P1 sixth round on PR #1938): wrap
     :meth:`SynthesisExecutor.file_insights_pre_reply` in a best-
     effort guard so a transient GitHub failure inside the insight-
     filer (marker search or issue create) does NOT drop the
     user-visible reply.
+
+    Returns ``True`` when filing completed cleanly (so the matching
+    ``execute_effects_only`` call can pass
+    ``insights_already_filed=True`` and skip the post-reply re-file).
+    Returns ``False`` on failure (codex P2 seventh round on PR
+    #1938) so the caller leaves ``insights_already_filed=False`` and
+    the post-reply effects pass re-attempts the file — without
+    that, a transient pre-reply failure permanently lost the
+    insight instead of retrying.
 
     The reply is the primary user-facing artifact; insight filing is
     bookkeeping.  HOL-18's claim-grounding critic remains the
@@ -3862,9 +3913,12 @@ def _safe_file_insights_pre_reply(
     except Exception:
         log.exception(
             "HOL-26: file_insights_pre_reply failed for %s — "
-            "proceeding with reply post",
+            "proceeding with reply post; post-reply effects will "
+            "retry the file",
             where,
         )
+        return False
+    return True
 
 
 def _hol25_verdict_framing(verdict: IntentVerdict) -> str:
@@ -3957,9 +4011,18 @@ def _hol28_terminal_thread_framing(
         "touched.  Do NOT post per-task; this is the single closing "
         "summary for the whole thread.",
         "",
-        f"This commenter's change request: {intent.change_request}",
         f"Their comment id: {intent.comment_id} ({intent.timestamp})",
     ]
+    # Codex P2 (seventh round) on PR #1938: only include the
+    # change_request line when it's a real, non-empty value.  The
+    # HOL-28 worker wire constructs a synthetic anchor intent with
+    # ``change_request=""``; interpolating a placeholder string here
+    # would leak fabricated request text into the user-visible reply.
+    if intent.change_request.strip():
+        parts.insert(
+            len(parts) - 1,
+            f"This commenter's change request: {intent.change_request}",
+        )
     if completed_tasks:
         parts.append("")
         parts.append("Tasks that LANDED (use commit titles in the story):")

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -57,6 +57,7 @@ from fido.types import (
     ActivePR,
     IntentVerdict,
     RescopeIntent,
+    TaskStatus,
     TaskType,
     verdict_is_material,
 )
@@ -2763,6 +2764,88 @@ class Dispatcher:
         except Exception:
             log.exception("failed to notify intent comment %s", intent.comment_id)
 
+    def notify_newly_terminal_intent_threads(
+        self,
+        prev_tasks: list[dict[str, Any]],
+        new_tasks: list[dict[str, Any]],
+        *,
+        batch_intents: list[RescopeIntent],
+        pr: int,
+        agent: ProviderAgent,
+        prompts: Prompts,
+    ) -> None:
+        """HOL-28 / #1922: emit one per-thread aggregate reply for every
+        intent whose thread just transitioned from non-terminal to
+        terminal across the ``prev_tasks`` → ``new_tasks`` snapshot pair.
+
+        Wired by the task-completion path: when the worker marks a task
+        COMPLETED (or the rescope marks one SKIPPED), call this with the
+        before/after task lists.  ``newly_terminal_intent_threads``
+        (HOL-27) computes which intents transitioned; this method posts
+        the aggregate reply per intent.
+
+        Issue comments are silently skipped (same INV-F rule as
+        ``_notify_intent_outcome``: webhook already replied at triage).
+        Bot threads are included (per HOL-28 issue: "Bot threads
+        included" — humans need to follow what landed; so do bots).
+        """
+        from fido.types import newly_terminal_intent_threads
+
+        intents_by_cid = {i.comment_id: i for i in batch_intents}
+        transitioned_cids = newly_terminal_intent_threads(prev_tasks, new_tasks)
+        if not transitioned_cids:
+            return
+        repo = self._repo_cfg.name
+        for cid in transitioned_cids:
+            intent = intents_by_cid.get(cid)
+            if intent is None:
+                # Intent not in the current batch (e.g. comment shaped
+                # tasks across multiple rescope runs and this batch
+                # only carries a subset).  Skip — caller is responsible
+                # for passing the full intent set.
+                continue
+            if intent.comment_type != "pulls":
+                log.info(
+                    "skipping terminal-thread notification for issue "
+                    "comment %s (webhook already replied at triage)",
+                    cid,
+                )
+                continue
+            completed = [
+                t
+                for t in new_tasks
+                if cid in (t.get("contributing_intents") or ())
+                and str(t.get("status")) == TaskStatus.COMPLETED.value
+            ]
+            skipped = [
+                t
+                for t in new_tasks
+                if cid in (t.get("contributing_intents") or ())
+                and str(t.get("status")) == TaskStatus.SKIPPED.value
+            ]
+            framing = _hol28_terminal_thread_framing(intent, completed, skipped)
+            body = safe_voice_turn(
+                agent,
+                prompts.persona_wrap(framing),
+                model=agent.voice_model,
+                allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+                system_prompt=prompts.reply_system_prompt(),
+                log_prefix="notify_terminal_intent_threads",
+            )
+            try:
+                self._gh.reply_to_review_comment(repo, pr, body, intent.comment_id)
+                log.info(
+                    "notified terminal thread for intent comment %s "
+                    "(%d completed, %d skipped)",
+                    cid,
+                    len(completed),
+                    len(skipped),
+                )
+            except Exception:
+                log.exception(
+                    "failed to notify terminal thread for intent comment %s", cid
+                )
+
     def _make_reorder_kwargs(
         self,
         registry: ActivityReporter,
@@ -3668,6 +3751,52 @@ def _hol25_verdict_framing(verdict: IntentVerdict) -> str:
                 "the superseding intent.\n\n"
                 f"Rescope narrative: {narrative}"
             )
+
+
+def _hol28_terminal_thread_framing(
+    intent: RescopeIntent,
+    completed_tasks: list[dict[str, Any]],
+    skipped_tasks: list[dict[str, Any]],
+) -> str:
+    """HOL-28 / #1922: per-thread terminal aggregate framing.
+
+    Built when an intent thread transitions to fully-terminal — every
+    task carrying *intent*'s comment_id in ``contributing_intents`` is
+    now COMPLETED or SKIPPED.  The framing lists what landed (commit
+    titles) and what was skipped (with the skip narrative if present),
+    so Opus can generate a single per-thread reply summarising
+    everything the requester's comment shaped.
+
+    Voice-text-not-templated: this is the INSTRUCTION sent to Opus
+    (deterministic fact-carrier); Opus generates the user-visible
+    prose per call.
+    """
+    parts: list[str] = [
+        "Every task this PR comment shaped has reached terminal state — "
+        "either landed as a commit or skipped with reason.  Tell this "
+        "commenter the AGGREGATE story across all the tasks their ask "
+        "touched.  Do NOT post per-task; this is the single closing "
+        "summary for the whole thread.",
+        "",
+        f"This commenter's change request: {intent.change_request}",
+        f"Their comment id: {intent.comment_id} ({intent.timestamp})",
+    ]
+    if completed_tasks:
+        parts.append("")
+        parts.append("Tasks that LANDED (use commit titles in the story):")
+        for task in completed_tasks:
+            title = (task.get("title") or "").strip() or "(untitled)"
+            parts.append(f"- {task['id']}: {title}")
+    if skipped_tasks:
+        parts.append("")
+        parts.append("Tasks that were SKIPPED (carry the skip reason verbatim):")
+        for task in skipped_tasks:
+            title = (task.get("title") or "").strip() or "(untitled)"
+            reason = (task.get("description") or "").strip() or "(no reason recorded)"
+            parts.append(f"- {task['id']}: {title} — {reason}")
+    parts.append("")
+    parts.append("Write a brief aggregate reply.")
+    return "\n".join(parts)
 
 
 def _rocq_intent_rows(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2024,6 +2024,48 @@ class Dispatcher:
             registry=registry,
         )
 
+    def replay_pending_rescope_intents(
+        self,
+        registry: ActivityReporter,
+        *,
+        agent: ProviderAgent,
+        prompts: Prompts,
+    ) -> int:
+        """Re-fire rescope intents left in ``state='pending'`` across a restart.
+
+        Codex P1 (twelfth round) on PR #1938: a crash between the
+        visible ACT reply landing and ``_on_done`` marking the outbox
+        row applied leaves an orphan pending row.  GitHub does not
+        redeliver an already-successful webhook, so without startup
+        replay the rescope is permanently lost.
+
+        Reconstructs a ``RescopeIntent`` from each pending row's
+        persisted payload and re-dispatches through the trigger.
+        ``claim_rescope_intent`` sees the pending row, refreshes
+        ``claimed_at``, and returns True; ``reorder_tasks_background``
+        runs; ``_on_done`` advances state to ``applied`` on success.
+
+        Returns the number of intents re-dispatched.
+        """
+        store = FidoStore(self._repo_cfg.work_dir)
+        pending = store.pending_rescope_intents()
+        if not pending:
+            return 0
+        trigger = _BackgroundRescopeTrigger(
+            registry,
+            agent=agent,
+            prompts=prompts,
+            dispatcher=self,
+            store=store,
+        )
+        for intent in pending:
+            log.info(
+                "replaying pending rescope intent for comment %d",
+                intent.comment_id,
+            )
+            trigger.trigger_rescope(intent)
+        return len(pending)
+
     def recover_reply_promises(
         self,
         fido_dir: Path,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1490,11 +1490,14 @@ class Dispatcher:
         self._insight_dedup_transport_counter = InsightDedupTransportCounter(
             escalator=self._escalate_insight_dedup_transport_failure,
         )
-        # HOL-16 follow-up / #1934: process-local per-intent
-        # task-creation-drop counter; escalates via the Dispatcher-
-        # bound method when an intent's drops cross threshold.
+        # HOL-16 follow-up / #1934 (codex P2 on PR #1938): per-intent
+        # task-creation-drop counter backed by ``FidoStore`` so the
+        # streak survives Fido restarts.  Escalates via the
+        # Dispatcher-bound method when an intent's drops cross
+        # threshold.
         self._task_creation_drop_counter = TaskCreationDropCounter(
             escalator=self._escalate_task_creation_drop_streak,
+            store=FidoStore(self._repo_cfg.work_dir),
         )
 
     def _escalate_task_creation_drop_streak(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -412,6 +412,131 @@ _BUG_REPO = "FidoCanCode/home"
 _BUG_LABEL = "Bug"
 
 
+@dataclass(frozen=True)
+class StuckOnCriticContext:
+    """HOL-21 / #1915: context bundle for ``file_stuck_on_critic_bug``.
+
+    Every critic that detects exhaustion (HOL-15..HOL-19) builds one
+    of these and hands it to the shared filing helper.  The shape is
+    deliberately critic-agnostic so the bug body, idempotency
+    marker, and title template are all uniform across emission
+    points — the auto-filed bug is recognizably the same shape
+    whether it came from intent-coverage exhaustion on a triage
+    reply or task-completion exhaustion on a worker commit.
+
+    Fields:
+
+    - ``emission_point``: short label identifying which critic
+      exhausted (``"intent-coverage"``, ``"task-completion"``, etc.).
+      Part of the idempotency key so two different critics
+      exhausting on the same target still file separate bugs.
+    - ``source_repo`` / ``source_pr``: where the exhaustion happened.
+    - ``target_kind`` / ``target_id``: what the critic was working on
+      when it exhausted (``"comment"``/``"task"``).  Part of the
+      idempotency key.
+    - ``source_link``: clickable URL to the target.
+    - ``gaps``: every failed verdict's gap text, in order.
+    - ``attempts_preview``: per-attempt response preview when
+      available (HOL-15/18 carry these; HOL-17 task-completion may
+      use the per-attempt commit summary instead; HOL-16/19 leave
+      empty when their exhaustion paths land).
+    """
+
+    emission_point: str
+    source_repo: str
+    source_pr: int
+    target_kind: str
+    target_id: str
+    source_link: str
+    gaps: tuple[str, ...]
+    attempts_preview: tuple[str, ...] = ()
+
+
+def file_stuck_on_critic_bug(ctx: StuckOnCriticContext, *, gh: GitHub) -> str | None:
+    """HOL-21 / #1915: file (idempotently) a bug on :data:`_BUG_REPO`
+    for a critic exhaustion.
+
+    Returns the bug URL on success (whether newly filed or reused
+    from an idempotency-marker hit), or ``None`` when both the
+    marker search AND the create call fail — caller decides whether
+    to soften the BLOCKED-comment wording (no URL to cite) or carry
+    on silently.
+
+    Idempotency marker keyed on
+    ``(emission_point, source_repo, source_pr, target_kind, target_id)``
+    so retry attempts of the same exhaustion route reuse the
+    existing bug instead of spamming ``_BUG_REPO`` with duplicates.
+    Two different critics exhausting on the same target file
+    SEPARATE bugs because the emission point is part of the key —
+    different root causes warrant separate tickets.
+    """
+    bug_marker = (
+        f"<!-- critic-exhaustion: {ctx.emission_point}:"
+        f"{ctx.source_repo}#{ctx.source_pr}:"
+        f"{ctx.target_kind}:{ctx.target_id} -->"
+    )
+    bug_title = (
+        f"Bug: {ctx.emission_point} critic exhausted "
+        f"on {ctx.source_repo}#{ctx.source_pr} {ctx.target_kind} {ctx.target_id}"
+    )
+    gap_lines = (
+        "\n".join(f"  {i + 1}. {gap}" for i, gap in enumerate(ctx.gaps))
+        or "  (no gaps recorded)"
+    )
+    if ctx.attempts_preview:
+        attempts_block = "\n".join(
+            f"  {i + 1}. {preview!r}" for i, preview in enumerate(ctx.attempts_preview)
+        )
+    else:
+        attempts_block = "  (no per-attempt previews recorded)"
+    bug_body = (
+        f"## Critic exhaustion\n\n"
+        f"- Critic: `{ctx.emission_point}`\n"
+        f"- Source: {ctx.source_link}\n"
+        f"- Source repo / PR: `{ctx.source_repo}#{ctx.source_pr}`\n"
+        f"- Target: `{ctx.target_kind} {ctx.target_id}`\n"
+        f"- Attempts: {len(ctx.gaps)}\n\n"
+        f"## Critic gaps (one per attempt)\n\n{gap_lines}\n\n"
+        f"## Per-attempt previews\n\n{attempts_block}\n\n"
+        f"{bug_marker}\n"
+    )
+    try:
+        existing_bugs = gh.search_issues(_BUG_REPO, f'"{bug_marker}" in:body is:issue')
+    except Exception as search_exc:
+        log.warning(
+            "stuck-on-critic[%s]: bug-marker search failed (%s) — "
+            "proceeding to file (may create a duplicate)",
+            ctx.emission_point,
+            search_exc,
+        )
+        existing_bugs = []
+    if existing_bugs:
+        url = existing_bugs[0].get("html_url")
+        log.info(
+            "stuck-on-critic[%s]: existing bug found for %s#%d %s %s — reusing %s",
+            ctx.emission_point,
+            ctx.source_repo,
+            ctx.source_pr,
+            ctx.target_kind,
+            ctx.target_id,
+            url,
+        )
+        return str(url) if url else None
+    try:
+        return str(gh.create_issue(_BUG_REPO, bug_title, bug_body, labels=[_BUG_LABEL]))
+    except Exception as file_exc:
+        log.warning(
+            "stuck-on-critic[%s]: failed to auto-file bug for %s#%d %s %s (%s)",
+            ctx.emission_point,
+            ctx.source_repo,
+            ctx.source_pr,
+            ctx.target_kind,
+            ctx.target_id,
+            file_exc,
+        )
+        return None
+
+
 def _route_critic_exhausted_blocked(
     exc: "SynthesisCriticExhaustedError",
     target: CommentTarget,
@@ -458,74 +583,24 @@ def _route_critic_exhausted_blocked(
     """
     source_link = _insight_source_link(target)
 
-    bug_title = (
-        f"Bug: synthesis {exc.label} critic exhausted "
-        f"on {target.repo}#{target.pr} comment {target.comment_id}"
+    # HOL-21 / #1915: bug-filing is shared infrastructure now —
+    # ``file_stuck_on_critic_bug`` handles the body, idempotency
+    # marker, and URL return for ALL critic exhaustion routes
+    # (synthesis critics here + per-leaf retry budgets for HOL-16/
+    # HOL-17/HOL-19 in their own modules).
+    bug_url = file_stuck_on_critic_bug(
+        StuckOnCriticContext(
+            emission_point=exc.label,
+            source_repo=target.repo,
+            source_pr=target.pr,
+            target_kind="comment",
+            target_id=str(target.comment_id),
+            source_link=source_link,
+            gaps=tuple(exc.critic_gaps),
+            attempts_preview=tuple(exc.synthesis_attempts),
+        ),
+        gh=gh,
     )
-    gap_lines = "\n".join(f"  {i + 1}. {gap}" for i, gap in enumerate(exc.critic_gaps))
-    attempt_lines = "\n".join(
-        f"  {i + 1}. {preview!r}" for i, preview in enumerate(exc.synthesis_attempts)
-    )
-    # Codex on PR #1932: idempotency marker keyed on
-    # ``(critic_label, source_repo, source_pr, source_comment_id)``
-    # so a retry of this route (e.g. comment-post failed and the
-    # promise stayed claimed) doesn't file a SECOND bug for the same
-    # exhaustion.  Without this, transient GitHub failures spamming
-    # ``_BUG_REPO`` with duplicate Bug issues that obscure real
-    # incidents.  Two different critics exhausting on the same
-    # comment file separate bugs (different root causes) because the
-    # label is part of the key.
-    bug_marker = (
-        f"<!-- critic-exhaustion: {exc.label}:"
-        f"{target.repo}#{target.pr}:{target.comment_id} -->"
-    )
-    bug_body = (
-        f"## Critic exhaustion\n\n"
-        f"- Critic: `{exc.label}`\n"
-        f"- Source comment: {source_link}\n"
-        f"- Source repo / PR: `{target.repo}#{target.pr}`\n"
-        f"- Source comment id: `{target.comment_id}`\n"
-        f"- Attempts: {len(exc.synthesis_attempts)}\n\n"
-        f"## Critic gaps (one per attempt)\n\n{gap_lines}\n\n"
-        f"## Synthesis attempts (reply_text preview)\n\n{attempt_lines}\n\n"
-        f"{bug_marker}\n"
-    )
-    bug_url: str | None = None
-    try:
-        existing_bugs = gh.search_issues(_BUG_REPO, f'"{bug_marker}" in:body is:issue')
-    except Exception as search_exc:
-        log.warning(
-            "critic-exhausted route: bug-marker search failed (%s) — "
-            "proceeding to file (may create a duplicate)",
-            search_exc,
-        )
-        existing_bugs = []
-    if existing_bugs:
-        bug_url = existing_bugs[0].get("html_url")
-        log.info(
-            "critic-exhausted route: existing bug found for %s#%d "
-            "comment %d critic=%s — reusing %s",
-            target.repo,
-            target.pr,
-            target.comment_id,
-            exc.label,
-            bug_url,
-        )
-    else:
-        try:
-            bug_url = gh.create_issue(
-                _BUG_REPO, bug_title, bug_body, labels=[_BUG_LABEL]
-            )
-        except Exception as file_exc:
-            log.warning(
-                "critic-exhausted route: failed to auto-file bug for "
-                "%s#%d comment %d (%s) — BLOCKED comment will note the "
-                "filing failure instead of claiming a URL",
-                target.repo,
-                target.pr,
-                target.comment_id,
-                file_exc,
-            )
 
     if bug_url:
         filing_line = f"Auto-filed against `{_BUG_REPO}` for follow-up: {bug_url}"
@@ -782,6 +857,14 @@ def build_review_comment_action(
             "comment_type": "pulls",
             "lineage_key": lineage_key,
             "lineage_comment_ids": list(lineage_comment_ids),
+            # HOL-22 / #1916: identifies the GitHub review submission
+            # this comment belongs to.  The eager-eyes predicate uses
+            # it to detect "same-submission batch" vs "solo comment
+            # arriving during an unrelated batch" (closes #1875).
+            # None for review comments that aren't part of a
+            # submission (e.g. single-line comments without a
+            # review wrapper); the predicate's fallback handles that.
+            "pull_request_review_id": comment.get("pull_request_review_id"),
         },
         comment_body=body,
         is_bot=is_bot,
@@ -1229,8 +1312,18 @@ def _queued_pr_comment_action(
     author: str,
     is_bot: bool,
     context: dict[str, Any],
+    pull_request_review_id: int | None = None,
 ) -> Action:
-    """Wake the worker for a durably queued PR comment without using provider."""
+    """Wake the worker for a durably queued PR comment without using provider.
+
+    HOL-22 / #1916: ``pull_request_review_id`` plumbs through so the
+    eager-eyes predicate in ``server.py`` (which reads it off
+    ``action.thread`` on the queued/recovery path) can scope its
+    "same-batch" check to the review submission this comment belongs
+    to.  Without the propagation, the predicate falls back to the
+    legacy unscoped check and the #1875 scenario keeps reproducing on
+    the live webhook → queue → dispatch path (codex on PR #1937).
+    """
     return Action(
         prompt=prompt,
         preempts_worker=True,
@@ -1243,6 +1336,7 @@ def _queued_pr_comment_action(
             "url": html_url,
             "author": author,
             "comment_type": comment_type,
+            "pull_request_review_id": pull_request_review_id,
         },
     )
 
@@ -1503,6 +1597,9 @@ class Dispatcher:
                 html_url=comment.get("html_url", ""),
                 author=user,
                 is_bot=is_bot,
+                # HOL-22 / #1916: scope eager-eyes to same review
+                # submission (codex on PR #1937).
+                pull_request_review_id=comment.get("pull_request_review_id"),
                 context={
                     "comment_body": comment_body,
                     "delivery_id": delivery_id,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2489,17 +2489,34 @@ class Dispatcher:
         if direct_promise is not None:
             FidoStore(repo_cfg.work_dir).ack_promise(direct_promise.promise_id)
 
-        # Execute post-reply effects: remove eyes, add final emoji, trigger
-        # rescope.  Only runs if we have a real comment_id to react on (the
-        # ``target`` was constructed up-front for the same reason).  Reuses the
-        # ``executor`` instance built before the synthesis call so the failure
-        # path could share its eyes-removal helper.
         if target is not None:
-            executor.execute_effects_only(
-                synthesis_response,
-                target,
-                insights_already_filed=pre_reply_insights_filed,
-            )
+            if existing_artifact_id is None:
+                # Original (non-replay) pass: run the full post-reply
+                # effects sequence — eyes removal, final emoji,
+                # rescope trigger, and (when ``insights_already_filed``
+                # is False) the insight filing retry that didn't get
+                # to land pre-reply.
+                executor.execute_effects_only(
+                    synthesis_response,
+                    target,
+                    insights_already_filed=pre_reply_insights_filed,
+                )
+            else:
+                # Codex P1 (eighth round) on PR #1938: replay path.
+                # The original pass already ran the full post-reply
+                # sequence — eyes/emoji/rescope all fired against the
+                # now-already-recorded reply artifact.  Running
+                # ``execute_effects_only`` again would re-trigger
+                # ``trigger_rescope``, which is NOT idempotent — one
+                # actionable comment would rescope/preempt every time
+                # the replay path runs.  Retry ONLY the insight
+                # filing.
+                _safe_retry_file_insights(
+                    executor,
+                    synthesis_response,
+                    target,
+                    where=(f"PR #{info.get('pr')} comment {info.get('comment_id')}"),
+                )
 
         return (category, titles)
 
@@ -2747,16 +2764,23 @@ class Dispatcher:
         if direct_promise is not None:
             FidoStore(repo_cfg.work_dir).ack_promise(direct_promise.promise_id)
 
-        # Execute post-reply effects: remove eyes, add final emoji, trigger
-        # rescope.  Reuses the ``executor`` and ``issue_target`` constructed
-        # before the synthesis call so the failure path could share its
-        # eyes-removal helper.
+        # Codex P1 (eighth round) on PR #1938: split original vs.
+        # replay paths — see the matching comment on
+        # ``reply_to_comment``.
         if issue_target is not None:
-            executor.execute_effects_only(
-                synthesis_response,
-                issue_target,
-                insights_already_filed=pre_reply_insights_filed,
-            )
+            if existing_artifact_id is None:
+                executor.execute_effects_only(
+                    synthesis_response,
+                    issue_target,
+                    insights_already_filed=pre_reply_insights_filed,
+                )
+            else:
+                _safe_retry_file_insights(
+                    executor,
+                    synthesis_response,
+                    issue_target,
+                    where=f"{repo_full} #{number} comment {comment_id}",
+                )
 
         log.info(
             "reply_to_issue_comment: complete for PR #%s (category=%s)",
@@ -2961,11 +2985,17 @@ class Dispatcher:
 
         Best-effort post: transport failures log but do not propagate.
         """
+        # Codex P2 (eighth round) on PR #1938: anchor comparison
+        # goes through ``int(...)`` normalization so a string-typed
+        # ``thread.comment_id`` in any sibling row doesn't make that
+        # sibling invisible during the "still pending?" filter.
+        from fido.types import hol28_anchor_key
+
         terminal = {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
         anchored = [
             t
             for t in new_tasks
-            if (t.get("thread") or {}).get("comment_id") == anchor_intent.comment_id
+            if hol28_anchor_key(t.get("thread")) == anchor_intent.comment_id
         ]
         completed = [
             t for t in anchored if str(t.get("status")) == TaskStatus.COMPLETED.value
@@ -3876,6 +3906,33 @@ def _intent_arrival_indices(intents: list[RescopeIntent]) -> dict[int, int]:
     """
     ordered = sorted(intents, key=lambda i: i.timestamp)
     return {intent.comment_id: idx for idx, intent in enumerate(ordered)}
+
+
+def _safe_retry_file_insights(
+    executor: "SynthesisExecutor",
+    response: "CommentResponse",
+    target: "CommentTarget",
+    *,
+    where: str,
+) -> None:
+    """HOL-26 / #1920 (codex P1 eighth round on PR #1938): wrap
+    :meth:`SynthesisExecutor.retry_file_insights` in a best-effort
+    guard for the replay-path insight-only retry.
+
+    Catches and logs — the original reply post landed in a prior
+    pass, so a failure here just leaves the insight not-yet-filed
+    (HOL-18's claim-grounding critic remains the verification
+    backstop).
+    """
+    try:
+        executor.retry_file_insights(response, target)
+    except Exception:
+        log.exception(
+            "HOL-26: insight-filing replay retry failed for %s — "
+            "original reply remains posted; HOL-18 prose-grounding "
+            "critic is the verification backstop",
+            where,
+        )
 
 
 def _safe_file_insights_pre_reply(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -15,6 +15,7 @@ from fido.critics import (
     INSIGHT_REPO,
     InsightDedupTransportCounter,
     InsightDedupVerdict,
+    TaskCreationDropCounter,
     run_insight_dedup_critic,
 )
 from fido.github import GitHub
@@ -1489,6 +1490,43 @@ class Dispatcher:
         self._insight_dedup_transport_counter = InsightDedupTransportCounter(
             escalator=self._escalate_insight_dedup_transport_failure,
         )
+        # HOL-16 follow-up / #1934: process-local per-intent
+        # task-creation-drop counter; escalates via the Dispatcher-
+        # bound method when an intent's drops cross threshold.
+        self._task_creation_drop_counter = TaskCreationDropCounter(
+            escalator=self._escalate_task_creation_drop_streak,
+        )
+
+    def _escalate_task_creation_drop_streak(
+        self, intent_comment_id: int, count: int
+    ) -> None:
+        """HOL-16 follow-up / #1934: escalator bound to the
+        Dispatcher's per-intent
+        :class:`TaskCreationDropCounter`.  Files a bug against
+        ``FidoCanCode/home`` when a single intent_comment_id has had
+        N proposals dropped in a row — either Opus keeps re-proposing
+        legitimately-distinct work the critic mis-classifies, or the
+        comment's intent isn't being honoured.
+        """
+        file_stuck_on_critic_bug(
+            StuckOnCriticContext(
+                emission_point="task-creation",
+                source_repo=self._repo_cfg.name,
+                source_pr=0,
+                target_kind="comment",
+                target_id=str(intent_comment_id),
+                source_link=(
+                    f"(process-local — comment {intent_comment_id} had "
+                    f"{count} proposals dropped by the task-creation critic "
+                    f"in {self._repo_cfg.name})"
+                ),
+                gaps=(
+                    f"{count} consecutive task-creation drops attributed to "
+                    f"comment #{intent_comment_id}",
+                ),
+            ),
+            gh=self._gh,
+        )
 
     def _escalate_insight_dedup_transport_failure(self, count: int) -> None:
         """HOL-19 follow-up / #1935: escalator bound to the
@@ -2962,6 +3000,11 @@ class Dispatcher:
             "_on_inprogress_affected": on_inprogress_affected,
             "agent": agent,
             "prompts": prompts,
+            # HOL-16 follow-up / #1934: process-local per-intent
+            # drop counter shared across this Dispatcher's rescope
+            # batches; escalates via the Dispatcher-bound escalator
+            # method when an intent's drops cross threshold.
+            "task_creation_drop_counter": self._task_creation_drop_counter,
         }
         issue_ctx, pr_ctx = _load_active_context_for_rescope(
             work_dir, repo_cfg.name, gh

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2341,6 +2341,16 @@ class Dispatcher:
                 ),
                 promise_ids=promise_ids,
             )
+            # HOL-26 / #1920: file insights BEFORE the reply post so any
+            # claim in the reply body about a filed insight is true at
+            # the moment of posting.  Sequenced here (not inside
+            # executor.execute_effects_only below) because the
+            # production reply path threads the outbox protocol through
+            # its own post — the convenience execute() chain doesn't
+            # apply.  Matching ``insights_already_filed=True`` on the
+            # effects call prevents double-filing.
+            if target is not None:
+                executor.file_insights_pre_reply(synthesis_response, target)
             log.info("posting reply to PR #%s: %s", info["pr"], body[:80])
             posted = gh.reply_to_review_comment(
                 info["repo"], info["pr"], body, info["comment_id"]
@@ -2374,7 +2384,9 @@ class Dispatcher:
         # ``executor`` instance built before the synthesis call so the failure
         # path could share its eyes-removal helper.
         if target is not None:
-            executor.execute_effects_only(synthesis_response, target)
+            executor.execute_effects_only(
+                synthesis_response, target, insights_already_filed=True
+            )
 
         return (category, titles)
 
@@ -2588,6 +2600,11 @@ class Dispatcher:
                 ),
                 promise_ids=promise_ids,
             )
+            # HOL-26 / #1920: file insights BEFORE the reply post.  See
+            # the matching comment on the review-comment path; the
+            # invariant is the same.
+            if issue_target is not None:
+                executor.file_insights_pre_reply(synthesis_response, issue_target)
             log.info("posting issue comment reply on PR #%s: %s", number, body[:80])
             posted = gh.comment_issue(repo_full, number, body)
             log.info("reply posted on PR #%s", number)
@@ -2615,7 +2632,9 @@ class Dispatcher:
         # before the synthesis call so the failure path could share its
         # eyes-removal helper.
         if issue_target is not None:
-            executor.execute_effects_only(synthesis_response, issue_target)
+            executor.execute_effects_only(
+                synthesis_response, issue_target, insights_already_filed=True
+            )
 
         log.info(
             "reply_to_issue_comment: complete for PR #%s (category=%s)",
@@ -3011,6 +3030,21 @@ class Dispatcher:
                 affected_task_ids = [
                     tid for tid in verdict.affected_task_ids if tid in tasks_by_id
                 ]
+                # Codex P2 on PR #1938: honored verdicts can omit
+                # ``affected_task_ids`` even when they shaped real
+                # tasks (the field is optional on the dataclass).
+                # Without this fallback, the divergence check below
+                # sees no descriptions and ``verdict_is_material``
+                # returns False for honored — silently skipping the
+                # reply for what's actually a divergent landing.
+                # Fall back to every task whose
+                # ``contributing_intents`` lists this comment id.
+                if not affected_task_ids:
+                    affected_task_ids = [
+                        tid
+                        for tid, t in tasks_by_id.items()
+                        if cid in (t.get("contributing_intents") or ())
+                    ]
                 descs = tuple(
                     (tasks_by_id[tid].get("description") or "")
                     for tid in affected_task_ids

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -13,6 +13,7 @@ from typing import Any
 from fido.config import Config, RepoConfig
 from fido.critics import (
     INSIGHT_REPO,
+    InsightDedupTransportCounter,
     InsightDedupVerdict,
     run_insight_dedup_critic,
 )
@@ -157,6 +158,7 @@ class _GitHubInsightFiler:
         agent: ProviderAgent | None = None,
         prompts: Prompts | None = None,
         critic_system_prompt: str | None = None,
+        transport_counter: InsightDedupTransportCounter | None = None,
     ) -> None:
         # All three of agent / prompts / critic_system_prompt are
         # required for the HOL-19 critic to fire.  If any is None the
@@ -167,6 +169,12 @@ class _GitHubInsightFiler:
         self._agent = agent
         self._prompts = prompts
         self._critic_system_prompt = critic_system_prompt
+        # HOL-19 follow-up / #1935: when an
+        # ``InsightDedupTransportCounter`` is injected, transport-failure
+        # patterns escalate to a bug via the counter's escalator.  None
+        # in tests; production wiring in ``Dispatcher`` constructs one
+        # bound to ``file_stuck_on_critic_bug``.
+        self._transport_counter = transport_counter
 
     def file_insight(self, insight: Insight, target: CommentTarget) -> None:
         """File *insight* as a GitHub issue against :data:`_INSIGHT_REPO`.
@@ -298,6 +306,7 @@ class _GitHubInsightFiler:
             agent=self._agent,
             prompts=self._prompts,
             critic_system_prompt=self._critic_system_prompt,
+            transport_counter=self._transport_counter,
         )
 
     def _recent_insights_for_critic(self) -> list[dict[str, str]]:
@@ -1471,6 +1480,39 @@ class Dispatcher:
         self._sync_fn = sync_fn
         self._reorder_coalesce_state = reorder_coalesce_state
         self._get_commit_summary_fn = get_commit_summary_fn
+        # HOL-19 follow-up / #1935: one process-local
+        # transport-failure counter shared across all insight-dedup
+        # critic calls for this Dispatcher (= this repo).  Escalates
+        # via ``file_stuck_on_critic_bug`` when consecutive transport
+        # failures cross the threshold, then suppresses re-fires until
+        # a successful critic call resets it.
+        self._insight_dedup_transport_counter = InsightDedupTransportCounter(
+            escalator=self._escalate_insight_dedup_transport_failure,
+        )
+
+    def _escalate_insight_dedup_transport_failure(self, count: int) -> None:
+        """HOL-19 follow-up / #1935: escalator bound to the
+        Dispatcher's process-local
+        :class:`InsightDedupTransportCounter`.  Files a bug against
+        ``FidoCanCode/home`` so the critic infra failure is visible
+        for follow-up, idempotent via the shared
+        ``file_stuck_on_critic_bug`` marker.
+        """
+        file_stuck_on_critic_bug(
+            StuckOnCriticContext(
+                emission_point="insight-dedup-transport",
+                source_repo=self._repo_cfg.name,
+                source_pr=0,
+                target_kind="critic",
+                target_id="insight-dedup",
+                source_link=(
+                    f"(process-local — {count} consecutive transport failures "
+                    f"in {self._repo_cfg.name})"
+                ),
+                gaps=(f"{count} consecutive transport failures",),
+            ),
+            gh=self._gh,
+        )
 
     def dispatch(
         self,
@@ -2175,6 +2217,7 @@ class Dispatcher:
                     critic_system_prompt=prompts.critic_system_prompt(
                         issue=issue_ctx, pr=pr_ctx
                     ),
+                    transport_counter=self._insight_dedup_transport_counter,
                 ),
                 fido_logins=FIDO_LOGINS,
             )
@@ -2492,6 +2535,7 @@ class Dispatcher:
                     critic_system_prompt=prompts.critic_system_prompt(
                         issue=issue_ctx, pr=pr_ctx
                     ),
+                    transport_counter=self._insight_dedup_transport_counter,
                 ),
                 fido_logins=FIDO_LOGINS,
             )

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2888,87 +2888,82 @@ class Dispatcher:
         except Exception:
             log.exception("failed to notify intent comment %s", intent.comment_id)
 
-    def notify_newly_terminal_intent_threads(
+    def notify_terminal_task_thread(
         self,
-        prev_tasks: list[dict[str, Any]],
-        new_tasks: list[dict[str, Any]],
+        task: dict[str, Any],
+        anchor_intent: RescopeIntent,
         *,
-        batch_intents: list[RescopeIntent],
         pr: int,
         agent: ProviderAgent,
         prompts: Prompts,
     ) -> None:
-        """HOL-28 / #1922: emit one per-thread aggregate reply for every
-        intent whose thread just transitioned from non-terminal to
-        terminal across the ``prev_tasks`` → ``new_tasks`` snapshot pair.
+        """HOL-28 / #1922: post the per-thread terminal aggregate reply
+        for *task* at *anchor_intent*'s comment.
 
-        Wired by the task-completion path: when the worker marks a task
-        COMPLETED (or the rescope marks one SKIPPED), call this with the
-        before/after task lists.  ``newly_terminal_intent_threads``
-        (HOL-27) computes which intents transitioned; this method posts
-        the aggregate reply per intent.
+        Codex P1 (fifth round) on PR #1938: the prior shape iterated
+        ``contributing_intents`` and emitted per-intent.  That had two
+        problems:
 
-        Issue comments are silently skipped (same INV-F rule as
-        ``_notify_intent_outcome``: webhook already replied at triage).
-        Bot threads are included (per HOL-28 issue: "Bot threads
-        included" — humans need to follow what landed; so do bots).
+        1. Per-intent emission required per-intent ``comment_type``
+           metadata the tasks.json schema doesn't carry — so a
+           hardcoded fallback could route an issue-comment id through
+           the review-comment endpoint.
+        2. When the worker passed only the task-anchor intent (to
+           avoid the wrong-endpoint hole), terminal threads for
+           non-anchor contributing intents were silently dropped.
+
+        The reconciled contract: HOL-28's job is the closing summary
+        at the task's PRIMARY thread.  Cross-author divergence
+        notifications at rescope time are HOL-24's job.  Tasks whose
+        secondary contributing-intent threads also deserve a closing
+        summary are a future leaf that needs per-intent ``comment_type``
+        in the schema; the predicate ``newly_terminal_intent_threads``
+        (HOL-27) remains a building block for that future work.
+
+        The caller is responsible for:
+
+        - Verifying the task just transitioned from non-terminal to
+          terminal (so this method fires exactly once per terminal
+          transition).
+        - Constructing *anchor_intent* from the task's primary thread
+          (``task["thread"]``) with the correct ``comment_type``.
+
+        Best-effort post: transport failures log but do not propagate.
         """
-        from fido.types import newly_terminal_intent_threads
-
-        intents_by_cid = {i.comment_id: i for i in batch_intents}
-        transitioned_cids = newly_terminal_intent_threads(prev_tasks, new_tasks)
-        if not transitioned_cids:
-            return
-        repo = self._repo_cfg.name
-        for cid in transitioned_cids:
-            intent = intents_by_cid.get(cid)
-            if intent is None:
-                # Intent not in the current batch (e.g. comment shaped
-                # tasks across multiple rescope runs and this batch
-                # only carries a subset).  Skip — caller is responsible
-                # for passing the full intent set.
-                continue
-            if intent.comment_type != "pulls":
-                log.info(
-                    "skipping terminal-thread notification for issue "
-                    "comment %s (webhook already replied at triage)",
-                    cid,
-                )
-                continue
-            completed = [
-                t
-                for t in new_tasks
-                if cid in (t.get("contributing_intents") or ())
-                and str(t.get("status")) == TaskStatus.COMPLETED.value
-            ]
-            skipped = [
-                t
-                for t in new_tasks
-                if cid in (t.get("contributing_intents") or ())
-                and str(t.get("status")) == TaskStatus.SKIPPED.value
-            ]
-            framing = _hol28_terminal_thread_framing(intent, completed, skipped)
-            body = safe_voice_turn(
-                agent,
-                prompts.persona_wrap(framing),
-                model=agent.voice_model,
-                allowed_tools=READ_ONLY_ALLOWED_TOOLS,
-                system_prompt=prompts.reply_system_prompt(),
-                log_prefix="notify_terminal_intent_threads",
+        status = str(task.get("status"))
+        completed = [task] if status == TaskStatus.COMPLETED.value else []
+        skipped = [task] if status == TaskStatus.SKIPPED.value else []
+        if not completed and not skipped:
+            log.info(
+                "notify_terminal_task_thread: task %s is not in a "
+                "terminal status (%r) — skipping",
+                task.get("id"),
+                status,
             )
-            try:
-                self._gh.reply_to_review_comment(repo, pr, body, intent.comment_id)
-                log.info(
-                    "notified terminal thread for intent comment %s "
-                    "(%d completed, %d skipped)",
-                    cid,
-                    len(completed),
-                    len(skipped),
-                )
-            except Exception:
-                log.exception(
-                    "failed to notify terminal thread for intent comment %s", cid
-                )
+            return
+        framing = _hol28_terminal_thread_framing(anchor_intent, completed, skipped)
+        body = safe_voice_turn(
+            agent,
+            prompts.persona_wrap(framing),
+            model=agent.voice_model,
+            allowed_tools=READ_ONLY_ALLOWED_TOOLS,
+            system_prompt=prompts.reply_system_prompt(),
+            log_prefix="notify_terminal_task_thread",
+        )
+        try:
+            self._gh.reply_to_review_comment(
+                self._repo_cfg.name, pr, body, anchor_intent.comment_id
+            )
+            log.info(
+                "notified terminal task thread for task %s at comment %s",
+                task.get("id"),
+                anchor_intent.comment_id,
+            )
+        except Exception:
+            log.exception(
+                "failed to notify terminal task thread for task %s",
+                task.get("id"),
+            )
 
     def _make_reorder_kwargs(
         self,

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -160,20 +160,22 @@ class _BackgroundRescopeTrigger:
         def _mark_applied() -> None:
             self._store.mark_rescope_intent_applied(intent.comment_id)
 
-        try:
-            self._dispatcher.reorder_tasks_background(
-                intent.change_request,
-                self._registry,
-                agent=self._agent,
-                prompts=self._prompts,
-                intents=[intent],
-                _on_done=_mark_applied,
-            )
-        except Exception:
-            # Synchronous failure between claim and dispatch start:
-            # release the pending claim so the next trigger fires.
-            self._store.release_rescope_intent_claim(intent.comment_id)
-            raise
+        # Codex P1 (sixteenth round) on PR #1938: don't delete the
+        # pending row on dispatch failure.  The row IS the durable
+        # recovery signal — startup replay relies on it being there.
+        # Deleting it on failure loses the only path that re-fires
+        # the intent (GitHub will not redeliver a successful webhook).
+        # ``claim_rescope_intent`` already treats pending rows as
+        # retryable, so leaving the row pending lets the next trigger
+        # or startup-replay retry cleanly.
+        self._dispatcher.reorder_tasks_background(
+            intent.change_request,
+            self._registry,
+            agent=self._agent,
+            prompts=self._prompts,
+            intents=[intent],
+            _on_done=_mark_applied,
+        )
 
 
 _INSIGHT_REPO = INSIGHT_REPO
@@ -2027,6 +2029,7 @@ class Dispatcher:
     def replay_pending_rescope_intents(
         self,
         registry: ActivityReporter,
+        pr_number: int,
         *,
         agent: ProviderAgent,
         prompts: Prompts,
@@ -2048,7 +2051,17 @@ class Dispatcher:
         Returns the number of intents re-dispatched.
         """
         store = FidoStore(self._repo_cfg.work_dir)
-        pending = store.pending_rescope_intents()
+        all_pending = store.pending_rescope_intents()
+        # Codex P1 (sixteenth round) on PR #1938: filter by the
+        # currently-active PR so an orphan pending intent from a
+        # different (e.g. now-closed) PR doesn't rescope the active
+        # task queue with stale change-request text.
+        repo_name = self._repo_cfg.name
+        pending = [
+            intent
+            for intent in all_pending
+            if intent.repo == repo_name and intent.pr_number == pr_number
+        ]
         if not pending:
             return 0
         trigger = _BackgroundRescopeTrigger(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -3463,11 +3463,24 @@ class Dispatcher:
                     entry["pending"] = (commit_summary, kwargs, list(intents or []))
                 else:
                     accumulated = list(existing[2]) + list(intents or [])
-                    existing_chain = existing[1].get("_after_applies")
+                    existing_kwargs = existing[1]
+                    existing_chain = existing_kwargs.get("_after_applies")
                     new_chain = kwargs.get("_after_applies")
                     if existing_chain is not None and new_chain is not None:
                         existing_chain.extend(new_chain)
-                    entry["pending"] = (commit_summary, existing[1], accumulated)
+                    # Codex P2 (fifteenth round) on PR #1938: keep
+                    # the latest caller's fresh issue/pr context
+                    # (used by the rescope prompt and the reply
+                    # notifier), but preserve the existing batch's
+                    # ``_on_done`` — the single closure that owns
+                    # the shared ``_after_applies`` list — so
+                    # sync+rewrite still run ONCE for the coalesced
+                    # batch.  Latest kwargs win for every field
+                    # EXCEPT the on_done / shared-list pair.
+                    merged = dict(kwargs)
+                    merged["_on_done"] = existing_kwargs.get("_on_done")
+                    merged["_after_applies"] = existing_chain
+                    entry["pending"] = (commit_summary, merged, accumulated)
                 return
             entry["running"] = True
             entry["pending"] = None

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -731,29 +731,6 @@ _reorder_coalesce: dict[str, dict[str, Any]] = {}
 _reorder_coalesce_lock = threading.Lock()
 
 
-def _chain_on_done(
-    prev: Callable[[], None] | None,
-    new: Callable[[], None] | None,
-) -> Callable[[], None] | None:
-    """Chain two ``_on_done`` callbacks so both run after the batch lands.
-
-    Used when coalescing rescope triggers into a single pending batch:
-    every originating caller's after-apply hook must fire (e.g. so the
-    rescope outbox advances every coalesced intent to ``applied``), not
-    just the latest caller's.
-    """
-    if prev is None:
-        return new
-    if new is None:
-        return prev
-
-    def chained() -> None:
-        prev()
-        new()
-
-    return chained
-
-
 class WebhookIngressOracle:
     """Per-process at-least-once delivery vs exactly-once dispatch oracle.
 
@@ -3171,6 +3148,17 @@ class Dispatcher:
             sync_fn if sync_fn is not None else _real_sync_tasks
         )
 
+        # Codex P2 (fourteenth round) on PR #1938: per-caller
+        # after-apply hooks live in a mutable shared list so
+        # coalesced callers can be appended without re-wrapping the
+        # ``_on_done`` closure.  ``on_done`` runs sync+rewrite ONCE
+        # for the batch and then fires every after-apply, so all
+        # coalesced intents are marked applied — and the expensive
+        # external writes happen exactly once.
+        after_applies: list[Callable[[], None]] = []
+        if after_apply is not None:
+            after_applies.append(after_apply)
+
         def on_done() -> None:
             _effective_sync(work_dir, gh)
             rewrite_fn(
@@ -3180,14 +3168,8 @@ class Dispatcher:
                 _state=State(work_dir / ".git" / "fido"),
                 _tasks=Tasks(work_dir),
             )
-            # Codex P1 (tenth round) on PR #1938: chain the
-            # caller-supplied after-apply hook (e.g. the rescope
-            # outbox's ``mark_rescope_intent_applied``) AFTER
-            # tasks.json has been synced + the PR description
-            # rewritten.  The applied-marker fires only on
-            # successful completion of the durable apply.
-            if after_apply is not None:
-                after_apply()
+            for hook in after_applies:
+                hook()
 
         def on_inprogress_affected(task_id: str) -> None:
             log.info(
@@ -3218,6 +3200,13 @@ class Dispatcher:
             # batches; escalates via the Dispatcher-bound escalator
             # method when an intent's drops cross threshold.
             "task_creation_drop_counter": self._task_creation_drop_counter,
+            # Mutable shared list captured by ``on_done``.  Stored
+            # alongside ``_on_done`` so the coalesce branch can
+            # extend it when a new caller piles onto an in-flight
+            # batch (codex P2 fourteenth round on PR #1938).  Not
+            # forwarded to ``reorder_tasks`` — popped at the
+            # boundary.
+            "_after_applies": after_applies,
         }
         issue_ctx, pr_ctx = _load_active_context_for_rescope(
             work_dir, repo_cfg.name, gh
@@ -3454,29 +3443,31 @@ class Dispatcher:
             if _release_untriaged_on_finish:
                 entry["untriaged_holds"] = int(entry.get("untriaged_holds", 0)) + 1
             if entry["running"]:
-                # Coalesce: latest commit_summary and kwargs win; intents accumulate
+                # Coalesce: latest commit_summary wins; intents accumulate
                 # so every originating comment is tracked even when multiple
                 # comment-triggered rescopes arrive during the same Opus call.
                 #
-                # Codex P1 (thirteenth round) on PR #1938: chain ``_on_done``
-                # callbacks across coalesced callers so every originating
-                # intent's after-apply hook fires when the batch lands.
-                # Without chaining, only the latest caller's
-                # ``mark_rescope_intent_applied`` runs and intermediate
-                # coalesced intents stay durably ``pending`` forever — a
-                # later restart re-runs them and duplicates task/reply
-                # effects.
+                # Codex P2 (fourteenth round) on PR #1938: keep the
+                # existing pending batch's ``_on_done`` (so its sync
+                # and PR-body rewrite run ONCE for the coalesced
+                # batch) and extend its mutable ``_after_applies``
+                # list with this caller's after-apply hook.  Every
+                # coalesced intent gets marked applied without
+                # duplicating the expensive external writes — and if
+                # the sync/rewrite step fails, NO intent is marked
+                # applied (the apply hooks only run after both
+                # succeed), so a restart correctly replays the
+                # whole batch.
                 existing = entry["pending"]
                 if existing is None:
                     entry["pending"] = (commit_summary, kwargs, list(intents or []))
                 else:
                     accumulated = list(existing[2]) + list(intents or [])
-                    merged_kwargs = dict(kwargs)
-                    merged_kwargs["_on_done"] = _chain_on_done(
-                        existing[1].get("_on_done"),
-                        kwargs.get("_on_done"),
-                    )
-                    entry["pending"] = (commit_summary, merged_kwargs, accumulated)
+                    existing_chain = existing[1].get("_after_applies")
+                    new_chain = kwargs.get("_after_applies")
+                    if existing_chain is not None and new_chain is not None:
+                        existing_chain.extend(new_chain)
+                    entry["pending"] = (commit_summary, existing[1], accumulated)
                 return
             entry["running"] = True
             entry["pending"] = None
@@ -3523,11 +3514,15 @@ class Dispatcher:
                         agent=kw.get("agent"),
                         prompts=kw.get("prompts"),
                     )
+                    # ``_after_applies`` is a side-channel captured
+                    # by ``_on_done``'s closure; it must not reach
+                    # ``reorder_tasks`` (not part of its signature).
+                    reorder_kw = {k: v for k, v in kw.items() if k != "_after_applies"}
                     reorder(
                         registry.tasks_for(repo_cfg.name),
                         cs,
                         intents=current_intents or None,
-                        **kw,
+                        **reorder_kw,
                     )
                     log.info("rescope BG: iteration %d complete", iteration)
                     with _reorder_coalesce_lock:

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -2634,6 +2634,7 @@ class Dispatcher:
         result: list[dict[str, Any]],
         agent: ProviderAgent | None = None,
         prompts: Prompts | None = None,
+        verdict: IntentVerdict | None = None,
     ) -> None:
         """Post a per-intent reply per the INV-F reply-back rule.
 
@@ -2696,7 +2697,15 @@ class Dispatcher:
                 seen_cids.add(other_cid)
                 co_contributing.append(other)
 
-        if isinstance(kind, oracle.NotifyDropped):
+        # HOL-25 / #1919: when the call carries a verdict (HOL-24 path),
+        # use outcome+narrative framing so the prose grounds in what the
+        # rescope actually decided rather than the cross-author oracle's
+        # default "a later commenter caused..." story (which may not be
+        # true — a no_op verdict can stand alone with no other commenter
+        # involved).
+        if verdict is not None:
+            framing = _hol25_verdict_framing(verdict)
+        elif isinstance(kind, oracle.NotifyDropped):
             framing = (
                 "A change request from a PR comment was DROPPED by the rescope "
                 "because a later commenter's intent caused the task this "
@@ -2945,6 +2954,7 @@ class Dispatcher:
                     result=result,
                     agent=agent,
                     prompts=prompts,
+                    verdict=verdict,  # HOL-25: drives outcome-aware framing
                 )
                 notified_cids.add(cid)
 
@@ -3593,6 +3603,71 @@ def _intent_arrival_indices(intents: list[RescopeIntent]) -> dict[int, int]:
     """
     ordered = sorted(intents, key=lambda i: i.timestamp)
     return {intent.comment_id: idx for idx, intent in enumerate(ordered)}
+
+
+def _hol25_verdict_framing(verdict: IntentVerdict) -> str:
+    """HOL-25 / #1919: per-thread material-divergence framing built from
+    the rescope verdict's outcome + narrative.
+
+    Falls under the voice-text-not-templated rule: this builds the
+    INSTRUCTION sent to Opus (a deterministic fact-carrier), not the
+    user-visible reply text — Opus generates that per call from these
+    facts.  Each outcome carries a different story shape:
+
+    - ``no_op``: the request didn't land in the queue at all.  The
+      narrative explains why; the reply must NOT pretend work is in
+      flight.
+    - ``honored`` (divergent): a task DID land, but its scope reads
+      differently from the literal change_request.  Reply explains
+      the reshape so the requester doesn't think their exact ask was
+      queued verbatim.
+    - ``reshaped``: same shape as honored-divergent at the user-facing
+      level; the verdict's narrative carries the rescope's reasoning.
+    - ``superseded``: another later intent in the same batch took
+      precedence.  ``by_intent_comment_id`` (when set) names the
+      superseding intent so the prompt can render the link.
+    """
+    # IntentVerdict.__post_init__ enforces non-empty narrative on every
+    # outcome (HOL-3 / #1897) and ``by_intent_comment_id`` on superseded
+    # (INV-E / #1803), so we can trust both here without fallback branches.
+    narrative = (verdict.narrative or "").strip()
+    match verdict.outcome:
+        case "no_op":
+            return (
+                "A change request from a PR comment was NOT queued by the "
+                "rescope.  Tell this commenter their ask did not land, and "
+                "explain WHY using the rescope's narrative below.  Do NOT "
+                "imply work is in flight — nothing was queued.\n\n"
+                f"Rescope narrative: {narrative}"
+            )
+        case "honored":
+            return (
+                "A change request from a PR comment WAS queued, but the "
+                "task that landed reads differently from the literal ask.  "
+                "Tell this commenter their ask landed and explain the "
+                "reshape using the rescope's narrative below.  Do NOT "
+                "claim the task description matches verbatim — it diverges.\n\n"
+                f"Rescope narrative: {narrative}"
+            )
+        case "reshaped":
+            return (
+                "A change request from a PR comment was RESHAPED by the "
+                "rescope into a different-scope task.  Tell this commenter "
+                "the STORY of how their ask was reshaped using the "
+                "rescope's narrative below.  Do NOT claim work is done — "
+                "the rescope only restructured the plan.\n\n"
+                f"Rescope narrative: {narrative}"
+            )
+        case "superseded":
+            return (
+                f"A change request from a PR comment was SUPERSEDED by intent "
+                f"comment #{verdict.by_intent_comment_id} "
+                "in the same rescope batch.  Tell this commenter their ask "
+                "was overridden using the rescope's narrative below.  Do "
+                "NOT say their work is done — it was dropped in favour of "
+                "the superseding intent.\n\n"
+                f"Rescope narrative: {narrative}"
+            )
 
 
 def _rocq_intent_rows(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -1502,7 +1502,7 @@ class Dispatcher:
 
     def _escalate_task_creation_drop_streak(
         self, intent_comment_id: int, count: int
-    ) -> None:
+    ) -> bool:
         """HOL-16 follow-up / #1934: escalator bound to the
         Dispatcher's per-intent
         :class:`TaskCreationDropCounter`.  Files a bug against
@@ -1510,49 +1510,69 @@ class Dispatcher:
         N proposals dropped in a row — either Opus keeps re-proposing
         legitimately-distinct work the critic mis-classifies, or the
         comment's intent isn't being honoured.
+
+        Returns ``True`` on successful bug file/reuse (the helper
+        returns a URL).  Returns ``False`` on transient failure
+        (``file_stuck_on_critic_bug`` returns ``None``) so the counter
+        leaves its escalated latch clear and retries on the next drop
+        — without this, a transient GitHub error at the first
+        threshold crossing would permanently suppress escalation
+        across restarts (codex P1 on PR #1938).
         """
-        file_stuck_on_critic_bug(
-            StuckOnCriticContext(
-                emission_point="task-creation",
-                source_repo=self._repo_cfg.name,
-                source_pr=0,
-                target_kind="comment",
-                target_id=str(intent_comment_id),
-                source_link=(
-                    f"(process-local — comment {intent_comment_id} had "
-                    f"{count} proposals dropped by the task-creation critic "
-                    f"in {self._repo_cfg.name})"
+        return (
+            file_stuck_on_critic_bug(
+                StuckOnCriticContext(
+                    emission_point="task-creation",
+                    source_repo=self._repo_cfg.name,
+                    source_pr=0,
+                    target_kind="comment",
+                    target_id=str(intent_comment_id),
+                    source_link=(
+                        f"(durable — comment {intent_comment_id} had "
+                        f"{count} proposals dropped by the task-creation critic "
+                        f"in {self._repo_cfg.name})"
+                    ),
+                    gaps=(
+                        f"{count} consecutive task-creation drops attributed to "
+                        f"comment #{intent_comment_id}",
+                    ),
                 ),
-                gaps=(
-                    f"{count} consecutive task-creation drops attributed to "
-                    f"comment #{intent_comment_id}",
-                ),
-            ),
-            gh=self._gh,
+                gh=self._gh,
+            )
+            is not None
         )
 
-    def _escalate_insight_dedup_transport_failure(self, count: int) -> None:
+    def _escalate_insight_dedup_transport_failure(self, count: int) -> bool:
         """HOL-19 follow-up / #1935: escalator bound to the
         Dispatcher's process-local
         :class:`InsightDedupTransportCounter`.  Files a bug against
         ``FidoCanCode/home`` so the critic infra failure is visible
         for follow-up, idempotent via the shared
         ``file_stuck_on_critic_bug`` marker.
+
+        Returns ``True`` on success / ``False`` on transient failure
+        (same contract as the task-creation escalator — see codex P1
+        on PR #1938).  The counter releases its already-escalated
+        latch on ``False`` so the next transport failure retries the
+        bug filing.
         """
-        file_stuck_on_critic_bug(
-            StuckOnCriticContext(
-                emission_point="insight-dedup-transport",
-                source_repo=self._repo_cfg.name,
-                source_pr=0,
-                target_kind="critic",
-                target_id="insight-dedup",
-                source_link=(
-                    f"(process-local — {count} consecutive transport failures "
-                    f"in {self._repo_cfg.name})"
+        return (
+            file_stuck_on_critic_bug(
+                StuckOnCriticContext(
+                    emission_point="insight-dedup-transport",
+                    source_repo=self._repo_cfg.name,
+                    source_pr=0,
+                    target_kind="critic",
+                    target_id="insight-dedup",
+                    source_link=(
+                        f"(process-local — {count} consecutive transport failures "
+                        f"in {self._repo_cfg.name})"
+                    ),
+                    gaps=(f"{count} consecutive transport failures",),
                 ),
-                gaps=(f"{count} consecutive transport failures",),
-            ),
-            gh=self._gh,
+                gh=self._gh,
+            )
+            is not None
         )
 
     def dispatch(

--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -52,7 +52,14 @@ from fido.tasks import (
     Tasks,
     thread_comment_author_for_auto_resolve_oracle,
 )
-from fido.types import ActiveIssue, ActivePR, IntentVerdict, RescopeIntent, TaskType
+from fido.types import (
+    ActiveIssue,
+    ActivePR,
+    IntentVerdict,
+    RescopeIntent,
+    TaskType,
+    verdict_is_material,
+)
 from fido.worker import ActivityReporter
 
 log = logging.getLogger(__name__)
@@ -2864,7 +2871,6 @@ class Dispatcher:
             task_id_to_positive: dict[str, int],
             verdicts: list["IntentVerdict"],
         ) -> None:
-            del verdicts  # reserved; not consumed by the current rule
             if pr_ctx is None:
                 return
             intent_rows = _rocq_intent_rows(intents)
@@ -2873,6 +2879,7 @@ class Dispatcher:
                 intent_rows, task_records, op_inputs
             )
             positive_to_task_id = {pos: tid for tid, pos in task_id_to_positive.items()}
+            notified_cids: set[int] = set()
             for cid, kind in entries:
                 intent = intents_by_cid[cid]
                 affected_positives = oracle.intent_contributing_tasks(cid, task_records)
@@ -2891,6 +2898,55 @@ class Dispatcher:
                     agent=agent,
                     prompts=prompts,
                 )
+                notified_cids.add(cid)
+
+            # HOL-24 / #1918: verdict-based per-thread reply gating.
+            # The oracle above covers the cross-author destructive-op
+            # cases that pre-date the verdict envelope.  This pass uses
+            # the HOL-23 ``verdict_is_material`` predicate to catch
+            # verdicts the oracle misses — primarily ``no_op`` drops
+            # (the request silently disappeared, closes the #1890
+            # class of failure) and honored-but-divergent (Opus queued
+            # something different from what the user asked).  Dedupes
+            # against the oracle path by intent_comment_id so we never
+            # double-notify.
+            tasks_by_id = {t["id"]: t for t in result}
+            for verdict in verdicts:
+                cid = verdict.intent_comment_id
+                if cid in notified_cids:
+                    continue
+                intent = intents_by_cid[cid]
+                affected_task_ids = [
+                    tid for tid in verdict.affected_task_ids if tid in tasks_by_id
+                ]
+                descs = tuple(
+                    (tasks_by_id[tid].get("description") or "")
+                    for tid in affected_task_ids
+                )
+                if not verdict_is_material(intent, verdict, task_descriptions=descs):
+                    continue
+                # Map outcome → existing NotifyKind.  no_op shares the
+                # "your ask was dropped" emotional shape with NotifyDropped;
+                # reshaped/honored-divergent/superseded all share "your ask
+                # landed but in a form different from what you wrote" with
+                # NotifyChanged.  HOL-25 will refine prose framing per
+                # outcome inside ``_notify_intent_outcome``.
+                kind: oracle.NotifyKind = (
+                    oracle.NotifyDropped()
+                    if verdict.outcome == "no_op"
+                    else oracle.NotifyChanged()
+                )
+                self._notify_intent_outcome(
+                    intent,
+                    kind,
+                    pr=pr_ctx.number,
+                    batch_intents=intents,
+                    affected_task_ids=affected_task_ids,
+                    result=result,
+                    agent=agent,
+                    prompts=prompts,
+                )
+                notified_cids.add(cid)
 
         return on_rescope_apply
 

--- a/src/fido/server.py
+++ b/src/fido/server.py
@@ -832,13 +832,33 @@ class WebhookHandler(BaseHTTPRequestHandler):
                 _eyes_ctype = str(_eyes_comment_info.get("comment_type", "issues"))
                 _eyes_cid = _eyes_comment_info.get("comment_id")
                 if _eyes_repo and isinstance(_eyes_cid, int):
+                    # HOL-22 / #1916: pull the review submission id (if
+                    # any) so the predicate scopes "batched with this"
+                    # to comments from the SAME submission rather than
+                    # any open comment in the repo (closes #1875).
+                    _eyes_review_id_raw = _eyes_comment_info.get(
+                        "pull_request_review_id"
+                    )
+                    _eyes_review_id = (
+                        int(_eyes_review_id_raw)
+                        if isinstance(_eyes_review_id_raw, int)
+                        else None
+                    )
                     if FidoStore(repo_cfg.work_dir).has_other_open_pr_comments(
-                        repo=_eyes_repo, exclude_comment_id=_eyes_cid
+                        repo=_eyes_repo,
+                        exclude_comment_id=_eyes_cid,
+                        review_id=_eyes_review_id,
                     ):
                         log.debug(
                             "eager eyes skipped for comment %d — repo has "
-                            "other open comments; worker posts eyes on claim",
+                            "other open comments from %s; worker posts eyes "
+                            "on claim",
                             _eyes_cid,
+                            (
+                                f"review {_eyes_review_id}"
+                                if _eyes_review_id is not None
+                                else "the same repo (no review-id scoping)"
+                            ),
                         )
                     else:
                         try:

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -3,6 +3,7 @@
 import fcntl
 import json
 import os
+import re
 import shutil
 import subprocess
 import urllib.request
@@ -115,6 +116,54 @@ class IssueCacheInfo:
     last_reconcile_drift: int
 
 
+@dataclass(frozen=True)
+class BlockedTaskInfo:
+    """HOL-29 / #1923: one BLOCKED task surfaced to ``./fido status``.
+
+    Picked up by ``repo_status`` when a task's status is ``blocked``
+    AND its description carries the ``CRITIC EXHAUSTED`` marker that
+    HOL-21's escalation helper appends.  Surfacing these in the
+    status output lets a human see at a glance which tasks have
+    auto-blocked themselves, without having to read tasks.json.
+
+    The bug-file URL isn't stored in tasks.json today (it's on the
+    PR thread as a BLOCKED comment); a future leaf could persist it
+    here for direct linking from status.
+    """
+
+    task_id: str
+    title: str
+    final_gap: str
+    attempt_count: int
+
+
+_CRITIC_EXHAUSTED_RE = re.compile(
+    r"CRITIC EXHAUSTED \((?P<count>\d+) attempts\): (?P<gap>.+?)$",
+    re.MULTILINE,
+)
+
+
+def _blocked_critic_tasks(task_list: list[dict[str, Any]]) -> list[BlockedTaskInfo]:
+    """Scan *task_list* for HOL-21-escalated BLOCKED tasks."""
+    out: list[BlockedTaskInfo] = []
+    for task in task_list:
+        if task.get("status") != "blocked":
+            continue
+        desc = task.get("description") or ""
+        match = _CRITIC_EXHAUSTED_RE.search(desc)
+        if match is None:
+            continue
+        out.append(
+            BlockedTaskInfo(
+                task_id=str(task.get("id", "")),
+                title=str(task.get("title", "")),
+                final_gap=match.group("gap").strip(),
+                attempt_count=int(match.group("count")),
+            )
+        )
+    return out
+
+
 @dataclass
 class RepoStatus:
     name: str
@@ -148,6 +197,11 @@ class RepoStatus:
     claude_talker: ClaudeTalkerInfo | None = None
     rescoping: bool = False  # True while a background Opus reorder is in flight
     issue_cache: IssueCacheInfo | None = None
+    # HOL-29 / #1923: BLOCKED tasks whose description carries the
+    # HOL-21 ``CRITIC EXHAUSTED`` marker.  Surfaced in the formatter
+    # so a human can see at a glance which tasks have auto-blocked
+    # themselves (and find the auto-filed bug from the PR thread).
+    blocked_critic_tasks: list[BlockedTaskInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -751,6 +805,7 @@ def repo_status(
     task_list = Tasks(repo_config.work_dir).list()
     pending = sum(1 for t in task_list if t["status"] == "pending")
     completed = sum(1 for t in task_list if t["status"] == "completed")
+    blocked_critic_tasks = _blocked_critic_tasks(task_list)
 
     current = _current_task(task_list)
     task_number, task_total = _task_position(task_list)
@@ -796,6 +851,7 @@ def repo_status(
         claude_talker=claude_talker,
         rescoping=rescoping,
         issue_cache=issue_cache,
+        blocked_critic_tasks=blocked_critic_tasks,
     )
 
 
@@ -1198,7 +1254,35 @@ def _format_repo_body(repo: RepoStatus, *, c: Color) -> list[str]:
 
     body.extend(_format_webhook_lines(repo, c=c))
 
+    body.extend(_format_blocked_critic_lines(repo, c=c))
+
     return body
+
+
+def _format_blocked_critic_lines(repo: RepoStatus, *, c: Color) -> list[str]:
+    """HOL-29 / #1923: surface HOL-21-escalated BLOCKED tasks.
+
+    Empty list when no escalations are on the queue.  Each blocked
+    task gets one line: ``BLOCKED: <title> — <final-gap> (N attempts)``
+    in red so the human sees the escalation at a glance.  The bug
+    URL lives on the PR thread (not in tasks.json today); a human
+    can follow the PR comment for it.
+    """
+    if not repo.blocked_critic_tasks:
+        return []
+    lines: list[str] = []
+    for blocked in repo.blocked_critic_tasks:
+        gap_preview = (
+            blocked.final_gap
+            if len(blocked.final_gap) <= 80
+            else blocked.final_gap[:77] + "..."
+        )
+        lines.append(
+            f"  {c.color(RED, 'BLOCKED:')} {blocked.title} "
+            f"{c.color(DIM, '—')} {gap_preview} "
+            f"{c.color(DIM, f'({blocked.attempt_count} attempts)')}"
+        )
+    return lines
 
 
 def _should_show_worker_line(repo: RepoStatus) -> bool:

--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -144,21 +144,49 @@ _CRITIC_EXHAUSTED_RE = re.compile(
 
 
 def _blocked_critic_tasks(task_list: list[dict[str, Any]]) -> list[BlockedTaskInfo]:
-    """Scan *task_list* for HOL-21-escalated BLOCKED tasks."""
+    """Scan *task_list* for HOL-21-escalated BLOCKED tasks.
+
+    Prefers the structured ``critic_gap_chain`` field (HOL-21 codex
+    P2 on PR #1938 / #1938 follow-up): the final gap is its last
+    entry and the attempt count is its length.  Falls back to the
+    free-form ``CRITIC EXHAUSTED (N attempts): gap`` marker for
+    legacy escalations recorded before the structured field landed —
+    and when falling back, takes the LAST match (not the first) so
+    a re-escalation after an unblock surfaces the current attempt's
+    trace rather than the carried-over old one.
+    """
     out: list[BlockedTaskInfo] = []
     for task in task_list:
         if task.get("status") != "blocked":
             continue
+        chain_raw = task.get("critic_gap_chain")
+        if isinstance(chain_raw, list) and chain_raw:
+            chain: list[str] = [str(g) for g in chain_raw if isinstance(g, str)]
+            if chain:
+                out.append(
+                    BlockedTaskInfo(
+                        task_id=str(task.get("id", "")),
+                        title=str(task.get("title", "")),
+                        final_gap=chain[-1].strip(),
+                        attempt_count=len(chain),
+                    )
+                )
+                continue
         desc = task.get("description") or ""
-        match = _CRITIC_EXHAUSTED_RE.search(desc)
-        if match is None:
+        # ``re.findall`` returns every match; take the LAST so post-
+        # unblock re-escalations don't surface the stale earlier
+        # marker (which the unblock-and-retry cycle didn't clear from
+        # the description text).
+        matches = list(_CRITIC_EXHAUSTED_RE.finditer(desc))
+        if not matches:
             continue
+        last = matches[-1]
         out.append(
             BlockedTaskInfo(
                 task_id=str(task.get("id", "")),
                 title=str(task.get("title", "")),
-                final_gap=match.group("gap").strip(),
-                attempt_count=int(match.group("count")),
+                final_gap=last.group("gap").strip(),
+                attempt_count=int(last.group("count")),
             )
         )
     return out

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -18,7 +18,7 @@ ReplyOutboxEffectState = Literal["prepared", "claimed", "delivered", "failed"]
 
 REPLY_PROMISE_MARKER_PREFIX = "fido:reply-promise:"
 _PROMISE_MARKER_RE = re.compile(r"<!--\s*fido:reply-promise:([0-9a-fA-F-]{36})\s*-->")
-_SCHEMA_VERSION = 6
+_SCHEMA_VERSION = 7
 
 
 @dataclass(frozen=True)

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal, cast
 
+from fido.types import RescopeIntent
+
 ReplyOwner = Literal["webhook", "worker", "recovery"]
 ClaimState = Literal["in_progress", "completed", "retryable_failed"]
 PromiseState = Literal["prepared", "posted", "acked", "failed"]
@@ -986,27 +988,40 @@ class FidoStore:
                 (int(intent_comment_id),),
             )
 
-    def pending_rescope_intents(self) -> list[dict[str, object]]:
+    def pending_rescope_intents(self) -> list[RescopeIntent]:
         """Return all un-applied (state='pending') outbox entries
-        for replay after a Fido restart.  Each entry carries the
-        full intent payload so a recovery pass can reconstruct a
-        ``RescopeIntent`` and re-dispatch the trigger.
+        as reconstructed ``RescopeIntent`` records, ordered by
+        ``claimed_at`` (oldest first) so replay preserves arrival
+        order.
 
-        Recovery wiring (replaying these intents on Dispatcher init)
-        is a follow-up — this method exposes the data so that work
-        can land independently.
+        Consumed by ``Dispatcher.replay_pending_rescope_intents`` on
+        worker first-iteration recovery to close the
+        crash-between-claim-and-_on_done window — GitHub will not
+        redeliver the original webhook, so startup replay is the only
+        path that re-fires an orphaned rescope.
         """
         with self._transaction() as conn:
             rows = conn.execute(
                 """
                 SELECT intent_comment_id, change_request, intent_timestamp,
-                       author, comment_type, repo, pr_number, claimed_at
+                       author, comment_type, repo, pr_number
                 FROM rescope_intent_outbox
                 WHERE state = 'pending'
                 ORDER BY claimed_at
                 """,
             ).fetchall()
-            return [dict(row) for row in rows]
+            return [
+                RescopeIntent(
+                    change_request=row["change_request"],
+                    comment_id=row["intent_comment_id"],
+                    timestamp=row["intent_timestamp"],
+                    comment_type=row["comment_type"],
+                    author=row["author"],
+                    repo=row["repo"],
+                    pr_number=row["pr_number"],
+                )
+                for row in rows
+            ]
 
     def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]:
         """HOL-16 follow-up / #1934 (codex P2 on PR #1938): record a

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -858,6 +858,83 @@ class FidoStore:
             assert retried is not None
             return self._pr_comment_record_from_row(retried)
 
+    def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]:
+        """HOL-16 follow-up / #1934 (codex P2 on PR #1938): record a
+        task-creation critic drop attributed to *intent_comment_id*.
+
+        Returns ``(new_count, already_escalated)``.  Atomically
+        increments the count and reports whether the escalator has
+        already fired for this intent — callers use the
+        already-escalated flag to suppress duplicate bug filings.
+        """
+        now = _utcnow()
+        with self._transaction() as conn:
+            row = conn.execute(
+                """
+                SELECT drop_count, escalated
+                FROM task_creation_drops
+                WHERE intent_comment_id = ?
+                """,
+                (int(intent_comment_id),),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    """
+                    INSERT INTO task_creation_drops
+                        (intent_comment_id, drop_count, escalated, updated_at)
+                    VALUES (?, 1, 0, ?)
+                    """,
+                    (int(intent_comment_id), now),
+                )
+                return (1, False)
+            new_count = int(row["drop_count"]) + 1
+            already_escalated = bool(int(row["escalated"]))
+            conn.execute(
+                """
+                UPDATE task_creation_drops
+                SET drop_count = ?, updated_at = ?
+                WHERE intent_comment_id = ?
+                """,
+                (new_count, now, int(intent_comment_id)),
+            )
+            return (new_count, already_escalated)
+
+    def mark_task_creation_drop_escalated(self, intent_comment_id: int) -> None:
+        """Set the escalated flag for *intent_comment_id* so subsequent
+        ``bump_task_creation_drop`` calls report ``already_escalated=True``
+        and the counter suppresses duplicate escalator fires until the
+        intent's drops are reset.
+        """
+        now = _utcnow()
+        with self._transaction() as conn:
+            conn.execute(
+                """
+                UPDATE task_creation_drops
+                SET escalated = 1, updated_at = ?
+                WHERE intent_comment_id = ?
+                """,
+                (now, int(intent_comment_id)),
+            )
+
+    def reset_inactive_task_creation_drops(self, active_intent_ids: set[int]) -> int:
+        """Drop counter rows for any intent_comment_id NOT in
+        *active_intent_ids* — those intents have no live contributing
+        tasks anymore, so the drop streak is broken.  Returns the row
+        count cleared (for logging / tests)."""
+        with self._transaction() as conn:
+            if not active_intent_ids:
+                cursor = conn.execute("DELETE FROM task_creation_drops")
+                return cursor.rowcount
+            placeholders = ",".join("?" for _ in active_intent_ids)
+            cursor = conn.execute(
+                f"""
+                DELETE FROM task_creation_drops
+                WHERE intent_comment_id NOT IN ({placeholders})
+                """,
+                tuple(int(cid) for cid in active_intent_ids),
+            )
+            return cursor.rowcount
+
     def clear_pr_comment_queue(self, *, repo: str, pr_number: int) -> int:
         """Delete queued comment state for a PR after merge/close cleanup."""
         with self._transaction() as conn:
@@ -1418,6 +1495,19 @@ CREATE TABLE IF NOT EXISTS transition_audit_log (
     subject TEXT NOT NULL,
     payload_json TEXT NOT NULL,
     created_at TEXT NOT NULL
+);
+
+-- HOL-16 follow-up / #1934 (codex P2 on PR #1938): durable per-
+-- ``intent_comment_id`` drop counter for the task-creation critic.
+-- The process-local counter was lost on Fido restart, which could
+-- prevent the exhaustion bug from ever filing.  Survives restarts;
+-- ``reset_inactive_task_creation_drops`` clears rows for intents
+-- with no live contributing tasks after each rescope batch.
+CREATE TABLE IF NOT EXISTS task_creation_drops (
+    intent_comment_id INTEGER PRIMARY KEY,
+    drop_count INTEGER NOT NULL,
+    escalated INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL
 );
 """
 

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -18,7 +18,7 @@ ReplyOutboxEffectState = Literal["prepared", "claimed", "delivered", "failed"]
 
 REPLY_PROMISE_MARKER_PREFIX = "fido:reply-promise:"
 _PROMISE_MARKER_RE = re.compile(r"<!--\s*fido:reply-promise:([0-9a-fA-F-]{36})\s*-->")
-_SCHEMA_VERSION = 8
+_SCHEMA_VERSION = 9
 
 
 @dataclass(frozen=True)
@@ -858,34 +858,108 @@ class FidoStore:
             assert retried is not None
             return self._pr_comment_record_from_row(retried)
 
-    def claim_rescope_trigger(self, intent_comment_id: int) -> bool:
-        """HOL-26 / #1920 (codex P1 ninth round on PR #1938):
-        atomically claim "rescope-triggered for this intent_comment_id".
+    def claim_rescope_intent(
+        self,
+        *,
+        intent_comment_id: int,
+        change_request: str,
+        intent_timestamp: str,
+        author: str,
+        comment_type: str,
+        repo: str,
+        pr_number: int,
+    ) -> bool:
+        """HOL-26 / #1920 (codex P1 ninth/tenth rounds on PR #1938):
+        atomically claim the rescope intent in the durable outbox.
 
         Returns ``True`` when this call is the first to claim the
         intent (caller should fire the rescope), ``False`` when an
-        earlier claim already exists (caller should skip — the
-        rescope was already triggered, even across Fido restarts).
+        earlier claim already exists in any state.
 
-        Used by ``_BackgroundRescopeTrigger.trigger_rescope`` to make
-        rescope firing durably idempotent per intent.  Without this,
-        a replay of an already-acked reply re-fires rescope/preempt;
-        the previous P1 fix (skip-effects-on-replay) traded that
-        bug for "effects never run if crash happens between artifact
-        record and effects" (codex P1 ninth round).  Durable rescope
-        dedup lets the replay path safely re-run all effects.
+        Persists the full intent payload (change_request / author /
+        comment_type / repo / pr_number) so a future
+        ``pending_rescope_intents`` recovery pass can replay
+        un-applied intents after a Fido crash.  Without persisting
+        the payload, a process-restart between claim and the
+        background rescope thread would permanently lose the user's
+        ACT — the reply was posted but the work never landed.
         """
         now = _utcnow()
         with self._transaction() as conn:
             cursor = conn.execute(
                 """
-                INSERT OR IGNORE INTO rescope_triggered
-                    (intent_comment_id, triggered_at)
-                VALUES (?, ?)
+                INSERT OR IGNORE INTO rescope_intent_outbox
+                    (intent_comment_id, change_request, intent_timestamp,
+                     author, comment_type, repo, pr_number,
+                     state, claimed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
                 """,
-                (int(intent_comment_id), now),
+                (
+                    int(intent_comment_id),
+                    str(change_request),
+                    str(intent_timestamp),
+                    str(author),
+                    str(comment_type),
+                    str(repo),
+                    int(pr_number) if isinstance(pr_number, int) else 0,  # noqa: SIM222  # pyright: ignore[reportUnnecessaryIsInstance]
+                    now,
+                ),
             )
             return cursor.rowcount > 0
+
+    def mark_rescope_intent_applied(self, intent_comment_id: int) -> None:
+        """Mark a previously-claimed rescope intent as durably applied
+        — the background rescope thread completed (tasks.json
+        committed).  Called from the rescope's ``_on_done`` callback so
+        the durable applied-state only advances after the work
+        actually landed.
+        """
+        with self._transaction() as conn:
+            conn.execute(
+                """
+                UPDATE rescope_intent_outbox
+                SET state = 'applied'
+                WHERE intent_comment_id = ?
+                """,
+                (int(intent_comment_id),),
+            )
+
+    def release_rescope_intent_claim(self, intent_comment_id: int) -> None:
+        """Release a stuck pending claim — used when a synchronous
+        thread-start or dispatch failure raises after the claim
+        landed.  Without release, the next trigger sees the durable
+        claim, skips dispatch, and the rescope never runs.
+        """
+        with self._transaction() as conn:
+            conn.execute(
+                """
+                DELETE FROM rescope_intent_outbox
+                WHERE intent_comment_id = ? AND state = 'pending'
+                """,
+                (int(intent_comment_id),),
+            )
+
+    def pending_rescope_intents(self) -> list[dict[str, object]]:
+        """Return all un-applied (state='pending') outbox entries
+        for replay after a Fido restart.  Each entry carries the
+        full intent payload so a recovery pass can reconstruct a
+        ``RescopeIntent`` and re-dispatch the trigger.
+
+        Recovery wiring (replaying these intents on Dispatcher init)
+        is a follow-up — this method exposes the data so that work
+        can land independently.
+        """
+        with self._transaction() as conn:
+            rows = conn.execute(
+                """
+                SELECT intent_comment_id, change_request, intent_timestamp,
+                       author, comment_type, repo, pr_number, claimed_at
+                FROM rescope_intent_outbox
+                WHERE state = 'pending'
+                ORDER BY claimed_at
+                """,
+            ).fetchall()
+            return [dict(row) for row in rows]
 
     def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]:
         """HOL-16 follow-up / #1934 (codex P2 on PR #1938): record a
@@ -1526,9 +1600,16 @@ CREATE TABLE IF NOT EXISTS transition_audit_log (
     created_at TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS rescope_triggered (
+CREATE TABLE IF NOT EXISTS rescope_intent_outbox (
     intent_comment_id INTEGER PRIMARY KEY,
-    triggered_at TEXT NOT NULL
+    change_request TEXT NOT NULL,
+    intent_timestamp TEXT NOT NULL,
+    author TEXT NOT NULL,
+    comment_type TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending',
+    claimed_at TEXT NOT NULL
 );
 
 -- HOL-16 follow-up / #1934 (codex P2 on PR #1938): durable per-

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -869,43 +869,90 @@ class FidoStore:
         repo: str,
         pr_number: int,
     ) -> bool:
-        """HOL-26 / #1920 (codex P1 ninth/tenth rounds on PR #1938):
-        atomically claim the rescope intent in the durable outbox.
+        """HOL-26 / #1920 (codex P1 ninth/tenth/eleventh rounds on
+        PR #1938): atomically claim the rescope intent in the durable
+        outbox.
 
-        Returns ``True`` when this call is the first to claim the
-        intent (caller should fire the rescope), ``False`` when an
-        earlier claim already exists in any state.
+        Returns ``True`` when the caller should fire the rescope:
 
-        Persists the full intent payload (change_request / author /
-        comment_type / repo / pr_number) so a future
-        ``pending_rescope_intents`` recovery pass can replay
-        un-applied intents after a Fido crash.  Without persisting
-        the payload, a process-restart between claim and the
-        background rescope thread would permanently lose the user's
-        ACT — the reply was posted but the work never landed.
+        - First claim for this intent: INSERT a ``pending`` row, return True.
+        - Pre-existing ``pending`` row: UPDATE ``claimed_at`` (refresh
+          payload) and return True.  A pending row means "claim was
+          recorded but the work never durably applied" — likely a
+          crash between claim and ``_on_done``, or a redelivery of
+          the same comment.  Retrying is correct: in-process
+          duplicate dispatches get coalesced by ``_reorder_coalesce``,
+          and cross-restart replay is exactly the recovery path the
+          outbox enables.
+        - ``applied`` row: return False.  The rescope already
+          durably completed (tasks.json synced + PR description
+          rewritten); re-firing would duplicate the work.
+
+        Persists the full intent payload so a future
+        ``pending_rescope_intents`` recovery sweep can also replay
+        un-applied intents on startup (separate follow-up — the
+        normal-trigger retry path covers the common redelivery
+        case shipped here).
         """
         now = _utcnow()
         with self._transaction() as conn:
-            cursor = conn.execute(
+            row = conn.execute(
                 """
-                INSERT OR IGNORE INTO rescope_intent_outbox
-                    (intent_comment_id, change_request, intent_timestamp,
-                     author, comment_type, repo, pr_number,
-                     state, claimed_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+                SELECT state
+                FROM rescope_intent_outbox
+                WHERE intent_comment_id = ?
+                """,
+                (int(intent_comment_id),),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    """
+                    INSERT INTO rescope_intent_outbox
+                        (intent_comment_id, change_request, intent_timestamp,
+                         author, comment_type, repo, pr_number,
+                         state, claimed_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+                    """,
+                    (
+                        int(intent_comment_id),
+                        str(change_request),
+                        str(intent_timestamp),
+                        str(author),
+                        str(comment_type),
+                        repo,
+                        int(pr_number),
+                        now,
+                    ),
+                )
+                return True
+            if row["state"] == "applied":
+                return False
+            # Stale pending — refresh payload + claimed_at so a
+            # retried claim races with the latest known shape.
+            conn.execute(
+                """
+                UPDATE rescope_intent_outbox
+                SET change_request = ?,
+                    intent_timestamp = ?,
+                    author = ?,
+                    comment_type = ?,
+                    repo = ?,
+                    pr_number = ?,
+                    claimed_at = ?
+                WHERE intent_comment_id = ?
                 """,
                 (
-                    int(intent_comment_id),
                     str(change_request),
                     str(intent_timestamp),
                     str(author),
                     str(comment_type),
-                    str(repo),
-                    int(pr_number) if isinstance(pr_number, int) else 0,  # noqa: SIM222  # pyright: ignore[reportUnnecessaryIsInstance]
+                    repo,
+                    int(pr_number),
                     now,
+                    int(intent_comment_id),
                 ),
             )
-            return cursor.rowcount > 0
+            return True
 
     def mark_rescope_intent_applied(self, intent_comment_id: int) -> None:
         """Mark a previously-claimed rescope intent as durably applied

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -665,7 +665,13 @@ class FidoStore:
             ).fetchall()
         return [int(row[0]) for row in rows]
 
-    def has_other_open_pr_comments(self, *, repo: str, exclude_comment_id: int) -> bool:
+    def has_other_open_pr_comments(
+        self,
+        *,
+        repo: str,
+        exclude_comment_id: int,
+        review_id: int | None = None,
+    ) -> bool:
         """Return whether *repo* has any other open queue entries.
 
         "Open" means ``state IN ('pending', 'in_progress', 'retryable_failed')``
@@ -674,20 +680,65 @@ class FidoStore:
         comment for the same repo, this comment is part of a batch and the
         worker will post eyes when it claims the comment in pickup order
         (#1662).
+
+        HOL-22 / #1916: when ``review_id`` is provided (the incoming
+        comment is part of a specific GitHub review submission), only
+        OTHER queue entries from the SAME review submission count as
+        "batched with this comment".  A solo human comment queued
+        behind an unrelated batch from a different review submission
+        is no longer falsely classified as batched — it still gets
+        the sub-1s eyes ack (closes #1875).  When ``review_id`` is
+        None (top-level PR comments, issue comments, anything not
+        from a review), fall back to the legacy "any other open"
+        check.
         """
         self.ensure_schema()
         with closing(self._connect()) as conn:
-            row = conn.execute(
-                """
-                SELECT 1
-                FROM pr_comment_queue
-                WHERE repo = ?
-                  AND comment_id != ?
-                  AND state IN ('pending', 'in_progress', 'retryable_failed')
-                LIMIT 1
-                """,
-                (repo, int(exclude_comment_id)),
-            ).fetchone()
+            if review_id is None:
+                row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM pr_comment_queue
+                    WHERE repo = ?
+                      AND comment_id != ?
+                      AND state IN ('pending', 'in_progress', 'retryable_failed')
+                    LIMIT 1
+                    """,
+                    (repo, int(exclude_comment_id)),
+                ).fetchone()
+            else:
+                # Filter on the JSON-encoded payload's
+                # ``pull_request_review_id`` so only comments from the
+                # SAME review submission count.  Rows without that
+                # field (e.g. queued before HOL-22 landed, or
+                # non-review comment types) compare as NULL and are
+                # correctly excluded — they're "not part of this
+                # review", which is exactly what we want.
+                #
+                # Codex on PR #1937: ``payload_json`` is the envelope
+                # ``_enqueue_pr_comment_webhook`` writes —
+                # ``{"event": ..., "delivery_id": ..., "payload":
+                # <github-webhook-body>}`` — so GitHub's per-comment
+                # ``pull_request_review_id`` lives at
+                # ``$.payload.comment.pull_request_review_id``.  An
+                # earlier version of this query used the top-level
+                # path which always resolved NULL against real rows,
+                # leaving the scoping silently broken in production.
+                row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM pr_comment_queue
+                    WHERE repo = ?
+                      AND comment_id != ?
+                      AND state IN ('pending', 'in_progress', 'retryable_failed')
+                      AND json_extract(
+                            payload_json,
+                            '$.payload.comment.pull_request_review_id'
+                          ) = ?
+                    LIMIT 1
+                    """,
+                    (repo, int(exclude_comment_id), int(review_id)),
+                ).fetchone()
         return row is not None
 
     def claim_next_pr_comment(

--- a/src/fido/store.py
+++ b/src/fido/store.py
@@ -18,7 +18,7 @@ ReplyOutboxEffectState = Literal["prepared", "claimed", "delivered", "failed"]
 
 REPLY_PROMISE_MARKER_PREFIX = "fido:reply-promise:"
 _PROMISE_MARKER_RE = re.compile(r"<!--\s*fido:reply-promise:([0-9a-fA-F-]{36})\s*-->")
-_SCHEMA_VERSION = 7
+_SCHEMA_VERSION = 8
 
 
 @dataclass(frozen=True)
@@ -858,6 +858,35 @@ class FidoStore:
             assert retried is not None
             return self._pr_comment_record_from_row(retried)
 
+    def claim_rescope_trigger(self, intent_comment_id: int) -> bool:
+        """HOL-26 / #1920 (codex P1 ninth round on PR #1938):
+        atomically claim "rescope-triggered for this intent_comment_id".
+
+        Returns ``True`` when this call is the first to claim the
+        intent (caller should fire the rescope), ``False`` when an
+        earlier claim already exists (caller should skip — the
+        rescope was already triggered, even across Fido restarts).
+
+        Used by ``_BackgroundRescopeTrigger.trigger_rescope`` to make
+        rescope firing durably idempotent per intent.  Without this,
+        a replay of an already-acked reply re-fires rescope/preempt;
+        the previous P1 fix (skip-effects-on-replay) traded that
+        bug for "effects never run if crash happens between artifact
+        record and effects" (codex P1 ninth round).  Durable rescope
+        dedup lets the replay path safely re-run all effects.
+        """
+        now = _utcnow()
+        with self._transaction() as conn:
+            cursor = conn.execute(
+                """
+                INSERT OR IGNORE INTO rescope_triggered
+                    (intent_comment_id, triggered_at)
+                VALUES (?, ?)
+                """,
+                (int(intent_comment_id), now),
+            )
+            return cursor.rowcount > 0
+
     def bump_task_creation_drop(self, intent_comment_id: int) -> tuple[int, bool]:
         """HOL-16 follow-up / #1934 (codex P2 on PR #1938): record a
         task-creation critic drop attributed to *intent_comment_id*.
@@ -1495,6 +1524,11 @@ CREATE TABLE IF NOT EXISTS transition_audit_log (
     subject TEXT NOT NULL,
     payload_json TEXT NOT NULL,
     created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rescope_triggered (
+    intent_comment_id INTEGER PRIMARY KEY,
+    triggered_at TEXT NOT NULL
 );
 
 -- HOL-16 follow-up / #1934 (codex P2 on PR #1938): durable per-

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -141,25 +141,6 @@ class SynthesisExecutor:
         self._insight_filer = insight_filer
         self._fido_logins = fido_logins
 
-    def retry_file_insights(
-        self,
-        response: CommentResponse,
-        target: CommentTarget,
-    ) -> None:
-        """HOL-26 / #1920 (codex P1 eighth round on PR #1938): retry
-        ONLY the insight-filing step, without replaying any other
-        post-reply effects (eyes, emoji, rescope).
-
-        Use this on the reply-artifact-already-recorded replay path:
-        the original pass posted the reply AND ran the eyes/emoji/
-        rescope side effects; only the insight file may still need to
-        complete.  Running the full :meth:`execute_effects_only` on
-        replay would re-trigger ``trigger_rescope``, which is NOT
-        idempotent — one actionable comment would rescope/preempt
-        more than once.
-        """
-        self._file_insights(response, target)
-
     def file_insights_pre_reply(
         self,
         response: CommentResponse,

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -148,21 +148,27 @@ class SynthesisExecutor:
     ) -> ReviewReplyOutcome:
         """Post the reply and run all post-reply effects in one call.
 
-        Thin convenience wrapper: posts the reply via :meth:`_post_reply`,
-        then delegates to :meth:`execute_effects_only` for the eyes /
-        emoji / rescope / insights / outcome chain.  Production callers
-        in ``events.py`` use :meth:`execute_effects_only` directly because
-        they own the reply-posting step (so the outbox protocol can thread
-        through it).  This entry point is retained for callers that don't
-        need that control.
+        HOL-26 / #1920: files insights FIRST so the reply post sequences
+        AFTER their durability is established.  The full sequencing-layer
+        fix (synthesis prompt sees ``insights_with_urls[]`` so the LLM
+        can weave URLs into prose by construction) requires splitting
+        synthesis into two LLM calls; that's a substantial restructure
+        out of scope here.  The minimal viable fix in this method
+        addresses the ordering contract — insights exist as durable
+        GitHub issues before any user-visible reply claims they do.
+        HOL-18's reply-prose claim-grounding critic remains the
+        verification-layer backstop for URL-in-prose.
         """
+        self._file_insights(response, target)
         self._post_reply(response.reply_text, target)
-        return self.execute_effects_only(response, target)
+        return self.execute_effects_only(response, target, insights_already_filed=True)
 
     def execute_effects_only(
         self,
         response: CommentResponse,
         target: CommentTarget,
+        *,
+        insights_already_filed: bool = False,
     ) -> ReviewReplyOutcome:
         """Execute post-reply effects for *response* against *target*.
 
@@ -206,8 +212,10 @@ class SynthesisExecutor:
         # 3. Trigger rescope if change_request present
         self._maybe_trigger_rescope(response, target)
 
-        # 4. File insights if any
-        self._file_insights(response, target)
+        # 4. File insights if any (HOL-26: may have already been filed
+        #    pre-reply by execute() to sequence durability before prose).
+        if not insights_already_filed:
+            self._file_insights(response, target)
 
         # 5. Return outcome for Rocq oracle
         return outcome_for_response(response)

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -141,6 +141,29 @@ class SynthesisExecutor:
         self._insight_filer = insight_filer
         self._fido_logins = fido_logins
 
+    def file_insights_pre_reply(
+        self,
+        response: CommentResponse,
+        target: CommentTarget,
+    ) -> None:
+        """HOL-26 / #1920: file insights BEFORE the reply is posted, so
+        the durable GitHub issues exist before any user-visible reply
+        can claim they do.
+
+        Public hook used by production reply paths (``Dispatcher``'s
+        ``reply_to_review_comment`` / ``reply_to_issue_comment``) which
+        own their own post step and must call this before posting.  The
+        matching ``execute_effects_only`` call must then pass
+        ``insights_already_filed=True`` so the post-reply effects pass
+        does not double-file.
+
+        The convenience entry :meth:`execute` chains this + post +
+        post-reply effects internally; production callers that thread
+        the outbox protocol through their own post can't use that
+        chain and split it explicitly via this hook.
+        """
+        self._file_insights(response, target)
+
     def execute(
         self,
         response: CommentResponse,
@@ -158,8 +181,15 @@ class SynthesisExecutor:
         GitHub issues before any user-visible reply claims they do.
         HOL-18's reply-prose claim-grounding critic remains the
         verification-layer backstop for URL-in-prose.
+
+        Production callers in ``Dispatcher`` use
+        :meth:`file_insights_pre_reply` + their own outbox-routed post
+        + :meth:`execute_effects_only` (with
+        ``insights_already_filed=True``) instead of this entry point,
+        because they need to thread the outbox protocol through the
+        post step.
         """
-        self._file_insights(response, target)
+        self.file_insights_pre_reply(response, target)
         self._post_reply(response.reply_text, target)
         return self.execute_effects_only(response, target, insights_already_filed=True)
 

--- a/src/fido/synthesis_executor.py
+++ b/src/fido/synthesis_executor.py
@@ -141,6 +141,25 @@ class SynthesisExecutor:
         self._insight_filer = insight_filer
         self._fido_logins = fido_logins
 
+    def retry_file_insights(
+        self,
+        response: CommentResponse,
+        target: CommentTarget,
+    ) -> None:
+        """HOL-26 / #1920 (codex P1 eighth round on PR #1938): retry
+        ONLY the insight-filing step, without replaying any other
+        post-reply effects (eyes, emoji, rescope).
+
+        Use this on the reply-artifact-already-recorded replay path:
+        the original pass posted the reply AND ran the eyes/emoji/
+        rescope side effects; only the insight file may still need to
+        complete.  Running the full :meth:`execute_effects_only` on
+        replay would re-trigger ``trigger_rescope``, which is NOT
+        idempotent — one actionable comment would rescope/preempt
+        more than once.
+        """
+        self._file_insights(response, target)
+
     def file_insights_pre_reply(
         self,
         response: CommentResponse,

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -2593,11 +2593,18 @@ def _apply_task_creation_verdicts(
     ordered_items: list[dict[str, Any]],
     verdicts: list["TaskCreationVerdict | None"],
     current: list[dict[str, Any]],
-    *,
-    drop_counter: "TaskCreationDropCounter | None" = None,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], list[int]]:
     """Apply pre-gathered task-creation verdicts against the CURRENT
     queue, dropping/fanning items per verdict.
+
+    Returns ``(items_after_apply, dropped_intent_comment_ids)``.  The
+    second list (codex P1 sixth round on PR #1938) lets the caller
+    record drops in the durable
+    :class:`~fido.critics.TaskCreationDropCounter` AFTER
+    ``_validate_rescope_batch`` confirms the batch is being applied;
+    without the deferred-record split, a rejected batch advanced the
+    counter for drops that never actually shipped, which could file
+    false stuck-on-critic bugs.
 
     Re-validates drop targets against ``current`` at apply time so a
     concurrent deletion of the target task between the unlocked
@@ -2612,6 +2619,7 @@ def _apply_task_creation_verdicts(
         f"{len(verdicts)} verdicts"
     )
     out: list[dict[str, Any]] = []
+    dropped_intent_cids: list[int] = []
     pending_queue_ids = _pending_queue_ids(current)
     # Codex on PR #1932: a drop verdict whose target is being CLOSED
     # by the same batch (status="completed", absorbed by another
@@ -2668,19 +2676,16 @@ def _apply_task_creation_verdicts(
                 target_id,
                 verdict.rationale,
             )
-            # HOL-16 follow-up / #1934: bump the per-intent drop
-            # counter for every intent_comment_id whose comment
-            # contributed to this dropped proposal.  After N drops
-            # attributed to the same intent the counter escalates
-            # via its injected escalator (the comment is the source
-            # of repeated rejected proposals — either Opus keeps
-            # re-proposing legitimately distinct work the critic
-            # mis-classifies, or the comment's intent isn't being
-            # honoured).
-            if drop_counter is not None:
-                for cid in item.get("contributing_intents") or ():
-                    if isinstance(cid, int):
-                        drop_counter.record_drop(cid)
+            # HOL-16 follow-up / #1934 (codex P1 sixth round on PR
+            # #1938): RECORD every contributing intent_comment_id
+            # for caller-side counter bumping, but do NOT bump the
+            # durable counter here — the batch may still get rejected
+            # at validation time below.  ``reorder_tasks`` calls
+            # ``drop_counter.record_drop`` for these ids only after
+            # ``_validate_rescope_batch`` confirms apply.
+            for cid in item.get("contributing_intents") or ():
+                if isinstance(cid, int):
+                    dropped_intent_cids.append(cid)
             continue
         if verdict.fans_out:
             log.info(
@@ -2707,7 +2712,7 @@ def _apply_task_creation_verdicts(
             continue
         # distinct + single: pass through.
         out.append(item)
-    return out
+    return out, dropped_intent_cids
 
 
 def _apply_task_creation_critics(
@@ -2724,11 +2729,17 @@ def _apply_task_creation_critics(
     and :func:`_apply_task_creation_verdicts` separately so the slow
     LLM verdict calls happen outside the tasks.json flock while the
     apply still revalidates drop targets against the live queue.
+
+    Discards the dropped-intent-cids list from
+    :func:`_apply_task_creation_verdicts` (drop-counter wiring is the
+    caller's job — this wrapper is for tests that don't exercise
+    the counter).
     """
     verdicts = _gather_task_creation_verdicts(
         ordered_items, current, critic_fn=critic_fn
     )
-    return _apply_task_creation_verdicts(ordered_items, verdicts, current)
+    items, _dropped = _apply_task_creation_verdicts(ordered_items, verdicts, current)
+    return items
 
 
 def _make_new_tasks_from_opus(
@@ -3883,11 +3894,10 @@ def reorder_tasks(
         # got deleted between gather and lock acquisition cause the
         # proposed task to be KEPT, not silently dropped (Rob review
         # on PR #1932).
-        ordered_items = _apply_task_creation_verdicts(
+        ordered_items, dropped_intent_cids = _apply_task_creation_verdicts(
             ordered_items,
             task_creation_verdicts,
             current,
-            drop_counter=task_creation_drop_counter,
         )
         validation_errors = _validate_rescope_batch(current, ordered_items)
         if validation_errors:
@@ -4018,13 +4028,22 @@ def reorder_tasks(
         # nothing to sync.  Skip every post-commit callback (codex on #1733).
         return
 
-    # HOL-16 follow-up / #1934: reset the per-intent drop counter for
-    # any intent_comment_id that no longer has live contributing tasks
-    # in the post-batch result.  An intent's drop streak only matters
-    # while the intent is still actively trying to land work; once it
-    # has either been fully covered or moved on, a fresh start clears
-    # the slate so a later, unrelated drop doesn't carry old debt.
+    # HOL-16 follow-up / #1934 (codex P1 sixth round on PR #1938):
+    # record the drops the critic chose ONLY AFTER the batch passed
+    # validation and got applied above.  Bumping in the apply step
+    # itself was wrong — a rejected batch advanced the durable counter
+    # for drops that never actually shipped, which could file false
+    # stuck-on-critic bugs.
     if task_creation_drop_counter is not None:
+        for cid in dropped_intent_cids:
+            task_creation_drop_counter.record_drop(cid)
+        # Then reset the per-intent drop counter for any
+        # intent_comment_id that no longer has live contributing
+        # tasks in the post-batch result.  An intent's drop streak
+        # only matters while it's still trying to land work; once
+        # the comment has been fully covered or the system moved on,
+        # a fresh start clears the slate so a later unrelated drop
+        # doesn't carry old debt.
         active_intent_ids: set[int] = set()
         for t in result:
             for cid in t.get("contributing_intents") or ():

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -16,7 +16,7 @@ from typing import IO, TYPE_CHECKING, Any, Protocol
 if TYPE_CHECKING:
     from fido.appstate import FidoState, TaskListSnapshot
     from fido.atomic import AtomicUpdater
-    from fido.critics import TaskCreationVerdict
+    from fido.critics import TaskCreationDropCounter, TaskCreationVerdict
 
 from fido.claude import ClaudeClient
 from fido.github import GitHub
@@ -2593,6 +2593,8 @@ def _apply_task_creation_verdicts(
     ordered_items: list[dict[str, Any]],
     verdicts: list["TaskCreationVerdict | None"],
     current: list[dict[str, Any]],
+    *,
+    drop_counter: "TaskCreationDropCounter | None" = None,
 ) -> list[dict[str, Any]]:
     """Apply pre-gathered task-creation verdicts against the CURRENT
     queue, dropping/fanning items per verdict.
@@ -2666,6 +2668,19 @@ def _apply_task_creation_verdicts(
                 target_id,
                 verdict.rationale,
             )
+            # HOL-16 follow-up / #1934: bump the per-intent drop
+            # counter for every intent_comment_id whose comment
+            # contributed to this dropped proposal.  After N drops
+            # attributed to the same intent the counter escalates
+            # via its injected escalator (the comment is the source
+            # of repeated rejected proposals — either Opus keeps
+            # re-proposing legitimately distinct work the critic
+            # mis-classifies, or the comment's intent isn't being
+            # honoured).
+            if drop_counter is not None:
+                for cid in item.get("contributing_intents") or ():
+                    if isinstance(cid, int):
+                        drop_counter.record_drop(cid)
             continue
         if verdict.fans_out:
             log.info(
@@ -3587,6 +3602,7 @@ def reorder_tasks(
     ]
     | None = None,
     _on_done: Callable[[], None] | None = None,
+    task_creation_drop_counter: "TaskCreationDropCounter | None" = None,
 ) -> None:
     """Reorder pending tasks by Opus dependency analysis.
 
@@ -3868,7 +3884,10 @@ def reorder_tasks(
         # proposed task to be KEPT, not silently dropped (Rob review
         # on PR #1932).
         ordered_items = _apply_task_creation_verdicts(
-            ordered_items, task_creation_verdicts, current
+            ordered_items,
+            task_creation_verdicts,
+            current,
+            drop_counter=task_creation_drop_counter,
         )
         validation_errors = _validate_rescope_batch(current, ordered_items)
         if validation_errors:
@@ -3998,6 +4017,20 @@ def reorder_tasks(
         # write).  Neither makes sense after a rejection: nothing committed,
         # nothing to sync.  Skip every post-commit callback (codex on #1733).
         return
+
+    # HOL-16 follow-up / #1934: reset the per-intent drop counter for
+    # any intent_comment_id that no longer has live contributing tasks
+    # in the post-batch result.  An intent's drop streak only matters
+    # while the intent is still actively trying to land work; once it
+    # has either been fully covered or moved on, a fresh start clears
+    # the slate so a later, unrelated drop doesn't carry old debt.
+    if task_creation_drop_counter is not None:
+        active_intent_ids: set[int] = set()
+        for t in result:
+            for cid in t.get("contributing_intents") or ():
+                if isinstance(cid, int):
+                    active_intent_ids.add(cid)
+        task_creation_drop_counter.reset_inactive_intents(active_intent_ids)
 
     if _on_changes is not None:
         # Always call with the (possibly empty) list — the production

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -4388,12 +4388,21 @@ class Tasks(JsonFileStore):
 
         Called when a new PR comment arrives so the worker can re-evaluate
         whether it is still blocked.  Returns the number of tasks unblocked.
+
+        Also resets ``critic_retry_count`` to 0 on every unblocked task —
+        without this (codex P1 on PR #1938), a task that escalated to
+        BLOCKED on the HOL-17 budget would carry the at-budget counter
+        back into PENDING.  The next critic failure would immediately
+        re-escalate the task to BLOCKED with no real retry window.
+        Unblocking is the user signalling "give this another go" — they
+        deserve a fresh budget.
         """
         count = 0
         with self.modify() as task_list:
             for t in task_list:
                 if t.get("status") == TaskStatus.BLOCKED:
                     t["status"] = str(TaskStatus.PENDING)
+                    t["critic_retry_count"] = 0
                     count += 1
         if count:
             log.info("unblocked %d task(s)", count)

--- a/src/fido/tasks.py
+++ b/src/fido/tasks.py
@@ -4436,6 +4436,11 @@ class Tasks(JsonFileStore):
                 if t.get("status") == TaskStatus.BLOCKED:
                     t["status"] = str(TaskStatus.PENDING)
                     t["critic_retry_count"] = 0
+                    # Codex P2 on PR #1938: clear the structured gap
+                    # chain alongside the counter so the next round of
+                    # retries starts with a clean trace, not the
+                    # carry-over from the previous escalation.
+                    t["critic_gap_chain"] = []
                     count += 1
         if count:
             log.info("unblocked %d task(s)", count)

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -372,6 +372,59 @@ class IntentVerdict:
             )
 
 
+def verdict_is_material(
+    intent: "RescopeIntent",
+    verdict: IntentVerdict,
+    *,
+    task_descriptions: tuple[str, ...] = (),
+) -> bool:
+    """HOL-23 / #1917: True when *verdict* warrants a per-thread reply
+    posted back to *intent*'s origin comment.
+
+    Used by HOL-24 to gate which verdicts in a rescope batch produce
+    outbox reply effects.  The triage reply already covered the
+    user-visible acknowledgement for the comment; this predicate
+    decides whether the rescope's actual decision diverged enough
+    from "I queued exactly what you asked" to warrant a follow-up
+    voice reply.
+
+    Rules:
+
+    - ``outcome != "honored"`` (``reshaped`` / ``superseded`` /
+      ``no_op``) → always material.  These are user-visible
+      decisions the triage reply couldn't have anticipated.
+    - ``outcome == "honored"`` with ``task_descriptions`` supplied:
+      material when NO task description contains
+      ``intent.change_request`` verbatim (case-insensitive).  Per
+      HOL-23's "**Open**: should honored-with-divergence count as
+      material? Default yes ('you said X, I queued Y')" — yes by
+      default; the caller can pass the descriptions of the tasks
+      this verdict's ``affected_task_ids`` produced so the
+      heuristic can answer.  Without ``task_descriptions`` the
+      caller is signalling "don't try" and we fall back to "honored
+      = not material" (triage reply was enough).
+
+    The change_request → task-description containment check is a
+    deliberately simple heuristic; it catches the obvious
+    "you said X, I queued <much-longer-thing>" divergence without
+    needing LLM judgement.  A future leaf could refine with a
+    similarity-based check if false negatives appear in practice.
+    """
+    if verdict.outcome != "honored":
+        return True
+    if not task_descriptions:
+        return False
+    request = intent.change_request.strip().lower()
+    if not request:
+        return False
+    for desc in task_descriptions:
+        if request in (desc or "").strip().lower():
+            # The change_request text is verbatim in this task's
+            # description — not divergent enough to be material.
+            return False
+    return True
+
+
 @dataclass(frozen=True)
 class RescopeIntent:
     """Origin metadata for a rescope trigger from comment synthesis.

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -419,6 +419,32 @@ def intent_thread_terminal(
     return all(_task_status_terminal(t) for t in contributing_tasks)
 
 
+def hol28_anchor_key(thread: object) -> int | None:
+    """HOL-28 / #1922 (codex P2 eighth round on PR #1938): normalize
+    a task's ``thread["comment_id"]`` to an ``int`` for consistent
+    anchor matching across worker + dispatcher.
+
+    Persisted tasks.json can store the comment id as either ``int``
+    or ``str`` (other task code already round-trips through
+    ``int(...)``), so a strict ``isinstance(int)`` check skips
+    string-id rows and a strict ``==`` compare misses string-vs-int
+    sibling matches.  Returns ``None`` when the thread is missing,
+    not a mapping, has no comment_id, or the id can't be coerced —
+    callers treat ``None`` as "no anchor" rather than as a match.
+    """
+    if not isinstance(thread, Mapping):
+        return None
+    raw = thread.get("comment_id")
+    # ``bool`` is an ``int`` subclass; reject so ``True``/``False``
+    # can't sneak in as a fake comment id.
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return int(raw)  # type: ignore[arg-type]
+    except TypeError, ValueError:
+        return None
+
+
 def newly_terminal_intent_threads(
     prev_tasks: Sequence[Mapping[str, Any]],
     new_tasks: Sequence[Mapping[str, Any]],

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -1,6 +1,6 @@
 """Shared type definitions for fido."""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal
@@ -391,7 +391,7 @@ def _task_status_terminal(task: Mapping[str, Any]) -> bool:
 
 
 def intent_thread_terminal(
-    intent_comment_id: int, tasks: list[Mapping[str, Any]]
+    intent_comment_id: int, tasks: Sequence[Mapping[str, Any]]
 ) -> bool:
     """HOL-27 / #1921: True when every task carrying *intent_comment_id*
     in its ``contributing_intents`` is in a terminal status
@@ -420,8 +420,8 @@ def intent_thread_terminal(
 
 
 def newly_terminal_intent_threads(
-    prev_tasks: list[Mapping[str, Any]],
-    new_tasks: list[Mapping[str, Any]],
+    prev_tasks: Sequence[Mapping[str, Any]],
+    new_tasks: Sequence[Mapping[str, Any]],
 ) -> tuple[int, ...]:
     """HOL-27 helper: intent comment ids whose threads were NOT terminal
     in *prev_tasks* but ARE terminal in *new_tasks*.

--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -372,6 +372,88 @@ class IntentVerdict:
             )
 
 
+_TERMINAL_TASK_STATUSES: frozenset[str] = frozenset(
+    {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
+)
+
+
+def _task_status_terminal(task: Mapping[str, Any]) -> bool:
+    """True when *task*'s status is terminal (COMPLETED or SKIPPED).
+
+    Reads ``task["status"]`` and tolerates either the StrEnum instance
+    or the raw string form — both serialisations exist in tasks.json
+    today (tasks.py mixes them) and HOL-27 must work over both.
+    """
+    status = task.get("status")
+    if isinstance(status, TaskStatus):
+        return status.value in _TERMINAL_TASK_STATUSES
+    return str(status) in _TERMINAL_TASK_STATUSES
+
+
+def intent_thread_terminal(
+    intent_comment_id: int, tasks: list[Mapping[str, Any]]
+) -> bool:
+    """HOL-27 / #1921: True when every task carrying *intent_comment_id*
+    in its ``contributing_intents`` is in a terminal status
+    (``COMPLETED`` or ``SKIPPED``).
+
+    The "intent thread" terminal predicate: an intent is terminal when
+    every task it shaped has reached a terminal status — no pending,
+    no in-progress, no blocked work remains for that comment.  HOL-28
+    consumes this to emit one per-thread aggregate reply at the moment
+    of transition (so the requester hears one summary covering every
+    task their comment touched, not N replies as each task finishes).
+
+    A vacuous thread (no task lists this intent as a contributor) is
+    considered NOT terminal — the absence-of-contribution case means
+    the intent never actually entered the queue (a pre-rescope drop),
+    which HOL-24's verdict-based path already covers via no_op
+    notification.  This predicate is specifically about the
+    "everything-this-intent-shaped finished" transition.
+    """
+    contributing_tasks = [
+        t for t in tasks if intent_comment_id in (t.get("contributing_intents") or ())
+    ]
+    if not contributing_tasks:
+        return False
+    return all(_task_status_terminal(t) for t in contributing_tasks)
+
+
+def newly_terminal_intent_threads(
+    prev_tasks: list[Mapping[str, Any]],
+    new_tasks: list[Mapping[str, Any]],
+) -> tuple[int, ...]:
+    """HOL-27 helper: intent comment ids whose threads were NOT terminal
+    in *prev_tasks* but ARE terminal in *new_tasks*.
+
+    Insertion-ordered by first appearance across *new_tasks* (so the
+    HOL-28 emission loop posts replies in a stable, predictable order).
+    De-duplicated.
+
+    Both lists must be drawn from the same tasks.json snapshot timeline
+    (a before/after pair around a single reducer transition).  Used by
+    the task-completion path to detect "this complete-op was the last
+    one that intent thread T was waiting on" — exactly the moment a
+    terminal aggregate reply is owed.
+    """
+    candidates: list[int] = []
+    seen: set[int] = set()
+    for task in new_tasks:
+        for cid in task.get("contributing_intents") or ():
+            if cid in seen:
+                continue
+            seen.add(cid)
+            candidates.append(cid)
+    transitioned: list[int] = []
+    for cid in candidates:
+        if intent_thread_terminal(cid, prev_tasks):
+            # Already terminal before the transition — not newly so.
+            continue
+        if intent_thread_terminal(cid, new_tasks):
+            transitioned.append(cid)
+    return tuple(transitioned)
+
+
 def verdict_is_material(
     intent: "RescopeIntent",
     verdict: IntentVerdict,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5479,6 +5479,15 @@ class Worker:
             assert self._registry is not None, (
                 "Worker._registry is required for recover_reply_promises"
             )
+            # Seed the PR-body work queue BEFORE either recovery path
+            # so any rescope they spawn operates on a seeded
+            # ``tasks.json``.  ``recover_reply_promises`` re-runs
+            # synthesis on queued ACT replies — synthesis can trigger
+            # a rescope (see ``execute_effects_only``) — so seeding
+            # only before ``replay_pending_rescope_intents`` is not
+            # enough.  Codex P2 (thirteenth/fourteenth rounds) on
+            # PR #1938.
+            self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             recovered_promises = self._dispatcher.recover_reply_promises(
                 ctx.fido_dir,
                 pr_number,
@@ -5486,7 +5495,6 @@ class Worker:
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
             )
-            self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             if self._first_iteration:
                 # Codex P1 (twelfth round) on PR #1938: drain orphan
                 # pending rescope intents (visible ACT reply succeeded
@@ -5494,11 +5502,6 @@ class Worker:
                 # between).  GitHub will not redeliver the original
                 # webhook, so startup replay is the only path that
                 # closes the lost-rescope window.
-                #
-                # Codex P2 (thirteenth round) on PR #1938: seed the
-                # PR-body work queue BEFORE launching the recovered
-                # rescope, so the replay thread doesn't rescope against
-                # an unseeded/partially-seeded ``tasks.json``.
                 replayed = self._dispatcher.replay_pending_rescope_intents(
                     self._registry,
                     agent=self._provider_agent,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -89,6 +89,7 @@ from fido.types import (
     TaskSnapshot,
     TaskStatus,
     TaskType,
+    hol28_anchor_key,
 )
 
 
@@ -3822,8 +3823,13 @@ class Worker:
             return
         thread = task.get("thread") or {}
         comment_type = thread.get("comment_type")
-        anchor_comment_id = thread.get("comment_id")
-        if comment_type != "pulls" or not isinstance(anchor_comment_id, int):
+        # Codex P2 (eighth round) on PR #1938: normalize the anchor
+        # via ``hol28_anchor_key`` so a string-typed comment_id in
+        # the persisted task (other task code round-trips through
+        # ``int(...)``) doesn't skip the emission or — worse — make
+        # a sibling task invisible during the transition check.
+        anchor_comment_id = hol28_anchor_key(thread)
+        if comment_type != "pulls" or anchor_comment_id is None:
             log.info(
                 "HOL-28: skipping terminal-thread emission for task %s "
                 "(thread=%r — only PR review-comment anchors emit "
@@ -3855,7 +3861,7 @@ class Worker:
         # "no original ask recorded" instead of inventing one.
         anchor_intent = RescopeIntent(
             change_request="",
-            comment_id=int(anchor_comment_id),
+            comment_id=anchor_comment_id,
             timestamp="",
             comment_type="pulls",
         )
@@ -6074,9 +6080,7 @@ def _hol28_anchor_thread_just_became_terminal(
 
     def _all_terminal(tasks: list[dict[str, Any]]) -> bool:
         anchored = [
-            t
-            for t in tasks
-            if (t.get("thread") or {}).get("comment_id") == anchor_comment_id
+            t for t in tasks if hol28_anchor_key(t.get("thread")) == anchor_comment_id
         ]
         if not anchored:
             return False

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3797,17 +3797,21 @@ class Worker:
         prev_tasks: list[dict[str, Any]],
         pr_number: int,
     ) -> None:
-        """HOL-28 / #1922 (codex P1 on PR #1938): emit one per-thread
-        aggregate reply for every intent whose contributing tasks just
-        became fully terminal.
+        """HOL-28 / #1922 wire: emit ONE aggregate reply at the task's
+        primary thread anchor when *task* just transitioned from non-
+        terminal to terminal across the *prev_tasks* → current snapshot.
 
-        Synthesizes stub ``RescopeIntent`` objects from the comment ids
-        on the just-completed task's ``contributing_intents`` — they
-        aren't durably persisted across the rescope-to-completion span,
-        so the ``change_request`` field is a placeholder.  The aggregate
-        framing in ``Dispatcher`` reads task titles / descriptions from
-        the post-completion task list, so the per-thread story still
-        names the landed commits even with a stub change_request.
+        Codex P1 (fifth round) on PR #1938: the previous shape called
+        a dispatcher method that iterated ``contributing_intents`` and
+        skipped any not in ``batch_intents``.  Passing only the task
+        anchor meant secondary contributing threads were silently
+        dropped; passing every contributing_intent re-opened the
+        wrong-endpoint hole.  The reconciled contract is per-task,
+        not per-contributing-intent — HOL-28 is the closing summary
+        at the task's primary thread; HOL-24's verdict-based path
+        already covers cross-author divergence at rescope time.
+        Per-secondary-thread closing summaries need per-intent
+        ``comment_type`` schema work; a future leaf.
 
         Best-effort: a transient GitHub failure mustn't crash task
         completion.  The terminal task status is already the durable
@@ -3816,25 +3820,18 @@ class Worker:
         prompts = self._prompts
         if prompts is None:
             return
-        # Codex P1 (second round) on PR #1938: emit ONE reply at the
-        # task's PRIMARY thread anchor (``task["thread"]``) rather
-        # than per-contributing-intent.  The earlier "synthesize an
-        # intent per contributing_intent with comment_type='pulls'"
-        # was wrong on two axes:
-        #
-        # 1. ``contributing_intents`` is a flat ``list[int]`` with no
-        #    per-intent ``comment_type``, so a hardcoded fallback
-        #    routed issue-comment ids through ``reply_to_review_comment``.
-        # 2. Mixed-contributor tasks would have produced N replies
-        #    across N threads with the same body — noisy and lossy.
-        #
-        # The canonical thread a requester follows for a task is the
-        # one anchored on the task itself.  HOL-24's verdict-based
-        # reply path already covers cross-author divergence
-        # notifications at rescope time; HOL-28 is the closing summary
-        # at the primary thread.  Per-contributing-intent emission
-        # would require a tasks.json schema change to carry per-intent
-        # ``comment_type`` — left as a separate follow-up.
+        # Caller-side transition check: only emit when this task JUST
+        # transitioned from non-terminal to terminal.  ``_finish_task``
+        # snapshots prev BEFORE ``complete_with_resolve``, so this
+        # predicate fires exactly once per terminal completion.
+        terminal = {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
+        new_status = str(task.get("status"))
+        if new_status not in terminal:
+            return
+        prev_task = next((t for t in prev_tasks if t.get("id") == task.get("id")), None)
+        prev_status = str(prev_task.get("status")) if prev_task else None
+        if prev_status in terminal:
+            return
         thread = task.get("thread") or {}
         comment_type = thread.get("comment_type")
         anchor_comment_id = thread.get("comment_id")
@@ -3848,19 +3845,16 @@ class Worker:
                 thread,
             )
             return
-        batch_intents = [
-            RescopeIntent(
-                change_request="(task-anchor reconstruction)",
-                comment_id=int(anchor_comment_id),
-                timestamp="",
-                comment_type="pulls",
-            )
-        ]
+        anchor_intent = RescopeIntent(
+            change_request="(task-anchor reconstruction)",
+            comment_id=int(anchor_comment_id),
+            timestamp="",
+            comment_type="pulls",
+        )
         try:
-            self._dispatcher.notify_newly_terminal_intent_threads(
-                prev_tasks=prev_tasks,
-                new_tasks=self._tasks.list(),
-                batch_intents=batch_intents,
+            self._dispatcher.notify_terminal_task_thread(
+                task=task,
+                anchor_intent=anchor_intent,
                 pr=pr_number,
                 agent=self._provider_agent,
                 prompts=prompts,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3846,16 +3846,23 @@ class Worker:
             anchor_comment_id, prev_tasks, new_tasks
         ):
             return
+        # Codex P2 (seventh round) on PR #1938:
+        # ``change_request=""`` (not a placeholder string) so a
+        # downstream framing that interpolates the field can't leak
+        # fabricated request text into the user-visible reply.  The
+        # framing also reads task titles/descriptions for the per-
+        # task story, so an empty change_request degrades cleanly to
+        # "no original ask recorded" instead of inventing one.
         anchor_intent = RescopeIntent(
-            change_request="(task-anchor reconstruction)",
+            change_request="",
             comment_id=int(anchor_comment_id),
             timestamp="",
             comment_type="pulls",
         )
         try:
             self._dispatcher.notify_terminal_task_thread(
-                task=task,
-                anchor_intent=anchor_intent,
+                new_tasks,
+                anchor_intent,
                 pr=pr_number,
                 agent=self._provider_agent,
                 prompts=prompts,

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -85,6 +85,7 @@ from fido.types import (
     ClosedPR,
     ClosedSubIssue,
     GitIdentity,
+    RescopeIntent,
     TaskSnapshot,
     TaskStatus,
     TaskType,
@@ -3476,105 +3477,115 @@ class Worker:
         # ``_HOL17_MAX_REPARK_BUDGET = 3``: the 1st/2nd re-parks
         # bump the count to 1/2; the 3rd failure is THE escalation
         # (we don't re-park a 3rd time and then escalate on a 4th).
-        prior_count = int(task.get("critic_retry_count") or 0)
-        prior_gaps = _CRITIC_GAP_RE.findall((task.get("description") or "").rstrip())
-        if prior_count + 1 >= _HOL17_MAX_REPARK_BUDGET:
-            log.warning(
-                "task-completion critic budget exhausted for %s (%d "
-                "prior failures + current): escalating to BLOCKED + "
-                "auto-file bug",
-                task["id"],
-                prior_count,
-            )
-            self._escalate_task_completion_critic_exhausted(
-                task=task,
-                gap_chain=(*prior_gaps, gap),
-                repo=repo,
-                pr_number=pr_number,
-            )
-            return
-        # Append the critic gap to the task description so the next
-        # worker turn reads it as guidance.  Markdown bullet under a
-        # CRITIC: header keeps existing description content intact.
+        # HOL-21 / #1915, codex P1 on PR #1938: the budget decision
+        # MUST read the live counter under the same lock that mutates
+        # state.  Reading ``task["critic_retry_count"]`` (the stale
+        # snapshot the worker passed in) and deciding outside the lock
+        # races against a concurrent rescope / counter reset, so a
+        # stale at-budget snapshot could escalate even when the live
+        # counter was just reset.
         #
-        # Rob review on PR #1932: if a concurrent rescope closed, split,
-        # merged, or removed this task while the critic was running, we
-        # must NOT force the stale row back to in_progress — that would
-        # silently overwrite the rescope's decision.  Only re-park when
-        # the row still exists AND is in a non-terminal status (the
-        # rescope hasn't moved it).  Terminal statuses (COMPLETED,
-        # SKIPPED, BLOCKED) mean the row was claimed by concurrent
-        # work; leave it alone and log the no-op.
+        # Single modify() block decides both branches based on live
+        # state and atomically mutates the row.  Side effects (bug
+        # filing, BLOCKED PR comment, git-reset, current_task_id
+        # clearing) run AFTER the lock releases, keyed off the
+        # decision captured in the loop.
         nonterminal = (
             str(TaskStatus.PENDING),
             str(TaskStatus.IN_PROGRESS),
         )
-        reparked = False
-        repark_target_found = False
+        decision: str = "missing"
+        escalate_gap_chain: tuple[str, ...] = ()
         with self._tasks.modify() as live:
             for live_task in live:
                 if live_task["id"] != task["id"]:
                     continue
-                repark_target_found = True
                 current_status = live_task.get("status")
                 if current_status not in nonterminal:
                     log.warning(
-                        "task-completion critic re-park skipped for %s: "
+                        "task-completion critic skipped for %s: "
                         "concurrent rescope moved it to %r",
                         task["id"],
                         current_status,
                     )
+                    decision = "skipped_terminal"
                     break
+                live_count = int(live_task.get("critic_retry_count") or 0)
+                if live_count + 1 >= _HOL17_MAX_REPARK_BUDGET:
+                    # Escalate inline: mark BLOCKED + append exhaustion
+                    # marker.  Gap chain built from the LIVE description
+                    # so it reflects the current retry trace, not the
+                    # stale snapshot.
+                    live_gaps = _CRITIC_GAP_RE.findall(
+                        (live_task.get("description") or "").rstrip()
+                    )
+                    escalate_gap_chain = (*live_gaps, gap)
+                    existing = (live_task.get("description") or "").rstrip()
+                    appended_marker = (
+                        f"CRITIC EXHAUSTED ({len(escalate_gap_chain)} attempts): {gap}"
+                    )
+                    live_task["description"] = (
+                        f"{existing}\n\n{appended_marker}"
+                        if existing
+                        else appended_marker
+                    )
+                    live_task["status"] = str(TaskStatus.BLOCKED)
+                    decision = "escalated"
+                    break
+                # Re-park: append CRITIC gap, bump counter, IN_PROGRESS.
                 existing = (live_task.get("description") or "").rstrip()
                 appended = (
                     f"{existing}\n\nCRITIC: {gap}" if existing else f"CRITIC: {gap}"
                 )
                 live_task["description"] = appended
                 live_task["status"] = str(TaskStatus.IN_PROGRESS)
-                # HOL-21 / #1915 (codex on PR #1933): bump the
-                # structured retry counter so the next
-                # re-park-budget check is accurate even when the
-                # description carries unrelated ``CRITIC:`` text.
-                live_task["critic_retry_count"] = (
-                    int(live_task.get("critic_retry_count") or 0) + 1
-                )
-                reparked = True
+                live_task["critic_retry_count"] = live_count + 1
+                decision = "reparked"
                 break
-        if not repark_target_found:
+
+        if decision == "missing":
             log.warning(
                 "task-completion critic re-park skipped for %s: task no "
                 "longer in queue (concurrent rescope removed it)",
                 task["id"],
             )
-        # Rob follow-up review on PR #1932: when re-park is skipped
-        # (terminal status OR row removed), the soft-reset above left
-        # the rolled-back commit's changes staged.  Without that
-        # context this becomes an orphan staged diff the NEXT task
-        # would inherit — silently picking up work from a task the
-        # queue no longer intends to run.  Discard it.  ``git reset
-        # --hard HEAD`` resets working tree + index to match the
-        # post-soft-reset HEAD, dropping every change we just rolled
-        # back.  Only fires on the no-repark branches — the normal
-        # re-park path preserves the staged changes for the retry.
-        if not reparked:
+
+        if decision == "escalated":
+            log.warning(
+                "task-completion critic budget exhausted for %s (%d "
+                "attempts): BLOCKED + auto-file bug",
+                task["id"],
+                len(escalate_gap_chain),
+            )
+            self._file_critic_exhaustion_signals(
+                task=task,
+                gap_chain=escalate_gap_chain,
+                repo=repo,
+                pr_number=pr_number,
+            )
+
+        # When NOT re-parked (terminal, missing, or escalated), the
+        # soft-reset above left the rolled-back commit's changes staged
+        # — no retry is coming, so discard them to avoid feeding them
+        # to the next unrelated task.  The re-park path preserves the
+        # staged changes for the worker's next turn.
+        if decision != "reparked":
             log.warning(
                 "discarding orphan staged changes from rolled-back commit "
-                "(rescope already moved task %s)",
+                "(task %s, decision=%s)",
                 task["id"],
+                decision,
             )
             self._git(["reset", "--hard", "HEAD"])
-        # codex r3293424367 on PR #1932: clear ``current_task_id``
-        # after re-parking.  Otherwise a stale "active task" marker
-        # lets ``_maybe_abort_for_new_task`` fire on unrelated incoming
-        # work, which routes through ``_cleanup_aborted_task`` and
-        # calls ``git_clean()`` — destroying the staged changes we
-        # just preserved for the worker's retry turn.  The task is
-        # marked IN_PROGRESS so the picker still resumes it first
-        # next cycle.
+
+        # codex r3293424367 on PR #1932: clear ``current_task_id`` so
+        # ``_maybe_abort_for_new_task`` doesn't fire on unrelated
+        # incoming work between turns.  The re-parked task is marked
+        # IN_PROGRESS so the picker resumes it first next cycle anyway.
         with self._state.modify() as state:
             state.pop("current_task_id", None)
 
-    def _escalate_task_completion_critic_exhausted(
+    def _file_critic_exhaustion_signals(
         self,
         *,
         task: dict[str, Any],
@@ -3582,97 +3593,29 @@ class Worker:
         repo: str | None,
         pr_number: int | None,
     ) -> None:
-        """HOL-21 / #1915: end the re-park cycle when the task-
-        completion critic has rejected the same task
-        ``_HOL17_MAX_REPARK_BUDGET`` times in a row.
+        """HOL-21 side-effect helper — file a bug + post BLOCKED PR
+        comment after the caller has ALREADY mutated the task row to
+        BLOCKED under its own lock.
 
-        Side effects:
+        Split out from ``_escalate_task_completion_critic_exhausted``
+        per codex P1 on PR #1938 so the production path
+        (``_handle_task_completion_critic_failure``) can do BOTH the
+        budget decision AND the BLOCKED state mutation inside ONE
+        ``self._tasks.modify()`` block — without a stale-snapshot race
+        between the budget check and the state mutation.
 
-        1. Discard the staged changes from the just-rolled-back
-           commit (``git reset --hard HEAD``).  No retry is coming,
-           so leaving the staged diff would feed it to the next
-           unrelated task.
-        2. Mark the task BLOCKED so the picker skips it.  Clear
-           ``current_task_id`` so the next worker cycle picks fresh.
-        3. Auto-file a bug on ``_BUG_REPO`` via the shared HOL-21
-           helper (idempotent — repeated escalation on the same
-           task reuses the existing bug rather than spamming).
-        4. When ``repo`` / ``pr_number`` are known, post a BLOCKED
-           comment on the PR pointing at the bug.  Best-effort: a
-           transient GitHub failure here mustn't crash the worker
-           loop, the BLOCKED task status + bug filing are already
-           the durable signals.
+        Bug filing is idempotent (the helper checks for an existing
+        bug body marker before creating).  PR comment is best-effort:
+        a transient GitHub failure mustn't crash the worker loop —
+        the BLOCKED task status + bug filing are already the durable
+        signals.
         """
-        # Local import to avoid the worker → events → worker cycle
-        # at module-import time (events.py imports Worker types).
+        # Local import to avoid the worker → events → worker cycle.
         from fido.events import (
             StuckOnCriticContext,
             file_stuck_on_critic_bug,
         )
 
-        self._git(["reset", "--hard", "HEAD"])
-
-        # Codex on PR #1933: guard the BLOCKED-marking the same way
-        # the re-park path guards re-park.  If a concurrent rescope
-        # already moved this task to a terminal state (COMPLETED /
-        # SKIPPED / BLOCKED) or removed it from the queue entirely,
-        # overwriting the row to BLOCKED would silently clobber the
-        # rescope's decision (P1).  Track whether we actually
-        # blocked the row so the side-effect arms (bug-file +
-        # BLOCKED-comment) can short-circuit when the target is
-        # gone — no point posting "BLOCKED" for a task that
-        # ceased to exist between the critic turn and now (P2).
-        nonterminal = (
-            str(TaskStatus.PENDING),
-            str(TaskStatus.IN_PROGRESS),
-        )
-        blocked_locally = False
-        with self._tasks.modify() as live:
-            for live_task in live:
-                if live_task["id"] != task["id"]:
-                    continue
-                current_status = live_task.get("status")
-                if current_status not in nonterminal:
-                    log.warning(
-                        "task-completion critic escalation skipped for %s: "
-                        "concurrent rescope moved it to %r — leaving alone",
-                        task["id"],
-                        current_status,
-                    )
-                    break
-                live_task["status"] = str(TaskStatus.BLOCKED)
-                # Append the final gap to the description so the
-                # BLOCKED record carries the full retry trace too
-                # (the bug body has it, but readers of tasks.json
-                # see it without leaving the file).
-                existing = (live_task.get("description") or "").rstrip()
-                final_gap = gap_chain[-1] if gap_chain else "(no gap recorded)"
-                appended_marker = (
-                    f"CRITIC EXHAUSTED ({len(gap_chain)} attempts): {final_gap}"
-                )
-                live_task["description"] = (
-                    f"{existing}\n\n{appended_marker}" if existing else appended_marker
-                )
-                blocked_locally = True
-                break
-
-        with self._state.modify() as state:
-            state.pop("current_task_id", None)
-
-        if not blocked_locally:
-            # Task was already terminal or already removed — no
-            # external signals (bug filing, BLOCKED comment) because
-            # there's nothing meaningful to escalate.  The hard-reset
-            # above already discarded the staged diff and
-            # ``current_task_id`` is cleared.
-            log.info(
-                "task-completion critic escalation: no external signals "
-                "fired for %s (row was already terminal or removed)",
-                task["id"],
-            )
-            return
-
-        # Build the source link from whatever PR context we have.
         if repo and pr_number:
             source_link = f"https://github.com/{repo}/pull/{pr_number}"
         else:
@@ -3722,6 +3665,86 @@ class Worker:
                     bug_url or "(none)",
                 )
 
+    def _escalate_task_completion_critic_exhausted(
+        self,
+        *,
+        task: dict[str, Any],
+        gap_chain: tuple[str, ...],
+        repo: str | None,
+        pr_number: int | None,
+    ) -> None:
+        """HOL-21 / #1915: end the re-park cycle when the task-
+        completion critic has rejected the same task
+        ``_HOL17_MAX_REPARK_BUDGET`` times in a row.
+
+        Side effects:
+
+        1. Discard the staged changes from the just-rolled-back
+           commit (``git reset --hard HEAD``).  No retry is coming,
+           so leaving the staged diff would feed it to the next
+           unrelated task.
+        2. Mark the task BLOCKED so the picker skips it.  Clear
+           ``current_task_id`` so the next worker cycle picks fresh.
+        3. Auto-file a bug on ``_BUG_REPO`` via the shared HOL-21
+           helper (idempotent — repeated escalation on the same
+           task reuses the existing bug rather than spamming).
+        4. When ``repo`` / ``pr_number`` are known, post a BLOCKED
+           comment on the PR pointing at the bug.  Best-effort: a
+           transient GitHub failure here mustn't crash the worker
+           loop, the BLOCKED task status + bug filing are already
+           the durable signals.
+        """
+        self._git(["reset", "--hard", "HEAD"])
+
+        # Codex on PR #1933: guard the BLOCKED-marking the same way
+        # the re-park path guards re-park.  If a concurrent rescope
+        # already moved this task to a terminal state or removed it,
+        # overwriting to BLOCKED would clobber the rescope's decision.
+        nonterminal = (
+            str(TaskStatus.PENDING),
+            str(TaskStatus.IN_PROGRESS),
+        )
+        blocked_locally = False
+        with self._tasks.modify() as live:
+            for live_task in live:
+                if live_task["id"] != task["id"]:
+                    continue
+                current_status = live_task.get("status")
+                if current_status not in nonterminal:
+                    log.warning(
+                        "task-completion critic escalation skipped for %s: "
+                        "concurrent rescope moved it to %r — leaving alone",
+                        task["id"],
+                        current_status,
+                    )
+                    break
+                live_task["status"] = str(TaskStatus.BLOCKED)
+                existing = (live_task.get("description") or "").rstrip()
+                final_gap = gap_chain[-1] if gap_chain else "(no gap recorded)"
+                appended_marker = (
+                    f"CRITIC EXHAUSTED ({len(gap_chain)} attempts): {final_gap}"
+                )
+                live_task["description"] = (
+                    f"{existing}\n\n{appended_marker}" if existing else appended_marker
+                )
+                blocked_locally = True
+                break
+
+        with self._state.modify() as state:
+            state.pop("current_task_id", None)
+
+        if not blocked_locally:
+            log.info(
+                "task-completion critic escalation: no external signals "
+                "fired for %s (row was already terminal or removed)",
+                task["id"],
+            )
+            return
+
+        self._file_critic_exhaustion_signals(
+            task=task, gap_chain=gap_chain, repo=repo, pr_number=pr_number
+        )
+
     def _finish_task(
         self,
         task: dict[str, Any],
@@ -3740,6 +3763,10 @@ class Worker:
         """
         config = self._config
         allowed_bots = config.allowed_bots if config is not None else frozenset()
+        # HOL-28 / #1922 (codex P1 on PR #1938): snapshot the task list
+        # BEFORE completion so the post-completion diff can identify
+        # which intent threads just transitioned to fully-terminal.
+        prev_tasks = self._tasks.list()
         self._tasks.complete_with_resolve(
             task["id"],
             self.gh,
@@ -3756,6 +3783,61 @@ class Worker:
             repo_ctx.gh_user,
             leak_before_ids,
         )
+
+        self._emit_hol28_terminal_reply_for(
+            task=task, prev_tasks=prev_tasks, pr_number=pr_number
+        )
+
+    def _emit_hol28_terminal_reply_for(
+        self,
+        *,
+        task: dict[str, Any],
+        prev_tasks: list[dict[str, Any]],
+        pr_number: int,
+    ) -> None:
+        """HOL-28 / #1922 (codex P1 on PR #1938): emit one per-thread
+        aggregate reply for every intent whose contributing tasks just
+        became fully terminal.
+
+        Synthesizes stub ``RescopeIntent`` objects from the comment ids
+        on the just-completed task's ``contributing_intents`` — they
+        aren't durably persisted across the rescope-to-completion span,
+        so the ``change_request`` field is a placeholder.  The aggregate
+        framing in ``Dispatcher`` reads task titles / descriptions from
+        the post-completion task list, so the per-thread story still
+        names the landed commits even with a stub change_request.
+
+        Best-effort: a transient GitHub failure mustn't crash task
+        completion.  The terminal task status is already the durable
+        signal that work landed.
+        """
+        contributing = task.get("contributing_intents") or ()
+        prompts = self._prompts
+        if not contributing or prompts is None:
+            return
+        batch_intents = [
+            RescopeIntent(
+                change_request="(reconstructed from contributing_intents)",
+                comment_id=int(cid),
+                timestamp="",
+                comment_type="pulls",
+            )
+            for cid in contributing
+        ]
+        try:
+            self._dispatcher.notify_newly_terminal_intent_threads(
+                prev_tasks=prev_tasks,
+                new_tasks=self._tasks.list(),
+                batch_intents=batch_intents,
+                pr=pr_number,
+                agent=self._provider_agent,
+                prompts=prompts,
+            )
+        except Exception:
+            log.exception(
+                "HOL-28: per-thread terminal aggregate reply failed for task %s",
+                task["id"],
+            )
 
     def _apply_setup_outcome(self, output: str) -> tuple[str, bool, str]:
         """Parse the setup_outcome sentinel from *output* and CRUD the task list.

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3820,18 +3820,6 @@ class Worker:
         prompts = self._prompts
         if prompts is None:
             return
-        # Caller-side transition check: only emit when this task JUST
-        # transitioned from non-terminal to terminal.  ``_finish_task``
-        # snapshots prev BEFORE ``complete_with_resolve``, so this
-        # predicate fires exactly once per terminal completion.
-        terminal = {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
-        new_status = str(task.get("status"))
-        if new_status not in terminal:
-            return
-        prev_task = next((t for t in prev_tasks if t.get("id") == task.get("id")), None)
-        prev_status = str(prev_task.get("status")) if prev_task else None
-        if prev_status in terminal:
-            return
         thread = task.get("thread") or {}
         comment_type = thread.get("comment_type")
         anchor_comment_id = thread.get("comment_id")
@@ -3844,6 +3832,19 @@ class Worker:
                 task.get("id"),
                 thread,
             )
+            return
+        # Codex P1 (sixth round) on PR #1938: the transition predicate
+        # is THREAD-level, not task-level.  When one comment shaped
+        # multiple tasks (e.g. rescope splits), completing the first
+        # task previously fired the closing summary while sibling
+        # tasks were still pending — and the second task's completion
+        # fired ANOTHER closing summary for the same thread.  Fire
+        # only when EVERY task anchored at this thread is terminal in
+        # the new snapshot AND wasn't all-terminal in the prev one.
+        new_tasks = self._tasks.list()
+        if not _hol28_anchor_thread_just_became_terminal(
+            anchor_comment_id, prev_tasks, new_tasks
+        ):
             return
         anchor_intent = RescopeIntent(
             change_request="(task-anchor reconstruction)",
@@ -6039,3 +6040,39 @@ class WorkerThread(threading.Thread):
                     provider = self._provider
                 if provider is not None:
                     provider.agent.stop_session()
+
+
+def _hol28_anchor_thread_just_became_terminal(
+    anchor_comment_id: int,
+    prev_tasks: list[dict[str, Any]],
+    new_tasks: list[dict[str, Any]],
+) -> bool:
+    """HOL-28 / #1922 transition predicate at the thread level.
+
+    Returns ``True`` iff every task anchored at ``anchor_comment_id``
+    (i.e. ``task["thread"]["comment_id"] == anchor_comment_id``) is
+    in a terminal status (COMPLETED or SKIPPED) in *new_tasks* AND
+    wasn't all-terminal in *prev_tasks*.
+
+    Codex P1 (sixth round) on PR #1938: per-task transition was the
+    wrong granularity — completing the first of several
+    same-thread tasks would fire the closing summary while sibling
+    tasks were still pending.  Thread-level transition fires once
+    per thread, when the LAST contributing task completes.
+
+    Vacuous case (no tasks anchored at this comment_id) returns
+    False — there's nothing to summarize.
+    """
+    terminal = {TaskStatus.COMPLETED.value, TaskStatus.SKIPPED.value}
+
+    def _all_terminal(tasks: list[dict[str, Any]]) -> bool:
+        anchored = [
+            t
+            for t in tasks
+            if (t.get("thread") or {}).get("comment_id") == anchor_comment_id
+        ]
+        if not anchored:
+            return False
+        return all(str(t.get("status")) in terminal for t in anchored)
+
+    return _all_terminal(new_tasks) and not _all_terminal(prev_tasks)

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5486,6 +5486,24 @@ class Worker:
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
             )
+            if self._first_iteration:
+                # Codex P1 (twelfth round) on PR #1938: drain orphan
+                # pending rescope intents (visible ACT reply succeeded
+                # but ``_on_done`` never fired because Fido crashed
+                # between).  GitHub will not redeliver the original
+                # webhook, so startup replay is the only path that
+                # closes the lost-rescope window.
+                replayed = self._dispatcher.replay_pending_rescope_intents(
+                    self._registry,
+                    agent=self._provider_agent,
+                    prompts=self._get_prompts(),
+                )
+                if replayed:
+                    log.warning(
+                        "replayed %d pending rescope intent(s) for %s",
+                        replayed,
+                        repo_ctx.repo,
+                    )
             self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             if self._first_iteration and not pr_is_fresh:
                 # One-shot replay of missed issue_comment webhooks (fix #794).

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1101,6 +1101,22 @@ def ci_ready_for_review(
 
 _BODY_TAG_RE = re.compile(r"<body>\s*(.*?)\s*</body>", re.DOTALL | re.IGNORECASE)
 
+# HOL-21 / #1915: task-completion critic re-park budget.  Each
+# failed critic verdict re-parks the task IN_PROGRESS and appends
+# ``CRITIC: <gap>`` to the description for the next worker turn.
+# After this many failures on the SAME task, escalate to BLOCKED +
+# auto-file bug instead of cycling indefinitely.  Matches the
+# spirit of ``MAX_RETRIES`` for synthesis-critic exhaustion (HOL-
+# 20) — same shape of "give up after N, file a bug for follow-up".
+_HOL17_MAX_REPARK_BUDGET = 3
+
+# Matches the ``CRITIC: <gap-text>`` lines appended to a task
+# description on each failed task-completion critic verdict.  Used
+# by the re-park-budget check above to count prior failures and by
+# the escalation path to build the gap chain for the auto-filed
+# bug body.
+_CRITIC_GAP_RE = re.compile(r"^CRITIC: (.+)$", re.MULTILINE)
+
 
 def _extract_body(raw: str | None) -> str:
     """Extract content between <body>...</body> tags from provider output.
@@ -3393,21 +3409,45 @@ class Worker:
         )
 
     def _handle_task_completion_critic_failure(
-        self, task: dict[str, Any], gap: str
+        self,
+        task: dict[str, Any],
+        gap: str,
+        *,
+        repo: str | None = None,
+        pr_number: int | None = None,
     ) -> None:
-        """HOL-17 / #1911: handle a failed task-completion critic verdict.
+        """HOL-17 / #1911 + HOL-21 / #1915: handle a failed task-
+        completion critic verdict.
 
-        Reverses the just-landed commit (``git reset --soft HEAD~1`` —
+        On the first ``_HOL17_MAX_REPARK_BUDGET`` failures: reverse
+        the just-landed commit (``git reset --soft HEAD~1`` —
         changes remain staged so the worker's next turn sees them),
-        appends the critic gap to the task description so the next
-        worker turn has guidance, and marks the task IN_PROGRESS so
+        append the critic gap to the task description so the next
+        worker turn has guidance, and mark the task IN_PROGRESS so
         the picker re-selects it on the next cycle.
 
+        When the budget is exhausted (the task description already
+        carries ``_HOL17_MAX_REPARK_BUDGET`` ``CRITIC:`` markers
+        from prior failures): stop re-parking, mark the task BLOCKED,
+        post a BLOCKED comment on the PR, auto-file a bug via the
+        shared HOL-21 ``file_stuck_on_critic_bug`` helper.  The
+        task no longer cycles indefinitely on the same complaint —
+        a human (or a future re-decomposition rescope) has to
+        intervene.
+
         The reset is destructive on the LOCAL commit only — nothing
-        was pushed yet, so no remote state changes.  The staged
-        changes survive: the worker can refine them, ``git restore
-        --staged`` selected files to drop scope-creep, or amend its
-        approach based on the gap.
+        was pushed yet, so no remote state changes.  In the re-park
+        case the staged changes survive: the worker can refine them
+        or amend.  In the escalation case the staged changes are
+        discarded (``git reset --hard HEAD``) because there's no
+        retry to keep them for.
+
+        ``repo`` / ``pr_number`` are optional only for legacy callers
+        (and the migrating tests); production paths pass them so the
+        escalation branch can post the BLOCKED comment and build the
+        bug-file source link.  When omitted on the escalation path
+        we still file the bug (with a placeholder source link) but
+        skip the PR comment.
         """
         log.warning(
             "task-completion critic FAILED for %s — soft-resetting "
@@ -3421,6 +3461,38 @@ class Worker:
         # corruption rather than papering over it with an in_progress
         # task that has a phantom commit ahead of upstream.
         self._git(["reset", "--soft", "HEAD~1"])
+        # HOL-21 / #1915: track retry count in a structured field on
+        # the task itself (``critic_retry_count``) — not by parsing
+        # ``CRITIC:`` markers in the description, which would
+        # miscount a user-authored description that happens to
+        # contain "CRITIC:" text (codex on PR #1933).  Gap chain
+        # still gets appended to the description below for the next
+        # worker turn's guidance, but the BUDGET decision uses the
+        # counter.
+        #
+        # Budget interpretation (codex on PR #1933): exceeding the
+        # configured budget on THIS failure triggers escalation
+        # immediately, not on the next one.  With
+        # ``_HOL17_MAX_REPARK_BUDGET = 3``: the 1st/2nd re-parks
+        # bump the count to 1/2; the 3rd failure is THE escalation
+        # (we don't re-park a 3rd time and then escalate on a 4th).
+        prior_count = int(task.get("critic_retry_count") or 0)
+        prior_gaps = _CRITIC_GAP_RE.findall((task.get("description") or "").rstrip())
+        if prior_count + 1 >= _HOL17_MAX_REPARK_BUDGET:
+            log.warning(
+                "task-completion critic budget exhausted for %s (%d "
+                "prior failures + current): escalating to BLOCKED + "
+                "auto-file bug",
+                task["id"],
+                prior_count,
+            )
+            self._escalate_task_completion_critic_exhausted(
+                task=task,
+                gap_chain=(*prior_gaps, gap),
+                repo=repo,
+                pr_number=pr_number,
+            )
+            return
         # Append the critic gap to the task description so the next
         # worker turn reads it as guidance.  Markdown bullet under a
         # CRITIC: header keeps existing description content intact.
@@ -3459,6 +3531,13 @@ class Worker:
                 )
                 live_task["description"] = appended
                 live_task["status"] = str(TaskStatus.IN_PROGRESS)
+                # HOL-21 / #1915 (codex on PR #1933): bump the
+                # structured retry counter so the next
+                # re-park-budget check is accurate even when the
+                # description carries unrelated ``CRITIC:`` text.
+                live_task["critic_retry_count"] = (
+                    int(live_task.get("critic_retry_count") or 0) + 1
+                )
                 reparked = True
                 break
         if not repark_target_found:
@@ -3494,6 +3573,154 @@ class Worker:
         # next cycle.
         with self._state.modify() as state:
             state.pop("current_task_id", None)
+
+    def _escalate_task_completion_critic_exhausted(
+        self,
+        *,
+        task: dict[str, Any],
+        gap_chain: tuple[str, ...],
+        repo: str | None,
+        pr_number: int | None,
+    ) -> None:
+        """HOL-21 / #1915: end the re-park cycle when the task-
+        completion critic has rejected the same task
+        ``_HOL17_MAX_REPARK_BUDGET`` times in a row.
+
+        Side effects:
+
+        1. Discard the staged changes from the just-rolled-back
+           commit (``git reset --hard HEAD``).  No retry is coming,
+           so leaving the staged diff would feed it to the next
+           unrelated task.
+        2. Mark the task BLOCKED so the picker skips it.  Clear
+           ``current_task_id`` so the next worker cycle picks fresh.
+        3. Auto-file a bug on ``_BUG_REPO`` via the shared HOL-21
+           helper (idempotent — repeated escalation on the same
+           task reuses the existing bug rather than spamming).
+        4. When ``repo`` / ``pr_number`` are known, post a BLOCKED
+           comment on the PR pointing at the bug.  Best-effort: a
+           transient GitHub failure here mustn't crash the worker
+           loop, the BLOCKED task status + bug filing are already
+           the durable signals.
+        """
+        # Local import to avoid the worker → events → worker cycle
+        # at module-import time (events.py imports Worker types).
+        from fido.events import (
+            StuckOnCriticContext,
+            file_stuck_on_critic_bug,
+        )
+
+        self._git(["reset", "--hard", "HEAD"])
+
+        # Codex on PR #1933: guard the BLOCKED-marking the same way
+        # the re-park path guards re-park.  If a concurrent rescope
+        # already moved this task to a terminal state (COMPLETED /
+        # SKIPPED / BLOCKED) or removed it from the queue entirely,
+        # overwriting the row to BLOCKED would silently clobber the
+        # rescope's decision (P1).  Track whether we actually
+        # blocked the row so the side-effect arms (bug-file +
+        # BLOCKED-comment) can short-circuit when the target is
+        # gone — no point posting "BLOCKED" for a task that
+        # ceased to exist between the critic turn and now (P2).
+        nonterminal = (
+            str(TaskStatus.PENDING),
+            str(TaskStatus.IN_PROGRESS),
+        )
+        blocked_locally = False
+        with self._tasks.modify() as live:
+            for live_task in live:
+                if live_task["id"] != task["id"]:
+                    continue
+                current_status = live_task.get("status")
+                if current_status not in nonterminal:
+                    log.warning(
+                        "task-completion critic escalation skipped for %s: "
+                        "concurrent rescope moved it to %r — leaving alone",
+                        task["id"],
+                        current_status,
+                    )
+                    break
+                live_task["status"] = str(TaskStatus.BLOCKED)
+                # Append the final gap to the description so the
+                # BLOCKED record carries the full retry trace too
+                # (the bug body has it, but readers of tasks.json
+                # see it without leaving the file).
+                existing = (live_task.get("description") or "").rstrip()
+                final_gap = gap_chain[-1] if gap_chain else "(no gap recorded)"
+                appended_marker = (
+                    f"CRITIC EXHAUSTED ({len(gap_chain)} attempts): {final_gap}"
+                )
+                live_task["description"] = (
+                    f"{existing}\n\n{appended_marker}" if existing else appended_marker
+                )
+                blocked_locally = True
+                break
+
+        with self._state.modify() as state:
+            state.pop("current_task_id", None)
+
+        if not blocked_locally:
+            # Task was already terminal or already removed — no
+            # external signals (bug filing, BLOCKED comment) because
+            # there's nothing meaningful to escalate.  The hard-reset
+            # above already discarded the staged diff and
+            # ``current_task_id`` is cleared.
+            log.info(
+                "task-completion critic escalation: no external signals "
+                "fired for %s (row was already terminal or removed)",
+                task["id"],
+            )
+            return
+
+        # Build the source link from whatever PR context we have.
+        if repo and pr_number:
+            source_link = f"https://github.com/{repo}/pull/{pr_number}"
+        else:
+            source_link = "(worker context — no PR link available)"
+
+        bug_url = file_stuck_on_critic_bug(
+            StuckOnCriticContext(
+                emission_point="task-completion",
+                source_repo=repo or "(unknown)",
+                source_pr=pr_number or 0,
+                target_kind="task",
+                target_id=str(task["id"]),
+                source_link=source_link,
+                gaps=tuple(gap_chain),
+            ),
+            gh=self.gh,
+        )
+
+        if repo and pr_number:
+            blocked_body = (
+                f"**BLOCKED**: task-completion critic exhausted "
+                f"{len(gap_chain)} attempts on task `{task['id']}` "
+                f"({task.get('title', '(no title)')!r}).\n\n"
+                f"The Layer 2 critic kept rejecting the commit.  Final gap:\n\n"
+                f"> {gap_chain[-1] if gap_chain else '(no gap recorded)'}\n\n"
+            )
+            if bug_url:
+                blocked_body += (
+                    f"Auto-filed against `FidoCanCode/home` for follow-up: {bug_url}\n"
+                )
+            else:
+                blocked_body += (
+                    "Auto-filing against `FidoCanCode/home` FAILED — see "
+                    "Fido logs for the full gap chain.\n"
+                )
+            try:
+                self.gh.comment_issue(repo, pr_number, blocked_body)
+            except Exception as exc:
+                log.warning(
+                    "HOL-21: failed to post BLOCKED comment on %s#%d "
+                    "for task %s (%s) — task is still marked BLOCKED, "
+                    "bug at %s",
+                    repo,
+                    pr_number,
+                    task["id"],
+                    exc,
+                    bug_url or "(none)",
+                )
 
     def _finish_task(
         self,
@@ -4368,7 +4595,10 @@ class Worker:
                         )
                         if not completion_verdict.passed:
                             self._handle_task_completion_critic_failure(
-                                task, completion_verdict.gap
+                                task,
+                                completion_verdict.gap,
+                                repo=repo_ctx.repo,
+                                pr_number=pr_number,
                             )
                             # Rob review on PR #1932: the rolled-back turn
                             # may have leaked top-level PR comments via the

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -1111,13 +1111,6 @@ _BODY_TAG_RE = re.compile(r"<body>\s*(.*?)\s*</body>", re.DOTALL | re.IGNORECASE
 # 20) — same shape of "give up after N, file a bug for follow-up".
 _HOL17_MAX_REPARK_BUDGET = 3
 
-# Matches the ``CRITIC: <gap-text>`` lines appended to a task
-# description on each failed task-completion critic verdict.  Used
-# by the re-park-budget check above to count prior failures and by
-# the escalation path to build the gap chain for the auto-filed
-# bug body.
-_CRITIC_GAP_RE = re.compile(r"^CRITIC: (.+)$", re.MULTILINE)
-
 
 def _extract_body(raw: str | None) -> str:
     """Extract content between <body>...</body> tags from provider output.
@@ -3511,15 +3504,22 @@ class Worker:
                     decision = "skipped_terminal"
                     break
                 live_count = int(live_task.get("critic_retry_count") or 0)
+                # Codex P2 on PR #1938: store the gap chain as a
+                # structured field instead of regex-parsing free-form
+                # description text.  Prior retry cycles or unrelated
+                # quoted text containing "CRITIC:" used to inflate the
+                # bug body's attempt count and gap list; the
+                # structured chain is precise and gets reset alongside
+                # the retry counter on unblock.  Description still
+                # gets the gap appended for the next worker turn's
+                # guidance (informational only — the budget AND the
+                # bug body now use the structured fields).
+                live_chain_raw = live_task.get("critic_gap_chain") or ()
+                live_chain: tuple[str, ...] = tuple(
+                    str(g) for g in live_chain_raw if isinstance(g, str)
+                )
                 if live_count + 1 >= _HOL17_MAX_REPARK_BUDGET:
-                    # Escalate inline: mark BLOCKED + append exhaustion
-                    # marker.  Gap chain built from the LIVE description
-                    # so it reflects the current retry trace, not the
-                    # stale snapshot.
-                    live_gaps = _CRITIC_GAP_RE.findall(
-                        (live_task.get("description") or "").rstrip()
-                    )
-                    escalate_gap_chain = (*live_gaps, gap)
+                    escalate_gap_chain = (*live_chain, gap)
                     existing = (live_task.get("description") or "").rstrip()
                     appended_marker = (
                         f"CRITIC EXHAUSTED ({len(escalate_gap_chain)} attempts): {gap}"
@@ -3530,9 +3530,10 @@ class Worker:
                         else appended_marker
                     )
                     live_task["status"] = str(TaskStatus.BLOCKED)
+                    live_task["critic_gap_chain"] = list(escalate_gap_chain)
                     decision = "escalated"
                     break
-                # Re-park: append CRITIC gap, bump counter, IN_PROGRESS.
+                # Re-park: append CRITIC gap, bump counter + chain, IN_PROGRESS.
                 existing = (live_task.get("description") or "").rstrip()
                 appended = (
                     f"{existing}\n\nCRITIC: {gap}" if existing else f"CRITIC: {gap}"
@@ -3540,6 +3541,7 @@ class Worker:
                 live_task["description"] = appended
                 live_task["status"] = str(TaskStatus.IN_PROGRESS)
                 live_task["critic_retry_count"] = live_count + 1
+                live_task["critic_gap_chain"] = [*live_chain, gap]
                 decision = "reparked"
                 break
 
@@ -3814,6 +3816,29 @@ class Worker:
         contributing = task.get("contributing_intents") or ()
         prompts = self._prompts
         if not contributing or prompts is None:
+            return
+        # Codex P2 on PR #1938: ``contributing_intents`` is just a list
+        # of comment ids — no per-intent ``comment_type``.  Falling
+        # back to hardcoded ``"pulls"`` is wrong when the originating
+        # comment was a top-level issue comment (would call
+        # ``reply_to_review_comment`` with an issue-comment id).  The
+        # task's ``thread`` field DOES carry the comment_type of the
+        # task's origin thread, which is the correct fallback for
+        # tasks whose contributing intents share an origin lane.
+        # When the thread metadata is missing or the lane is
+        # ``"issues"``, skip the emission rather than risk a wrong-
+        # endpoint reply — the terminal task status is already the
+        # durable signal that work landed.
+        thread = task.get("thread") or {}
+        comment_type = thread.get("comment_type")
+        if comment_type != "pulls":
+            log.info(
+                "HOL-28: skipping terminal-thread emission for task %s "
+                "(thread.comment_type=%r — only review-comment threads "
+                "currently emit aggregate replies)",
+                task.get("id"),
+                comment_type,
+            )
             return
         batch_intents = [
             RescopeIntent(

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -3813,41 +3813,48 @@ class Worker:
         completion.  The terminal task status is already the durable
         signal that work landed.
         """
-        contributing = task.get("contributing_intents") or ()
         prompts = self._prompts
-        if not contributing or prompts is None:
+        if prompts is None:
             return
-        # Codex P2 on PR #1938: ``contributing_intents`` is just a list
-        # of comment ids — no per-intent ``comment_type``.  Falling
-        # back to hardcoded ``"pulls"`` is wrong when the originating
-        # comment was a top-level issue comment (would call
-        # ``reply_to_review_comment`` with an issue-comment id).  The
-        # task's ``thread`` field DOES carry the comment_type of the
-        # task's origin thread, which is the correct fallback for
-        # tasks whose contributing intents share an origin lane.
-        # When the thread metadata is missing or the lane is
-        # ``"issues"``, skip the emission rather than risk a wrong-
-        # endpoint reply — the terminal task status is already the
-        # durable signal that work landed.
+        # Codex P1 (second round) on PR #1938: emit ONE reply at the
+        # task's PRIMARY thread anchor (``task["thread"]``) rather
+        # than per-contributing-intent.  The earlier "synthesize an
+        # intent per contributing_intent with comment_type='pulls'"
+        # was wrong on two axes:
+        #
+        # 1. ``contributing_intents`` is a flat ``list[int]`` with no
+        #    per-intent ``comment_type``, so a hardcoded fallback
+        #    routed issue-comment ids through ``reply_to_review_comment``.
+        # 2. Mixed-contributor tasks would have produced N replies
+        #    across N threads with the same body — noisy and lossy.
+        #
+        # The canonical thread a requester follows for a task is the
+        # one anchored on the task itself.  HOL-24's verdict-based
+        # reply path already covers cross-author divergence
+        # notifications at rescope time; HOL-28 is the closing summary
+        # at the primary thread.  Per-contributing-intent emission
+        # would require a tasks.json schema change to carry per-intent
+        # ``comment_type`` — left as a separate follow-up.
         thread = task.get("thread") or {}
         comment_type = thread.get("comment_type")
-        if comment_type != "pulls":
+        anchor_comment_id = thread.get("comment_id")
+        if comment_type != "pulls" or not isinstance(anchor_comment_id, int):
             log.info(
                 "HOL-28: skipping terminal-thread emission for task %s "
-                "(thread.comment_type=%r — only review-comment threads "
-                "currently emit aggregate replies)",
+                "(thread=%r — only PR review-comment anchors emit "
+                "aggregate replies; HOL-24 already handles issue-"
+                "comment and cross-author cases)",
                 task.get("id"),
-                comment_type,
+                thread,
             )
             return
         batch_intents = [
             RescopeIntent(
-                change_request="(reconstructed from contributing_intents)",
-                comment_id=int(cid),
+                change_request="(task-anchor reconstruction)",
+                comment_id=int(anchor_comment_id),
                 timestamp="",
                 comment_type="pulls",
             )
-            for cid in contributing
         ]
         try:
             self._dispatcher.notify_newly_terminal_intent_threads(

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5504,6 +5504,7 @@ class Worker:
                 # closes the lost-rescope window.
                 replayed = self._dispatcher.replay_pending_rescope_intents(
                     self._registry,
+                    pr_number,
                     agent=self._provider_agent,
                     prompts=self._get_prompts(),
                 )

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5486,6 +5486,7 @@ class Worker:
                 agent=self._provider_agent,
                 prompts=self._get_prompts(),
             )
+            self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             if self._first_iteration:
                 # Codex P1 (twelfth round) on PR #1938: drain orphan
                 # pending rescope intents (visible ACT reply succeeded
@@ -5493,6 +5494,11 @@ class Worker:
                 # between).  GitHub will not redeliver the original
                 # webhook, so startup replay is the only path that
                 # closes the lost-rescope window.
+                #
+                # Codex P2 (thirteenth round) on PR #1938: seed the
+                # PR-body work queue BEFORE launching the recovered
+                # rescope, so the replay thread doesn't rescope against
+                # an unseeded/partially-seeded ``tasks.json``.
                 replayed = self._dispatcher.replay_pending_rescope_intents(
                     self._registry,
                     agent=self._provider_agent,
@@ -5504,7 +5510,6 @@ class Worker:
                         replayed,
                         repo_ctx.repo,
                     )
-            self.seed_tasks_from_pr_body(repo_ctx.repo, pr_number)
             if self._first_iteration and not pr_is_fresh:
                 # One-shot replay of missed issue_comment webhooks (fix #794).
                 # Runs only on the first iteration per WorkerThread lifetime

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -31,6 +31,7 @@ class _FakeDispatcher:
         backfill_side_effect: (Callable[..., int] | BaseException | None) = None,
         recover_return: bool = False,
         recover_side_effect: (Callable[..., bool] | BaseException | None) = None,
+        replay_pending_rescope_intents_return: int = 0,
         reply_to_comment_return: tuple[str, list[str]] = ("ANSWER", []),
         reply_to_comment_side_effect: (
             Callable[..., tuple[str, list[str]]] | BaseException | None
@@ -45,6 +46,7 @@ class _FakeDispatcher:
         self.launch_sync_calls: int = 0
         self.reorder_tasks_background_calls: list[tuple] = []
         self.recover_reply_promises_calls: list[dict[str, object]] = []
+        self.replay_pending_rescope_intents_calls: list[dict[str, object]] = []
         self.reply_to_comment_calls: list[tuple] = []
         self.reply_to_issue_comment_calls: list[tuple] = []
         self._dispatch_return = dispatch_return
@@ -53,6 +55,9 @@ class _FakeDispatcher:
         self._backfill_side_effect = backfill_side_effect
         self._recover_return = recover_return
         self._recover_side_effect = recover_side_effect
+        self._replay_pending_rescope_intents_return = (
+            replay_pending_rescope_intents_return
+        )
         self._reply_to_comment_return = reply_to_comment_return
         self._reply_to_comment_side_effect = reply_to_comment_side_effect
         self._reply_to_issue_comment_return = reply_to_issue_comment_return
@@ -128,6 +133,22 @@ class _FakeDispatcher:
         if isinstance(self._recover_side_effect, BaseException):
             raise self._recover_side_effect
         return self._recover_return
+
+    def replay_pending_rescope_intents(
+        self,
+        registry: object,
+        *,
+        agent: object,
+        prompts: object,
+    ) -> int:
+        self.replay_pending_rescope_intents_calls.append(
+            {
+                "registry": registry,
+                "agent": agent,
+                "prompts": prompts,
+            }
+        )
+        return self._replay_pending_rescope_intents_return
 
     def reply_to_comment(
         self,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -137,6 +137,7 @@ class _FakeDispatcher:
     def replay_pending_rescope_intents(
         self,
         registry: object,
+        pr_number: int,
         *,
         agent: object,
         prompts: object,
@@ -144,6 +145,7 @@ class _FakeDispatcher:
         self.replay_pending_rescope_intents_calls.append(
             {
                 "registry": registry,
+                "pr_number": pr_number,
                 "agent": agent,
                 "prompts": prompts,
             }

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1774,3 +1774,65 @@ class TestTaskCreationDropCounter:
         counter.record_drop(101)
         counter.record_drop(101)
         counter.reset_inactive_intents(set())
+
+    def test_durable_store_backend_survives_counter_recreation(
+        self, tmp_path: object
+    ) -> None:
+        # Codex P2 on PR #1938 (#1934 acceptance): the counter MUST
+        # persist drops across counter object recreations (simulating
+        # a Fido restart between drops).  Wire a real ``FidoStore``
+        # backend and verify the streak carries across two counter
+        # instances.
+        from fido.critics import TaskCreationDropCounter
+        from fido.store import FidoStore
+
+        store = FidoStore(tmp_path)  # type: ignore[arg-type]
+        calls: list[tuple[int, int]] = []
+        counter1 = TaskCreationDropCounter(
+            threshold=3,
+            escalator=lambda cid, count: calls.append((cid, count)),
+            store=store,
+        )
+        counter1.record_drop(101)
+        counter1.record_drop(101)
+        assert calls == []
+        # Simulate a Fido restart: drop the in-memory counter object;
+        # construct a new one against the same durable store.
+        del counter1
+        counter2 = TaskCreationDropCounter(
+            threshold=3,
+            escalator=lambda cid, count: calls.append((cid, count)),
+            store=store,
+        )
+        # Streak survived — the third drop escalates.
+        counter2.record_drop(101)
+        assert calls == [(101, 3)]
+
+    def test_durable_store_escalated_latch_survives_recreation(
+        self, tmp_path: object
+    ) -> None:
+        # The already-escalated latch is also durable — re-firing the
+        # escalator across a "restart" must be suppressed until reset.
+        from fido.critics import TaskCreationDropCounter
+        from fido.store import FidoStore
+
+        store = FidoStore(tmp_path)  # type: ignore[arg-type]
+        calls: list[tuple[int, int]] = []
+        counter1 = TaskCreationDropCounter(
+            threshold=2,
+            escalator=lambda cid, count: calls.append((cid, count)),
+            store=store,
+        )
+        counter1.record_drop(101)
+        counter1.record_drop(101)
+        assert calls == [(101, 2)]
+        del counter1
+        counter2 = TaskCreationDropCounter(
+            threshold=2,
+            escalator=lambda cid, count: calls.append((cid, count)),
+            store=store,
+        )
+        counter2.record_drop(101)
+        counter2.record_drop(101)
+        # No re-fire — latch durably preserved.
+        assert calls == [(101, 2)]

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1546,3 +1546,141 @@ class TestRunInsightDedupCritic:
                 prompts=_FakeInsightDedupPrompts(),
                 critic_system_prompt="critic-sys",
             )
+
+
+class TestInsightDedupTransportCounter:
+    """HOL-19 follow-up / #1935: consecutive-transport-failure counter
+    escalates via the injected escalator after crossing the threshold;
+    parse failures don't bump or reset; verdict-shape-valid responses
+    reset."""
+
+    def test_escalates_at_threshold(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=3, escalator=calls.append)
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        assert calls == []
+        counter.record_transport_failure()
+        assert calls == [3]
+
+    def test_already_escalated_suppresses_re_fire(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        # Escalated once, then suppressed until reset.
+        assert calls == [2]
+
+    def test_success_resets_counter_and_escalation_latch(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        assert calls == [2]
+        counter.record_success()
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        # Fresh escalation after the reset.
+        assert calls == [2, 2]
+
+    def test_none_escalator_no_op(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        counter = InsightDedupTransportCounter(threshold=1, escalator=None)
+        # Must not raise.
+        counter.record_transport_failure()
+        counter.record_transport_failure()
+        counter.record_success()
+
+
+class TestInsightDedupCriticTransportCounterWiring:
+    """``run_insight_dedup_critic`` calls the counter on transport
+    failure and on verdict-shape-valid success."""
+
+    def _proposed(self) -> dict[str, str]:
+        return {"title": "t", "hook": "h", "why": "w"}
+
+    def _recent(self) -> list[dict[str, str]]:
+        return [{"title": "rt", "body": "rb", "url": "https://github.com/o/r/issues/1"}]
+
+    def test_transport_failure_bumps_counter(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=1, escalator=calls.append)
+        agent = _FakeAgent(run_turn_exception=RuntimeError("network"))
+        run_insight_dedup_critic(
+            proposed_insight=self._proposed(),
+            recent_insights=self._recent(),
+            agent=agent,
+            prompts=_FakeInsightDedupPrompts(),
+            critic_system_prompt="critic-sys",
+            transport_counter=counter,
+        )
+        assert calls == [1]
+
+    def test_verdict_valid_response_resets_counter(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        # Pre-bump to threshold-1 so escalation doesn't fire.
+        counter.record_transport_failure()
+        # Verdict-shape-valid response: is_duplicate=false (any well-formed envelope).
+        agent = _FakeAgent(run_turn_responses=['{"is_duplicate": false}'])
+        run_insight_dedup_critic(
+            proposed_insight=self._proposed(),
+            recent_insights=self._recent(),
+            agent=agent,
+            prompts=_FakeInsightDedupPrompts(),
+            critic_system_prompt="critic-sys",
+            transport_counter=counter,
+        )
+        # Counter reset — a fresh round of failures starts fresh.
+        agent2 = _FakeAgent(run_turn_exception=RuntimeError("network"))
+        run_insight_dedup_critic(
+            proposed_insight=self._proposed(),
+            recent_insights=self._recent(),
+            agent=agent2,
+            prompts=_FakeInsightDedupPrompts(),
+            critic_system_prompt="critic-sys",
+            transport_counter=counter,
+        )
+        # Only 1 transport failure after reset; below threshold.
+        assert calls == []
+
+    def test_parse_failure_does_not_reset(self) -> None:
+        from fido.critics import InsightDedupTransportCounter
+
+        calls: list[int] = []
+        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter.record_transport_failure()
+        # Parse failure: no JSON.
+        agent = _FakeAgent(run_turn_responses=["garbage no json here"])
+        run_insight_dedup_critic(
+            proposed_insight=self._proposed(),
+            recent_insights=self._recent(),
+            agent=agent,
+            prompts=_FakeInsightDedupPrompts(),
+            critic_system_prompt="critic-sys",
+            transport_counter=counter,
+        )
+        # Counter still at 1.  Next transport failure should escalate at threshold=2.
+        agent2 = _FakeAgent(run_turn_exception=RuntimeError("network"))
+        run_insight_dedup_critic(
+            proposed_insight=self._proposed(),
+            recent_insights=self._recent(),
+            agent=agent2,
+            prompts=_FakeInsightDedupPrompts(),
+            critic_system_prompt="critic-sys",
+            transport_counter=counter,
+        )
+        assert calls == [2]

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1558,7 +1558,9 @@ class TestInsightDedupTransportCounter:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=3, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=3, escalator=lambda c: calls.append(c) or True
+        )
         counter.record_transport_failure()
         counter.record_transport_failure()
         assert calls == []
@@ -1569,7 +1571,9 @@ class TestInsightDedupTransportCounter:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=2, escalator=lambda c: calls.append(c) or True
+        )
         counter.record_transport_failure()
         counter.record_transport_failure()
         counter.record_transport_failure()
@@ -1581,7 +1585,9 @@ class TestInsightDedupTransportCounter:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=2, escalator=lambda c: calls.append(c) or True
+        )
         counter.record_transport_failure()
         counter.record_transport_failure()
         assert calls == [2]
@@ -1600,6 +1606,33 @@ class TestInsightDedupTransportCounter:
         counter.record_transport_failure()
         counter.record_success()
 
+    def test_failed_escalator_releases_latch_and_retries(self) -> None:
+        # Codex P1 follow-up on PR #1938: when the escalator returns
+        # False (transient bug-file failure), the already-escalated
+        # latch must be released so the next transport failure
+        # retries the escalation — without this a transient GitHub
+        # error at the first threshold crossing permanently
+        # suppresses future escalations.
+        from fido.critics import InsightDedupTransportCounter
+
+        results = iter([False, True])
+        fire_count = [0]
+
+        def flaky_escalator(_count: int) -> bool:
+            fire_count[0] += 1
+            return next(results)
+
+        counter = InsightDedupTransportCounter(threshold=1, escalator=flaky_escalator)
+        # First failure fires escalator → returns False → latch released.
+        counter.record_transport_failure()
+        assert fire_count[0] == 1
+        # Second failure fires AGAIN (because latch was released) → True.
+        counter.record_transport_failure()
+        assert fire_count[0] == 2
+        # Third failure: latch now set, no re-fire.
+        counter.record_transport_failure()
+        assert fire_count[0] == 2
+
 
 class TestInsightDedupCriticTransportCounterWiring:
     """``run_insight_dedup_critic`` calls the counter on transport
@@ -1615,7 +1648,9 @@ class TestInsightDedupCriticTransportCounterWiring:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=1, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=1, escalator=lambda c: calls.append(c) or True
+        )
         agent = _FakeAgent(run_turn_exception=RuntimeError("network"))
         run_insight_dedup_critic(
             proposed_insight=self._proposed(),
@@ -1631,7 +1666,9 @@ class TestInsightDedupCriticTransportCounterWiring:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=2, escalator=lambda c: calls.append(c) or True
+        )
         # Pre-bump to threshold-1 so escalation doesn't fire.
         counter.record_transport_failure()
         # Verdict-shape-valid response: is_duplicate=false (any well-formed envelope).
@@ -1661,7 +1698,9 @@ class TestInsightDedupCriticTransportCounterWiring:
         from fido.critics import InsightDedupTransportCounter
 
         calls: list[int] = []
-        counter = InsightDedupTransportCounter(threshold=2, escalator=calls.append)
+        counter = InsightDedupTransportCounter(
+            threshold=2, escalator=lambda c: calls.append(c) or True
+        )
         counter.record_transport_failure()
         # Parse failure: no JSON.
         agent = _FakeAgent(run_turn_responses=["garbage no json here"])
@@ -1696,7 +1735,7 @@ class TestTaskCreationDropCounter:
 
         calls: list[tuple[int, int]] = []
         counter = TaskCreationDropCounter(
-            threshold=3, escalator=lambda cid, count: calls.append((cid, count))
+            threshold=3, escalator=lambda cid, count: calls.append((cid, count)) or True
         )
         counter.record_drop(101)
         counter.record_drop(101)
@@ -1709,7 +1748,7 @@ class TestTaskCreationDropCounter:
 
         calls: list[tuple[int, int]] = []
         counter = TaskCreationDropCounter(
-            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count)) or True
         )
         counter.record_drop(101)
         counter.record_drop(202)
@@ -1722,7 +1761,7 @@ class TestTaskCreationDropCounter:
 
         calls: list[tuple[int, int]] = []
         counter = TaskCreationDropCounter(
-            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count)) or True
         )
         counter.record_drop(101)
         counter.record_drop(101)
@@ -1735,7 +1774,7 @@ class TestTaskCreationDropCounter:
 
         calls: list[tuple[int, int]] = []
         counter = TaskCreationDropCounter(
-            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count)) or True
         )
         counter.record_drop(101)
         counter.record_drop(101)  # escalates
@@ -1752,7 +1791,7 @@ class TestTaskCreationDropCounter:
 
         calls: list[tuple[int, int]] = []
         counter = TaskCreationDropCounter(
-            threshold=3, escalator=lambda cid, count: calls.append((cid, count))
+            threshold=3, escalator=lambda cid, count: calls.append((cid, count)) or True
         )
         counter.record_drop(101)
         counter.record_drop(202)
@@ -1790,7 +1829,7 @@ class TestTaskCreationDropCounter:
         calls: list[tuple[int, int]] = []
         counter1 = TaskCreationDropCounter(
             threshold=3,
-            escalator=lambda cid, count: calls.append((cid, count)),
+            escalator=lambda cid, count: calls.append((cid, count)) or True,
             store=store,
         )
         counter1.record_drop(101)
@@ -1801,7 +1840,7 @@ class TestTaskCreationDropCounter:
         del counter1
         counter2 = TaskCreationDropCounter(
             threshold=3,
-            escalator=lambda cid, count: calls.append((cid, count)),
+            escalator=lambda cid, count: calls.append((cid, count)) or True,
             store=store,
         )
         # Streak survived — the third drop escalates.
@@ -1820,7 +1859,7 @@ class TestTaskCreationDropCounter:
         calls: list[tuple[int, int]] = []
         counter1 = TaskCreationDropCounter(
             threshold=2,
-            escalator=lambda cid, count: calls.append((cid, count)),
+            escalator=lambda cid, count: calls.append((cid, count)) or True,
             store=store,
         )
         counter1.record_drop(101)
@@ -1829,10 +1868,48 @@ class TestTaskCreationDropCounter:
         del counter1
         counter2 = TaskCreationDropCounter(
             threshold=2,
-            escalator=lambda cid, count: calls.append((cid, count)),
+            escalator=lambda cid, count: calls.append((cid, count)) or True,
             store=store,
         )
         counter2.record_drop(101)
         counter2.record_drop(101)
         # No re-fire — latch durably preserved.
         assert calls == [(101, 2)]
+
+    def test_failed_escalator_does_not_persist_latch(self, tmp_path: object) -> None:
+        # Codex P1 follow-up on PR #1938: if file_stuck_on_critic_bug
+        # returned None (transient GitHub failure), the durable
+        # escalated=1 latch must NOT be set — otherwise a transient
+        # failure at the first threshold crossing permanently
+        # suppresses escalation across restarts even though no bug
+        # was filed.
+        from fido.critics import TaskCreationDropCounter
+        from fido.store import FidoStore
+
+        store = FidoStore(tmp_path)  # type: ignore[arg-type]
+        results = iter([False, True])
+        calls: list[tuple[int, int]] = []
+
+        def flaky_escalator(cid: int, count: int) -> bool:
+            calls.append((cid, count))
+            return next(results)
+
+        counter1 = TaskCreationDropCounter(
+            threshold=2, escalator=flaky_escalator, store=store
+        )
+        counter1.record_drop(101)
+        counter1.record_drop(101)  # crosses threshold; escalator returns False
+        assert calls == [(101, 2)]
+        # Simulate a restart with the durable store carrying state.
+        del counter1
+        counter2 = TaskCreationDropCounter(
+            threshold=2, escalator=flaky_escalator, store=store
+        )
+        # Next drop should re-fire because the latch was NOT persisted
+        # on the failed attempt.  This time the escalator returns True
+        # → latch persists going forward.
+        counter2.record_drop(101)
+        assert calls == [(101, 2), (101, 3)]
+        # Further drops on 101 don't re-fire (latch now durably set).
+        counter2.record_drop(101)
+        assert calls == [(101, 2), (101, 3)]

--- a/tests/test_critics.py
+++ b/tests/test_critics.py
@@ -1684,3 +1684,93 @@ class TestInsightDedupCriticTransportCounterWiring:
             transport_counter=counter,
         )
         assert calls == [2]
+
+
+class TestTaskCreationDropCounter:
+    """HOL-16 follow-up / #1934: per-intent task-creation drop counter
+    escalates after N drops attributed to the same intent_comment_id;
+    resets when the intent has no live contributing tasks."""
+
+    def test_escalates_at_threshold_for_single_intent(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        calls: list[tuple[int, int]] = []
+        counter = TaskCreationDropCounter(
+            threshold=3, escalator=lambda cid, count: calls.append((cid, count))
+        )
+        counter.record_drop(101)
+        counter.record_drop(101)
+        assert calls == []
+        counter.record_drop(101)
+        assert calls == [(101, 3)]
+
+    def test_drops_for_different_intents_tracked_separately(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        calls: list[tuple[int, int]] = []
+        counter = TaskCreationDropCounter(
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+        )
+        counter.record_drop(101)
+        counter.record_drop(202)
+        counter.record_drop(101)
+        # 101 hit threshold; 202 hasn't.
+        assert calls == [(101, 2)]
+
+    def test_already_escalated_suppresses_re_fire(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        calls: list[tuple[int, int]] = []
+        counter = TaskCreationDropCounter(
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+        )
+        counter.record_drop(101)
+        counter.record_drop(101)
+        counter.record_drop(101)
+        counter.record_drop(101)
+        assert calls == [(101, 2)]
+
+    def test_reset_inactive_intents_clears_counter_and_latch(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        calls: list[tuple[int, int]] = []
+        counter = TaskCreationDropCounter(
+            threshold=2, escalator=lambda cid, count: calls.append((cid, count))
+        )
+        counter.record_drop(101)
+        counter.record_drop(101)  # escalates
+        assert calls == [(101, 2)]
+        # Intent 101 has no live contributing tasks anymore — reset.
+        counter.reset_inactive_intents(active_intent_ids=set())
+        # Fresh drops can escalate again.
+        counter.record_drop(101)
+        counter.record_drop(101)
+        assert calls == [(101, 2), (101, 2)]
+
+    def test_reset_inactive_keeps_active_intents(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        calls: list[tuple[int, int]] = []
+        counter = TaskCreationDropCounter(
+            threshold=3, escalator=lambda cid, count: calls.append((cid, count))
+        )
+        counter.record_drop(101)
+        counter.record_drop(202)
+        # Both 101 and 202 stay active.
+        counter.reset_inactive_intents(active_intent_ids={101, 202})
+        # Counters preserved — one more drop on 101 doesn't escalate yet
+        # (count is now 2, threshold is 3).
+        counter.record_drop(101)
+        assert calls == []
+        # But 101 now reaches threshold.
+        counter.record_drop(101)
+        assert calls == [(101, 3)]
+
+    def test_none_escalator_no_op(self) -> None:
+        from fido.critics import TaskCreationDropCounter
+
+        counter = TaskCreationDropCounter(threshold=1, escalator=None)
+        # Must not raise.
+        counter.record_drop(101)
+        counter.record_drop(101)
+        counter.reset_inactive_intents(set())

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4938,13 +4938,24 @@ class TestNotifyTerminalTaskThread:
             comment_type="pulls",
         )
 
+    def _pulls_task(
+        self, tid: str, status: str, anchor_cid: int = 999, **extra: object
+    ) -> dict[str, object]:
+        row: dict[str, object] = {
+            "id": tid,
+            "status": status,
+            "thread": {"comment_type": "pulls", "comment_id": anchor_cid},
+        }
+        row.update(extra)
+        return row
+
     def test_completed_task_fires_reply_at_anchor(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        task = {"id": "t1", "status": "completed", "title": "did it"}
+        new_tasks = [self._pulls_task("t1", "completed", title="did it")]
         Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
-            task=task,
-            anchor_intent=self._anchor(999),
+            new_tasks,
+            self._anchor(999),
             pr=42,
             agent=_client("Done."),
             prompts=Prompts("p"),
@@ -4955,48 +4966,133 @@ class TestNotifyTerminalTaskThread:
     def test_skipped_task_fires_reply(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        task = {
-            "id": "t1",
-            "status": "skipped",
-            "title": "y",
-            "description": "no longer needed",
-        }
+        new_tasks = [
+            self._pulls_task(
+                "t1",
+                "skipped",
+                title="y",
+                description="no longer needed",
+            )
+        ]
         Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
-            task=task,
-            anchor_intent=self._anchor(),
+            new_tasks,
+            self._anchor(),
             pr=42,
             agent=_client("Done."),
             prompts=Prompts("p"),
         )
         gh.reply_to_review_comment.assert_called_once()
 
-    def test_non_terminal_task_silently_skipped(self, tmp_path: Path) -> None:
+    def test_non_terminal_anchored_task_skips_dispatch(self, tmp_path: Path) -> None:
+        # Even if SOME anchored tasks are terminal, a single sibling
+        # still pending blocks the closing summary.
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        task = {"id": "t1", "status": "in_progress"}
+        new_tasks = [
+            self._pulls_task("t1", "completed"),
+            self._pulls_task("t2", "pending"),
+        ]
         Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
-            task=task,
-            anchor_intent=self._anchor(),
+            new_tasks,
+            self._anchor(),
             pr=42,
             agent=_client("nope"),
             prompts=Prompts("p"),
         )
         gh.reply_to_review_comment.assert_not_called()
 
+    def test_aggregate_includes_all_sibling_tasks(self, tmp_path: Path) -> None:
+        # Codex P2 (seventh round) on PR #1938: when the closing
+        # summary fires for a multi-task thread, it must mention ALL
+        # sibling terminal tasks, not just one.
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        class _CapturingAgent:
+            voice_model = "claude-opus-4-7"
+
+            def run_turn(self, prompt: str, **_kw: object) -> str:
+                captured.append(prompt)
+                return "Done."
+
+        gh = MagicMock()
+        new_tasks = [
+            self._pulls_task("t1", "completed", title="first commit"),
+            self._pulls_task("t2", "completed", title="second commit"),
+            self._pulls_task("t3", "skipped", title="dropped", description="why"),
+        ]
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            new_tasks,
+            self._anchor(),
+            pr=42,
+            agent=_CapturingAgent(),  # type: ignore[arg-type]
+            prompts=Prompts("p"),
+        )
+        assert captured, "agent.run_turn was not called"
+        framing = captured[0]
+        assert "t1: first commit" in framing
+        assert "t2: second commit" in framing
+        assert "t3: dropped — why" in framing
+
+    def test_anchor_empty_change_request_not_leaked(self, tmp_path: Path) -> None:
+        # Codex P2 (seventh round) on PR #1938: the worker constructs
+        # the anchor intent with ``change_request=""`` to avoid
+        # leaking a placeholder string into the reply.  The framing
+        # must NOT include the change_request line when the field is
+        # empty.
+        cfg = self._cfg(tmp_path)
+        captured: list[str] = []
+
+        class _CapturingAgent:
+            voice_model = "claude-opus-4-7"
+
+            def run_turn(self, prompt: str, **_kw: object) -> str:
+                captured.append(prompt)
+                return "Done."
+
+        gh = MagicMock()
+        anchor = RescopeIntent(
+            change_request="",
+            comment_id=999,
+            timestamp="",
+            comment_type="pulls",
+        )
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            [self._pulls_task("t1", "completed", title="x")],
+            anchor,
+            pr=42,
+            agent=_CapturingAgent(),  # type: ignore[arg-type]
+            prompts=Prompts("p"),
+        )
+        framing = captured[0]
+        assert "change request" not in framing.lower()
+        # And the placeholder string from older versions must not appear.
+        assert "task-anchor reconstruction" not in framing
+
     def test_post_failure_logged_not_raised(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
         gh.reply_to_review_comment.side_effect = RuntimeError("api down")
-        # Must not raise — the worker's task-completion path can't be
-        # gated on per-reply transport errors.
-        task = {"id": "t1", "status": "completed", "title": "x"}
         Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
-            task=task,
-            anchor_intent=self._anchor(),
+            [self._pulls_task("t1", "completed", title="x")],
+            self._anchor(),
             pr=42,
             agent=_client("Done."),
             prompts=Prompts("p"),
         )
+
+    def test_no_anchored_tasks_skips_dispatch(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        # Anchor is comment 999 but no tasks live at that anchor.
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            [self._pulls_task("t1", "completed", anchor_cid=12345)],
+            self._anchor(999),
+            pr=42,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        gh.reply_to_review_comment.assert_not_called()
 
 
 class TestNotifyIntentOutcome:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4698,6 +4698,222 @@ class TestBuildOnRescopeApply:
         assert comment_ids == [101]  # once, not twice
 
 
+class TestHol28TerminalThreadFraming:
+    """HOL-28 / #1922: per-thread terminal aggregate framing names
+    landed commits + skipped tasks + carries the requester's ask."""
+
+    def _intent(self, comment_id: int = 101) -> RescopeIntent:
+        return RescopeIntent(
+            change_request="please rename the parser",
+            comment_id=comment_id,
+            timestamp="2024-01-15T10:00:00+00:00",
+        )
+
+    def test_lists_landed_commits(self) -> None:
+        from fido.events import _hol28_terminal_thread_framing
+
+        completed = [{"id": "t1", "title": "rename parser module"}]
+        framing = _hol28_terminal_thread_framing(self._intent(), completed, [])
+        assert "LANDED" in framing
+        assert "t1: rename parser module" in framing
+
+    def test_lists_skipped_tasks_with_reason(self) -> None:
+        from fido.events import _hol28_terminal_thread_framing
+
+        skipped = [
+            {
+                "id": "t2",
+                "title": "rename internal helper",
+                "description": "redundant with t1; skipping",
+            }
+        ]
+        framing = _hol28_terminal_thread_framing(self._intent(), [], skipped)
+        assert "SKIPPED" in framing
+        assert "t2: rename internal helper — redundant with t1; skipping" in framing
+
+    def test_carries_intent_change_request(self) -> None:
+        from fido.events import _hol28_terminal_thread_framing
+
+        framing = _hol28_terminal_thread_framing(self._intent(), [], [])
+        assert "please rename the parser" in framing
+        assert "comment id: 101" in framing
+
+    def test_skipped_with_no_reason_uses_fallback(self) -> None:
+        from fido.events import _hol28_terminal_thread_framing
+
+        skipped = [{"id": "t1", "title": "x", "description": ""}]
+        framing = _hol28_terminal_thread_framing(self._intent(), [], skipped)
+        assert "(no reason recorded)" in framing
+
+    def test_untitled_task_uses_fallback(self) -> None:
+        from fido.events import _hol28_terminal_thread_framing
+
+        completed = [{"id": "t1", "title": ""}]
+        framing = _hol28_terminal_thread_framing(self._intent(), completed, [])
+        assert "t1: (untitled)" in framing
+
+
+class TestNotifyNewlyTerminalIntentThreads:
+    """HOL-28 wire: ``Dispatcher.notify_newly_terminal_intent_threads``
+    posts one aggregate reply per intent whose thread just transitioned
+    to fully-terminal across a tasks.json before/after snapshot."""
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _intent(self, comment_id: int, comment_type: str = "pulls") -> RescopeIntent:
+        return RescopeIntent(
+            change_request=f"req {comment_id}",
+            comment_id=comment_id,
+            timestamp="2024-01-15T10:00:00+00:00",
+            comment_type=comment_type,
+        )
+
+    def test_no_transition_no_reply(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "completed", "contributing_intents": [101]}
+            ],
+            new_tasks=[
+                {"id": "t1", "status": "completed", "contributing_intents": [101]}
+            ],
+            batch_intents=[self._intent(101)],
+            pr=42,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        gh.reply_to_review_comment.assert_not_called()
+
+    def test_transition_fires_one_reply(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
+            ],
+            new_tasks=[
+                {
+                    "id": "t1",
+                    "status": "completed",
+                    "title": "did it",
+                    "contributing_intents": [101],
+                }
+            ],
+            batch_intents=[self._intent(101)],
+            pr=42,
+            agent=_client("Done."),
+            prompts=Prompts("p"),
+        )
+        gh.reply_to_review_comment.assert_called_once()
+        assert gh.reply_to_review_comment.call_args.args[3] == 101
+
+    def test_issue_comment_skipped(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
+            ],
+            new_tasks=[
+                {"id": "t1", "status": "completed", "contributing_intents": [101]}
+            ],
+            batch_intents=[self._intent(101, comment_type="issues")],
+            pr=42,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        gh.reply_to_review_comment.assert_not_called()
+
+    def test_intent_missing_from_batch_skipped(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        # transitioned cid is 101 but batch_intents only knows 202.
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
+            ],
+            new_tasks=[
+                {"id": "t1", "status": "completed", "contributing_intents": [101]}
+            ],
+            batch_intents=[self._intent(202)],
+            pr=42,
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        gh.reply_to_review_comment.assert_not_called()
+
+    def test_post_failure_logged_not_raised(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        gh.reply_to_review_comment.side_effect = RuntimeError("api down")
+        # Must not raise — the worker's task-completion path can't be
+        # gated on per-reply transport errors.
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
+            ],
+            new_tasks=[
+                {"id": "t1", "status": "completed", "contributing_intents": [101]}
+            ],
+            batch_intents=[self._intent(101)],
+            pr=42,
+            agent=_client("Done."),
+            prompts=Prompts("p"),
+        )
+
+    def test_multiple_intents_each_get_one_reply(self, tmp_path: Path) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        Dispatcher(
+            cfg, cfg.repos["owner/repo"], gh
+        ).notify_newly_terminal_intent_threads(
+            prev_tasks=[
+                {"id": "t1", "status": "in_progress", "contributing_intents": [101]},
+                {"id": "t2", "status": "pending", "contributing_intents": [202]},
+            ],
+            new_tasks=[
+                {
+                    "id": "t1",
+                    "status": "completed",
+                    "title": "x",
+                    "contributing_intents": [101],
+                },
+                {
+                    "id": "t2",
+                    "status": "skipped",
+                    "title": "y",
+                    "description": "no longer needed",
+                    "contributing_intents": [202],
+                },
+            ],
+            batch_intents=[self._intent(101), self._intent(202)],
+            pr=42,
+            agent=_client("Done."),
+            prompts=Prompts("p"),
+        )
+        comment_ids = [c.args[3] for c in gh.reply_to_review_comment.call_args_list]
+        assert comment_ids == [101, 202]
+
+
 class TestNotifyIntentOutcome:
     """INV-F (#1804): ``_notify_intent_outcome`` posts a per-intent
     reply with framing keyed on the oracle's ``NotifyKind``."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -43,7 +43,7 @@ from fido.synthesis import CommentResponse, Insight
 from fido.synthesis_call import SynthesisCriticExhaustedError, SynthesisExhaustedError
 from fido.synthesis_executor import CommentTarget
 from fido.tasks import Tasks
-from fido.types import ActiveIssue, ActivePR, RescopeIntent
+from fido.types import ActiveIssue, ActivePR, IntentVerdict, RescopeIntent
 from fido.worker import ActivityReporter
 from tests.fakes import _FakeDispatcher
 
@@ -4551,6 +4551,96 @@ class TestBuildOnRescopeApply:
         ]
         cb(result, op_inputs, {"t1": 1, "t2": 2}, [])
         gh.reply_to_review_comment.assert_not_called()
+
+    def test_no_op_verdict_notifies_via_hol24_path(self, tmp_path: Path) -> None:
+        # HOL-24 / #1918: the oracle doesn't fire for no_op verdicts
+        # (nothing reorganized), so the verdict-based pass picks them
+        # up and notifies the requester their ask was silently dropped.
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        alice = self._intent(101, author="alice")
+        cb = Dispatcher(cfg, cfg.repos["owner/repo"], gh)._build_on_rescope_apply(
+            intents=[alice],
+            pr_ctx=self._pr(),
+            agent=_client("Reply text"),
+            prompts=Prompts("p"),
+        )
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="no_op",
+            narrative="dropped because the requested change conflicts with the spec",
+        )
+        cb([], [], {}, [verdict])
+        comment_ids = [c.args[3] for c in gh.reply_to_review_comment.call_args_list]
+        assert comment_ids == [101]
+
+    def test_honored_non_divergent_verdict_silent(self, tmp_path: Path) -> None:
+        # HOL-24: an honored verdict whose task description contains
+        # the change_request verbatim is NOT material — triage reply
+        # was enough, no second voice reply.
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        alice = self._intent(101, author="alice")
+        cb = Dispatcher(cfg, cfg.repos["owner/repo"], gh)._build_on_rescope_apply(
+            intents=[alice],
+            pr_ctx=self._pr(),
+            agent=_client("nope"),
+            prompts=Prompts("p"),
+        )
+        result = [
+            {
+                "id": "t1",
+                "title": "t",
+                "description": "implement req 101 exactly as written",
+                "contributing_intents": [101],
+            }
+        ]
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="honored",
+            narrative="queued as asked",
+            affected_task_ids=("t1",),
+        )
+        cb(result, [], {"t1": 1}, [verdict])
+        gh.reply_to_review_comment.assert_not_called()
+
+    def test_verdict_dedupes_against_oracle_path(self, tmp_path: Path) -> None:
+        # HOL-24: if the oracle already notified intent 101 (cross-author
+        # rewrite), a material verdict for the same intent_comment_id
+        # must NOT double-notify.
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        alice = self._intent(101, "2024-01-15T10:00:00+00:00", author="alice")
+        bob = self._intent(202, "2024-01-15T10:01:00+00:00", author="bob")
+        cb = Dispatcher(cfg, cfg.repos["owner/repo"], gh)._build_on_rescope_apply(
+            intents=[alice, bob],
+            pr_ctx=self._pr(),
+            agent=_client("Reply text"),
+            prompts=Prompts("p"),
+        )
+        result = [
+            {
+                "id": "t1",
+                "title": "Renamed by bob",
+                "description": "",
+                "contributing_intents": [101, 202],
+            }
+        ]
+        op_inputs = [
+            task_queue_rescope.OpInput(
+                oi_op=task_queue_rescope.RewriteTask(1, "Renamed by bob", ""),
+                oi_intents=[202],
+            )
+        ]
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="reshaped",
+            narrative="rewritten",
+            affected_task_ids=("t1",),
+        )
+        cb(result, op_inputs, {"t1": 1}, [verdict])
+        comment_ids = [c.args[3] for c in gh.reply_to_review_comment.call_args_list]
+        assert comment_ids == [101]  # once, not twice
 
 
 class TestNotifyIntentOutcome:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4171,16 +4171,6 @@ class TestReorderTasksBackground:
         # Second call: intent2 and intent3 accumulated
         assert calls[1][2].get("intents") == [intent2, intent3]
 
-    def test_chain_on_done_returns_other_when_one_is_none(self) -> None:
-        from fido.events import _chain_on_done
-
-        def a() -> None:
-            pass
-
-        assert _chain_on_done(None, a) is a
-        assert _chain_on_done(a, None) is a
-        assert _chain_on_done(None, None) is None
-
     def test_on_done_chains_across_coalesced_calls(self, tmp_path: Path) -> None:
         # Codex P1 (thirteenth round) on PR #1938: when multiple
         # rescope triggers coalesce while a batch is running, every

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4872,46 +4872,6 @@ class TestHol28TerminalThreadFraming:
         assert "t1: (untitled)" in framing
 
 
-class TestSafeRetryFileInsights:
-    """HOL-26 / #1920 (codex P1 eighth round on PR #1938): replay-
-    path insight-only retry swallows exceptions so a transient
-    failure on retry doesn't propagate up the reply handler."""
-
-    def test_swallows_exception(self) -> None:
-        from fido.events import _safe_retry_file_insights
-
-        class _Boom:
-            def retry_file_insights(self, _r: object, _t: object) -> None:
-                raise RuntimeError("GitHub down")
-
-        # Must not raise.
-        _safe_retry_file_insights(
-            _Boom(),  # type: ignore[arg-type]
-            object(),  # type: ignore[arg-type]
-            object(),  # type: ignore[arg-type]
-            where="test",
-        )
-
-    def test_passes_through_on_success(self) -> None:
-        from fido.events import _safe_retry_file_insights
-
-        seen: list[tuple[object, object]] = []
-
-        class _Spy:
-            def retry_file_insights(self, r: object, t: object) -> None:
-                seen.append((r, t))
-
-        resp = object()
-        target = object()
-        _safe_retry_file_insights(
-            _Spy(),  # type: ignore[arg-type]
-            resp,  # type: ignore[arg-type]
-            target,  # type: ignore[arg-type]
-            where="test",
-        )
-        assert seen == [(resp, target)]
-
-
 class TestSafeFileInsightsPreReply:
     """HOL-26 / #1920 (codex P1 sixth round on PR #1938): the
     production reply paths wrap ``file_insights_pre_reply`` so a
@@ -5924,6 +5884,20 @@ class TestDispatchReviewCommentNoNumber:
         assert result is None
 
 
+class _FakeRescopeTriggerStore:
+    """Codex P1 ninth round on PR #1938: hand-rolled stand-in for
+    ``FidoStore.claim_rescope_trigger`` used in
+    ``_BackgroundRescopeTrigger`` tests."""
+
+    def __init__(self, *, claims_succeed: bool) -> None:
+        self._claims_succeed = claims_succeed
+        self.claimed_ids: list[int] = []
+
+    def claim_rescope_trigger(self, intent_comment_id: int) -> bool:
+        self.claimed_ids.append(intent_comment_id)
+        return self._claims_succeed
+
+
 class TestBackgroundRescopeTrigger:
     """_BackgroundRescopeTrigger delegates to Dispatcher.reorder_tasks_background."""
 
@@ -5949,6 +5923,7 @@ class TestBackgroundRescopeTrigger:
             agent=MagicMock(),
             prompts=Prompts("p"),
             dispatcher=fake_dispatcher,
+            store=_FakeRescopeTriggerStore(claims_succeed=True),
         )
         trigger.trigger_rescope(intent)
 
@@ -5966,6 +5941,7 @@ class TestBackgroundRescopeTrigger:
             agent=MagicMock(),
             prompts=Prompts("p"),
             dispatcher=fake_dispatcher,
+            store=_FakeRescopeTriggerStore(claims_succeed=True),
         )
         trigger.trigger_rescope(intent)
 
@@ -5984,12 +5960,49 @@ class TestBackgroundRescopeTrigger:
             agent=fake_agent,
             prompts=fake_prompts,
             dispatcher=fake_dispatcher,
+            store=_FakeRescopeTriggerStore(claims_succeed=True),
         )
         trigger.trigger_rescope(self._make_intent("Refactor the parser"))
 
         _, kwargs = fake_dispatcher.reorder_tasks_background_calls[0]
         assert kwargs["agent"] is fake_agent
         assert kwargs["prompts"] is fake_prompts
+
+    def test_trigger_rescope_skips_when_store_claims_fail(self) -> None:
+        # Codex P1 (ninth round) on PR #1938: when the durable
+        # ``claim_rescope_trigger`` returns False, the rescope was
+        # already triggered (this Fido process or another after a
+        # restart) — skip the dispatch.  Prevents replay of the
+        # post-reply effects from re-firing rescope/preempt.
+        fake_dispatcher = _FakeDispatcher()
+        store = _FakeRescopeTriggerStore(claims_succeed=False)
+        trigger = _BackgroundRescopeTrigger(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+            dispatcher=fake_dispatcher,
+            store=store,
+        )
+        trigger.trigger_rescope(self._make_intent(comment_id=42))
+        assert store.claimed_ids == [42]
+        # No dispatch — duplicate rescope was suppressed.
+        assert fake_dispatcher.reorder_tasks_background_calls == []
+
+    def test_trigger_rescope_claims_before_dispatch(self) -> None:
+        # Claim happens before the dispatch so a crash mid-dispatch
+        # doesn't leave the claim un-set (replay would re-fire).
+        fake_dispatcher = _FakeDispatcher()
+        store = _FakeRescopeTriggerStore(claims_succeed=True)
+        trigger = _BackgroundRescopeTrigger(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+            dispatcher=fake_dispatcher,
+            store=store,
+        )
+        trigger.trigger_rescope(self._make_intent(comment_id=99))
+        assert store.claimed_ids == [99]
+        assert len(fake_dispatcher.reorder_tasks_background_calls) == 1
 
 
 class TestReplyToCommentElseBranch:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4872,6 +4872,46 @@ class TestHol28TerminalThreadFraming:
         assert "t1: (untitled)" in framing
 
 
+class TestSafeRetryFileInsights:
+    """HOL-26 / #1920 (codex P1 eighth round on PR #1938): replay-
+    path insight-only retry swallows exceptions so a transient
+    failure on retry doesn't propagate up the reply handler."""
+
+    def test_swallows_exception(self) -> None:
+        from fido.events import _safe_retry_file_insights
+
+        class _Boom:
+            def retry_file_insights(self, _r: object, _t: object) -> None:
+                raise RuntimeError("GitHub down")
+
+        # Must not raise.
+        _safe_retry_file_insights(
+            _Boom(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            where="test",
+        )
+
+    def test_passes_through_on_success(self) -> None:
+        from fido.events import _safe_retry_file_insights
+
+        seen: list[tuple[object, object]] = []
+
+        class _Spy:
+            def retry_file_insights(self, r: object, t: object) -> None:
+                seen.append((r, t))
+
+        resp = object()
+        target = object()
+        _safe_retry_file_insights(
+            _Spy(),  # type: ignore[arg-type]
+            resp,  # type: ignore[arg-type]
+            target,  # type: ignore[arg-type]
+            where="test",
+        )
+        assert seen == [(resp, target)]
+
+
 class TestSafeFileInsightsPreReply:
     """HOL-26 / #1920 (codex P1 sixth round on PR #1938): the
     production reply paths wrap ``file_insights_pre_reply`` so a

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -135,6 +135,11 @@ def _make_mock_gh() -> MagicMock:
     # through ``uuid.uuid5`` (events.py:403), which would TypeError on
     # an auto-mocked sub-MagicMock.
     gh.create_issue.return_value = "https://github.com/owner/repo/issues/0"
+    # ``get_repo_info`` returns the repo slug; production sites pass it
+    # as a string into ``CommentTarget.repo`` (and downstream into the
+    # ``rescope_intent_outbox`` SQLite row), which would TypeError on an
+    # auto-mocked sub-MagicMock.
+    gh.get_repo_info.return_value = "owner/repo"
     return gh
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5885,17 +5885,35 @@ class TestDispatchReviewCommentNoNumber:
 
 
 class _FakeRescopeTriggerStore:
-    """Codex P1 ninth round on PR #1938: hand-rolled stand-in for
-    ``FidoStore.claim_rescope_trigger`` used in
+    """Codex P1 ninth/tenth rounds on PR #1938: hand-rolled stand-in
+    for the rescope-intent outbox used in
     ``_BackgroundRescopeTrigger`` tests."""
 
     def __init__(self, *, claims_succeed: bool) -> None:
         self._claims_succeed = claims_succeed
         self.claimed_ids: list[int] = []
+        self.applied_ids: list[int] = []
+        self.released_ids: list[int] = []
 
-    def claim_rescope_trigger(self, intent_comment_id: int) -> bool:
+    def claim_rescope_intent(
+        self,
+        *,
+        intent_comment_id: int,
+        change_request: str,
+        intent_timestamp: str,
+        author: str,
+        comment_type: str,
+        repo: str,
+        pr_number: int,
+    ) -> bool:
         self.claimed_ids.append(intent_comment_id)
         return self._claims_succeed
+
+    def mark_rescope_intent_applied(self, intent_comment_id: int) -> None:
+        self.applied_ids.append(intent_comment_id)
+
+    def release_rescope_intent_claim(self, intent_comment_id: int) -> None:
+        self.released_ids.append(intent_comment_id)
 
 
 class TestBackgroundRescopeTrigger:
@@ -5987,6 +6005,56 @@ class TestBackgroundRescopeTrigger:
         assert store.claimed_ids == [42]
         # No dispatch — duplicate rescope was suppressed.
         assert fake_dispatcher.reorder_tasks_background_calls == []
+
+    def test_trigger_rescope_marks_applied_via_on_done(self) -> None:
+        # Codex P1 (tenth round) on PR #1938: the durable
+        # ``applied`` state advances only after the rescope's
+        # ``_on_done`` callback fires (i.e. tasks.json has been
+        # synced and the PR description rewritten).  The trigger
+        # wires ``_on_done`` to ``mark_rescope_intent_applied`` so
+        # the applied marker matches "work durably landed."
+        fake_dispatcher = _FakeDispatcher()
+        store = _FakeRescopeTriggerStore(claims_succeed=True)
+        trigger = _BackgroundRescopeTrigger(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+            dispatcher=fake_dispatcher,
+            store=store,
+        )
+        trigger.trigger_rescope(self._make_intent(comment_id=77))
+        # The trigger should have passed an _on_done callable.
+        assert len(fake_dispatcher.reorder_tasks_background_calls) == 1
+        _, kwargs = fake_dispatcher.reorder_tasks_background_calls[0]
+        on_done = kwargs["_on_done"]
+        # Applied marker fires only AFTER the on_done callback runs.
+        assert store.applied_ids == []
+        on_done()
+        assert store.applied_ids == [77]
+
+    def test_trigger_rescope_releases_claim_on_synchronous_failure(self) -> None:
+        # Codex P1 (tenth round) on PR #1938: a synchronous failure
+        # between claim and dispatch must release the pending claim
+        # so the next trigger fires.  Without release, the next
+        # attempt sees the durable claim, skips dispatch, and the
+        # rescope never runs.
+        class _BoomDispatcher:
+            def reorder_tasks_background(self, *_args: object, **_kw: object) -> None:
+                raise RuntimeError("thread-start failed")
+
+        store = _FakeRescopeTriggerStore(claims_succeed=True)
+        trigger = _BackgroundRescopeTrigger(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+            dispatcher=_BoomDispatcher(),  # type: ignore[arg-type]
+            store=store,
+        )
+        with pytest.raises(RuntimeError, match="thread-start failed"):
+            trigger.trigger_rescope(self._make_intent(comment_id=88))
+        assert store.claimed_ids == [88]
+        assert store.released_ids == [88]
+        assert store.applied_ids == []
 
     def test_trigger_rescope_claims_before_dispatch(self) -> None:
         # Claim happens before the dispatch so a crash mid-dispatch
@@ -7001,6 +7069,52 @@ class TestMakeReorderKwargsActiveContext:
         assert isinstance(pr, ActivePR)
         assert pr.number == 99
         assert pr.url == "https://github.com/owner/repo/pull/99"
+
+
+class TestMakeReorderKwargsAfterApply:
+    """Codex P1 tenth round on PR #1938: ``_make_reorder_kwargs``
+    chains a caller-supplied ``after_apply`` callback after the
+    built-in sync/rewrite on_done sequence.  The rescope-intent
+    outbox uses this to advance ``state='applied'`` ONLY after the
+    durable apply completes."""
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def test_after_apply_fires_when_on_done_invoked(self, tmp_path: Path) -> None:
+        calls: list[str] = []
+        gh = MagicMock()
+
+        def rewrite_fn(*_a: object, **_kw: object) -> None:
+            calls.append("rewrite")
+
+        def sync_fn(_w: Path, _g: object) -> None:
+            calls.append("sync")
+
+        def after_apply() -> None:
+            calls.append("after_apply")
+
+        kwargs = Dispatcher(
+            self._cfg(tmp_path), self._cfg(tmp_path).repos["owner/repo"], gh
+        )._make_reorder_kwargs(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            rewrite_fn,
+            sync_fn,
+            after_apply=after_apply,
+        )
+        kwargs["_on_done"]()
+        # after_apply runs LAST — after sync and rewrite, so the
+        # applied-marker only advances on successful durable apply.
+        assert calls == ["sync", "rewrite", "after_apply"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7989,6 +7989,23 @@ class TestDispatcher:
         mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
         assert count == 0
 
+    def test_insight_dedup_transport_escalator_files_bug(self, tmp_path: Path) -> None:
+        # HOL-19 follow-up / #1935: when the process-local
+        # transport-failure counter crosses the threshold, the
+        # Dispatcher-bound escalator files a bug via
+        # ``file_stuck_on_critic_bug``.
+        cfg = _config(tmp_path)
+        repo_cfg = _repo_cfg(tmp_path)
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/9999"
+        d = Dispatcher(cfg, repo_cfg, gh)
+        d._escalate_insight_dedup_transport_failure(3)
+        gh.create_issue.assert_called_once()
+        args = gh.create_issue.call_args.args
+        assert args[0] == "FidoCanCode/home"
+        assert "insight-dedup-transport" in args[2]
+
     def test_launch_sync_calls_background(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path)
         mock_gh = MagicMock()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7032,6 +7032,124 @@ class TestGitHubInsightFiler:
         assert captured["recent_count"] == _INSIGHT_RECENT_LIMIT
 
 
+class TestFileStuckOnCriticBug:
+    """HOL-21 / #1915: shared bug-file helper for ALL critic
+    exhaustion routes (HOL-15..HOL-19).  Pulled out of
+    ``_route_critic_exhausted_blocked`` so per-leaf retry budgets
+    for HOL-16/HOL-17/HOL-19 can call it without duplicating the
+    idempotency-marker + body templating logic."""
+
+    def _ctx(
+        self,
+        *,
+        emission_point: str = "task-completion",
+        target_kind: str = "task",
+        target_id: str = "t-9",
+        attempts_preview: tuple[str, ...] = (),
+    ) -> object:
+        from fido.events import StuckOnCriticContext
+
+        return StuckOnCriticContext(
+            emission_point=emission_point,
+            source_repo="owner/repo",
+            source_pr=42,
+            target_kind=target_kind,
+            target_id=target_id,
+            source_link="https://github.com/owner/repo/pull/42",
+            gaps=("g1", "g2", "g3"),
+            attempts_preview=attempts_preview,
+        )
+
+    def test_files_new_bug_with_idempotency_marker(self) -> None:
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/1000"
+
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/1000"
+        body = gh.create_issue.call_args.args[2]
+        assert "<!-- critic-exhaustion: task-completion:" in body
+        assert "owner/repo#42:task:t-9 -->" in body
+        for gap in ("g1", "g2", "g3"):
+            assert gap in body
+        title = gh.create_issue.call_args.args[1]
+        assert "task-completion critic exhausted" in title
+        # Default empty attempts_preview → sentinel line in body.
+        assert "(no per-attempt previews recorded)" in body
+
+    def test_reuses_existing_bug_on_marker_hit(self) -> None:
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = [
+            {"html_url": "https://github.com/FidoCanCode/home/issues/2000"}
+        ]
+
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/2000"
+        gh.create_issue.assert_not_called()
+
+    def test_search_failure_falls_through_to_create(self) -> None:
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.side_effect = RuntimeError("503")
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/3000"
+
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url == "https://github.com/FidoCanCode/home/issues/3000"
+
+    def test_create_failure_returns_none(self) -> None:
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.side_effect = RuntimeError("500")
+
+        url = file_stuck_on_critic_bug(self._ctx(), gh=gh)
+        assert url is None
+
+    def test_emission_point_part_of_idempotency_key(self) -> None:
+        """Two different critics exhausting on the same target file
+        SEPARATE bugs because the emission_point is in the marker."""
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        file_stuck_on_critic_bug(self._ctx(emission_point="task-completion"), gh=gh)
+        intent_body = gh.create_issue.call_args.args[2]
+        gh.reset_mock()
+        gh.search_issues.return_value = []
+
+        file_stuck_on_critic_bug(self._ctx(emission_point="task-creation"), gh=gh)
+        creation_body = gh.create_issue.call_args.args[2]
+
+        assert "task-completion:" in intent_body
+        assert "task-creation:" in creation_body
+        assert "task-completion:" not in creation_body
+
+    def test_attempts_preview_when_provided(self) -> None:
+        """When the caller has per-attempt previews (HOL-15/18 path
+        always does), they're rendered in the bug body."""
+        from fido.events import file_stuck_on_critic_bug
+
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        file_stuck_on_critic_bug(
+            self._ctx(attempts_preview=("preview-A", "preview-B")), gh=gh
+        )
+        body = gh.create_issue.call_args.args[2]
+        assert "preview-A" in body
+        assert "preview-B" in body
+        assert "(no per-attempt previews recorded)" not in body
+
+
 class TestRouteCriticExhaustedBlocked:
     """HOL-20 / #1914: critic-exhaustion route — BLOCKED PR comment +
     auto-filed bug carrying the full retry trace."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4171,6 +4171,80 @@ class TestReorderTasksBackground:
         # Second call: intent2 and intent3 accumulated
         assert calls[1][2].get("intents") == [intent2, intent3]
 
+    def test_chain_on_done_returns_other_when_one_is_none(self) -> None:
+        from fido.events import _chain_on_done
+
+        def a() -> None:
+            pass
+
+        assert _chain_on_done(None, a) is a
+        assert _chain_on_done(a, None) is a
+        assert _chain_on_done(None, None) is None
+
+    def test_on_done_chains_across_coalesced_calls(self, tmp_path: Path) -> None:
+        # Codex P1 (thirteenth round) on PR #1938: when multiple
+        # rescope triggers coalesce while a batch is running, every
+        # caller's ``_on_done`` must fire after the coalesced batch
+        # lands.  Without chaining, only the latest caller's
+        # ``mark_rescope_intent_applied`` runs and intermediate
+        # coalesced intents stay durably ``pending`` forever — a
+        # later restart re-runs them and duplicates effects.
+        state: dict[str, object] = {}
+        started: list[object] = []
+        fired: list[str] = []
+
+        # Real ``reorder_tasks`` invokes the ``_on_done`` kwarg after
+        # a successful reorder; the mock reproduces that contract so
+        # the chaining is observable end-to-end.
+        def mock_reorder(work_dir: Path, commit_summary: str, **kwargs: object) -> None:
+            on_done = kwargs.get("_on_done")
+            if callable(on_done):
+                on_done()
+
+        gh = MagicMock()
+        # Call A: starts the thread.  Its _on_done fires after the
+        # FIRST iteration.
+        self._dispatcher(
+            tmp_path,
+            gh,
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csA",
+            registry=MagicMock(spec=ActivityReporter),
+            _on_done=lambda: fired.append("A"),
+        )
+        # Calls B and C coalesce — both must fire after the coalesced
+        # batch lands.
+        self._dispatcher(
+            tmp_path,
+            MagicMock(),
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csB",
+            registry=MagicMock(spec=ActivityReporter),
+            _on_done=lambda: fired.append("B"),
+        )
+        self._dispatcher(
+            tmp_path,
+            MagicMock(),
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csC",
+            registry=MagicMock(spec=ActivityReporter),
+            _on_done=lambda: fired.append("C"),
+        )
+        assert len(started) == 1
+        self._run_thread(started)
+        # A fired from its own iteration; B and C both fired from the
+        # coalesced iteration via the chained _on_done.
+        assert fired == ["A", "B", "C"]
+
     def test_running_flag_cleared_after_no_pending(self, tmp_path: Path) -> None:
         """After a normal run with no pending call, running is set to False."""
         state: dict = {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1172,6 +1172,69 @@ class TestRecoverReplyPromises:
         assert FidoStore(tmp_path).recoverable_promises() == []
 
 
+class TestReplayPendingRescopeIntents:
+    """Codex P1 (twelfth round) on PR #1938: startup replay drains any
+    pending rescope intents orphaned by a crash between the visible
+    ACT reply and ``_on_done``.  GitHub will not redeliver a
+    successful webhook, so this is the only path that closes the
+    lost-rescope window.
+    """
+
+    def test_no_pending_returns_zero(self, tmp_path: Path) -> None:
+        gh = _make_mock_gh()
+        replayed = Dispatcher(
+            _config(tmp_path), _repo_cfg(tmp_path), gh
+        ).replay_pending_rescope_intents(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+        )
+        assert replayed == 0
+
+    def test_pending_intent_is_redispatched(self, tmp_path: Path) -> None:
+        # Seed a pending row directly via the store: this is the
+        # state that a crash-between-claim-and-_on_done leaves
+        # behind.
+        store = FidoStore(tmp_path)
+        assert store.claim_rescope_intent(
+            intent_comment_id=909,
+            change_request="please refactor the parser",
+            intent_timestamp="2024-01-15T10:00:00+00:00",
+            author="owner",
+            comment_type="issues",
+            repo="owner/repo",
+            pr_number=7,
+        )
+        gh = _make_mock_gh()
+        thread_starts: list[object] = []
+        coalesce_state: dict[str, object] = {}
+
+        replayed = Dispatcher(
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            thread_start_fn=thread_starts.append,
+            reorder_coalesce_state=coalesce_state,
+        ).replay_pending_rescope_intents(
+            MagicMock(spec=ActivityReporter),
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+        )
+
+        assert replayed == 1
+        # reorder_tasks_background was called for the pending row —
+        # the coalesce state has an entry for this work_dir and the
+        # thread-start fn was invoked (without actually starting a
+        # daemon thread).
+        assert len(thread_starts) == 1
+        assert str(tmp_path) in coalesce_state
+        # _on_done has not fired (thread never ran), so the outbox
+        # row is still pending — exactly what the next restart
+        # would replay again until the rescope completes.
+        pending = store.pending_rescope_intents()
+        assert [intent.comment_id for intent in pending] == [909]
+
+
 class TestIsAllowed:
     def _repo_cfg(
         self, tmp_path: Path, collaborators: frozenset[str] = frozenset({"owner"})

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4659,6 +4659,43 @@ class TestBuildOnRescopeApply:
         assert "#202" in framing
         assert "overridden by a later directive" in framing
 
+    def test_honored_verdict_falls_back_to_contributing_intents(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex P2 on PR #1938: an honored verdict that omits
+        # ``affected_task_ids`` would skip the divergence check (no
+        # task descriptions to compare against → not material → silent
+        # drop), even when the resulting task text diverges.  Fall
+        # back to every task whose contributing_intents lists this
+        # intent's comment_id.
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        alice = self._intent(101, author="alice")
+        cb = Dispatcher(cfg, cfg.repos["owner/repo"], gh)._build_on_rescope_apply(
+            intents=[alice],
+            pr_ctx=self._pr(),
+            agent=_client("Reply text"),
+            prompts=Prompts("p"),
+        )
+        result = [
+            {
+                "id": "t1",
+                "title": "Renamed",
+                "description": "completely different from the ask",
+                "contributing_intents": [101],
+            }
+        ]
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="honored",
+            narrative="queued as asked",
+            affected_task_ids=(),  # omitted
+        )
+        cb(result, [], {"t1": 1}, [verdict])
+        # Divergence detected via the fallback — reply fires.
+        comment_ids = [c.args[3] for c in gh.reply_to_review_comment.call_args_list]
+        assert comment_ids == [101]
+
     def test_verdict_dedupes_against_oracle_path(self, tmp_path: Path) -> None:
         # HOL-24: if the oracle already notified intent 101 (cross-author
         # rewrite), a material verdict for the same intent_comment_id

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4171,6 +4171,62 @@ class TestReorderTasksBackground:
         # Second call: intent2 and intent3 accumulated
         assert calls[1][2].get("intents") == [intent2, intent3]
 
+    def test_coalesced_batch_uses_latest_callers_kwargs(self, tmp_path: Path) -> None:
+        # Codex P2 (fifteenth round) on PR #1938: the coalesced batch
+        # runs with the LATEST caller's kwargs (fresh issue/pr context
+        # for the rescope prompt and reply notifier), even though the
+        # ``_on_done`` and shared ``_after_applies`` list come from
+        # the existing batch.  Verified through ``agent``, which is a
+        # per-call kwarg that flows straight through to the reorder
+        # call site.
+        state: dict[str, object] = {}
+        started: list[object] = []
+        calls, mock_reorder = self._capture_reorder_calls()
+
+        agent_a = MagicMock(name="agent_a")
+        agent_b = MagicMock(name="agent_b")
+        agent_c = MagicMock(name="agent_c")
+        gh = MagicMock()
+        self._dispatcher(
+            tmp_path,
+            gh,
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csA",
+            registry=MagicMock(spec=ActivityReporter),
+            agent=agent_a,
+        )
+        self._dispatcher(
+            tmp_path,
+            MagicMock(),
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csB",
+            registry=MagicMock(spec=ActivityReporter),
+            agent=agent_b,
+        )
+        self._dispatcher(
+            tmp_path,
+            MagicMock(),
+            thread_start_fn=lambda t: started.append(t),
+            reorder_fn=mock_reorder,
+            reorder_coalesce_state=state,
+        ).reorder_tasks_background(
+            "csC",
+            registry=MagicMock(spec=ActivityReporter),
+            agent=agent_c,
+        )
+        self._run_thread(started)
+        assert len(calls) == 2
+        # First iteration ran with A's agent.
+        assert calls[0][2].get("agent") is agent_a
+        # Coalesced iteration ran with C's agent (latest), NOT B's.
+        assert calls[1][2].get("agent") is agent_c
+
     def test_on_done_chains_across_coalesced_calls(self, tmp_path: Path) -> None:
         # Codex P1 (thirteenth round) on PR #1938: when multiple
         # rescope triggers coalesce while a batch is running, every

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7989,6 +7989,25 @@ class TestDispatcher:
         mock_gh.get_issue_comments.assert_called_once_with(repo_cfg.name, 42)
         assert count == 0
 
+    def test_task_creation_drop_escalator_files_bug(self, tmp_path: Path) -> None:
+        # HOL-16 follow-up / #1934: when the process-local per-intent
+        # drop counter crosses the threshold, the Dispatcher-bound
+        # escalator files a bug via ``file_stuck_on_critic_bug`` with
+        # ``emission_point="task-creation"`` and the comment id as
+        # ``target_id``.
+        cfg = _config(tmp_path)
+        repo_cfg = _repo_cfg(tmp_path)
+        gh = MagicMock()
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/9998"
+        d = Dispatcher(cfg, repo_cfg, gh)
+        d._escalate_task_creation_drop_streak(intent_comment_id=12345, count=3)
+        gh.create_issue.assert_called_once()
+        args = gh.create_issue.call_args.args
+        assert args[0] == "FidoCanCode/home"
+        assert "task-creation" in args[2]
+        assert "12345" in args[2]
+
     def test_insight_dedup_transport_escalator_files_bug(self, tmp_path: Path) -> None:
         # HOL-19 follow-up / #1935: when the process-local
         # transport-failure counter crosses the threshold, the

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4872,10 +4872,12 @@ class TestHol28TerminalThreadFraming:
         assert "t1: (untitled)" in framing
 
 
-class TestNotifyNewlyTerminalIntentThreads:
-    """HOL-28 wire: ``Dispatcher.notify_newly_terminal_intent_threads``
-    posts one aggregate reply per intent whose thread just transitioned
-    to fully-terminal across a tasks.json before/after snapshot."""
+class TestNotifyTerminalTaskThread:
+    """HOL-28 wire: ``Dispatcher.notify_terminal_task_thread`` posts
+    the aggregate reply at *anchor_intent*'s comment for the
+    just-terminal task.  Caller-side transition check moved to the
+    worker per codex P1 (fifth round) on PR #1938 — the dispatcher
+    method is now a focused post-with-framing helper."""
 
     def _cfg(self, tmp_path: Path) -> Config:
         return Config(
@@ -4887,91 +4889,53 @@ class TestNotifyNewlyTerminalIntentThreads:
             sub_dir=tmp_path / "sub",
         )
 
-    def _intent(self, comment_id: int, comment_type: str = "pulls") -> RescopeIntent:
+    def _anchor(self, comment_id: int = 999) -> RescopeIntent:
         return RescopeIntent(
-            change_request=f"req {comment_id}",
+            change_request="(task-anchor reconstruction)",
             comment_id=comment_id,
-            timestamp="2024-01-15T10:00:00+00:00",
-            comment_type=comment_type,
+            timestamp="",
+            comment_type="pulls",
         )
 
-    def test_no_transition_no_reply(self, tmp_path: Path) -> None:
+    def test_completed_task_fires_reply_at_anchor(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "completed", "contributing_intents": [101]}
-            ],
-            new_tasks=[
-                {"id": "t1", "status": "completed", "contributing_intents": [101]}
-            ],
-            batch_intents=[self._intent(101)],
-            pr=42,
-            agent=_client("nope"),
-            prompts=Prompts("p"),
-        )
-        gh.reply_to_review_comment.assert_not_called()
-
-    def test_transition_fires_one_reply(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        gh = MagicMock()
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
-            ],
-            new_tasks=[
-                {
-                    "id": "t1",
-                    "status": "completed",
-                    "title": "did it",
-                    "contributing_intents": [101],
-                }
-            ],
-            batch_intents=[self._intent(101)],
+        task = {"id": "t1", "status": "completed", "title": "did it"}
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            task=task,
+            anchor_intent=self._anchor(999),
             pr=42,
             agent=_client("Done."),
             prompts=Prompts("p"),
         )
         gh.reply_to_review_comment.assert_called_once()
-        assert gh.reply_to_review_comment.call_args.args[3] == 101
+        assert gh.reply_to_review_comment.call_args.args[3] == 999
 
-    def test_issue_comment_skipped(self, tmp_path: Path) -> None:
+    def test_skipped_task_fires_reply(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
-            ],
-            new_tasks=[
-                {"id": "t1", "status": "completed", "contributing_intents": [101]}
-            ],
-            batch_intents=[self._intent(101, comment_type="issues")],
+        task = {
+            "id": "t1",
+            "status": "skipped",
+            "title": "y",
+            "description": "no longer needed",
+        }
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            task=task,
+            anchor_intent=self._anchor(),
             pr=42,
-            agent=_client("nope"),
+            agent=_client("Done."),
             prompts=Prompts("p"),
         )
-        gh.reply_to_review_comment.assert_not_called()
+        gh.reply_to_review_comment.assert_called_once()
 
-    def test_intent_missing_from_batch_skipped(self, tmp_path: Path) -> None:
+    def test_non_terminal_task_silently_skipped(self, tmp_path: Path) -> None:
         cfg = self._cfg(tmp_path)
         gh = MagicMock()
-        # transitioned cid is 101 but batch_intents only knows 202.
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
-            ],
-            new_tasks=[
-                {"id": "t1", "status": "completed", "contributing_intents": [101]}
-            ],
-            batch_intents=[self._intent(202)],
+        task = {"id": "t1", "status": "in_progress"}
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            task=task,
+            anchor_intent=self._anchor(),
             pr=42,
             agent=_client("nope"),
             prompts=Prompts("p"),
@@ -4984,53 +4948,14 @@ class TestNotifyNewlyTerminalIntentThreads:
         gh.reply_to_review_comment.side_effect = RuntimeError("api down")
         # Must not raise — the worker's task-completion path can't be
         # gated on per-reply transport errors.
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "in_progress", "contributing_intents": [101]}
-            ],
-            new_tasks=[
-                {"id": "t1", "status": "completed", "contributing_intents": [101]}
-            ],
-            batch_intents=[self._intent(101)],
+        task = {"id": "t1", "status": "completed", "title": "x"}
+        Dispatcher(cfg, cfg.repos["owner/repo"], gh).notify_terminal_task_thread(
+            task=task,
+            anchor_intent=self._anchor(),
             pr=42,
             agent=_client("Done."),
             prompts=Prompts("p"),
         )
-
-    def test_multiple_intents_each_get_one_reply(self, tmp_path: Path) -> None:
-        cfg = self._cfg(tmp_path)
-        gh = MagicMock()
-        Dispatcher(
-            cfg, cfg.repos["owner/repo"], gh
-        ).notify_newly_terminal_intent_threads(
-            prev_tasks=[
-                {"id": "t1", "status": "in_progress", "contributing_intents": [101]},
-                {"id": "t2", "status": "pending", "contributing_intents": [202]},
-            ],
-            new_tasks=[
-                {
-                    "id": "t1",
-                    "status": "completed",
-                    "title": "x",
-                    "contributing_intents": [101],
-                },
-                {
-                    "id": "t2",
-                    "status": "skipped",
-                    "title": "y",
-                    "description": "no longer needed",
-                    "contributing_intents": [202],
-                },
-            ],
-            batch_intents=[self._intent(101), self._intent(202)],
-            pr=42,
-            agent=_client("Done."),
-            prompts=Prompts("p"),
-        )
-        comment_ids = [c.args[3] for c in gh.reply_to_review_comment.call_args_list]
-        assert comment_ids == [101, 202]
 
 
 class TestNotifyIntentOutcome:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4698,6 +4698,88 @@ class TestBuildOnRescopeApply:
         assert comment_ids == [101]  # once, not twice
 
 
+class TestHol34NoOpSilentDropRegression:
+    """HOL-34 / #1928: end-to-end regression for PR #1890's
+    no_op-silent-drop pattern.
+
+    Original failure (pre-epic): a rescope verdict of ``no_op`` for a
+    user's change request silently dropped the intent — no SKIPPED
+    marker, no reply-back, the requester never knew.  Once the HOL
+    chain landed (HOL-3 enforces narrative, HOL-6 creates SKIPPED
+    marker, HOL-23/24/25 emit per-thread reply with narrative), this
+    pattern can't recur.
+
+    This test pins the reply-back leg of the closure: a no_op verdict
+    in the rescope batch MUST produce a notification to the
+    originating commenter carrying the verdict's narrative.  HOL-6 +
+    SKIPPED marker is tested in test_tasks.py around the reducer
+    transition; this test is the events-side regression that closes
+    the whole story.
+    """
+
+    def _cfg(self, tmp_path: Path) -> Config:
+        return Config(
+            port=9000,
+            secret=b"test",
+            repos={"owner/repo": RepoConfig(name="owner/repo", work_dir=tmp_path)},
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+
+    def _intent(self, comment_id: int) -> RescopeIntent:
+        return RescopeIntent(
+            change_request="Please add retry logic to the cache lookup",
+            comment_id=comment_id,
+            timestamp="2024-01-15T10:00:00+00:00",
+            author="alice",
+        )
+
+    def _pr(self) -> ActivePR:
+        return ActivePR(
+            number=42,
+            title="t",
+            url="https://github.com/owner/repo/pull/42",
+            body="",
+        )
+
+    def test_pr_1890_no_op_drop_now_replies_with_narrative(
+        self, tmp_path: Path
+    ) -> None:
+        cfg = self._cfg(tmp_path)
+        gh = MagicMock()
+        gh.reply_to_review_comment.return_value = {"id": 999}
+        intent = self._intent(101)
+        cb = Dispatcher(cfg, cfg.repos["owner/repo"], gh)._build_on_rescope_apply(
+            intents=[intent],
+            pr_ctx=self._pr(),
+            agent=_client("Heard you — couldn't queue this; here's why."),
+            prompts=Prompts("p"),
+        )
+
+        # Rescope decided the request didn't fit the spec — no_op
+        # verdict with a narrative.  PRE-EPIC: silently dropped.
+        # POST-EPIC: HOL-24 sees the no_op via ``verdict_is_material``
+        # and emits a reply through ``_notify_intent_outcome``
+        # (HOL-25 framing carries the narrative).
+        no_op_verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="no_op",
+            narrative=(
+                "Retry logic is intentionally out-of-scope for the cache "
+                "layer per ARCH-7; routing this to the resilience epic "
+                "instead"
+            ),
+        )
+
+        cb([], [], {}, [no_op_verdict])
+
+        # The reply fires — the failure pattern is closed.
+        gh.reply_to_review_comment.assert_called_once()
+        # And it targets the originating commenter (alice's comment id).
+        assert gh.reply_to_review_comment.call_args.args[3] == 101
+
+
 class TestHol28TerminalThreadFraming:
     """HOL-28 / #1922: per-thread terminal aggregate framing names
     landed commits + skipped tasks + carries the requester's ask."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1186,10 +1186,45 @@ class TestReplayPendingRescopeIntents:
             _config(tmp_path), _repo_cfg(tmp_path), gh
         ).replay_pending_rescope_intents(
             MagicMock(spec=ActivityReporter),
+            7,
             agent=MagicMock(),
             prompts=Prompts("p"),
         )
         assert replayed == 0
+
+    def test_intents_for_other_pr_are_skipped(self, tmp_path: Path) -> None:
+        # Codex P1 (sixteenth round) on PR #1938: orphan pending
+        # intents from a now-closed/different PR must not rescope
+        # the currently-active PR's task queue with stale change-
+        # request text.  Replay filters by the active pr_number.
+        store = FidoStore(tmp_path)
+        assert store.claim_rescope_intent(
+            intent_comment_id=111,
+            change_request="stale request from a different PR",
+            intent_timestamp="2024-01-15T10:00:00+00:00",
+            author="owner",
+            comment_type="issues",
+            repo="owner/repo",
+            pr_number=99,
+        )
+        gh = _make_mock_gh()
+        thread_starts: list[object] = []
+        replayed = Dispatcher(
+            _config(tmp_path),
+            _repo_cfg(tmp_path),
+            gh,
+            thread_start_fn=thread_starts.append,
+            reorder_coalesce_state={},
+        ).replay_pending_rescope_intents(
+            MagicMock(spec=ActivityReporter),
+            7,
+            agent=MagicMock(),
+            prompts=Prompts("p"),
+        )
+        assert replayed == 0
+        assert thread_starts == []
+        # Row still pending — not consumed, just skipped.
+        assert [i.comment_id for i in store.pending_rescope_intents()] == [111]
 
     def test_pending_intent_is_redispatched(self, tmp_path: Path) -> None:
         # Seed a pending row directly via the store: this is the
@@ -1217,6 +1252,7 @@ class TestReplayPendingRescopeIntents:
             reorder_coalesce_state=coalesce_state,
         ).replay_pending_rescope_intents(
             MagicMock(spec=ActivityReporter),
+            7,
             agent=MagicMock(),
             prompts=Prompts("p"),
         )
@@ -6220,12 +6256,15 @@ class TestBackgroundRescopeTrigger:
         on_done()
         assert store.applied_ids == [77]
 
-    def test_trigger_rescope_releases_claim_on_synchronous_failure(self) -> None:
-        # Codex P1 (tenth round) on PR #1938: a synchronous failure
-        # between claim and dispatch must release the pending claim
-        # so the next trigger fires.  Without release, the next
-        # attempt sees the durable claim, skips dispatch, and the
-        # rescope never runs.
+    def test_trigger_rescope_preserves_pending_row_on_synchronous_failure(
+        self,
+    ) -> None:
+        # Codex P1 (sixteenth round) on PR #1938: a synchronous
+        # dispatch failure MUST leave the pending row intact — it
+        # is the only durable recovery signal once a webhook has
+        # been acked.  Startup replay (or the next trigger, since
+        # ``claim_rescope_intent`` treats pending rows as
+        # retryable) re-fires from this row.
         class _BoomDispatcher:
             def reorder_tasks_background(self, *_args: object, **_kw: object) -> None:
                 raise RuntimeError("thread-start failed")
@@ -6241,7 +6280,7 @@ class TestBackgroundRescopeTrigger:
         with pytest.raises(RuntimeError, match="thread-start failed"):
             trigger.trigger_rescope(self._make_intent(comment_id=88))
         assert store.claimed_ids == [88]
-        assert store.released_ids == [88]
+        assert store.released_ids == []
         assert store.applied_ids == []
 
     def test_trigger_rescope_claims_before_dispatch(self) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4872,6 +4872,47 @@ class TestHol28TerminalThreadFraming:
         assert "t1: (untitled)" in framing
 
 
+class TestSafeFileInsightsPreReply:
+    """HOL-26 / #1920 (codex P1 sixth round on PR #1938): the
+    production reply paths wrap ``file_insights_pre_reply`` so a
+    transient insight-filer failure does NOT drop the user-visible
+    reply."""
+
+    def test_swallows_exception(self) -> None:
+        from fido.events import _safe_file_insights_pre_reply
+
+        class _Boom:
+            def file_insights_pre_reply(self, _r: object, _t: object) -> None:
+                raise RuntimeError("GitHub down")
+
+        # Must not raise.
+        _safe_file_insights_pre_reply(
+            _Boom(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            object(),  # type: ignore[arg-type]
+            where="test",
+        )
+
+    def test_passes_response_and_target_on_success(self) -> None:
+        from fido.events import _safe_file_insights_pre_reply
+
+        seen: list[tuple[object, object]] = []
+
+        class _Spy:
+            def file_insights_pre_reply(self, r: object, t: object) -> None:
+                seen.append((r, t))
+
+        resp = object()
+        target = object()
+        _safe_file_insights_pre_reply(
+            _Spy(),  # type: ignore[arg-type]
+            resp,  # type: ignore[arg-type]
+            target,  # type: ignore[arg-type]
+            where="test",
+        )
+        assert seen == [(resp, target)]
+
+
 class TestNotifyTerminalTaskThread:
     """HOL-28 wire: ``Dispatcher.notify_terminal_task_thread`` posts
     the aggregate reply at *anchor_intent*'s comment for the

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4604,6 +4604,61 @@ class TestBuildOnRescopeApply:
         cb(result, [], {"t1": 1}, [verdict])
         gh.reply_to_review_comment.assert_not_called()
 
+    def test_hol25_no_op_framing_carries_narrative(self) -> None:
+        # HOL-25 / #1919: no_op verdict framing names the outcome
+        # explicitly AND includes the verdict's narrative so Opus has
+        # the rescope's reasoning to weave into the reply.
+        from fido.events import _hol25_verdict_framing
+
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="no_op",
+            narrative="duplicates work already queued as #42",
+        )
+        framing = _hol25_verdict_framing(verdict)
+        assert "NOT queued" in framing
+        assert "duplicates work already queued as #42" in framing
+        assert "in flight" in framing  # negative-claim guard
+
+    def test_hol25_honored_framing_carries_narrative(self) -> None:
+        from fido.events import _hol25_verdict_framing
+
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="honored",
+            narrative="scoped to the parser only, not the whole pipeline",
+        )
+        framing = _hol25_verdict_framing(verdict)
+        assert "queued" in framing
+        assert "scoped to the parser only" in framing
+        assert "verbatim" in framing  # negative-claim guard
+
+    def test_hol25_reshaped_framing_carries_narrative(self) -> None:
+        from fido.events import _hol25_verdict_framing
+
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="reshaped",
+            narrative="merged with adjacent typo fix as one commit",
+        )
+        framing = _hol25_verdict_framing(verdict)
+        assert "RESHAPED" in framing
+        assert "merged with adjacent typo fix as one commit" in framing
+
+    def test_hol25_superseded_framing_renders_by_intent_link(self) -> None:
+        from fido.events import _hol25_verdict_framing
+
+        verdict = IntentVerdict(
+            intent_comment_id=101,
+            outcome="superseded",
+            narrative="overridden by a later directive",
+            by_intent_comment_id=202,
+        )
+        framing = _hol25_verdict_framing(verdict)
+        assert "SUPERSEDED" in framing
+        assert "#202" in framing
+        assert "overridden by a later directive" in framing
+
     def test_verdict_dedupes_against_oracle_path(self, tmp_path: Path) -> None:
         # HOL-24: if the oracle already notified intent 101 (cross-author
         # rewrite), a material verdict for the same intent_comment_id

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3229,3 +3229,126 @@ class TestFetchActivitiesRateLimit:
         assert info is not None
         assert info.rest.used == 7
         assert info.graphql.used == 22
+
+
+# ---------------------------------------------------------------------------
+# HOL-29 / #1923 — BLOCKED-task display
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedCriticTasks:
+    """HOL-29: ``./fido status`` surfaces tasks the HOL-21 escalation
+    helper has marked BLOCKED."""
+
+    def test_blocked_critic_tasks_extracts_marker(self) -> None:
+        from fido.status import _blocked_critic_tasks
+
+        task_list = [
+            {
+                "id": "t-1",
+                "title": "Add retry logic",
+                "status": "blocked",
+                "description": (
+                    "Original notes here.\n\n"
+                    "CRITIC EXHAUSTED (3 attempts): diff includes "
+                    "unrelated formatting"
+                ),
+            },
+            # Non-blocked task — skipped.
+            {"id": "t-2", "title": "x", "status": "pending", "description": ""},
+            # Blocked but no CRITIC marker (e.g. blocked for another
+            # reason like #1247 unblock semantics) — skipped.
+            {"id": "t-3", "title": "y", "status": "blocked", "description": "stuck"},
+        ]
+
+        out = _blocked_critic_tasks(task_list)
+        assert len(out) == 1
+        assert out[0].task_id == "t-1"
+        assert out[0].title == "Add retry logic"
+        assert out[0].attempt_count == 3
+        assert "diff includes unrelated formatting" in out[0].final_gap
+
+    def test_format_status_renders_blocked_critic_line(self) -> None:
+        from fido.color import Color
+        from fido.status import BlockedTaskInfo, RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+            blocked_critic_tasks=[
+                BlockedTaskInfo(
+                    task_id="t-1",
+                    title="Add retry logic",
+                    final_gap="diff includes unrelated formatting",
+                    attempt_count=3,
+                ),
+            ],
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        blocked_line = next((line for line in lines if "BLOCKED:" in line), None)
+        assert blocked_line is not None
+        assert "Add retry logic" in blocked_line
+        assert "diff includes unrelated formatting" in blocked_line
+        assert "3 attempts" in blocked_line
+
+    def test_format_blocked_critic_line_truncates_long_gap(self) -> None:
+        from fido.color import Color
+        from fido.status import BlockedTaskInfo, RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+            blocked_critic_tasks=[
+                BlockedTaskInfo(
+                    task_id="t-1",
+                    title="Big task",
+                    final_gap="x" * 200,  # exceeds the 80-char cap
+                    attempt_count=3,
+                ),
+            ],
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        blocked_line = next(line for line in lines if "BLOCKED:" in line)
+        assert "..." in blocked_line
+        assert "x" * 200 not in blocked_line
+
+    def test_format_repo_body_omits_blocked_section_when_empty(self) -> None:
+        from fido.color import Color
+        from fido.status import RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        assert not any("BLOCKED:" in line for line in lines)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3268,6 +3268,55 @@ class TestBlockedCriticTasks:
         assert out[0].attempt_count == 3
         assert "diff includes unrelated formatting" in out[0].final_gap
 
+    def test_blocked_critic_tasks_prefers_structured_chain(self) -> None:
+        # Codex P2 on PR #1938: when ``critic_gap_chain`` is present
+        # on the task, the status display reads it instead of regex-
+        # parsing the description.  Pins the precedence so a stale
+        # CRITIC EXHAUSTED marker in the description text (carried
+        # across an unblock) can't outweigh the current structured
+        # state.
+        from fido.status import _blocked_critic_tasks
+
+        task_list = [
+            {
+                "id": "t-1",
+                "title": "Add retry logic",
+                "status": "blocked",
+                "critic_gap_chain": ["gap A", "gap B", "FINAL gap"],
+                # Stale description marker would say "5 attempts" if
+                # we fell back to the regex — assert we ignore it.
+                "description": "CRITIC EXHAUSTED (5 attempts): stale-marker",
+            }
+        ]
+        out = _blocked_critic_tasks(task_list)
+        assert len(out) == 1
+        assert out[0].attempt_count == 3
+        assert out[0].final_gap == "FINAL gap"
+
+    def test_blocked_critic_tasks_falls_back_to_last_marker_when_no_chain(
+        self,
+    ) -> None:
+        # When the structured field is absent and the description has
+        # multiple CRITIC EXHAUSTED markers (re-escalation after
+        # unblock left both), take the LAST — the current state.
+        from fido.status import _blocked_critic_tasks
+
+        task_list = [
+            {
+                "id": "t-1",
+                "title": "y",
+                "status": "blocked",
+                "description": (
+                    "CRITIC EXHAUSTED (3 attempts): old marker from before unblock\n\n"
+                    "CRITIC EXHAUSTED (2 attempts): current marker"
+                ),
+            }
+        ]
+        out = _blocked_critic_tasks(task_list)
+        assert len(out) == 1
+        assert out[0].attempt_count == 2
+        assert "current marker" in out[0].final_gap
+
     def test_format_status_renders_blocked_critic_line(self) -> None:
         from fido.color import Color
         from fido.status import BlockedTaskInfo, RepoStatus, _format_repo_body

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1535,3 +1535,53 @@ def test_extracted_oracle_matches_recovery_lifecycle() -> None:
     )
     assert same_claims == claims
     assert same_promises == promises
+
+
+def test_task_creation_drops_persist_across_store_instances(tmp_path: Path) -> None:
+    # HOL-16 follow-up / #1934 (codex P2 on PR #1938): the durable
+    # drop counter table survives FidoStore object recreations so a
+    # Fido restart doesn't lose the streak.
+    store1 = FidoStore(tmp_path)
+    count, escalated = store1.bump_task_creation_drop(123)
+    assert (count, escalated) == (1, False)
+    count, escalated = store1.bump_task_creation_drop(123)
+    assert (count, escalated) == (2, False)
+    store2 = FidoStore(tmp_path)
+    count, escalated = store2.bump_task_creation_drop(123)
+    assert (count, escalated) == (3, False)
+
+
+def test_task_creation_drops_mark_escalated_persists(tmp_path: Path) -> None:
+    store = FidoStore(tmp_path)
+    store.bump_task_creation_drop(123)
+    store.mark_task_creation_drop_escalated(123)
+    _, escalated = store.bump_task_creation_drop(123)
+    assert escalated is True
+
+
+def test_reset_inactive_task_creation_drops_keeps_active(tmp_path: Path) -> None:
+    store = FidoStore(tmp_path)
+    store.bump_task_creation_drop(101)
+    store.bump_task_creation_drop(202)
+    store.bump_task_creation_drop(303)
+    # Only 202 remains active.
+    cleared = store.reset_inactive_task_creation_drops({202})
+    assert cleared == 2
+    # 202's counter preserved at 1.
+    count, _ = store.bump_task_creation_drop(202)
+    assert count == 2
+    # 101 starts fresh.
+    count, _ = store.bump_task_creation_drop(101)
+    assert count == 1
+
+
+def test_reset_inactive_task_creation_drops_empty_active_clears_all(
+    tmp_path: Path,
+) -> None:
+    store = FidoStore(tmp_path)
+    store.bump_task_creation_drop(101)
+    store.bump_task_creation_drop(202)
+    cleared = store.reset_inactive_task_creation_drops(set())
+    assert cleared == 2
+    count, _ = store.bump_task_creation_drop(101)
+    assert count == 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -410,7 +410,7 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
             ).fetchall()
         }
 
-    assert version == 7
+    assert version == 8
     assert {
         "comment_claims",
         "reply_promises",
@@ -433,6 +433,10 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
         # task-creation drop counter requires schema version bump
         # so existing v6 installations create the new table.
         "task_creation_drops",
+        # codex P1 ninth round on PR #1938: durable rescope-
+        # triggered set (per intent_comment_id) makes the rescope
+        # trigger replay-safe.
+        "rescope_triggered",
     } <= tables
 
 
@@ -1615,3 +1619,40 @@ def test_reset_inactive_task_creation_drops_empty_active_clears_all(
     assert cleared == 2
     count, _ = store.bump_task_creation_drop(101)
     assert count == 1
+
+
+def test_claim_rescope_trigger_first_caller_succeeds(tmp_path: Path) -> None:
+    # HOL-26 / #1920 (codex P1 ninth round on PR #1938): the first
+    # claim per intent_comment_id returns True; subsequent claims
+    # (this process or after restart) return False.  Enforces
+    # at-most-once rescope per originating comment.
+    store = FidoStore(tmp_path)
+    assert store.claim_rescope_trigger(42) is True
+    assert store.claim_rescope_trigger(42) is False
+    # Different intent claim succeeds independently.
+    assert store.claim_rescope_trigger(99) is True
+
+
+def test_claim_rescope_trigger_persists_across_store_instances(tmp_path: Path) -> None:
+    store1 = FidoStore(tmp_path)
+    assert store1.claim_rescope_trigger(42) is True
+    # Simulate Fido restart: drop the in-memory store; the durable
+    # row should still suppress a second claim.
+    del store1
+    store2 = FidoStore(tmp_path)
+    assert store2.claim_rescope_trigger(42) is False
+
+
+def test_claim_rescope_trigger_schema_bumps_from_version_7(tmp_path: Path) -> None:
+    # Codex P1 ninth round on PR #1938: schema-version migration
+    # from v7 picks up the new rescope_triggered table.
+    import sqlite3
+
+    store = FidoStore(tmp_path)
+    store.ensure_schema()
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+        conn.execute("DROP TABLE rescope_triggered")
+        conn.commit()
+    FidoStore(tmp_path).ensure_schema()
+    assert FidoStore(tmp_path).claim_rescope_trigger(123) is True

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -410,7 +410,7 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
             ).fetchall()
         }
 
-    assert version == 8
+    assert version == 9
     assert {
         "comment_claims",
         "reply_promises",
@@ -433,10 +433,11 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
         # task-creation drop counter requires schema version bump
         # so existing v6 installations create the new table.
         "task_creation_drops",
-        # codex P1 ninth round on PR #1938: durable rescope-
-        # triggered set (per intent_comment_id) makes the rescope
-        # trigger replay-safe.
-        "rescope_triggered",
+        # codex P1 ninth/tenth rounds on PR #1938: durable rescope-
+        # intent outbox (per intent_comment_id with full intent
+        # payload + state) makes the rescope trigger replay-safe
+        # and recoverable after crashes.
+        "rescope_intent_outbox",
     } <= tables
 
 
@@ -1621,38 +1622,88 @@ def test_reset_inactive_task_creation_drops_empty_active_clears_all(
     assert count == 1
 
 
-def test_claim_rescope_trigger_first_caller_succeeds(tmp_path: Path) -> None:
-    # HOL-26 / #1920 (codex P1 ninth round on PR #1938): the first
-    # claim per intent_comment_id returns True; subsequent claims
-    # (this process or after restart) return False.  Enforces
-    # at-most-once rescope per originating comment.
+def _claim_intent(store: "FidoStore", cid: int, **overrides: object) -> bool:
+    """Helper: claim an intent with sensible test defaults."""
+    defaults: dict[str, object] = {
+        "intent_comment_id": cid,
+        "change_request": f"request {cid}",
+        "intent_timestamp": "2026-05-25T10:00:00+00:00",
+        "author": "alice",
+        "comment_type": "pulls",
+        "repo": "owner/repo",
+        "pr_number": 42,
+    }
+    defaults.update(overrides)
+    return store.claim_rescope_intent(**defaults)  # type: ignore[arg-type]
+
+
+def test_claim_rescope_intent_first_caller_succeeds(tmp_path: Path) -> None:
+    # HOL-26 / #1920 (codex P1 ninth/tenth rounds on PR #1938): the
+    # first claim per intent_comment_id returns True; subsequent
+    # claims (this process or after restart) return False.  Enforces
+    # at-most-once rescope dispatch per originating comment.
     store = FidoStore(tmp_path)
-    assert store.claim_rescope_trigger(42) is True
-    assert store.claim_rescope_trigger(42) is False
+    assert _claim_intent(store, 42) is True
+    assert _claim_intent(store, 42) is False
     # Different intent claim succeeds independently.
-    assert store.claim_rescope_trigger(99) is True
+    assert _claim_intent(store, 99) is True
 
 
-def test_claim_rescope_trigger_persists_across_store_instances(tmp_path: Path) -> None:
+def test_claim_rescope_intent_persists_across_store_instances(tmp_path: Path) -> None:
     store1 = FidoStore(tmp_path)
-    assert store1.claim_rescope_trigger(42) is True
-    # Simulate Fido restart: drop the in-memory store; the durable
-    # row should still suppress a second claim.
+    assert _claim_intent(store1, 42) is True
     del store1
     store2 = FidoStore(tmp_path)
-    assert store2.claim_rescope_trigger(42) is False
+    assert _claim_intent(store2, 42) is False
 
 
-def test_claim_rescope_trigger_schema_bumps_from_version_7(tmp_path: Path) -> None:
-    # Codex P1 ninth round on PR #1938: schema-version migration
-    # from v7 picks up the new rescope_triggered table.
+def test_release_rescope_intent_claim_allows_retry(tmp_path: Path) -> None:
+    # Synchronous dispatch failure path: after release, the next
+    # claim re-fires.
+    store = FidoStore(tmp_path)
+    assert _claim_intent(store, 42) is True
+    store.release_rescope_intent_claim(42)
+    assert _claim_intent(store, 42) is True
+
+
+def test_mark_rescope_intent_applied_blocks_subsequent_claims(
+    tmp_path: Path,
+) -> None:
+    # An applied intent is durably terminal — no future trigger
+    # re-fires.
+    store = FidoStore(tmp_path)
+    assert _claim_intent(store, 42) is True
+    store.mark_rescope_intent_applied(42)
+    assert _claim_intent(store, 42) is False
+    # Release on an applied row is a no-op (release only targets
+    # state='pending').
+    store.release_rescope_intent_claim(42)
+    assert _claim_intent(store, 42) is False
+
+
+def test_pending_rescope_intents_lists_unapplied(tmp_path: Path) -> None:
+    # Recovery surface: ``pending_rescope_intents`` returns only
+    # rows still in state='pending' (un-applied).
+    store = FidoStore(tmp_path)
+    assert _claim_intent(store, 42) is True
+    assert _claim_intent(store, 99) is True
+    store.mark_rescope_intent_applied(42)
+    pending = store.pending_rescope_intents()
+    assert [row["intent_comment_id"] for row in pending] == [99]
+    assert pending[0]["change_request"] == "request 99"
+    assert pending[0]["repo"] == "owner/repo"
+
+
+def test_rescope_intent_outbox_schema_bumps_from_version_8(tmp_path: Path) -> None:
+    # Codex P1 tenth round on PR #1938: schema-version migration
+    # from v8 picks up the new rescope_intent_outbox table.
     import sqlite3
 
     store = FidoStore(tmp_path)
     store.ensure_schema()
     with sqlite3.connect(store.db_path) as conn:
-        conn.execute("PRAGMA user_version = 7")
-        conn.execute("DROP TABLE rescope_triggered")
+        conn.execute("PRAGMA user_version = 8")
+        conn.execute("DROP TABLE rescope_intent_outbox")
         conn.commit()
     FidoStore(tmp_path).ensure_schema()
-    assert FidoStore(tmp_path).claim_rescope_trigger(123) is True
+    assert _claim_intent(FidoStore(tmp_path), 123) is True

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1700,7 +1700,7 @@ def test_claim_rescope_intent_pending_refreshes_payload(tmp_path: Path) -> None:
     _claim_intent(store, 42, change_request="second")
     pending = store.pending_rescope_intents()
     assert len(pending) == 1
-    assert pending[0]["change_request"] == "second"
+    assert pending[0].change_request == "second"
 
 
 def test_release_rescope_intent_claim_allows_retry(tmp_path: Path) -> None:
@@ -1731,9 +1731,9 @@ def test_pending_rescope_intents_lists_unapplied(tmp_path: Path) -> None:
     assert _claim_intent(store, 99) is True
     store.mark_rescope_intent_applied(42)
     pending = store.pending_rescope_intents()
-    assert [row["intent_comment_id"] for row in pending] == [99]
-    assert pending[0]["change_request"] == "request 99"
-    assert pending[0]["repo"] == "owner/repo"
+    assert [intent.comment_id for intent in pending] == [99]
+    assert pending[0].change_request == "request 99"
+    assert pending[0].repo == "owner/repo"
 
 
 def test_rescope_intent_outbox_schema_bumps_from_version_8(tmp_path: Path) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -410,7 +410,7 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
             ).fetchall()
         }
 
-    assert version == 6
+    assert version == 7
     assert {
         "comment_claims",
         "reply_promises",
@@ -429,7 +429,37 @@ def test_schema_includes_durable_store_skeleton(tmp_path: Path) -> None:
         "issue_cache_snapshots",
         "restart_metadata",
         "transition_audit_log",
+        # codex P1 (fourth round) on PR #1938: durable
+        # task-creation drop counter requires schema version bump
+        # so existing v6 installations create the new table.
+        "task_creation_drops",
     } <= tables
+
+
+def test_schema_bumps_from_version_6_creates_new_tables(tmp_path: Path) -> None:
+    # Codex P1 (fourth round) on PR #1938: an installation already at
+    # schema version 6 (e.g. existing production Fido databases) must
+    # pick up the v7 task_creation_drops table when ensure_schema
+    # runs.  Without the version bump, ``if version < _SCHEMA_VERSION``
+    # would skip the CREATE TABLE statements and the first
+    # bump_task_creation_drop() query would fail with "no such table".
+    import sqlite3
+
+    store = FidoStore(tmp_path)
+    # Simulate an existing v6 installation: ensure_schema once, then
+    # roll the version backwards to 6 so the next ensure_schema must
+    # actually run the v7 statements (and re-running v6 statements
+    # is idempotent thanks to CREATE TABLE IF NOT EXISTS).
+    store.ensure_schema()
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute("PRAGMA user_version = 6")
+        conn.execute("DROP TABLE task_creation_drops")
+        conn.commit()
+    # Re-run ensure_schema on the simulated old database.
+    FidoStore(tmp_path).ensure_schema()
+    # The bump query now works against the recreated table.
+    count, escalated = FidoStore(tmp_path).bump_task_creation_drop(42)
+    assert (count, escalated) == (1, False)
 
 
 def test_record_deferred_issue_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1638,23 +1638,69 @@ def _claim_intent(store: "FidoStore", cid: int, **overrides: object) -> bool:
 
 
 def test_claim_rescope_intent_first_caller_succeeds(tmp_path: Path) -> None:
-    # HOL-26 / #1920 (codex P1 ninth/tenth rounds on PR #1938): the
-    # first claim per intent_comment_id returns True; subsequent
-    # claims (this process or after restart) return False.  Enforces
-    # at-most-once rescope dispatch per originating comment.
+    # HOL-26 / #1920: first claim per intent_comment_id returns True.
+    # Different intents claim independently.
     store = FidoStore(tmp_path)
     assert _claim_intent(store, 42) is True
-    assert _claim_intent(store, 42) is False
-    # Different intent claim succeeds independently.
     assert _claim_intent(store, 99) is True
 
 
-def test_claim_rescope_intent_persists_across_store_instances(tmp_path: Path) -> None:
+def test_claim_rescope_intent_pending_row_is_retryable(tmp_path: Path) -> None:
+    # Codex P1 eleventh round on PR #1938: a pre-existing pending
+    # row means "claim was recorded but the work never durably
+    # applied" (likely a crash between claim and ``_on_done`` OR a
+    # webhook redelivery).  Retrying must succeed — duplicate
+    # dispatches get coalesced in-process by ``_reorder_coalesce``,
+    # and cross-restart replay is exactly what the outbox enables.
+    # Without retryability, ACT replies could be visible with no
+    # rescope ever applied.
+    store = FidoStore(tmp_path)
+    assert _claim_intent(store, 42) is True
+    # Same intent, while still pending, can be re-claimed.
+    assert _claim_intent(store, 42) is True
+
+
+def test_claim_rescope_intent_applied_row_blocks(tmp_path: Path) -> None:
+    # The applied state is durably terminal — no future trigger
+    # re-fires.
+    store = FidoStore(tmp_path)
+    assert _claim_intent(store, 42) is True
+    store.mark_rescope_intent_applied(42)
+    assert _claim_intent(store, 42) is False
+
+
+def test_claim_rescope_intent_pending_persists_across_restart(tmp_path: Path) -> None:
+    # Cross-restart redelivery: a pending row in the durable store
+    # survives a Fido restart, and the normal trigger path can
+    # re-claim it and dispatch the rescope.
     store1 = FidoStore(tmp_path)
     assert _claim_intent(store1, 42) is True
     del store1
     store2 = FidoStore(tmp_path)
+    # New process, same db: pending row → retryable.
+    assert _claim_intent(store2, 42) is True
+
+
+def test_claim_rescope_intent_applied_persists_across_restart(tmp_path: Path) -> None:
+    # Applied rows still block across restarts.
+    store1 = FidoStore(tmp_path)
+    assert _claim_intent(store1, 42) is True
+    store1.mark_rescope_intent_applied(42)
+    del store1
+    store2 = FidoStore(tmp_path)
     assert _claim_intent(store2, 42) is False
+
+
+def test_claim_rescope_intent_pending_refreshes_payload(tmp_path: Path) -> None:
+    # The re-claim of a pending row updates the payload (so a
+    # later recovery sweep sees the latest version of the
+    # change_request).
+    store = FidoStore(tmp_path)
+    _claim_intent(store, 42, change_request="first")
+    _claim_intent(store, 42, change_request="second")
+    pending = store.pending_rescope_intents()
+    assert len(pending) == 1
+    assert pending[0]["change_request"] == "second"
 
 
 def test_release_rescope_intent_claim_allows_retry(tmp_path: Path) -> None:
@@ -1666,17 +1712,13 @@ def test_release_rescope_intent_claim_allows_retry(tmp_path: Path) -> None:
     assert _claim_intent(store, 42) is True
 
 
-def test_mark_rescope_intent_applied_blocks_subsequent_claims(
-    tmp_path: Path,
-) -> None:
-    # An applied intent is durably terminal — no future trigger
-    # re-fires.
+def test_release_on_applied_row_is_noop(tmp_path: Path) -> None:
+    # Release only targets state='pending', so calling it after
+    # the row has already advanced to 'applied' must not clear
+    # the terminal marker.
     store = FidoStore(tmp_path)
     assert _claim_intent(store, 42) is True
     store.mark_rescope_intent_applied(42)
-    assert _claim_intent(store, 42) is False
-    # Release on an applied row is a no-op (release only targets
-    # state='pending').
     store.release_rescope_intent_claim(42)
     assert _claim_intent(store, 42) is False
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -929,6 +929,104 @@ def test_has_other_open_pr_comments_scopes_by_repo(tmp_path: Path) -> None:
     )
 
 
+def test_has_other_open_pr_comments_review_id_scopes_to_same_submission(
+    tmp_path: Path,
+) -> None:
+    """HOL-22 / #1916: when ``review_id`` is provided, only OTHER
+    queue entries from the SAME review submission count as
+    "batched with this comment".  A solo human comment queued
+    behind an unrelated batch from a DIFFERENT review submission
+    still gets sub-1s eager-eyes (closes #1875)."""
+    store = FidoStore(tmp_path)
+    # Batch from review submission 12345.
+    store.enqueue_pr_comment(
+        delivery_id="delivery-batch-a",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=1001,
+        author="bot",
+        is_bot=True,
+        body="batch a",
+        github_created_at="2026-04-30T10:00:00Z",
+        payload_json='{"payload":{"comment":{"pull_request_review_id":12345}}}',
+    )
+    # Solo human comment from a DIFFERENT submission 67890.
+    solo = store.enqueue_pr_comment(
+        delivery_id="delivery-solo",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=1002,
+        author="rob",
+        is_bot=False,
+        body="solo human",
+        github_created_at="2026-04-30T10:00:01Z",
+        payload_json='{"payload":{"comment":{"pull_request_review_id":67890}}}',
+    )
+    # With review-id scoping: no other open comment from the solo's
+    # submission → eager-eyes fires.
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=solo.comment_id,
+            review_id=67890,
+        )
+        is False
+    )
+    # Legacy unscoped call (review_id=None) still sees the batch
+    # comment → eager-eyes skipped.
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=solo.comment_id,
+        )
+        is True
+    )
+
+
+def test_has_other_open_pr_comments_review_id_detects_same_submission_batch(
+    tmp_path: Path,
+) -> None:
+    """HOL-22 sibling: when another open comment IS from the same
+    review submission, the scoped predicate returns True so eyes
+    is correctly skipped (the worker posts eyes on claim instead)."""
+    store = FidoStore(tmp_path)
+    # Two comments from the same review submission 99999.
+    store.enqueue_pr_comment(
+        delivery_id="delivery-batch-first",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=2001,
+        author="rob",
+        is_bot=False,
+        body="batch first",
+        github_created_at="2026-04-30T10:00:00Z",
+        payload_json='{"payload":{"comment":{"pull_request_review_id":99999}}}',
+    )
+    sibling = store.enqueue_pr_comment(
+        delivery_id="delivery-batch-sibling",
+        repo="owner/repo",
+        pr_number=7,
+        comment_type="pulls",
+        comment_id=2002,
+        author="rob",
+        is_bot=False,
+        body="batch sibling",
+        github_created_at="2026-04-30T10:00:01Z",
+        payload_json='{"payload":{"comment":{"pull_request_review_id":99999}}}',
+    )
+    assert (
+        store.has_other_open_pr_comments(
+            repo="owner/repo",
+            exclude_comment_id=sibling.comment_id,
+            review_id=99999,
+        )
+        is True
+    )
+
+
 def test_recover_in_progress_pr_comments_requeues_abandoned_claim(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_synthesis_executor.py
+++ b/tests/test_synthesis_executor.py
@@ -566,6 +566,28 @@ class TestExecutorInsightFiling:
 
         filer.file_insight.assert_called_once_with(insight, target)
 
+    def test_execute_files_insights_before_posting_reply(self) -> None:
+        """HOL-26: insights are durable as GitHub issues before the
+        user-visible reply can claim they exist."""
+        gh = _make_gh()
+        filer = _make_insight_filer()
+        order: list[str] = []
+        filer.file_insight.side_effect = lambda *_a, **_kw: order.append("file")
+        gh.reply_to_review_comment.side_effect = lambda *_a, **_kw: order.append("post")
+        gh.comment_issue.side_effect = lambda *_a, **_kw: order.append("post")
+        executor = SynthesisExecutor(gh, insight_filer=filer)
+
+        executor.execute(
+            _make_response(insights=[_make_insight()]),
+            _make_target(comment_type="pulls"),
+        )
+
+        assert order == ["file", "post"], (
+            f"expected filing before reply post, got {order}"
+        )
+        # And not double-filed by execute_effects_only:
+        assert filer.file_insight.call_count == 1
+
     def test_execute_effects_only_no_insights_no_filer_call(self) -> None:
         gh = _make_gh()
         gh.list_reactions.return_value = []

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6715,7 +6715,7 @@ class TestSkipMarkerEndToEnd:
         # Phase 2 (inside lock): apply against CURRENT queue, which is
         # now EMPTY (target deleted concurrently).
         current: list[dict] = []
-        result = _apply_task_creation_verdicts(items, verdicts, current)
+        result, _ = _apply_task_creation_verdicts(items, verdicts, current)
         titles = [it.get("title") for it in result]
         assert "Proposed new" in titles
 
@@ -6754,7 +6754,7 @@ class TestSkipMarkerEndToEnd:
             ),
         ]
 
-        result = _apply_task_creation_verdicts(items, verdicts, [existing])
+        result, _ = _apply_task_creation_verdicts(items, verdicts, [existing])
         titles = [it.get("title") for it in result]
         # The new proposal is KEPT — the named "duplicate of" target
         # is closing in the same batch, so dropping the proposal too
@@ -6794,7 +6794,7 @@ class TestSkipMarkerEndToEnd:
             ),
         ]
 
-        result = _apply_task_creation_verdicts(items, verdicts, [source, target])
+        result, _ = _apply_task_creation_verdicts(items, verdicts, [source, target])
         titles = [it.get("title") for it in result]
         # ``source`` is being absorbed by the merge in this batch —
         # the proposal that duplicates ``source`` must survive.
@@ -6835,7 +6835,7 @@ class TestSkipMarkerEndToEnd:
             ),
         ]
 
-        result = _apply_task_creation_verdicts(items, verdicts, [target])
+        result, _ = _apply_task_creation_verdicts(items, verdicts, [target])
         titles = [it.get("title") for it in result]
         assert "Proposed new (would dup target)" in titles
 
@@ -6866,7 +6866,7 @@ class TestSkipMarkerEndToEnd:
             ),
         ]
 
-        result = _apply_task_creation_verdicts(items, verdicts, [existing])
+        result, _ = _apply_task_creation_verdicts(items, verdicts, [existing])
         titles = [it.get("title") for it in result]
         assert "Proposed dup" not in titles
 
@@ -7371,26 +7371,16 @@ class TestTasksCompleteWithResolve:
 
 
 class TestApplyTaskCreationVerdictsDropCounter:
-    """HOL-16 follow-up / #1934: ``_apply_task_creation_verdicts``
-    bumps the per-intent drop counter for every contributing intent
-    on each dropped proposal."""
+    """HOL-16 follow-up / #1934 (codex P1 sixth round on PR #1938):
+    ``_apply_task_creation_verdicts`` RETURNS the contributing-intent
+    cids for each dropped proposal so the caller (``reorder_tasks``)
+    can bump the durable counter AFTER validation passes.  The earlier
+    in-apply bump advanced the counter even when a rejected batch
+    meant no drop actually shipped."""
 
-    def test_drop_bumps_counter_for_each_contributing_intent(self) -> None:
-        from fido.critics import TaskCreationDropCounter, TaskCreationVerdict
+    def test_drop_returns_each_contributing_intent_cid(self) -> None:
+        from fido.critics import TaskCreationVerdict
         from fido.tasks import _apply_task_creation_verdicts
-
-        recorded: list[int] = []
-        counter = TaskCreationDropCounter(
-            threshold=100, escalator=lambda cid, count: None
-        )
-        # Patch record_drop to observe calls.
-        original_record = counter.record_drop
-
-        def spy(cid: int) -> None:
-            recorded.append(cid)
-            original_record(cid)
-
-        counter.record_drop = spy  # type: ignore[method-assign]
 
         item = {
             "id": None,
@@ -7403,22 +7393,14 @@ class TestApplyTaskCreationVerdictsDropCounter:
         verdict = TaskCreationVerdict(
             relationship="duplicate_of", duplicate_of_id="t-existing"
         )
-        _apply_task_creation_verdicts(
-            [item], [verdict], [existing], drop_counter=counter
-        )
-        assert sorted(recorded) == [101, 202]
+        _items, dropped = _apply_task_creation_verdicts([item], [verdict], [existing])
+        assert sorted(dropped) == [101, 202]
 
-    def test_drop_skips_counter_when_target_missing(self) -> None:
+    def test_drop_returns_no_cids_when_target_missing(self) -> None:
         # When the target doesn't survive the batch, the proposal is
-        # KEPT (not dropped) — no counter bump.
-        from fido.critics import TaskCreationDropCounter, TaskCreationVerdict
+        # KEPT (not dropped) — no contributing-intent cids returned.
+        from fido.critics import TaskCreationVerdict
         from fido.tasks import _apply_task_creation_verdicts
-
-        recorded: list[int] = []
-        counter = TaskCreationDropCounter(
-            threshold=100, escalator=lambda cid, count: None
-        )
-        counter.record_drop = lambda cid: recorded.append(cid)  # type: ignore[method-assign]
 
         item = {
             "id": None,
@@ -7430,10 +7412,104 @@ class TestApplyTaskCreationVerdictsDropCounter:
         verdict = TaskCreationVerdict(
             relationship="duplicate_of", duplicate_of_id="t-gone"
         )
-        out = _apply_task_creation_verdicts([item], [verdict], [], drop_counter=counter)
+        items, dropped = _apply_task_creation_verdicts([item], [verdict], [])
         # Kept, not dropped.
-        assert out == [item]
+        assert items == [item]
+        assert dropped == []
+
+
+class TestReorderTasksDropCounterDeferredBump:
+    """Codex P1 sixth round on PR #1938: the durable
+    ``TaskCreationDropCounter`` is bumped by ``reorder_tasks`` AFTER
+    ``_validate_rescope_batch`` confirms the batch is being applied.
+    A rejected batch must NOT advance the counter — otherwise drops
+    that never actually shipped would file false stuck-on-critic bugs.
+    """
+
+    def test_rejected_batch_does_not_bump_counter(self, tmp_path: Path) -> None:
+        from fido.critics import TaskCreationDropCounter
+        from fido.tasks import Tasks, reorder_tasks
+        from fido.types import TaskType
+
+        Tasks(tmp_path).add(title="seed", task_type=TaskType.SPEC)
+
+        recorded: list[int] = []
+        counter = TaskCreationDropCounter(
+            threshold=100, escalator=lambda cid, count: None
+        )
+        counter.record_drop = lambda cid: recorded.append(cid)  # type: ignore[method-assign]
+
+        # Opus returns an operations envelope referencing an unknown id —
+        # ``_validate_rescope_batch`` rejects.  Even if there had been
+        # drops in the apply, the counter must stay clean.
+        client = _client('{"operations": [{"op": "keep", "id": "no-such-task"}]}')
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=client,
+            task_creation_drop_counter=counter,
+        )
         assert recorded == []
+
+
+class TestReorderTasksDropCounterDropBump:
+    """Codex P1 sixth round on PR #1938 happy path: a drop attributed
+    to an intent_comment_id, in a batch that PASSES validation, DOES
+    advance the durable counter (so the deferred-bump split still
+    preserves the legitimate counter advance)."""
+
+    def test_drop_in_accepted_batch_bumps_counter(self, tmp_path: Path) -> None:
+        from fido.critics import TaskCreationDropCounter
+        from fido.tasks import Tasks, reorder_tasks
+        from fido.types import TaskType
+
+        existing = Tasks(tmp_path).add(title="existing", task_type=TaskType.SPEC)
+
+        recorded: list[int] = []
+        counter = TaskCreationDropCounter(
+            threshold=100, escalator=lambda cid, count: None
+        )
+        counter.record_drop = lambda cid: recorded.append(cid)  # type: ignore[method-assign]
+
+        # Two LLM calls happen: the rescope ops envelope, then a
+        # task-creation critic verdict per ``new`` op.  Use
+        # ``side_effect`` so each call gets the right payload.
+        ops_response = json.dumps(
+            {
+                "operations": [
+                    {"op": "keep", "id": existing["id"]},
+                    {
+                        "op": "new",
+                        "title": "proposed-new",
+                        "description": "x",
+                        "type": "spec",
+                        "contributing_intents": [555],
+                    },
+                ]
+            }
+        )
+        critic_verdict = json.dumps(
+            {
+                "relationship": "duplicate_of",
+                "scope": "single",
+                "duplicate_of_id": existing["id"],
+                "rationale": "test",
+            }
+        )
+        client = _client(ops_response)
+        # First call: ops envelope; second call: critic verdict.
+        client.run_turn.side_effect = [ops_response, critic_verdict]
+        prompts = Prompts("p")
+
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=client,
+            prompts=prompts,
+            task_creation_drop_counter=counter,
+        )
+        # Drop fired, batch validated, counter advanced for 555.
+        assert recorded == [555]
 
 
 class TestReorderTasksDropCounterReset:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7368,3 +7368,117 @@ class TestTasksCompleteWithResolve:
                 task["id"], gh, syncer=lambda _w, _g: None
             )
         assert "thread resolution skipped" in caplog.text
+
+
+class TestApplyTaskCreationVerdictsDropCounter:
+    """HOL-16 follow-up / #1934: ``_apply_task_creation_verdicts``
+    bumps the per-intent drop counter for every contributing intent
+    on each dropped proposal."""
+
+    def test_drop_bumps_counter_for_each_contributing_intent(self) -> None:
+        from fido.critics import TaskCreationDropCounter, TaskCreationVerdict
+        from fido.tasks import _apply_task_creation_verdicts
+
+        recorded: list[int] = []
+        counter = TaskCreationDropCounter(
+            threshold=100, escalator=lambda cid, count: None
+        )
+        # Patch record_drop to observe calls.
+        original_record = counter.record_drop
+
+        def spy(cid: int) -> None:
+            recorded.append(cid)
+            original_record(cid)
+
+        counter.record_drop = spy  # type: ignore[method-assign]
+
+        item = {
+            "id": None,
+            "title": "new",
+            "description": "",
+            "type": "spec",
+            "contributing_intents": [101, 202],
+        }
+        existing = {"id": "t-existing", "title": "existing", "status": "pending"}
+        verdict = TaskCreationVerdict(
+            relationship="duplicate_of", duplicate_of_id="t-existing"
+        )
+        _apply_task_creation_verdicts(
+            [item], [verdict], [existing], drop_counter=counter
+        )
+        assert sorted(recorded) == [101, 202]
+
+    def test_drop_skips_counter_when_target_missing(self) -> None:
+        # When the target doesn't survive the batch, the proposal is
+        # KEPT (not dropped) — no counter bump.
+        from fido.critics import TaskCreationDropCounter, TaskCreationVerdict
+        from fido.tasks import _apply_task_creation_verdicts
+
+        recorded: list[int] = []
+        counter = TaskCreationDropCounter(
+            threshold=100, escalator=lambda cid, count: None
+        )
+        counter.record_drop = lambda cid: recorded.append(cid)  # type: ignore[method-assign]
+
+        item = {
+            "id": None,
+            "title": "new",
+            "description": "",
+            "type": "spec",
+            "contributing_intents": [101],
+        }
+        verdict = TaskCreationVerdict(
+            relationship="duplicate_of", duplicate_of_id="t-gone"
+        )
+        out = _apply_task_creation_verdicts([item], [verdict], [], drop_counter=counter)
+        # Kept, not dropped.
+        assert out == [item]
+        assert recorded == []
+
+
+class TestReorderTasksDropCounterReset:
+    """HOL-16 follow-up / #1934: after a successful rescope batch,
+    ``reorder_tasks`` calls ``reset_inactive_intents`` on the drop
+    counter so streaks for intents with no live contributing tasks
+    don't carry over to the next batch."""
+
+    def test_reset_called_with_active_intent_ids_after_apply(
+        self, tmp_path: Path
+    ) -> None:
+        from fido.critics import TaskCreationDropCounter
+        from fido.tasks import Tasks, reorder_tasks
+        from fido.types import TaskType
+
+        # Seed a task carrying contributing_intent 101 (Tasks.add
+        # doesn't accept contributing_intents directly, so mutate via
+        # the lock).
+        t = Tasks(tmp_path).add(title="T1", task_type=TaskType.SPEC)
+        with Tasks(tmp_path).modify() as live:
+            for row in live:
+                if row["id"] == t["id"]:
+                    row["contributing_intents"] = [101]
+
+        recorded_resets: list[set[int]] = []
+        counter = TaskCreationDropCounter(threshold=10)
+        original = counter.reset_inactive_intents
+
+        def spy(active: set[int]) -> None:
+            recorded_resets.append(set(active))
+            original(active)
+
+        counter.reset_inactive_intents = spy  # type: ignore[method-assign]
+
+        # Minimal valid keep-only operation envelope from Opus.
+        # The id in the operation must match the auto-generated task
+        # id from the seeded task.
+        client = _client(json.dumps({"operations": [{"op": "keep", "id": t["id"]}]}))
+        reorder_tasks(
+            Tasks(tmp_path),
+            "",
+            agent=client,
+            task_creation_drop_counter=counter,
+        )
+        # Reset was called with the active set including intent 101
+        # (drawn from the surviving task's contributing_intents).
+        assert recorded_resets, "reset_inactive_intents was never called"
+        assert 101 in recorded_resets[-1]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -842,6 +842,25 @@ class TestUnblockTasks:
     def test_returns_zero_on_empty_file(self, tmp_path: Path) -> None:
         assert Tasks(tmp_path).unblock_tasks() == 0
 
+    def test_resets_critic_retry_count_on_unblock(self, tmp_path: Path) -> None:
+        # Codex P1 on PR #1938: a task that escalated to BLOCKED on
+        # the HOL-17 budget would carry the at-budget counter back
+        # into PENDING when unblocked.  Without the reset, the very
+        # next critic failure re-escalates immediately.
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        t = Tasks(tmp_path).add(title="task", task_type=TaskType.SPEC)
+        Tasks(tmp_path).update(t["id"], TaskStatus.BLOCKED)
+        # Simulate the at-budget counter the escalation left behind.
+        with Tasks(tmp_path).modify() as live:
+            for row in live:
+                if row["id"] == t["id"]:
+                    row["critic_retry_count"] = _HOL17_MAX_REPARK_BUDGET
+        Tasks(tmp_path).unblock_tasks()
+        after = next(r for r in Tasks(tmp_path).list() if r["id"] == t["id"])
+        assert after["status"] == str(TaskStatus.PENDING)
+        assert after["critic_retry_count"] == 0
+
 
 # ── _build_task_list_snapshot ─────────────────────────────────────────────────
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -590,3 +590,186 @@ class TestVerdictIsMaterial:
             self._verdict("honored"),
             task_descriptions=("anything",),
         )
+
+
+class TestIntentThreadTerminal:
+    """HOL-27 / #1921: an intent is terminal when every task in its
+    contributing_intents has reached a terminal status."""
+
+    def _task(
+        self,
+        tid: str,
+        status: str,
+        contributing_intents: tuple[int, ...] = (),
+    ) -> dict[str, object]:
+        return {
+            "id": tid,
+            "status": status,
+            "contributing_intents": list(contributing_intents),
+        }
+
+    def test_all_completed_is_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "completed", (101,)),
+        ]
+        assert intent_thread_terminal(101, tasks)
+
+    def test_all_skipped_is_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [self._task("t1", "skipped", (101,))]
+        assert intent_thread_terminal(101, tasks)
+
+    def test_mixed_completed_and_skipped_is_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "skipped", (101,)),
+        ]
+        assert intent_thread_terminal(101, tasks)
+
+    def test_any_pending_is_not_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "pending", (101,)),
+        ]
+        assert not intent_thread_terminal(101, tasks)
+
+    def test_any_in_progress_is_not_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [self._task("t1", "in_progress", (101,))]
+        assert not intent_thread_terminal(101, tasks)
+
+    def test_any_blocked_is_not_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        tasks = [self._task("t1", "blocked", (101,))]
+        assert not intent_thread_terminal(101, tasks)
+
+    def test_no_contributing_tasks_is_not_terminal(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        # Vacuous case: intent 101 never landed on any task.  HOL-24's
+        # no_op path already notified; this predicate must NOT also
+        # fire (otherwise HOL-28 double-replies).
+        tasks = [self._task("t1", "completed", (202,))]
+        assert not intent_thread_terminal(101, tasks)
+
+    def test_tolerates_taskstatus_enum_instance(self) -> None:
+        from fido.types import TaskStatus, intent_thread_terminal
+
+        tasks = [
+            {
+                "id": "t1",
+                "status": TaskStatus.COMPLETED,
+                "contributing_intents": [101],
+            }
+        ]
+        assert intent_thread_terminal(101, tasks)
+
+    def test_ignores_tasks_not_contributing(self) -> None:
+        from fido.types import intent_thread_terminal
+
+        # t2 is pending but doesn't list intent 101 — must not block
+        # 101's terminal status.
+        tasks = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "pending", (202,)),
+        ]
+        assert intent_thread_terminal(101, tasks)
+
+
+class TestNewlyTerminalIntentThreads:
+    """HOL-27: identifies intent threads that transitioned from
+    non-terminal to terminal across a tasks.json before/after snapshot."""
+
+    def _task(
+        self,
+        tid: str,
+        status: str,
+        contributing_intents: tuple[int, ...] = (),
+    ) -> dict[str, object]:
+        return {
+            "id": tid,
+            "status": status,
+            "contributing_intents": list(contributing_intents),
+        }
+
+    def test_one_intent_transitioned(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        prev = [self._task("t1", "in_progress", (101,))]
+        new = [self._task("t1", "completed", (101,))]
+        assert newly_terminal_intent_threads(prev, new) == (101,)
+
+    def test_intent_already_terminal_excluded(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        # Intent 101 was already all-terminal before the transition,
+        # don't re-emit a reply for it.
+        prev = [self._task("t1", "completed", (101,))]
+        new = [self._task("t1", "completed", (101,))]
+        assert newly_terminal_intent_threads(prev, new) == ()
+
+    def test_intent_still_pending_excluded(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        prev = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "pending", (101,)),
+        ]
+        new = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "in_progress", (101,)),
+        ]
+        assert newly_terminal_intent_threads(prev, new) == ()
+
+    def test_multiple_intents_transitioned_in_insertion_order(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        prev = [
+            self._task("t1", "pending", (101,)),
+            self._task("t2", "pending", (202,)),
+        ]
+        new = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "completed", (202,)),
+        ]
+        # 101 first because t1 lists it first.
+        assert newly_terminal_intent_threads(prev, new) == (101, 202)
+
+    def test_de_duplicated(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        prev = [
+            self._task("t1", "pending", (101,)),
+            self._task("t2", "pending", (101,)),
+        ]
+        new = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "completed", (101,)),
+        ]
+        # 101 appears in both tasks but emitted once.
+        assert newly_terminal_intent_threads(prev, new) == (101,)
+
+    def test_partial_thread_transition_excluded(self) -> None:
+        from fido.types import newly_terminal_intent_threads
+
+        # Intent 101 contributes to t1 (now done) AND t2 (still pending)
+        # — thread is NOT yet terminal.
+        prev = [
+            self._task("t1", "pending", (101,)),
+            self._task("t2", "pending", (101,)),
+        ]
+        new = [
+            self._task("t1", "completed", (101,)),
+            self._task("t2", "pending", (101,)),
+        ]
+        assert newly_terminal_intent_threads(prev, new) == ()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -478,3 +478,115 @@ class TestTaskStatusSkipped:
         assert TaskStatus.SKIPPED != TaskStatus.BLOCKED
         assert TaskStatus.SKIPPED != TaskStatus.PENDING
         assert TaskStatus.SKIPPED != TaskStatus.IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# HOL-23 / #1917 — verdict_is_material predicate
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictIsMaterial:
+    """HOL-23 / #1917: predicate gates per-thread reply-back emission.
+
+    Test matrix covers each outcome × match/divergence combination
+    per the issue's acceptance criteria.
+    """
+
+    def _intent(self, change_request: str = "Fix the bug") -> object:
+        from fido.types import RescopeIntent
+
+        return RescopeIntent(
+            change_request=change_request,
+            comment_id=42,
+            timestamp="2026-05-24T10:00:00Z",
+        )
+
+    def _verdict(self, outcome: str) -> object:
+        from fido.types import IntentVerdict
+
+        return IntentVerdict(
+            intent_comment_id=42,
+            outcome=outcome,
+            narrative="x",
+        )
+
+    def test_reshaped_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert verdict_is_material(self._intent(), self._verdict("reshaped"))
+
+    def test_superseded_is_material(self) -> None:
+        from fido.types import IntentVerdict, verdict_is_material
+
+        verdict = IntentVerdict(
+            intent_comment_id=42,
+            outcome="superseded",
+            by_intent_comment_id=99,
+            narrative="x",
+        )
+        assert verdict_is_material(self._intent(), verdict)
+
+    def test_no_op_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert verdict_is_material(self._intent(), self._verdict("no_op"))
+
+    def test_honored_without_descriptions_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(self._intent(), self._verdict("honored"))
+
+    def test_honored_matching_task_description_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=("Fix the bug in the retry path.",),
+        )
+
+    def test_honored_diverging_task_description_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # Task description doesn't contain the change_request text —
+        # "you said X, I queued Y" pattern → material.
+        assert verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=("Refactor the entire retry subsystem.",),
+        )
+
+    def test_honored_case_insensitive_match(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(
+            self._intent("FIX THE BUG"),
+            self._verdict("honored"),
+            task_descriptions=("fix the bug pls.",),
+        )
+
+    def test_honored_with_multiple_tasks_any_match_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # If ANY task description covers the request verbatim, the
+        # intent is honoured-as-asked → not material.
+        assert not verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=(
+                "Unrelated description.",
+                "Fix the bug as part of the broader refactor.",
+            ),
+        )
+
+    def test_honored_with_empty_change_request_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # Empty change_request can't be a basis for divergence —
+        # callers shouldn't construct intents this way but the
+        # predicate must not divide-by-zero.
+        assert not verdict_is_material(
+            self._intent(""),
+            self._verdict("honored"),
+            task_descriptions=("anything",),
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -773,3 +773,49 @@ class TestNewlyTerminalIntentThreads:
             self._task("t2", "pending", (101,)),
         ]
         assert newly_terminal_intent_threads(prev, new) == ()
+
+
+class TestHol28AnchorKey:
+    """HOL-28 / #1922 (codex P2 eighth round on PR #1938): normalize
+    a task's ``thread["comment_id"]`` to an int so string/int mismatches
+    don't make sibling tasks invisible during the transition check."""
+
+    def test_int_passes_through(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key({"comment_id": 999, "comment_type": "pulls"}) == 999
+
+    def test_string_coerced_to_int(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key({"comment_id": "999"}) == 999
+
+    def test_none_thread_returns_none(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key(None) is None
+
+    def test_non_mapping_returns_none(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key("not-a-dict") is None
+        assert hol28_anchor_key(42) is None
+
+    def test_missing_comment_id_returns_none(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key({"comment_type": "pulls"}) is None
+
+    def test_bool_returns_none(self) -> None:
+        # ``bool`` is an ``int`` subclass — reject explicitly so
+        # ``True``/``False`` can't sneak in as a fake comment id.
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key({"comment_id": True}) is None
+        assert hol28_anchor_key({"comment_id": False}) is None
+
+    def test_uncoerceable_returns_none(self) -> None:
+        from fido.types import hol28_anchor_key
+
+        assert hol28_anchor_key({"comment_id": "not-a-number"}) is None
+        assert hol28_anchor_key({"comment_id": [1, 2, 3]}) is None

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13034,6 +13034,14 @@ class TestExecuteTask:
         # the budget and escalates.  Description gets prior gaps too
         # so the bug body's gap-chain assertions still see them.
         task["critic_retry_count"] = _HOL17_MAX_REPARK_BUDGET - 1
+        # Codex P2 on PR #1938: the gap chain is now a structured
+        # field on the task; seed it directly so the bug body sees
+        # the prior gaps (the regex-from-description path was
+        # deleted because it false-counted user-authored CRITIC:
+        # text in descriptions).
+        task["critic_gap_chain"] = [
+            f"prior gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 1)
+        ]
         prior_markers = "\n\n".join(
             f"CRITIC: prior gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 1)
         )
@@ -18073,6 +18081,7 @@ class TestEmitHol28TerminalReplyFor:
             "id": "t1",
             "status": "completed",
             "contributing_intents": [101, 202],
+            "thread": {"comment_type": "pulls", "comment_id": 101},
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
         worker._emit_hol28_terminal_reply_for(
@@ -18094,9 +18103,42 @@ class TestEmitHol28TerminalReplyFor:
             "id": "t1",
             "status": "completed",
             "contributing_intents": [101],
+            "thread": {"comment_type": "pulls", "comment_id": 101},
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
         # Must not raise — task completion can't be gated on per-reply errors.
         worker._emit_hol28_terminal_reply_for(
             task=task, prev_tasks=[{**task, "status": "in_progress"}], pr_number=42
         )
+
+    def test_skips_emission_when_task_thread_is_issue_comment(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex P2 on PR #1938: contributing_intents has no per-intent
+        # comment_type, so the wire falls back to the task's thread
+        # metadata.  When that's an issues lane, skip emission rather
+        # than risk calling reply_to_review_comment with an issue-
+        # comment id.
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "contributing_intents": [101],
+            "thread": {"comment_type": "issues", "comment_id": 101},
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []
+
+    def test_skips_emission_when_thread_metadata_missing(self, tmp_path: Path) -> None:
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "contributing_intents": [101],
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7924,6 +7924,44 @@ class TestRunSeedTasksIntegration:
             "recovered 1 in-progress PR comment claim(s) for owner/repo" in caplog.text
         )
 
+    def test_first_iteration_logs_pending_rescope_replay(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Codex P1 (twelfth round) on PR #1938: when first-iteration
+        # recovery drains pending rescope intents (crash between
+        # claim and _on_done), the warn-log surfaces the count so
+        # the operator sees the lost-rescope window closing.
+        gh = self._make_gh()
+        gh.view_issue.return_value = {"title": "t", "body": "", "state": "OPEN"}
+        gh.get_pr_state.return_value = "open"
+        mock_dispatcher = _FakeDispatcher(
+            backfill_return=0,
+            replay_pending_rescope_intents_return=2,
+        )
+        worker = Worker(
+            tmp_path,
+            gh,
+            first_iteration=True,
+            dispatcher=mock_dispatcher,
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        repo_ctx = self._make_mock_repo_ctx()
+        worker.create_context = MagicMock(return_value=self._make_mock_ctx(tmp_path))
+        worker.discover_repo_context = MagicMock(return_value=repo_ctx)
+        worker.setup_hooks = MagicMock(return_value=("c", "s"))
+        worker.teardown_hooks = MagicMock()
+        worker.get_current_issue = MagicMock(return_value=7)
+        worker.post_pickup_comment = MagicMock()
+        worker.find_or_create_pr = MagicMock(return_value=(42, "fix-bug", False))
+        worker.seed_tasks_from_pr_body = MagicMock()
+        worker.handle_ci = MagicMock(return_value=False)
+        worker.handle_queued_comments = MagicMock(return_value=False)
+        worker.handle_threads = MagicMock(return_value=False)
+        with caplog.at_level(logging.WARNING, logger="fido"):
+            worker.run()
+        assert "replayed 2 pending rescope intent(s) for owner/repo" in caplog.text
+        assert len(mock_dispatcher.replay_pending_rescope_intents_calls) == 1
+
     def test_backfill_skipped_for_fresh_pr(self, tmp_path: Path) -> None:
         """A freshly-created PR has no comments to backfill — skip the call to
         avoid one superfluous API round-trip."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18017,7 +18017,7 @@ class TestEmitHol28TerminalReplyFor:
 
         def notify_terminal_task_thread(
             self,
-            task: dict[str, object],
+            new_tasks: list[dict[str, object]],
             anchor_intent: object,
             *,
             pr: int,
@@ -18028,7 +18028,7 @@ class TestEmitHol28TerminalReplyFor:
                 raise self.raise_on_next
             self.calls.append(
                 {
-                    "task": task,
+                    "new_tasks": new_tasks,
                     "anchor_intent": anchor_intent,
                     "pr": pr,
                 }
@@ -18087,7 +18087,7 @@ class TestEmitHol28TerminalReplyFor:
         assert len(dispatcher.calls) == 1
         call = dispatcher.calls[0]
         assert call["pr"] == 42
-        assert call["task"] is task
+        assert task in call["new_tasks"]
         anchor = call["anchor_intent"]
         assert isinstance(anchor, RescopeIntent)
         assert anchor.comment_id == 999

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18056,23 +18056,23 @@ class TestEmitHol28TerminalReplyFor:
         worker._prompts = prompts  # type: ignore[assignment]
         return worker
 
-    def test_no_contributing_intents_skips_dispatcher(self, tmp_path: Path) -> None:
-        dispatcher = self._StubDispatcher()
-        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
-        task: dict[str, object] = {"id": "t1", "contributing_intents": []}
-        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
-        assert dispatcher.calls == []
-
     def test_no_prompts_skips_dispatcher(self, tmp_path: Path) -> None:
         dispatcher = self._StubDispatcher()
         worker = self._make_worker(tmp_path, dispatcher, prompts=None)
-        task: dict[str, object] = {"id": "t1", "contributing_intents": [101]}
+        task: dict[str, object] = {
+            "id": "t1",
+            "thread": {"comment_type": "pulls", "comment_id": 101},
+        }
         worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
         assert dispatcher.calls == []
 
-    def test_contributing_intents_synthesizes_stubs_and_calls(
-        self, tmp_path: Path
-    ) -> None:
+    def test_emits_one_reply_anchored_at_task_thread(self, tmp_path: Path) -> None:
+        # Codex P1 (second round) on PR #1938: HOL-28 emits ONE reply
+        # at the task's primary thread anchor, not per
+        # contributing_intent.  Per-contributing emission needed
+        # per-intent comment_type metadata that the tasks.json schema
+        # doesn't carry; HOL-24's verdict-based reply path already
+        # handles cross-author divergence at rescope time.
         from fido.types import RescopeIntent
 
         dispatcher = self._StubDispatcher()
@@ -18080,8 +18080,8 @@ class TestEmitHol28TerminalReplyFor:
         task: dict[str, object] = {
             "id": "t1",
             "status": "completed",
-            "contributing_intents": [101, 202],
-            "thread": {"comment_type": "pulls", "comment_id": 101},
+            "contributing_intents": [101, 202, 303],
+            "thread": {"comment_type": "pulls", "comment_id": 999},
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
         worker._emit_hol28_terminal_reply_for(
@@ -18091,8 +18091,10 @@ class TestEmitHol28TerminalReplyFor:
         call = dispatcher.calls[0]
         assert call["pr"] == 42
         intents = call["batch_intents"]
-        assert all(isinstance(i, RescopeIntent) for i in intents)
-        assert [i.comment_id for i in intents] == [101, 202]
+        # ONE synthetic intent anchored at the task's thread.
+        assert len(intents) == 1
+        assert isinstance(intents[0], RescopeIntent)
+        assert intents[0].comment_id == 999
         assert intents[0].comment_type == "pulls"
 
     def test_dispatcher_failure_logged_not_raised(self, tmp_path: Path) -> None:
@@ -18102,7 +18104,6 @@ class TestEmitHol28TerminalReplyFor:
         task: dict[str, object] = {
             "id": "t1",
             "status": "completed",
-            "contributing_intents": [101],
             "thread": {"comment_type": "pulls", "comment_id": 101},
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
@@ -18124,7 +18125,6 @@ class TestEmitHol28TerminalReplyFor:
         task: dict[str, object] = {
             "id": "t1",
             "status": "completed",
-            "contributing_intents": [101],
             "thread": {"comment_type": "issues", "comment_id": 101},
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
@@ -18137,7 +18137,6 @@ class TestEmitHol28TerminalReplyFor:
         task: dict[str, object] = {
             "id": "t1",
             "status": "completed",
-            "contributing_intents": [101],
         }
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
         worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -13173,7 +13173,13 @@ class TestExecuteTask:
         worker, gh = self._make_worker(tmp_path)
         task = self._pending_task("Add retry logic")
         task["status"] = "in_progress"
-        worker._tasks._task_list = [task]
+        # Include a sibling task so the modify() loop iterates past a
+        # non-matching id before finding the target — covers the
+        # ``if live_task["id"] != task["id"]: continue`` arm in
+        # ``_escalate_task_completion_critic_exhausted``.
+        sibling = self._pending_task("Sibling task")
+        sibling["id"] = "t-sibling"
+        worker._tasks._task_list = [sibling, task]
         gh.search_issues.return_value = []
         gh.create_issue.return_value = "https://x/issues/1"
 
@@ -13197,6 +13203,9 @@ class TestExecuteTask:
 
         affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
         assert affected["status"] == str(TaskStatus.BLOCKED)
+        # Sibling untouched.
+        sib_after = next(t for t in worker._tasks._task_list if t["id"] == "t-sibling")
+        assert sib_after["status"] != str(TaskStatus.BLOCKED)
         gh.create_issue.assert_called_once()
         gh.comment_issue.assert_not_called()
         assert ["reset", "--hard", "HEAD"] in git_calls
@@ -13338,6 +13347,65 @@ class TestExecuteTask:
         assert "CRITIC EXHAUSTED" not in affected["description"]
         # No bug filed on the budget-boundary case.
         gh.create_issue.assert_not_called()
+
+    def test_task_completion_critic_budget_uses_live_counter_not_stale_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1 on PR #1938: the budget decision must read
+        ``critic_retry_count`` from LIVE state under the lock, not
+        from the stale ``task`` snapshot passed in.  This test pins
+        the live-wins semantics by constructing a deliberate stale-
+        vs-live mismatch — the live counter is at-budget while the
+        passed-in snapshot says zero.  Result: escalate (the live
+        counter decides), not re-park (which the stale snapshot
+        would have driven)."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        # Stale snapshot: counter says zero (would re-park if used).
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        task["critic_retry_count"] = 0
+        # Live state: counter at budget - 1 (next failure escalates
+        # when the budget check uses the live read).
+        live_row = dict(task)
+        live_row["critic_retry_count"] = _HOL17_MAX_REPARK_BUDGET - 1
+        worker._tasks._task_list = [live_row]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "stale-vs-live divergent"}'
+        )
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        # Live counter drove the decision — task escalated to BLOCKED.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        assert "CRITIC EXHAUSTED" in affected["description"]
+        gh.create_issue.assert_called_once()
 
     def test_task_completion_critic_failure_cleans_up_leaked_comments(
         self, tmp_path: Path
@@ -17923,3 +17991,112 @@ class TestLeakedCommentCleanup:
             "owner/repo", 7, "fido-bot", before_ids=set()
         )
         gh.delete_issue_comment.assert_not_called()
+
+
+class TestEmitHol28TerminalReplyFor:
+    """HOL-28 / #1922 wire (codex P1 on PR #1938): the helper called
+    from ``_finish_task`` synthesizes ``RescopeIntent`` stubs from the
+    just-completed task's ``contributing_intents`` and hands them to
+    ``Dispatcher.notify_newly_terminal_intent_threads``.
+
+    The helper is best-effort: a transient dispatcher failure logs but
+    does not propagate."""
+
+    class _StubDispatcher:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+            self.raise_on_next: Exception | None = None
+
+        def notify_newly_terminal_intent_threads(
+            self,
+            prev_tasks: list[dict[str, object]],
+            new_tasks: list[dict[str, object]],
+            *,
+            batch_intents: list[object],
+            pr: int,
+            agent: object,
+            prompts: object,
+        ) -> None:
+            if self.raise_on_next is not None:
+                raise self.raise_on_next
+            self.calls.append(
+                {
+                    "prev_tasks": prev_tasks,
+                    "new_tasks": new_tasks,
+                    "batch_intents": batch_intents,
+                    "pr": pr,
+                }
+            )
+
+    def _make_worker(
+        self, tmp_path: Path, dispatcher: object, prompts: object | None
+    ) -> Worker:
+        gh = MagicMock()
+        gh.find_closed_prs_as_context.return_value = []
+        gh.fetch_closed_sub_issues.return_value = []
+        worker = Worker(
+            tmp_path,
+            gh,
+            registry=MagicMock(spec=ActivityReporter),
+            _tasks=_FakeTasks(),
+            provider_runner=_FakeProviderRunner(),
+            prompt_builder=_FakePromptBuilder(),
+            harness_committer_factory=_FakeHarnessCommitterFactory(),
+            task_syncer=_FakeTaskSyncer(),
+        )
+        worker._dispatcher = dispatcher  # type: ignore[assignment]
+        worker._prompts = prompts  # type: ignore[assignment]
+        return worker
+
+    def test_no_contributing_intents_skips_dispatcher(self, tmp_path: Path) -> None:
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {"id": "t1", "contributing_intents": []}
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []
+
+    def test_no_prompts_skips_dispatcher(self, tmp_path: Path) -> None:
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=None)
+        task: dict[str, object] = {"id": "t1", "contributing_intents": [101]}
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []
+
+    def test_contributing_intents_synthesizes_stubs_and_calls(
+        self, tmp_path: Path
+    ) -> None:
+        from fido.types import RescopeIntent
+
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "contributing_intents": [101, 202],
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(
+            task=task, prev_tasks=[{**task, "status": "in_progress"}], pr_number=42
+        )
+        assert len(dispatcher.calls) == 1
+        call = dispatcher.calls[0]
+        assert call["pr"] == 42
+        intents = call["batch_intents"]
+        assert all(isinstance(i, RescopeIntent) for i in intents)
+        assert [i.comment_id for i in intents] == [101, 202]
+        assert intents[0].comment_type == "pulls"
+
+    def test_dispatcher_failure_logged_not_raised(self, tmp_path: Path) -> None:
+        dispatcher = self._StubDispatcher()
+        dispatcher.raise_on_next = RuntimeError("GitHub down")
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "contributing_intents": [101],
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        # Must not raise — task completion can't be gated on per-reply errors.
+        worker._emit_hol28_terminal_reply_for(
+            task=task, prev_tasks=[{**task, "status": "in_progress"}], pr_number=42
+        )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18171,3 +18171,66 @@ class TestEmitHol28TerminalReplyFor:
         worker._tasks._task_list = [task]  # type: ignore[attr-defined]
         worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
         assert dispatcher.calls == []
+
+    def test_thread_with_pending_sibling_does_not_fire(self, tmp_path: Path) -> None:
+        # Codex P1 (sixth round) on PR #1938: when one comment shaped
+        # multiple tasks, completing the first must NOT fire the
+        # closing summary while the sibling is still pending.
+        # Thread-level transition predicate guards this.
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        t1: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        t2_pending: dict[str, object] = {
+            "id": "t2",
+            "status": "pending",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        worker._tasks._task_list = [t1, t2_pending]  # type: ignore[attr-defined]
+        prev = [
+            {**t1, "status": "in_progress"},
+            t2_pending,
+        ]
+        worker._emit_hol28_terminal_reply_for(task=t1, prev_tasks=prev, pr_number=42)
+        assert dispatcher.calls == []
+
+    def test_no_anchored_tasks_does_not_fire(self, tmp_path: Path) -> None:
+        # Vacuous case in the thread-level transition predicate: if
+        # the anchor comment_id matches no live task, return False.
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        worker._tasks._task_list = []  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []
+
+    def test_thread_fires_only_when_last_sibling_completes(
+        self, tmp_path: Path
+    ) -> None:
+        # Same scenario as above, but now t1 was already completed in
+        # prev and t2 just completed.  Thread transitions from
+        # not-all-terminal (t2 pending) to all-terminal — fire once.
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        t1: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        t2: dict[str, object] = {
+            "id": "t2",
+            "status": "completed",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        worker._tasks._task_list = [t1, t2]  # type: ignore[attr-defined]
+        prev = [t1, {**t2, "status": "in_progress"}]
+        worker._emit_hol28_terminal_reply_for(task=t2, prev_tasks=prev, pr_number=42)
+        assert len(dispatcher.calls) == 1
+        assert dispatcher.calls[0]["anchor_intent"].comment_id == 999

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18015,12 +18015,11 @@ class TestEmitHol28TerminalReplyFor:
             self.calls: list[dict[str, object]] = []
             self.raise_on_next: Exception | None = None
 
-        def notify_newly_terminal_intent_threads(
+        def notify_terminal_task_thread(
             self,
-            prev_tasks: list[dict[str, object]],
-            new_tasks: list[dict[str, object]],
+            task: dict[str, object],
+            anchor_intent: object,
             *,
-            batch_intents: list[object],
             pr: int,
             agent: object,
             prompts: object,
@@ -18029,9 +18028,8 @@ class TestEmitHol28TerminalReplyFor:
                 raise self.raise_on_next
             self.calls.append(
                 {
-                    "prev_tasks": prev_tasks,
-                    "new_tasks": new_tasks,
-                    "batch_intents": batch_intents,
+                    "task": task,
+                    "anchor_intent": anchor_intent,
                     "pr": pr,
                 }
             )
@@ -18067,12 +18065,11 @@ class TestEmitHol28TerminalReplyFor:
         assert dispatcher.calls == []
 
     def test_emits_one_reply_anchored_at_task_thread(self, tmp_path: Path) -> None:
-        # Codex P1 (second round) on PR #1938: HOL-28 emits ONE reply
-        # at the task's primary thread anchor, not per
-        # contributing_intent.  Per-contributing emission needed
-        # per-intent comment_type metadata that the tasks.json schema
-        # doesn't carry; HOL-24's verdict-based reply path already
-        # handles cross-author divergence at rescope time.
+        # Codex P1 (fifth round) on PR #1938: HOL-28 emits ONE reply
+        # at the task's primary thread anchor via
+        # ``notify_terminal_task_thread`` (not the prior
+        # ``notify_newly_terminal_intent_threads`` which iterated
+        # contributing_intents and could drop secondary threads).
         from fido.types import RescopeIntent
 
         dispatcher = self._StubDispatcher()
@@ -18090,12 +18087,45 @@ class TestEmitHol28TerminalReplyFor:
         assert len(dispatcher.calls) == 1
         call = dispatcher.calls[0]
         assert call["pr"] == 42
-        intents = call["batch_intents"]
-        # ONE synthetic intent anchored at the task's thread.
-        assert len(intents) == 1
-        assert isinstance(intents[0], RescopeIntent)
-        assert intents[0].comment_id == 999
-        assert intents[0].comment_type == "pulls"
+        assert call["task"] is task
+        anchor = call["anchor_intent"]
+        assert isinstance(anchor, RescopeIntent)
+        assert anchor.comment_id == 999
+        assert anchor.comment_type == "pulls"
+
+    def test_skips_emission_when_task_was_already_terminal(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex P1 (fifth round) on PR #1938: only fire on the
+        # non-terminal → terminal transition.  If the prev snapshot
+        # already showed terminal status (re-completion / replay /
+        # bug elsewhere), don't double-post.
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "completed",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(
+            task=task,
+            prev_tasks=[{**task, "status": "completed"}],
+            pr_number=42,
+        )
+        assert dispatcher.calls == []
+
+    def test_skips_emission_when_task_not_terminal(self, tmp_path: Path) -> None:
+        dispatcher = self._StubDispatcher()
+        worker = self._make_worker(tmp_path, dispatcher, prompts=object())
+        task: dict[str, object] = {
+            "id": "t1",
+            "status": "in_progress",
+            "thread": {"comment_type": "pulls", "comment_id": 999},
+        }
+        worker._tasks._task_list = [task]  # type: ignore[attr-defined]
+        worker._emit_hol28_terminal_reply_for(task=task, prev_tasks=[], pr_number=42)
+        assert dispatcher.calls == []
 
     def test_dispatcher_failure_logged_not_raised(self, tmp_path: Path) -> None:
         dispatcher = self._StubDispatcher()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12833,7 +12833,7 @@ class TestExecuteTask:
         # re-park logic.
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope arrives "now".
             worker._tasks._task_list[0]["status"] = "completed"
             real_handler(t, gap)
@@ -12884,7 +12884,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope removed the task entirely.
             worker._tasks._task_list.clear()
             real_handler(t, gap)
@@ -12938,7 +12938,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Concurrent rescope flipped the row to COMPLETED before the
             # critic-failure handler reached its re-park step.  Forces
             # the no-repark branch — which must then hard-reset to drop
@@ -12997,7 +12997,7 @@ class TestExecuteTask:
         worker._git = git_stub
         real_handler = worker._handle_task_completion_critic_failure
 
-        def racing_handler(t: dict, gap: str) -> None:
+        def racing_handler(t: dict, gap: str, **kwargs: object) -> None:
             # Row removed by concurrent rescope.
             worker._tasks._task_list.clear()
             real_handler(t, gap)
@@ -13007,6 +13007,337 @@ class TestExecuteTask:
 
         assert ["reset", "--soft", "HEAD~1"] in git_calls
         assert ["reset", "--hard", "HEAD"] in git_calls
+
+    def test_task_completion_critic_exhaustion_escalates_to_blocked(
+        self, tmp_path: Path
+    ) -> None:
+        """HOL-21 / #1915: after ``_HOL17_MAX_REPARK_BUDGET`` consecutive
+        critic failures on the same task, stop re-parking — mark the
+        task BLOCKED, auto-file a bug, post a BLOCKED comment on the
+        PR.  Without this the task cycles indefinitely on the same
+        complaint and blocks the queue."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        # Codex on PR #1933: budget is interpreted as "at the Nth
+        # failure, escalate" (>= comparison), and the counter lives
+        # on ``task["critic_retry_count"]`` not on parsed
+        # description text.  Seed ``critic_retry_count = budget - 1``
+        # so the next failure (in this test) is the one that hits
+        # the budget and escalates.  Description gets prior gaps too
+        # so the bug body's gap-chain assertions still see them.
+        task["critic_retry_count"] = _HOL17_MAX_REPARK_BUDGET - 1
+        prior_markers = "\n\n".join(
+            f"CRITIC: prior gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 1)
+        )
+        task["description"] = f"Original.\n\n{prior_markers}"
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "final straw"}'
+        )
+        gh.search_issues.return_value = []  # no existing bug
+        gh.create_issue.return_value = "https://github.com/FidoCanCode/home/issues/9001"
+        gh.comment_issue.return_value = {"id": 1}
+
+        git_calls: list[list[str]] = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            git_calls.append(args)
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        # Soft reset still fired (commit rolled back).
+        assert ["reset", "--soft", "HEAD~1"] in git_calls
+        # Hard reset fired (no retry coming, drop staged changes).
+        assert ["reset", "--hard", "HEAD"] in git_calls
+        # Task is BLOCKED, not IN_PROGRESS.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        # Description carries the CRITIC EXHAUSTED marker with attempt count.
+        assert "CRITIC EXHAUSTED" in affected["description"]
+        assert "final straw" in affected["description"]
+        # Bug filed on FidoCanCode/home.
+        gh.create_issue.assert_called_once()
+        bug_args = gh.create_issue.call_args.args
+        assert bug_args[0] == "FidoCanCode/home"
+        assert "task-completion critic exhausted" in bug_args[1]
+        # All prior gaps + the final straw are in the bug body.
+        bug_body = bug_args[2]
+        for i in range(_HOL17_MAX_REPARK_BUDGET - 1):
+            assert f"prior gap {i}" in bug_body
+        assert "final straw" in bug_body
+        # BLOCKED comment posted on the source PR.
+        comment_call = gh.comment_issue.call_args
+        assert comment_call.args[0] == "owner/repo"
+        assert comment_call.args[1] == 1
+        assert "BLOCKED" in comment_call.args[2]
+        assert "task-completion critic exhausted" in comment_call.args[2]
+        # current_task_id cleared so the picker moves on.
+        with worker._state.modify() as state:
+            assert state.get("current_task_id") is None
+
+    def test_task_completion_critic_exhaustion_handles_helper_failures(
+        self, tmp_path: Path
+    ) -> None:
+        """HOL-21 escalation must survive transient GitHub failures
+        in the bug-file + BLOCKED-comment steps.  The task is still
+        marked BLOCKED locally so the picker stops cycling it; the
+        external signals are best-effort.  Also exercises the
+        sibling-task path in the modify loop (covers the
+        ``if live_task["id"] != task["id"]: continue`` arm)."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        sibling = self._pending_task("Sibling")
+        sibling["id"] = "t-sibling"
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        # Codex on PR #1933: seed via the structured counter; one
+        # below budget so this failure escalates.
+        task["critic_retry_count"] = _HOL17_MAX_REPARK_BUDGET - 1
+        task["description"] = "\n\n".join(
+            f"CRITIC: gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 1)
+        )
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [sibling, task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "final"}'
+        )
+        gh.search_issues.return_value = []
+        gh.create_issue.side_effect = RuntimeError("bug file 500")
+        gh.comment_issue.side_effect = RuntimeError("comment 503")
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        # The BLOCKED comment wording reflects "filing FAILED" since
+        # the helper returned None (covers the no-URL branch).
+        comment_args = gh.comment_issue.call_args.args
+        assert "FAILED" in comment_args[2]
+
+    def test_task_completion_critic_exhaustion_without_pr_context(
+        self, tmp_path: Path
+    ) -> None:
+        """Direct unit test for the escalation helper covering the
+        no-PR-context branch (legacy callers / migrating tests pass
+        repo=None, pr_number=None).  Bug still files (with a
+        placeholder source link), BLOCKED comment is skipped."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+
+        worker, gh = self._make_worker(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["status"] = "in_progress"
+        worker._tasks._task_list = [task]
+        gh.search_issues.return_value = []
+        gh.create_issue.return_value = "https://x/issues/1"
+
+        git_calls: list[list[str]] = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            git_calls.append(args)
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout="", stderr=""
+            )
+
+        worker._git = git_stub
+        worker._escalate_task_completion_critic_exhausted(
+            task=task,
+            gap_chain=("g1", "g2", "g3", "g4"),
+            repo=None,
+            pr_number=None,
+        )
+
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.BLOCKED)
+        gh.create_issue.assert_called_once()
+        gh.comment_issue.assert_not_called()
+        assert ["reset", "--hard", "HEAD"] in git_calls
+
+    def test_task_completion_critic_exhaustion_respects_terminal_status(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex on PR #1933 P1: if a concurrent rescope already
+        moved the task to a terminal state (COMPLETED/SKIPPED/
+        BLOCKED) while the critic was running, the escalation
+        helper must NOT overwrite the row to BLOCKED.  Doing so
+        would silently clobber the rescope's decision — the same
+        race the re-park path explicitly guards against.  And with
+        no local BLOCKED-marking, no external signals (bug file,
+        PR comment) should fire either."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+
+        worker, gh = self._make_worker(tmp_path)
+        task = self._pending_task("Add retry logic")
+        # Pre-mark as COMPLETED (the simulated concurrent rescope
+        # decision).
+        task["status"] = str(TaskStatus.COMPLETED)
+        worker._tasks._task_list = [task]
+        gh.search_issues.return_value = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout="", stderr=""
+            )
+
+        worker._git = git_stub
+        worker._escalate_task_completion_critic_exhausted(
+            task=task,
+            gap_chain=("g1", "g2", "g3"),
+            repo="owner/repo",
+            pr_number=42,
+        )
+
+        # Row stays COMPLETED — escalation didn't overwrite.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.COMPLETED)
+        # No bug filed, no comment posted — short-circuited.
+        gh.create_issue.assert_not_called()
+        gh.comment_issue.assert_not_called()
+
+    def test_task_completion_critic_exhaustion_skips_when_task_removed(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex on PR #1933 P2: if the task disappears from
+        tasks.json during the critic run (a concurrent rescope
+        removed it), the modify loop does nothing, and the
+        side-effect arms (bug filing, BLOCKED comment) must
+        short-circuit too — no false external signals for a task
+        that no longer exists."""
+        import subprocess as _subprocess
+
+        worker, gh = self._make_worker(tmp_path)
+        task = self._pending_task("Add retry logic")
+        # Empty queue — task was removed by simulated concurrent
+        # rescope between the critic turn and this call.
+        worker._tasks._task_list = []
+        gh.search_issues.return_value = []
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout="", stderr=""
+            )
+
+        worker._git = git_stub
+        worker._escalate_task_completion_critic_exhausted(
+            task=task,
+            gap_chain=("g1", "g2", "g3"),
+            repo="owner/repo",
+            pr_number=42,
+        )
+
+        # No bug filed, no comment posted — the task is gone.
+        gh.create_issue.assert_not_called()
+        gh.comment_issue.assert_not_called()
+
+    def test_task_completion_critic_repark_just_below_budget(
+        self, tmp_path: Path
+    ) -> None:
+        """Budget boundary: at ``_HOL17_MAX_REPARK_BUDGET - 2``
+        prior failures, the next failure re-parks normally (the
+        one AFTER would escalate per the ``>=`` rule).  Pins the
+        off-by-one — codex on PR #1933 tightened budget semantics
+        so escalation fires AT the configured cap, not one past."""
+        import subprocess as _subprocess
+
+        from fido.types import TaskStatus
+        from fido.worker import _HOL17_MAX_REPARK_BUDGET
+
+        worker, gh = self._make_worker(tmp_path)
+        fido_dir = self._fido_dir(tmp_path)
+        task = self._pending_task("Add retry logic")
+        task["invariant"] = "x"
+        task["status"] = "in_progress"
+        # Two below the budget so this failure re-parks (counter
+        # becomes ``budget - 1``); the NEXT one would escalate.
+        task["critic_retry_count"] = max(0, _HOL17_MAX_REPARK_BUDGET - 2)
+        prior_markers = "\n\n".join(
+            f"CRITIC: gap {i}" for i in range(_HOL17_MAX_REPARK_BUDGET - 2)
+        )
+        task["description"] = f"Orig.\n\n{prior_markers}"
+        fake_runner = _FakeProviderRunner("sid", self._commit_complete_output())
+        worker._provider_runner = fake_runner
+        worker._tasks._task_list = [task]
+        worker.set_status = MagicMock()
+        worker.ensure_pushed = MagicMock(return_value=True)
+        worker._provider_agent.run_turn = MagicMock(
+            return_value='{"passed": false, "gap": "one more"}'
+        )
+
+        def git_stub(
+            args: list[str], check: bool = True, **_kw: object
+        ) -> "_subprocess.CompletedProcess[str]":
+            stdout = (
+                "diff --git a/x b/x\n+changed\n"
+                if args[:2] == ["show", "--no-color"]
+                else ""
+            )
+            return _subprocess.CompletedProcess(
+                args=["git", *args], returncode=0, stdout=stdout, stderr=""
+            )
+
+        worker._git = git_stub
+        worker.execute_task(fido_dir, self._repo_ctx(), 1, "branch")
+
+        # Task re-parked, NOT escalated.
+        affected = next(t for t in worker._tasks._task_list if t["id"] == task["id"])
+        assert affected["status"] == str(TaskStatus.IN_PROGRESS)
+        assert "CRITIC EXHAUSTED" not in affected["description"]
+        # No bug filed on the budget-boundary case.
+        gh.create_issue.assert_not_called()
 
     def test_task_completion_critic_failure_cleans_up_leaked_comments(
         self, tmp_path: Path


### PR DESCRIPTION
Consolidated single PR for epic #1894 per Rob's direction: one commit per leaf, in dependency order, on one branch.  All 10 epic leaves plus codex review fixes plus both HOL-21 follow-ups.

## Commits

| # | Leaf | Closes |
|---|------|--------|
| 4d3379c | HOL-21: stuck-on-critic infrastructure + HOL-17 re-park budget | #1915, #1914 |
| 5e2f889 | HOL-22: eager-eyes scoped to same review submission | #1916, #1875 |
| ca1587a | HOL-23: ``verdict_is_material`` predicate | #1917 |
| 3421568 | HOL-26: file insights before posting reply prose | #1920 |
| 1452ad5 | HOL-29: ``./fido status`` surfaces HOL-21-blocked tasks | #1923 |
| 7eedbe6 | HOL-24: rescope reducer emits per-thread reply effects via ``verdict_is_material`` | #1918 |
| 7cbc032 | HOL-25: per-thread material-divergence reply prose framing | #1919 |
| 9a7e6de | HOL-27: terminal-detection predicate + transition helper | #1921 |
| e44c9b6 | HOL-28: per-thread terminal aggregate reply | #1922 |
| 3bdf530 | HOL-34: regression test pins no_op-silent-drop closure | #1928, **#1894 (epic)** |
| 7d05c4a | Codex review on PR #1938 (5 items) | (review fixes) |
| 24d34cf | HOL-19 follow-up: insight-dedup transport-failure counter | #1935 |
| f29944e | HOL-16 follow-up: per-comment task-creation drop counter | #1934 |

## Codex review items addressed (commit 7d05c4a)

- **P1.1** HOL-26 on the production path — added ``file_insights_pre_reply`` hook called by both production reply handlers before their outbox-routed post.
- **P1.2** HOL-28 production wire — ``Worker._finish_task`` now calls ``notify_newly_terminal_intent_threads`` via a new ``_emit_hol28_terminal_reply_for`` helper.  Synthesizes ``RescopeIntent`` stubs from the just-completed task's ``contributing_intents`` (intents aren't durably persisted across rescope-to-completion).
- **P1.3** stale-snapshot race in the critic budget decision — collapsed re-park and escalate state mutations into ONE ``self._tasks.modify()`` block that reads ``critic_retry_count`` from live state.  Side effects (bug filing, BLOCKED PR comment) run AFTER the lock via a new ``_file_critic_exhaustion_signals`` helper.
- **P1.4** ``critic_retry_count`` not reset on unblock — ``unblock_tasks()`` now zeros the counter alongside the PENDING transition so a fresh budget applies after an unblock.
- **P2.1** honored materiality with omitted ``affected_task_ids`` — falls back to every task whose ``contributing_intents`` lists this intent's comment_id, so the divergence check sees real descriptions.

## Follow-up counters (commits 24d34cf, f29944e)

Both shipped as process-local counters (per the issue bodies, durable persistence "isn't worth building until we observe the pattern in production"):

- **#1935**: ``InsightDedupTransportCounter`` — bumps on transport-failure path of ``run_insight_dedup_critic``, resets on verdict-shape-valid response.  Escalates via ``file_stuck_on_critic_bug`` with ``emission_point="insight-dedup-transport"``.
- **#1934**: ``TaskCreationDropCounter`` — per-``intent_comment_id`` drop counter bumped on the task-creation critic's drop branch.  ``reset_inactive_intents(active)`` called after each batch apply with the intents still appearing in surviving tasks.  Escalates via ``file_stuck_on_critic_bug`` with ``emission_point="task-creation"``.

## Supersedes

- PR #1939 (HOL-23 standalone) — closed
- PR #1940 (HOL-29 standalone) — closed
- PR #1941 (HOL-26 standalone) — closed

## Test plan

- [x] ``./fido ci`` — 100% coverage, end-to-end green
- [x] Each leaf has focused unit tests in its commit
- [x] HOL-34's regression test pins the original PR #1890 failure
- [x] Codex review fixes each have pinning tests:
  - ``test_resets_critic_retry_count_on_unblock``
  - ``test_task_completion_critic_budget_uses_live_counter_not_stale_snapshot``
  - ``test_honored_verdict_falls_back_to_contributing_intents``
  - ``TestEmitHol28TerminalReplyFor`` (4 tests)
- [x] Both follow-up counters have focused tests + Dispatcher escalator end-to-end tests