### PR TITLE
HOL-23 of #1894: verdict_is_material predicate (closes #1917)

### DIFF
--- a/src/fido/types.py
+++ b/src/fido/types.py
@@ -372,6 +372,59 @@ class IntentVerdict:
             )
 
 
+def verdict_is_material(
+    intent: "RescopeIntent",
+    verdict: IntentVerdict,
+    *,
+    task_descriptions: tuple[str, ...] = (),
+) -> bool:
+    """HOL-23 / #1917: True when *verdict* warrants a per-thread reply
+    posted back to *intent*'s origin comment.
+
+    Used by HOL-24 to gate which verdicts in a rescope batch produce
+    outbox reply effects.  The triage reply already covered the
+    user-visible acknowledgement for the comment; this predicate
+    decides whether the rescope's actual decision diverged enough
+    from "I queued exactly what you asked" to warrant a follow-up
+    voice reply.
+
+    Rules:
+
+    - ``outcome != "honored"`` (``reshaped`` / ``superseded`` /
+      ``no_op``) → always material.  These are user-visible
+      decisions the triage reply couldn't have anticipated.
+    - ``outcome == "honored"`` with ``task_descriptions`` supplied:
+      material when NO task description contains
+      ``intent.change_request`` verbatim (case-insensitive).  Per
+      HOL-23's "**Open**: should honored-with-divergence count as
+      material? Default yes ('you said X, I queued Y')" — yes by
+      default; the caller can pass the descriptions of the tasks
+      this verdict's ``affected_task_ids`` produced so the
+      heuristic can answer.  Without ``task_descriptions`` the
+      caller is signalling "don't try" and we fall back to "honored
+      = not material" (triage reply was enough).
+
+    The change_request → task-description containment check is a
+    deliberately simple heuristic; it catches the obvious
+    "you said X, I queued <much-longer-thing>" divergence without
+    needing LLM judgement.  A future leaf could refine with a
+    similarity-based check if false negatives appear in practice.
+    """
+    if verdict.outcome != "honored":
+        return True
+    if not task_descriptions:
+        return False
+    request = intent.change_request.strip().lower()
+    if not request:
+        return False
+    for desc in task_descriptions:
+        if request in (desc or "").strip().lower():
+            # The change_request text is verbatim in this task's
+            # description — not divergent enough to be material.
+            return False
+    return True
+
+
 @dataclass(frozen=True)
 class RescopeIntent:
     """Origin metadata for a rescope trigger from comment synthesis.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -478,3 +478,115 @@ class TestTaskStatusSkipped:
         assert TaskStatus.SKIPPED != TaskStatus.BLOCKED
         assert TaskStatus.SKIPPED != TaskStatus.PENDING
         assert TaskStatus.SKIPPED != TaskStatus.IN_PROGRESS
+
+
+# ---------------------------------------------------------------------------
+# HOL-23 / #1917 — verdict_is_material predicate
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictIsMaterial:
+    """HOL-23 / #1917: predicate gates per-thread reply-back emission.
+
+    Test matrix covers each outcome × match/divergence combination
+    per the issue's acceptance criteria.
+    """
+
+    def _intent(self, change_request: str = "Fix the bug") -> object:
+        from fido.types import RescopeIntent
+
+        return RescopeIntent(
+            change_request=change_request,
+            comment_id=42,
+            timestamp="2026-05-24T10:00:00Z",
+        )
+
+    def _verdict(self, outcome: str) -> object:
+        from fido.types import IntentVerdict
+
+        return IntentVerdict(
+            intent_comment_id=42,
+            outcome=outcome,
+            narrative="x",
+        )
+
+    def test_reshaped_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert verdict_is_material(self._intent(), self._verdict("reshaped"))
+
+    def test_superseded_is_material(self) -> None:
+        from fido.types import IntentVerdict, verdict_is_material
+
+        verdict = IntentVerdict(
+            intent_comment_id=42,
+            outcome="superseded",
+            by_intent_comment_id=99,
+            narrative="x",
+        )
+        assert verdict_is_material(self._intent(), verdict)
+
+    def test_no_op_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert verdict_is_material(self._intent(), self._verdict("no_op"))
+
+    def test_honored_without_descriptions_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(self._intent(), self._verdict("honored"))
+
+    def test_honored_matching_task_description_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=("Fix the bug in the retry path.",),
+        )
+
+    def test_honored_diverging_task_description_is_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # Task description doesn't contain the change_request text —
+        # "you said X, I queued Y" pattern → material.
+        assert verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=("Refactor the entire retry subsystem.",),
+        )
+
+    def test_honored_case_insensitive_match(self) -> None:
+        from fido.types import verdict_is_material
+
+        assert not verdict_is_material(
+            self._intent("FIX THE BUG"),
+            self._verdict("honored"),
+            task_descriptions=("fix the bug pls.",),
+        )
+
+    def test_honored_with_multiple_tasks_any_match_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # If ANY task description covers the request verbatim, the
+        # intent is honoured-as-asked → not material.
+        assert not verdict_is_material(
+            self._intent("Fix the bug"),
+            self._verdict("honored"),
+            task_descriptions=(
+                "Unrelated description.",
+                "Fix the bug as part of the broader refactor.",
+            ),
+        )
+
+    def test_honored_with_empty_change_request_is_not_material(self) -> None:
+        from fido.types import verdict_is_material
+
+        # Empty change_request can't be a basis for divergence —
+        # callers shouldn't construct intents this way but the
+        # predicate must not divide-by-zero.
+        assert not verdict_is_material(
+            self._intent(""),
+            self._verdict("honored"),
+            task_descriptions=("anything",),
+        )


### PR DESCRIPTION
## Summary

Gates per-thread reply-back emission for HOL-24.  Returns True when the verdict's outcome is non-honored OR when ``honored`` with a divergent task description.

This is the building block for the deferred Layer 4 reply chain (HOL-24..HOL-28); landing it standalone so the rest can build on a reviewed foundation.

## Test plan

- [x] 9 cases in ``TestVerdictIsMaterial`` covering each outcome × match/divergence combination.
- [x] ``./fido ci`` green, 100% coverage held, 4845 tests pass.