### PR TITLE
HOL-29 of #1894: ./fido status surfaces HOL-21-blocked tasks (closes #1923)

### DIFF
--- a/src/fido/status.py
+++ b/src/fido/status.py
@@ -3,6 +3,7 @@
 import fcntl
 import json
 import os
+import re
 import shutil
 import subprocess
 import urllib.request
@@ -115,6 +116,54 @@ class IssueCacheInfo:
     last_reconcile_drift: int
 
 
+@dataclass(frozen=True)
+class BlockedTaskInfo:
+    """HOL-29 / #1923: one BLOCKED task surfaced to ``./fido status``.
+
+    Picked up by ``repo_status`` when a task's status is ``blocked``
+    AND its description carries the ``CRITIC EXHAUSTED`` marker that
+    HOL-21's escalation helper appends.  Surfacing these in the
+    status output lets a human see at a glance which tasks have
+    auto-blocked themselves, without having to read tasks.json.
+
+    The bug-file URL isn't stored in tasks.json today (it's on the
+    PR thread as a BLOCKED comment); a future leaf could persist it
+    here for direct linking from status.
+    """
+
+    task_id: str
+    title: str
+    final_gap: str
+    attempt_count: int
+
+
+_CRITIC_EXHAUSTED_RE = re.compile(
+    r"CRITIC EXHAUSTED \((?P<count>\d+) attempts\): (?P<gap>.+?)$",
+    re.MULTILINE,
+)
+
+
+def _blocked_critic_tasks(task_list: list[dict[str, Any]]) -> list[BlockedTaskInfo]:
+    """Scan *task_list* for HOL-21-escalated BLOCKED tasks."""
+    out: list[BlockedTaskInfo] = []
+    for task in task_list:
+        if task.get("status") != "blocked":
+            continue
+        desc = task.get("description") or ""
+        match = _CRITIC_EXHAUSTED_RE.search(desc)
+        if match is None:
+            continue
+        out.append(
+            BlockedTaskInfo(
+                task_id=str(task.get("id", "")),
+                title=str(task.get("title", "")),
+                final_gap=match.group("gap").strip(),
+                attempt_count=int(match.group("count")),
+            )
+        )
+    return out
+
+
 @dataclass
 class RepoStatus:
     name: str
@@ -148,6 +197,11 @@ class RepoStatus:
     claude_talker: ClaudeTalkerInfo | None = None
     rescoping: bool = False  # True while a background Opus reorder is in flight
     issue_cache: IssueCacheInfo | None = None
+    # HOL-29 / #1923: BLOCKED tasks whose description carries the
+    # HOL-21 ``CRITIC EXHAUSTED`` marker.  Surfaced in the formatter
+    # so a human can see at a glance which tasks have auto-blocked
+    # themselves (and find the auto-filed bug from the PR thread).
+    blocked_critic_tasks: list[BlockedTaskInfo] = field(default_factory=list)
 
 
 @dataclass
@@ -751,6 +805,7 @@ def repo_status(
     task_list = Tasks(repo_config.work_dir).list()
     pending = sum(1 for t in task_list if t["status"] == "pending")
     completed = sum(1 for t in task_list if t["status"] == "completed")
+    blocked_critic_tasks = _blocked_critic_tasks(task_list)
 
     current = _current_task(task_list)
     task_number, task_total = _task_position(task_list)
@@ -796,6 +851,7 @@ def repo_status(
         claude_talker=claude_talker,
         rescoping=rescoping,
         issue_cache=issue_cache,
+        blocked_critic_tasks=blocked_critic_tasks,
     )
 
 
@@ -1198,7 +1254,35 @@ def _format_repo_body(repo: RepoStatus, *, c: Color) -> list[str]:
 
     body.extend(_format_webhook_lines(repo, c=c))
 
+    body.extend(_format_blocked_critic_lines(repo, c=c))
+
     return body
+
+
+def _format_blocked_critic_lines(repo: RepoStatus, *, c: Color) -> list[str]:
+    """HOL-29 / #1923: surface HOL-21-escalated BLOCKED tasks.
+
+    Empty list when no escalations are on the queue.  Each blocked
+    task gets one line: ``BLOCKED: <title> — <final-gap> (N attempts)``
+    in red so the human sees the escalation at a glance.  The bug
+    URL lives on the PR thread (not in tasks.json today); a human
+    can follow the PR comment for it.
+    """
+    if not repo.blocked_critic_tasks:
+        return []
+    lines: list[str] = []
+    for blocked in repo.blocked_critic_tasks:
+        gap_preview = (
+            blocked.final_gap
+            if len(blocked.final_gap) <= 80
+            else blocked.final_gap[:77] + "..."
+        )
+        lines.append(
+            f"  {c.color(RED, 'BLOCKED:')} {blocked.title} "
+            f"{c.color(DIM, '—')} {gap_preview} "
+            f"{c.color(DIM, f'({blocked.attempt_count} attempts)')}"
+        )
+    return lines
 
 
 def _should_show_worker_line(repo: RepoStatus) -> bool:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -3229,3 +3229,126 @@ class TestFetchActivitiesRateLimit:
         assert info is not None
         assert info.rest.used == 7
         assert info.graphql.used == 22
+
+
+# ---------------------------------------------------------------------------
+# HOL-29 / #1923 — BLOCKED-task display
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedCriticTasks:
+    """HOL-29: ``./fido status`` surfaces tasks the HOL-21 escalation
+    helper has marked BLOCKED."""
+
+    def test_blocked_critic_tasks_extracts_marker(self) -> None:
+        from fido.status import _blocked_critic_tasks
+
+        task_list = [
+            {
+                "id": "t-1",
+                "title": "Add retry logic",
+                "status": "blocked",
+                "description": (
+                    "Original notes here.\n\n"
+                    "CRITIC EXHAUSTED (3 attempts): diff includes "
+                    "unrelated formatting"
+                ),
+            },
+            # Non-blocked task — skipped.
+            {"id": "t-2", "title": "x", "status": "pending", "description": ""},
+            # Blocked but no CRITIC marker (e.g. blocked for another
+            # reason like #1247 unblock semantics) — skipped.
+            {"id": "t-3", "title": "y", "status": "blocked", "description": "stuck"},
+        ]
+
+        out = _blocked_critic_tasks(task_list)
+        assert len(out) == 1
+        assert out[0].task_id == "t-1"
+        assert out[0].title == "Add retry logic"
+        assert out[0].attempt_count == 3
+        assert "diff includes unrelated formatting" in out[0].final_gap
+
+    def test_format_status_renders_blocked_critic_line(self) -> None:
+        from fido.color import Color
+        from fido.status import BlockedTaskInfo, RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+            blocked_critic_tasks=[
+                BlockedTaskInfo(
+                    task_id="t-1",
+                    title="Add retry logic",
+                    final_gap="diff includes unrelated formatting",
+                    attempt_count=3,
+                ),
+            ],
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        blocked_line = next((line for line in lines if "BLOCKED:" in line), None)
+        assert blocked_line is not None
+        assert "Add retry logic" in blocked_line
+        assert "diff includes unrelated formatting" in blocked_line
+        assert "3 attempts" in blocked_line
+
+    def test_format_blocked_critic_line_truncates_long_gap(self) -> None:
+        from fido.color import Color
+        from fido.status import BlockedTaskInfo, RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+            blocked_critic_tasks=[
+                BlockedTaskInfo(
+                    task_id="t-1",
+                    title="Big task",
+                    final_gap="x" * 200,  # exceeds the 80-char cap
+                    attempt_count=3,
+                ),
+            ],
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        blocked_line = next(line for line in lines if "BLOCKED:" in line)
+        assert "..." in blocked_line
+        assert "x" * 200 not in blocked_line
+
+    def test_format_repo_body_omits_blocked_section_when_empty(self) -> None:
+        from fido.color import Color
+        from fido.status import RepoStatus, _format_repo_body
+
+        repo = RepoStatus(
+            name="owner/repo",
+            fido_running=True,
+            issue=42,
+            pending=0,
+            completed=0,
+            current_task=None,
+            claude_pid=None,
+            claude_uptime=None,
+            worker_what=None,
+            crash_count=0,
+            last_crash_error=None,
+            worker_stuck=False,
+        )
+        lines = _format_repo_body(repo, c=Color(env={"NO_COLOR": "1"}))
+        assert not any("BLOCKED:" in line for line in lines)


### PR DESCRIPTION
## Summary

Adds ``BlockedTaskInfo`` + ``RepoStatus.blocked_critic_tasks`` + a formatter arm so ``./fido status`` shows tasks the HOL-21 escalation helper has marked BLOCKED.  Each shows as ``BLOCKED: <title> — <gap> (N attempts)`` in red.

## Test plan

- [x] 4 new tests covering marker extraction, full-body rendering, long-gap truncation, and the empty-list omission boundary.
- [x] ``./fido ci`` green, 100% coverage, 4840 tests pass.