### PR TITLE
Fix #1955: get _after_applies out of reorder_tasks kwargs

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -3149,8 +3149,20 @@ class Dispatcher:
         sync_fn: Callable[[Path, Any], None] | None = None,
         *,
         after_apply: Callable[[], None] | None = None,
-    ) -> dict[str, Any]:
-        """Build the kwargs dict for a :func:`~fido.tasks.reorder_tasks` call."""
+    ) -> tuple[dict[str, Any], list[Callable[[], None]]]:
+        """Build the kwargs dict for a :func:`~fido.tasks.reorder_tasks` call.
+
+        Returns ``(kwargs, after_applies)``.  Every value in *kwargs* is
+        a valid ``reorder_tasks`` parameter — the dict is safe to
+        ``**``-splat into the call without filtering.  *after_applies*
+        is the mutable list captured by ``_on_done``'s closure; the
+        coalesce branch in ``reorder_tasks_background`` extends it so
+        every coalesced caller's after-apply hook fires after a single
+        sync+rewrite (#1955 regression: previously the list was stored
+        in ``kwargs`` as ``_after_applies`` and leaked into
+        ``reorder_tasks`` from ``Worker.rescope_before_pick``, which
+        does not filter side-channel kwargs).
+        """
         from fido.tasks import sync_tasks as _real_sync_tasks
 
         repo_cfg = self._repo_cfg
@@ -3213,13 +3225,6 @@ class Dispatcher:
             # batches; escalates via the Dispatcher-bound escalator
             # method when an intent's drops cross threshold.
             "task_creation_drop_counter": self._task_creation_drop_counter,
-            # Mutable shared list captured by ``on_done``.  Stored
-            # alongside ``_on_done`` so the coalesce branch can
-            # extend it when a new caller piles onto an in-flight
-            # batch (codex P2 fourteenth round on PR #1938).  Not
-            # forwarded to ``reorder_tasks`` — popped at the
-            # boundary.
-            "_after_applies": after_applies,
         }
         issue_ctx, pr_ctx = _load_active_context_for_rescope(
             work_dir, repo_cfg.name, gh
@@ -3242,7 +3247,7 @@ class Dispatcher:
             agent=agent,
             prompts=prompts,
         )
-        return kwargs
+        return kwargs, after_applies
 
     def _build_on_rescope_apply(
         self,
@@ -3440,7 +3445,7 @@ class Dispatcher:
             prompts = Prompts(_load_persona(config))
 
         key = str(work_dir)
-        kwargs = self._make_reorder_kwargs(
+        kwargs, after_applies = self._make_reorder_kwargs(
             registry,
             agent,
             prompts,
@@ -3460,40 +3465,43 @@ class Dispatcher:
                 # so every originating comment is tracked even when multiple
                 # comment-triggered rescopes arrive during the same Opus call.
                 #
-                # Codex P2 (fourteenth round) on PR #1938: keep the
-                # existing pending batch's ``_on_done`` (so its sync
-                # and PR-body rewrite run ONCE for the coalesced
-                # batch) and extend its mutable ``_after_applies``
-                # list with this caller's after-apply hook.  Every
-                # coalesced intent gets marked applied without
-                # duplicating the expensive external writes — and if
-                # the sync/rewrite step fails, NO intent is marked
-                # applied (the apply hooks only run after both
-                # succeed), so a restart correctly replays the
-                # whole batch.
+                # Keep the existing pending batch's ``_on_done`` (which
+                # captures the existing ``after_applies`` list) so its
+                # sync+PR-body rewrite run ONCE for the coalesced
+                # batch.  Extend that same shared list with this
+                # caller's after-apply hook so every coalesced intent
+                # is marked applied after the single sync+rewrite
+                # succeeds.  If sync/rewrite fails, NO intent is marked
+                # applied — the apply hooks only run after both
+                # succeed, so a restart correctly replays the whole
+                # batch.  Latest *kwargs* still win for fresh issue/pr
+                # context (used by the rescope prompt and reply
+                # notifier).  Per codex P2 rounds 14–15 on PR #1938.
                 existing = entry["pending"]
                 if existing is None:
-                    entry["pending"] = (commit_summary, kwargs, list(intents or []))
+                    entry["pending"] = (
+                        commit_summary,
+                        kwargs,
+                        list(intents or []),
+                        after_applies,
+                    )
                 else:
-                    accumulated = list(existing[2]) + list(intents or [])
-                    existing_kwargs = existing[1]
-                    existing_chain = existing_kwargs.get("_after_applies")
-                    new_chain = kwargs.get("_after_applies")
-                    if existing_chain is not None and new_chain is not None:
-                        existing_chain.extend(new_chain)
-                    # Codex P2 (fifteenth round) on PR #1938: keep
-                    # the latest caller's fresh issue/pr context
-                    # (used by the rescope prompt and the reply
-                    # notifier), but preserve the existing batch's
-                    # ``_on_done`` — the single closure that owns
-                    # the shared ``_after_applies`` list — so
-                    # sync+rewrite still run ONCE for the coalesced
-                    # batch.  Latest kwargs win for every field
-                    # EXCEPT the on_done / shared-list pair.
+                    (
+                        _,
+                        existing_kwargs,
+                        existing_intents,
+                        existing_after_applies,
+                    ) = existing
+                    accumulated = existing_intents + list(intents or [])
+                    existing_after_applies.extend(after_applies)
                     merged = dict(kwargs)
-                    merged["_on_done"] = existing_kwargs.get("_on_done")
-                    merged["_after_applies"] = existing_chain
-                    entry["pending"] = (commit_summary, merged, accumulated)
+                    merged["_on_done"] = existing_kwargs["_on_done"]
+                    entry["pending"] = (
+                        commit_summary,
+                        merged,
+                        accumulated,
+                        existing_after_applies,
+                    )
                 return
             entry["running"] = True
             entry["pending"] = None
@@ -3540,15 +3548,11 @@ class Dispatcher:
                         agent=kw.get("agent"),
                         prompts=kw.get("prompts"),
                     )
-                    # ``_after_applies`` is a side-channel captured
-                    # by ``_on_done``'s closure; it must not reach
-                    # ``reorder_tasks`` (not part of its signature).
-                    reorder_kw = {k: v for k, v in kw.items() if k != "_after_applies"}
                     reorder(
                         registry.tasks_for(repo_cfg.name),
                         cs,
                         intents=current_intents or None,
-                        **reorder_kw,
+                        **kw,
                     )
                     log.info("rescope BG: iteration %d complete", iteration)
                     with _reorder_coalesce_lock:
@@ -3556,7 +3560,11 @@ class Dispatcher:
                         if pending is None:
                             break
                         state[key]["pending"] = None
-                        cs, kw, current_intents = pending
+                        # 4-tuple: (cs, kwargs, intents, after_applies).
+                        # The after_applies list is captured by kw's
+                        # on_done closure, so we don't need to bind it
+                        # here — the existing on_done already reads it.
+                        cs, kw, current_intents, _ = pending
             finally:
                 log.info("rescope BG: entering finally (iterations=%d)", iteration)
                 with _reorder_coalesce_lock:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5266,7 +5266,11 @@ class Worker:
         assert self._repo_cfg is not None, (
             "Worker._repo_cfg is required for rescope_before_pick"
         )
-        reorder_kwargs = self._make_reorder_kwargs_fn(
+        # ``_make_reorder_kwargs`` returns ``(kwargs, after_applies)``.
+        # ``rescope_before_pick`` has no per-caller after-apply hook,
+        # so the list is empty and can be discarded — ``on_done``'s
+        # closure still references the (empty) list and is shape-stable.
+        reorder_kwargs, _ = self._make_reorder_kwargs_fn(
             self._registry,
             self._provider_agent,
             self._get_prompts(),
@@ -5285,7 +5289,7 @@ class Worker:
         prompts: Prompts,
         rewrite_fn: Callable[..., None],
         sync_fn: Callable[[Path, Any], None] | None = None,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], list[Callable[[], None]]]:
         return self._dispatcher._make_reorder_kwargs(  # pyright: ignore[reportPrivateUsage]
             registry,
             agent,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7261,7 +7261,7 @@ class TestMakeReorderKwargsActiveContext:
 
     def test_no_issue_key_omitted_when_no_state(self, tmp_path: Path) -> None:
         gh = MagicMock()
-        kwargs = Dispatcher(
+        kwargs, _ = Dispatcher(
             self._cfg(tmp_path), self._repo_cfg(tmp_path), gh
         )._make_reorder_kwargs(MagicMock(), MagicMock(), MagicMock(), MagicMock())
         assert "issue" not in kwargs
@@ -7272,7 +7272,7 @@ class TestMakeReorderKwargsActiveContext:
         State(fido_dir).save({"issue": 5})
         gh = MagicMock()
         gh.view_issue.return_value = {"title": "Do the thing", "body": "Details."}
-        kwargs = Dispatcher(
+        kwargs, _ = Dispatcher(
             self._cfg(tmp_path), self._repo_cfg(tmp_path), gh
         )._make_reorder_kwargs(MagicMock(), MagicMock(), MagicMock(), MagicMock())
         assert "issue" in kwargs
@@ -7288,7 +7288,7 @@ class TestMakeReorderKwargsActiveContext:
         gh = MagicMock()
         gh.view_issue.return_value = {"title": "t", "body": ""}
         gh.get_pr.return_value = {"title": "Fix it (closes #5)", "body": ""}
-        kwargs = Dispatcher(
+        kwargs, _ = Dispatcher(
             self._cfg(tmp_path), self._repo_cfg(tmp_path), gh
         )._make_reorder_kwargs(MagicMock(), MagicMock(), MagicMock(), MagicMock())
         assert "pr" in kwargs
@@ -7328,7 +7328,7 @@ class TestMakeReorderKwargsAfterApply:
         def after_apply() -> None:
             calls.append("after_apply")
 
-        kwargs = Dispatcher(
+        kwargs, _ = Dispatcher(
             self._cfg(tmp_path), self._cfg(tmp_path).repos["owner/repo"], gh
         )._make_reorder_kwargs(
             MagicMock(),

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,6 +1,7 @@
 """Tests for fido.worker — WorkerContext, lock acquisition, git context."""
 
 import contextlib
+import inspect
 import json
 import logging
 import subprocess
@@ -10754,7 +10755,7 @@ class TestRescopeBeforePick:
         mock_reorder = MagicMock()
         worker._reorder_tasks_fn = mock_reorder
         worker._get_commit_summary_fn = MagicMock(return_value="abc def")
-        worker._make_reorder_kwargs_fn = MagicMock(return_value={})
+        worker._make_reorder_kwargs_fn = MagicMock(return_value=({}, []))
         worker.rescope_before_pick()
         mock_reorder.assert_called_once()
 
@@ -10769,7 +10770,7 @@ class TestRescopeBeforePick:
         mock_reorder = MagicMock()
         worker._reorder_tasks_fn = mock_reorder
         worker._get_commit_summary_fn = MagicMock(return_value="")
-        worker._make_reorder_kwargs_fn = MagicMock(return_value={})
+        worker._make_reorder_kwargs_fn = MagicMock(return_value=({}, []))
         worker.rescope_before_pick()
         assert mock_reorder.call_args[0][0] is worker._tasks
 
@@ -10781,7 +10782,7 @@ class TestRescopeBeforePick:
         mock_reorder = MagicMock()
         worker._reorder_tasks_fn = mock_reorder
         worker._get_commit_summary_fn = MagicMock(return_value="abc123 first commit")
-        worker._make_reorder_kwargs_fn = MagicMock(return_value={})
+        worker._make_reorder_kwargs_fn = MagicMock(return_value=({}, []))
         worker.rescope_before_pick()
         assert mock_reorder.call_args[0][1] == "abc123 first commit"
 
@@ -10795,7 +10796,7 @@ class TestRescopeBeforePick:
         worker._reorder_tasks_fn = MagicMock()
         worker._get_commit_summary_fn = MagicMock(return_value="")
         worker._make_reorder_kwargs_fn = MagicMock(
-            side_effect=lambda reg, *a, **kw: captured_registry.append(reg) or {}
+            side_effect=lambda reg, *a, **kw: (captured_registry.append(reg) or {}, [])
         )
         worker.rescope_before_pick()
         assert captured_registry == [worker._registry]  # noqa: SLF001
@@ -10814,9 +10815,59 @@ class TestRescopeBeforePick:
         mock_reorder = MagicMock()
         worker._reorder_tasks_fn = mock_reorder
         worker._get_commit_summary_fn = MagicMock(return_value="")
-        worker._make_reorder_kwargs_fn = MagicMock(return_value={})
+        worker._make_reorder_kwargs_fn = MagicMock(return_value=({}, []))
         worker.rescope_before_pick()
         mock_reorder.assert_called_once()
+
+
+class TestRescopeBeforePickRealKwargs:
+    """Regression test for #1955: ``rescope_before_pick`` consumes the
+    dict half of ``_make_reorder_kwargs``'s tuple return; nothing in
+    that dict may be a side-channel that ``reorder_tasks`` does not
+    accept.  The previous shape (``_after_applies`` stored inside
+    ``kwargs``) crashed every rescope with TypeError."""
+
+    def test_real_make_reorder_kwargs_does_not_leak_side_channels(
+        self, tmp_path: Path
+    ) -> None:
+        # Build a real Dispatcher so ``_make_reorder_kwargs`` runs
+        # the production code path, then verify every key in the
+        # returned kwargs is a valid ``reorder_tasks`` parameter
+        # name.  This catches any future drift where someone adds a
+        # side-channel kwarg to the dict.
+        from fido.events import Dispatcher
+        from fido.tasks import reorder_tasks
+
+        gh = MagicMock()
+        cfg = Config(
+            port=9000,
+            secret=b"test",
+            repos={
+                "owner/repo": RepoConfig(
+                    name="owner/repo",
+                    work_dir=tmp_path,
+                    provider=ProviderID.CLAUDE_CODE,
+                )
+            },
+            allowed_bots=frozenset(),
+            log_level="WARNING",
+            sub_dir=tmp_path / "sub",
+        )
+        dispatcher = Dispatcher(cfg, cfg.repos["owner/repo"], gh)
+        kwargs, after_applies = dispatcher._make_reorder_kwargs(  # noqa: SLF001
+            MagicMock(spec=ActivityReporter),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+        # The after-apply chain lives outside kwargs.
+        assert isinstance(after_applies, list)
+        # Every key in kwargs must be a valid ``reorder_tasks`` parameter.
+        reorder_params = set(inspect.signature(reorder_tasks).parameters)
+        leaked = set(kwargs) - reorder_params
+        assert leaked == set(), (
+            f"side-channel kwargs leaked into reorder_tasks call: {leaked}"
+        )
 
 
 class TestRunRescopeIntegration:
@@ -11026,9 +11077,9 @@ class TestNewDelegationMethods:
                 rewrite_fn: object,
                 sync_fn: object = None,
                 sync_tasks_fn: object = None,
-            ) -> dict[str, object]:  # type: ignore[override]
+            ) -> tuple[dict[str, object], list[object]]:  # type: ignore[override]
                 calls.append((registry, agent, prompts, rewrite_fn, {}))
-                return {"k": "v"}
+                return {"k": "v"}, []
 
         fake_registry = MagicMock(spec=ActivityReporter)
         fake_agent = MagicMock()
@@ -11049,7 +11100,7 @@ class TestNewDelegationMethods:
         assert len(calls) == 1
         assert calls[0][0] is fake_registry
         assert calls[0][1] is fake_agent
-        assert result == {"k": "v"}
+        assert result == ({"k": "v"}, [])
 
     def test_reorder_tasks_fn_delegates_to_collaborator(self, tmp_path: Path) -> None:
         mock_fn = MagicMock()


### PR DESCRIPTION
## Summary

Closes #1955. Regression from PR #1938 (codex round-14 fix) crashed every \`rescope_before_pick\` call with \`TypeError: reorder_tasks() got an unexpected keyword argument '_after_applies'\` — observed as 154 crash-restarts on FidoCanCode/home in ~1.5h, blocking PR #1951.

## Root cause

\`Dispatcher._make_reorder_kwargs\` stored the per-batch \`after_applies\` list **inside** the returned kwargs dict as \`_after_applies\` so the coalesce branch could extend it. \`reorder_tasks_background\` filtered the side-channel key before calling \`reorder_tasks\`, but \`Worker.rescope_before_pick\` consumed the same dict via \`_task_reorderer(**kwargs)\` and didn't.

## Fix

Take the side channel out of \`kwargs\` entirely. \`_make_reorder_kwargs\` now returns \`(kwargs, after_applies)\` — the list lives alongside the dict, not inside it. Coalesce-state's pending tuple grows from 3-tuple to 4-tuple to carry the list. Every key in the returned \`kwargs\` is now a valid \`reorder_tasks\` parameter; the filter at the reorder call site is gone — and so is the class of bug where a future caller forgets it.

## Test plan
- [x] \`./fido ci\` — 4974 passed at 100% coverage
- [x] Regression test in \`test_worker.py::TestRescopeBeforePickRealKwargs\` asserts every key in \`_make_reorder_kwargs\`'s returned dict matches a real \`reorder_tasks\` parameter, so any future side-channel addition fails CI immediately