### PR TITLE
Fix #1962: kill _configured_agent; webhook paths reuse worker session

### DIFF
--- a/src/fido/events.py
+++ b/src/fido/events.py
@@ -857,24 +857,6 @@ class WebhookIngressOracle:
         return new_state
 
 
-def _configured_agent(
-    config: Config,
-    repo_cfg: RepoConfig,
-    *,
-    _factory: DefaultProviderFactory | None = None,
-) -> ProviderAgent:
-    factory = (
-        _factory
-        if _factory is not None
-        else DefaultProviderFactory(session_system_file=config.sub_dir / "persona.md")
-    )
-    return factory.create_agent(
-        repo_cfg,
-        work_dir=repo_cfg.work_dir,
-        repo_name=repo_cfg.name,
-    )
-
-
 @dataclass
 class Action:
     prompt: str
@@ -2294,7 +2276,7 @@ class Dispatcher:
         repo_cfg = self._repo_cfg
         gh = self._gh
         if agent is None:
-            agent = _configured_agent(config, repo_cfg, _factory=self._provider_factory)
+            agent = registry.agent_for(repo_cfg.name)
         if prompts is None:
             prompts = Prompts(_load_persona(config))
         _synthesis_fn = self._call_synthesis_fn
@@ -2641,7 +2623,7 @@ class Dispatcher:
         repo_cfg = self._repo_cfg
         gh = self._gh
         if agent is None:
-            agent = _configured_agent(config, repo_cfg, _factory=self._provider_factory)
+            agent = registry.agent_for(repo_cfg.name)
         if prompts is None:
             prompts = Prompts(_load_persona(config))
         _synthesis_fn = self._call_synthesis_fn
@@ -2892,8 +2874,8 @@ class Dispatcher:
         batch_intents: list[RescopeIntent],
         affected_task_ids: list[str],
         result: list[dict[str, Any]],
-        agent: ProviderAgent | None = None,
-        prompts: Prompts | None = None,
+        agent: ProviderAgent,
+        prompts: Prompts,
         verdict: IntentVerdict | None = None,
     ) -> None:
         """Post a per-intent reply per the INV-F reply-back rule.
@@ -2915,7 +2897,6 @@ class Dispatcher:
         convention) and instructed never to imply the work is done — the
         rescope only replanned.
         """
-        config = self._config
         repo_cfg = self._repo_cfg
         repo = repo_cfg.name
         gh = self._gh
@@ -2930,11 +2911,6 @@ class Dispatcher:
                 intent.comment_id,
             )
             return
-
-        if agent is None:
-            agent = _configured_agent(config, repo_cfg, _factory=self._provider_factory)
-        if prompts is None:
-            prompts = Prompts(_load_persona(config))
 
         intents_by_cid = {i.comment_id: i for i in batch_intents}
         tasks_by_id = {t["id"]: t for t in result}
@@ -3253,8 +3229,8 @@ class Dispatcher:
         self,
         intents: list[RescopeIntent],
         pr_ctx: "ActivePR | None",
-        agent: "ProviderAgent | None",
-        prompts: "Prompts | None",
+        agent: ProviderAgent,
+        prompts: Prompts,
     ) -> Callable[
         [
             list[dict[str, Any]],
@@ -3440,7 +3416,7 @@ class Dispatcher:
             else _reorder_coalesce
         )
         if agent is None:
-            agent = _configured_agent(config, repo_cfg, _factory=self._provider_factory)
+            agent = registry.agent_for(repo_cfg.name)
         if prompts is None:
             prompts = Prompts(_load_persona(config))
 
@@ -3542,11 +3518,19 @@ class Dispatcher:
                     # current_intents (coalesced batches accumulate).
                     # pr_ctx and other context are immutable across
                     # iterations so re-extracting from kw is safe.
+                    # ``kw["agent"]`` is the hot worker session agent
+                    # plumbed in via ``_make_reorder_kwargs`` (#1962);
+                    # it is required for the per-intent reply-back
+                    # generation in ``_notify_intent_outcome``.
+                    iter_agent = kw["agent"]
+                    iter_prompts = kw["prompts"]
+                    assert iter_agent is not None
+                    assert iter_prompts is not None
                     kw["_on_rescope_apply"] = self._build_on_rescope_apply(
                         intents=current_intents,
                         pr_ctx=kw.get("pr"),
-                        agent=kw.get("agent"),
-                        prompts=kw.get("prompts"),
+                        agent=iter_agent,
+                        prompts=iter_prompts,
                     )
                     reorder(
                         registry.tasks_for(repo_cfg.name),

--- a/src/fido/registry.py
+++ b/src/fido/registry.py
@@ -28,7 +28,7 @@ from fido.atomic import AtomicUpdater
 from fido.config import Config, RepoConfig, default_sub_dir
 from fido.github import GitHub
 from fido.issue_cache import CacheMetrics, IssueCache
-from fido.provider import PromptSession, Provider
+from fido.provider import PromptSession, Provider, ProviderAgent
 from fido.provider_factory import DefaultProviderFactory
 from fido.repo import Repo
 from fido.rocq import handler_preemption as preemption_fsm
@@ -621,6 +621,23 @@ class WorkerRegistry:
     def tasks_for(self, repo_name: str) -> Tasks:
         """Convenience accessor for ``self.repo_for(name).tasks``."""
         return self._repos[repo_name].tasks
+
+    def agent_for(self, repo_name: str) -> ProviderAgent:
+        """Return the worker thread's hot ``ProviderAgent`` for *repo_name*.
+
+        Used by webhook-driven LLM call sites (synthesis, rescope) so
+        they reuse the worker's loaded session — the entire reason
+        preempt-always exists (#1230, #1962).  Raises ``RuntimeError``
+        when no agent is available (no worker, or session not yet
+        bootstrapped); callers MUST have a live worker for the repo.
+        """
+        agent = self._threads[repo_name].provider_agent
+        if agent is None:
+            raise RuntimeError(
+                f"no provider agent available for {repo_name} — "
+                f"webhook-driven LLM calls require a live worker session"
+            )
+        return agent
 
     def state_for(self, repo_name: str) -> State:
         """Convenience accessor for ``self.repo_for(name).state``."""

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -5734,12 +5734,23 @@ class WorkerThread(threading.Thread):
         session for webhook use) and the implementation (which used to
         spawn fresh agents next to the just-freed session).  Per #1962.
 
-        Safe to call from any thread — the ``_provider_lock`` covers the
-        provider field read.
+        Returns ``None`` until the worker has bootstrapped a live
+        session (``agent.session is not None``).  Codex P1 on #1963:
+        without this gate, a webhook landing during startup before
+        ``WorkerThread.run`` has called ``_create_session`` would get
+        the shared agent back with no session, then race the worker's
+        bootstrap to create one — reintroducing the duplicate-session
+        leak the modeled session lock is meant to prevent.
+
+        Safe to call from any thread — the ``_provider_lock`` covers
+        the provider field read; the agent's ``session`` attribute
+        read is a single pointer load.
         """
         with self._provider_lock:
             provider = self._provider
-        return provider.agent if provider is not None else None
+        if provider is None or provider.agent.session is None:
+            return None
+        return provider.agent
 
     @property
     def session_owner(self) -> str | None:

--- a/src/fido/worker.py
+++ b/src/fido/worker.py
@@ -261,6 +261,8 @@ class ActivityReporter(Protocol):
 
     def tasks_for(self, repo_name: str) -> Tasks: ...
 
+    def agent_for(self, repo_name: str) -> ProviderAgent: ...
+
     def state_for(self, repo_name: str) -> State: ...
 
 
@@ -5721,6 +5723,23 @@ class WorkerThread(threading.Thread):
         if provider is None:
             return False
         return provider.agent.recover_session()
+
+    @property
+    def provider_agent(self) -> ProviderAgent | None:
+        """The hot ``ProviderAgent`` this worker is using, or ``None``.
+
+        Returned for webhook-driven LLM calls (synthesis, rescope) so they
+        can reuse the worker's loaded session instead of spawning a fresh
+        agent.  Closes the gap between preempt-always's purpose (free the
+        session for webhook use) and the implementation (which used to
+        spawn fresh agents next to the just-freed session).  Per #1962.
+
+        Safe to call from any thread — the ``_provider_lock`` covers the
+        provider field read.
+        """
+        with self._provider_lock:
+            provider = self._provider
+        return provider.agent if provider is not None else None
 
     @property
     def session_owner(self) -> str | None:

--- a/tests/test_coverage_fills.py
+++ b/tests/test_coverage_fills.py
@@ -234,6 +234,11 @@ class _FakeEventRegistry:
         self.enter_untriaged = _FakeCallRecorder()
         self.exit_untriaged = _FakeCallRecorder()
         self.set_rescoping = _FakeCallRecorder()
+        # #1962: webhook-driven rescope pulls the worker's agent here.
+        # An opaque sentinel object is fine — no LLM call is exercised
+        # in this test class and this file avoids MagicMock by
+        # convention.
+        self.agent_for = _FakeCallRecorder(return_value=object())
 
 
 class _FakeTasksForDispatcher:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -15,7 +15,6 @@ from fido.events import (
     WebhookIngressOracle,
     _BackgroundRescopeTrigger,
     _build_issue_comment_action,
-    _configured_agent,
     _existing_reply_artifact,
     _get_commit_summary,
     _GitHubInsightFiler,
@@ -204,22 +203,11 @@ class TestNeedsMoreContext:
         with pytest.raises(ValueError, match="needs_more_context requires agent"):
             needs_more_context("some comment")
 
-    def test_configured_agent_uses_provider_factory(self, tmp_path: Path) -> None:
-        from fido.provider_factory import DefaultProviderFactory
-
-        cfg = _config(tmp_path)
-        cfg.repos["owner/repo"] = RepoConfig(
-            name="owner/repo",
-            work_dir=tmp_path,
-            provider=ProviderID.COPILOT_CLI,
-        )
-        sentinel = MagicMock()
-        factory = MagicMock(spec=DefaultProviderFactory)
-        factory.create_agent.return_value = sentinel
-        assert (
-            _configured_agent(cfg, cfg.repos["owner/repo"], _factory=factory)
-            is sentinel
-        )
+    # ``_configured_agent`` was deleted in #1962: webhook-driven LLM
+    # calls now require the worker's hot session via
+    # ``registry.agent_for(repo)`` instead of spawning a fresh agent
+    # from the provider factory.  The dedicated test for the deleted
+    # helper went with it.
 
 
 class TestRecoverReplyPromises:
@@ -3365,34 +3353,39 @@ class TestReplyToIssueComment:
         assert cat == "ACT"
         mock_gh.add_reaction.assert_not_called()
 
-    def test_defaults_to_repo_configured_agent(self, tmp_path: Path) -> None:
+    def test_pulls_agent_from_registry_when_not_supplied(self, tmp_path: Path) -> None:
+        # #1962: when the caller doesn't pass agent= explicitly,
+        # the dispatcher pulls the worker's hot session agent
+        # via ``registry.agent_for(repo)`` — NOT a freshly-spawned
+        # factory agent.
         cfg = self._cfg(tmp_path)
         action = self._action()
+        sentinel_agent = _client()
+        agent_for_calls: list[str] = []
 
-        create_agent_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        registry = MagicMock(spec=ActivityReporter)
 
-        class _FakeFactory:
-            def create_agent(self, *args: object, **kwargs: object) -> object:
-                create_agent_calls.append((args, kwargs))
-                return _client()
+        def _agent_for(repo: str) -> object:
+            agent_for_calls.append(repo)
+            return sentinel_agent
+
+        registry.agent_for.side_effect = _agent_for
 
         gh = self._mock_gh()
-        cat, titles = Dispatcher(
+        captured_agent: list[object] = []
+
+        def _capture_synthesis(*_args: object, **kwargs: object) -> object:
+            captured_agent.append(kwargs.get("agent"))
+            return _synthesis_response("ok", change_request="Do it")
+
+        cat, _titles = Dispatcher(
             cfg,
             self._repo_cfg(tmp_path),
             gh,
-            provider_factory=_FakeFactory(),  # type: ignore[arg-type]
-            call_synthesis_fn=lambda *a, **kw: _synthesis_response(
-                "ok", change_request="Do it"
-            ),
-        ).reply_to_issue_comment(
-            action,
-            registry=MagicMock(spec=ActivityReporter),
-        )
-        assert len(create_agent_calls) == 1
-        args, kwargs = create_agent_calls[0]
-        assert args == (self._repo_cfg(tmp_path),)
-        assert kwargs == {"work_dir": tmp_path, "repo_name": "owner/repo"}
+            call_synthesis_fn=_capture_synthesis,
+        ).reply_to_issue_comment(action, registry=registry)
+        assert agent_for_calls == ["owner/repo"]
+        assert captured_agent == [sentinel_agent]
         assert cat == "ACT"
 
     def test_includes_conversation_context_in_synthesis(self, tmp_path: Path) -> None:
@@ -3669,6 +3662,14 @@ class _FakeRescopeRegistry:
 
     def exit_untriaged(self, repo_name: str) -> None:
         self.calls.append(("exit_untriaged", repo_name))
+
+    def agent_for(self, _repo_name: str) -> object:
+        # The reorder code path requests the worker's hot agent here
+        # (#1962).  These tests assert ordering of inbox/rescoping
+        # bookkeeping — keep agent_for OUT of the calls list so the
+        # existing exact-list assertions stay tight.  Return a
+        # stand-in MagicMock; no LLM call is exercised.
+        return MagicMock()
 
     def abort_task(self, repo_name: str, *, task_id: str | None = None) -> None:
         self.calls.append(("abort_task", repo_name, task_id))
@@ -5444,33 +5445,10 @@ class TestNotifyIntentOutcome:
         joined = "\n".join(captured)
         assert "comment #999" not in joined
 
-    def test_default_agent_and_prompts_constructed_when_none(
-        self, tmp_path: Path
-    ) -> None:
-        intent = self._intent()
-        kwargs = self._kwargs(_client("Auto reply"))
-        del kwargs["agent"]
-        del kwargs["prompts"]
-
-        create_agent_calls: list[tuple[object, ...]] = []
-
-        class _FakeFactory:
-            def create_agent(self, *args: object, **kwargs: object) -> object:
-                create_agent_calls.append(args)
-                return _client("Auto reply")
-
-        cfg = self._cfg(tmp_path)
-        Dispatcher(
-            cfg,
-            cfg.repos["owner/repo"],
-            MagicMock(),
-            provider_factory=_FakeFactory(),  # type: ignore[arg-type]
-        )._notify_intent_outcome(
-            intent,
-            task_queue_rescope.NotifyChanged(),
-            **kwargs,
-        )
-        assert len(create_agent_calls) == 1
+    # The fresh-agent fallback was deleted in #1962 — ``_notify_intent_outcome``
+    # now requires the caller to pass the worker's hot session
+    # agent.  The matching test (default_agent_and_prompts_constructed_when_none)
+    # went with it.
 
 
 class TestBuildOpInputsAuthors:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -111,6 +111,10 @@ class _FakeThread:
         self.was_stopped: bool = False
         self._session_issue: int | None = None
         self.crash_error: str | None = None
+        # #1962: WorkerRegistry.agent_for reads this; default None
+        # means "no live session" → registry raises.  Tests set this
+        # to an object sentinel to simulate a live worker session.
+        self.provider_agent: object | None = None
         self.session_owner: str | None = None
         self.session_alive: bool = False
         self.session_pid: int | None = None
@@ -536,6 +540,44 @@ class TestWorkerRegistry:
         assert provider.session_alive is True
         assert provider.session_sent_count == 5
         assert provider.session_received_count == 3
+
+    def test_agent_for_returns_workers_provider_agent(self, tmp_path: Path) -> None:
+        # #1962: webhook-driven LLM calls reuse the worker's hot session
+        # via ``agent_for``.  When the worker has a live provider, this
+        # returns its agent.
+        sentinel_agent = object()
+        thread = _FakeThread()
+        thread.provider_agent = sentinel_agent
+        factory = _FakeThreadFactory(return_value=thread)
+        reader, updater = create_atomic(
+            FidoState(
+                repos=frozendict(),
+                github_limits=_ZERO_GITHUB_LIMITS,
+                process_started_at=_EPOCH,
+            )
+        )
+        reg = WorkerRegistry(factory, updater)
+        reg.start(_repo("foo/bar", tmp_path))
+        assert reg.agent_for("foo/bar") is sentinel_agent
+
+    def test_agent_for_raises_when_no_session(self, tmp_path: Path) -> None:
+        # #1962: when no provider/session is alive yet, ``agent_for``
+        # raises rather than silently spawning a fresh agent — that
+        # silent-spawn was the original bug.
+        thread = _FakeThread()
+        assert thread.provider_agent is None  # default
+        factory = _FakeThreadFactory(return_value=thread)
+        reader, updater = create_atomic(
+            FidoState(
+                repos=frozendict(),
+                github_limits=_ZERO_GITHUB_LIMITS,
+                process_started_at=_EPOCH,
+            )
+        )
+        reg = WorkerRegistry(factory, updater)
+        reg.start(_repo("foo/bar", tmp_path))
+        with pytest.raises(RuntimeError, match="no provider agent available"):
+            reg.agent_for("foo/bar")
 
     def test_repo_for_returns_publishing_repo_after_start(self, tmp_path: Path) -> None:
         """``repo_for`` returns the registry-owned :class:`Repo` whose

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17615,9 +17615,10 @@ class TestWorkerThread:
     def test_provider_agent_returns_providers_agent(self, tmp_path: Path) -> None:
         # #1962: WorkerRegistry.agent_for reaches the worker's hot
         # session via this property.  Returns the live provider's
-        # agent when one is attached.
+        # agent when one is attached AND has a live session.
         provider = MagicMock()
         sentinel_agent = MagicMock()
+        sentinel_agent.session = MagicMock()  # bootstrapped session
         provider.agent = sentinel_agent
         wt = WorkerThread(
             tmp_path,
@@ -17640,6 +17641,25 @@ class TestWorkerThread:
         )
         # Force-clear the provider so the None branch is observable.
         wt._provider = None  # noqa: SLF001
+        assert wt.provider_agent is None
+
+    def test_provider_agent_none_when_session_not_bootstrapped(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex P1 on #1963: a webhook landing during startup, before
+        # ``WorkerThread.run`` has called ``_create_session``, must NOT
+        # get the shared agent back — otherwise the webhook path can
+        # race the worker's bootstrap and create duplicate sessions
+        # outside the modeled session lock.
+        provider = MagicMock()
+        provider.agent.session = None  # provider exists, session does not
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
         assert wt.provider_agent is None
 
     def test_session_alive_false_when_no_session(self, tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17612,6 +17612,36 @@ class TestWorkerThread:
         wt.current_provider().agent.attach_session(mock_session)
         assert wt.session_owner == "worker-home"
 
+    def test_provider_agent_returns_providers_agent(self, tmp_path: Path) -> None:
+        # #1962: WorkerRegistry.agent_for reaches the worker's hot
+        # session via this property.  Returns the live provider's
+        # agent when one is attached.
+        provider = MagicMock()
+        sentinel_agent = MagicMock()
+        provider.agent = sentinel_agent
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            provider=provider,
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        assert wt.provider_agent is sentinel_agent
+
+    def test_provider_agent_none_when_no_provider(self, tmp_path: Path) -> None:
+        # #1962: with no provider attached, the property returns None
+        # so WorkerRegistry.agent_for can raise rather than silently
+        # spawn a fresh agent.
+        wt = WorkerThread(
+            tmp_path,
+            "owner/repo",
+            MagicMock(),
+            registry=MagicMock(spec=ActivityReporter),
+        )
+        # Force-clear the provider so the None branch is observable.
+        wt._provider = None  # noqa: SLF001
+        assert wt.provider_agent is None
+
     def test_session_alive_false_when_no_session(self, tmp_path: Path) -> None:
         wt = self._make_thread(tmp_path)
         assert wt.current_provider().agent.session is None


### PR DESCRIPTION
Closes #1962. Implementation companion to #1961.

WIP — see #1962 for the full picture.

## Plan

1. Add \`WorkerRegistry.agent_for(repo) -> ProviderAgent\` (raises if no worker exists for that repo).
2. Route \`Dispatcher\`'s webhook entry points (\`reply_to_comment\`, \`reply_to_issue_comment\`) through the registry instead of \`_configured_agent\`.
3. \`_BackgroundRescopeTrigger\` already takes an agent — make sure the synthesis-triggered path threads the worker's agent through it.
4. Delete \`_configured_agent\` from \`events.py\`.
5. Migrate tests that relied on the fresh-agent fallback to construct explicit agent fakes.

## Test plan
- [ ] \`./fido ci\` — 100% coverage maintained
- [ ] Regression: every webhook path uses the worker's \`_provider_agent\`, not a fresh one
- [ ] No remaining \`_configured_agent\` callers